### PR TITLE
mise.tomlにツール設定を追加

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+editorconfig-checker = "3.3.0"
+lefthook = "1.12.2"
+terraform = "1.12.2"


### PR DESCRIPTION
This pull request updates the `mise.toml` file to include new tools and their respective versions. These additions enhance the project's tooling configuration.

Tool additions:

* [`mise.toml`](diffhunk://#diff-3c9056799ce8e353b18de841a8b9c8492d46cb096e063c86fb0ce54cfcd117c2R1-R4): Added `editorconfig-checker` (version 3.3.0), `lefthook` (version 1.12.2), and `terraform` (version 1.12.2) under the `[tools]` section.