### PR TITLE
Copilotセットアップ用のGitHub Actionsワークフローを追加

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,30 @@
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v2
+      - name: Set up mise
+        uses: jdx/mise-action@v2
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow file to streamline the setup steps for Copilot-related tasks. The workflow is triggered on specific events and includes steps to set up the environment with necessary tools and dependencies.

### New GitHub Actions workflow:

* `.github/workflows/copilot-setup-steps.yml`: Added a new workflow named "Copilot Setup Steps" that runs on `ubuntu-latest`. It is triggered by `workflow_dispatch`, `push`, and `pull_request` events targeting the workflow file itself. The workflow includes steps to:
  - Checkout the code using `actions/checkout@v4`.
  - Use the `jdx/mise-action@v2` action.
  - Set up JDK 21 with Temurin distribution using `actions/setup-java@v4`.
  - Set up Gradle using `gradle/actions/setup-gradle@v4`.