### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ptiringo


### PR DESCRIPTION
This pull request updates the `.github/CODEOWNERS` file to assign `@ptiringo` as the code owner for all files in the repository.

- [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1): Added `@ptiringo` as the global code owner.