### PR TITLE
chore: Claude Code 用の SessionStart hook を追加

### DIFF
--- a/.claude/hooks/session-start-mise.sh
+++ b/.claude/hooks/session-start-mise.sh
@@ -7,7 +7,9 @@
 # プロジェクト指定バージョンの terraform 等を直接実行できる。
 #
 # mise が未インストールの環境では何もせず終了する（Claude Code の起動を妨げないため）。
+# $CLAUDE_ENV_FILE が未設定の場合（hook が Claude Code 以外の文脈で実行された等）も
+# 空文字へのリダイレクトで `ambiguous redirect` エラーになるのを避けるため何もせず終了する。
 
-if command -v mise >/dev/null 2>&1; then
+if command -v mise >/dev/null 2>&1 && [ -n "${CLAUDE_ENV_FILE:-}" ]; then
   mise hook-env -s bash >> "$CLAUDE_ENV_FILE"
 fi

--- a/.claude/hooks/session-start-mise.sh
+++ b/.claude/hooks/session-start-mise.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# SessionStart hook: mise が管理するツールを Claude Code のシェルセッションに読み込む。
+#
+# mise (https://mise.jdx.dev/) がプロジェクトごとに指定するツール（mise.toml 参照）を
+# Claude Code が起動するシェルでも利用できるようにするため、`mise hook-env` の出力を
+# $CLAUDE_ENV_FILE へ追記する。これにより `mise exec --` プレフィックス無しで
+# プロジェクト指定バージョンの terraform 等を直接実行できる。
+#
+# mise が未インストールの環境では何もせず終了する（Claude Code の起動を妨げないため）。
+
+if command -v mise >/dev/null 2>&1; then
+  mise hook-env -s bash >> "$CLAUDE_ENV_FILE"
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-start-mise.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ out/
 ### Kotlin ###
 .kotlin
 
+### Claude Code ###
+.claude/settings.local.json
+
 ### Terraform ###
 **/.terraform/*
 *.tfstate


### PR DESCRIPTION
## 概要

Claude Code のシェルセッションでも mise が管理するツール（terraform 等）を `mise exec --` プレフィックス無しで直接実行できるようにします。bos-workspace で運用実績のある仕組みを持ち込みます。

## 変更内容

- `.claude/hooks/session-start-mise.sh`: `mise hook-env -s bash` の出力を `$CLAUDE_ENV_FILE` に追記する hook スクリプト（mise 未インストール環境では何もせず終了）
- `.claude/settings.json`: 上記スクリプトを SessionStart で発火する hook 設定
- `.gitignore`: 個人ローカル設定 `.claude/settings.local.json` を除外対象に追加

## 動作確認

- [x] `CLAUDE_ENV_FILE` を一時ファイルにセットして hook スクリプトを単体実行 → exit 0
- [x] 出力された env file に `export PATH=...` で mise 管理の `terraform` / `ktlint` / `java` 等が含まれることを確認
- [x] `JAVA_HOME` / `GOROOT` / `GOBIN` が正しくエクスポートされることを確認
- [ ] マージ後、新規 Claude Code セッションで `which terraform` が mise の shim を返すこと

## 補足

マージ後、CLAUDE.md の「mise exec を使用したコマンド実行」セクションを「Claude Code でも直接実行可能」に書き換える別 PR を出す余地があります（本 PR のスコープ外）。