### PR TITLE
chore(infra): deployer SA の WIF binding を production environment に限定

### DIFF
--- a/infra/modules/cicd/main.tf
+++ b/infra/modules/cicd/main.tf
@@ -6,7 +6,8 @@ resource "google_service_account" "deployer" {
 
 # 既存WIF Pool（pt-workload-identity）からDeployer SAへのバインディング
 # principal:// (単数) で sub claim と完全一致させることで、
-# 「対象リポジトリ AND production environment」の AND 条件で制限している。
+# 「対象リポジトリ AND var.deploy_environment で指定した environment（既定: production）」の
+# AND 条件で制限している。
 # environment 側の保護ルール（main ブランチ限定、承認者必須など）は GitHub UI で設定。
 resource "google_service_account_iam_member" "deployer_workload_identity" {
   service_account_id = google_service_account.deployer.name

--- a/infra/modules/cicd/main.tf
+++ b/infra/modules/cicd/main.tf
@@ -5,10 +5,13 @@ resource "google_service_account" "deployer" {
 }
 
 # 既存WIF Pool（pt-workload-identity）からDeployer SAへのバインディング
+# principal:// (単数) で sub claim と完全一致させることで、
+# 「対象リポジトリ AND production environment」の AND 条件で制限している。
+# environment 側の保護ルール（main ブランチ限定、承認者必須など）は GitHub UI で設定。
 resource "google_service_account_iam_member" "deployer_workload_identity" {
   service_account_id = google_service_account.deployer.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/projects/${var.wif_project_number}/locations/global/workloadIdentityPools/github/attribute.repository/${var.github_repository}"
+  member             = "principal://iam.googleapis.com/projects/${var.wif_project_number}/locations/global/workloadIdentityPools/github/subject/repo:${var.github_repository}:environment:${var.deploy_environment}"
 }
 
 # DeployerサービスアカウントにArtifact Registry(apiリポジトリ)への書き込み権限を付与

--- a/infra/modules/cicd/variables.tf
+++ b/infra/modules/cicd/variables.tf
@@ -17,3 +17,9 @@ variable "project_id" {
   description = "GCP プロジェクト ID"
   type        = string
 }
+
+variable "deploy_environment" {
+  description = "デプロイを許可する GitHub Actions environment 名"
+  type        = string
+  default     = "production"
+}


### PR DESCRIPTION
## 概要

`deployer` SA を借用できる経路を「対象リポジトリの全イベント」から「対象リポジトリ AND `production` environment」に絞り込みます。GitHub Environment 側の保護ルール（main 限定、承認者必須など）と組み合わせて多層防御を構築します。

## 変更内容

- `infra/modules/cicd/main.tf`: `google_service_account_iam_member.deployer_workload_identity` の member を `principalSet://` (attribute.repository) から `principal://` (subject 完全一致) に変更
- `infra/modules/cicd/variables.tf`: `deploy_environment` 変数を追加（既定値 `"production"`）

### なぜ ref ベースではなく environment ベースなのか

GitHub Actions OIDC token の `sub` claim は workflow のトリガー条件で形式が変わります。

- ブランチ push: `repo:OWNER/REPO:ref:refs/heads/BRANCH`
- environment 指定: `repo:OWNER/REPO:environment:ENV_NAME`

`deploy.yml` は既に `environment: production` を指定しているため、deploy 実行時の `sub` は `repo:ptiringo/toy-box:environment:production` となります。ref ベースで縛ると現状デプロイが動かなくなるため、environment ベースが正解です。

`principal://` (単数) を使うことで、subject 完全一致による「リポジトリ AND environment」の AND 条件が成立します（`principalSet` は OR 結合になるため不適）。

## 動作確認

- [x] `terraform fmt -check -recursive`（lefthook pre-commit で実行）
- [x] `terraform validate` 通過
- [x] HCP Terraform 上で `terraform plan` を実行し、`google_service_account_iam_member.deployer_workload_identity` の member のみ差分が出ることを確認（HCP token が必要なためレビュー側で実施をお願いします）
- [ ] apply 後、main マージで production environment 経由のデプロイが成功すること
- [ ] （任意）`Settings → Environments → production` の **Deployment branches and tags** を `main` のみに設定

## 補足

WIF Provider の `attribute_mapping` で `google.subject = assertion.sub` がマッピングされていることが前提です。`providers/my-repo` の現行設定が異なる場合は事前に整合させる必要があります。