### PR TITLE
fix(ci): deploy.yml の paths-ignore でサブディレクトリの Markdown も対象にする

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
     paths-ignore:
       - 'infra/**'
-      - '*.md'
+      - '**/*.md'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## 概要

`deploy.yml` の `paths-ignore` パターン `*.md` がリポジトリルート直下の Markdown ファイルにしかマッチしないため、サブディレクトリ配下の Markdown 変更でも deploy が走ってしまう問題を修正します。`**/*.md` に変更して全階層をスキップ対象にします。

## 変更内容

- `.github/workflows/deploy.yml`: `paths-ignore` の `*.md` を `**/*.md` に変更

## 動作確認

- [x] PR #202 のマージ時（`.github/pull_request_template.md` のみ変更）に deploy.yml が誤って実行されていたことを確認済み
- [ ] 本 PR マージ後、Markdown のみを変更する PR をマージしても deploy.yml が走らないこと
- [ ] 通常の Kotlin / 設定ファイル変更では引き続き deploy.yml が実行されること