### PR TITLE
fix: Cloud Run デプロイ失敗を解消し PR で再発検知する smoke test を追加

### DIFF
--- a/.github/workflows/container-smoke-test.yml
+++ b/.github/workflows/container-smoke-test.yml
@@ -1,0 +1,65 @@
+# PR 時に bootBuildImage で生成したコンテナを Cloud Run と同じメモリ制約で起動し、
+# Paketo memory-calculator や Spring context の初期化が本番環境で成立することを検証します。
+# 本番デプロイの blocker となるコンテナ起動失敗を、main マージ前に検知するのが目的です。
+name: Container Smoke Test
+run-name: Container Smoke Test for ${{ github.ref }}
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'infra/**'
+      - '.claude/**'
+      - 'src/test/**'
+      - '**/*.md'
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'infra/**'
+      - '.claude/**'
+      - 'src/test/**'
+      - '**/*.md'
+
+jobs:
+  container-smoke-test:
+    runs-on: ubuntu-latest
+    name: Container Smoke Test
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up JDK
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version-file: '.java-version'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-provider: basic
+
+      - name: Build Docker image with bootBuildImage
+        run: ./gradlew bootBuildImage --imageName=api-smoke:test
+
+      # メモリ値は deploy.yml の --memory と揃えること。
+      - name: Smoke test container with prod-like memory limit
+        run: |
+          docker run -d --name api-smoke -m 1g -p 8080:8080 -e PORT=8080 api-smoke:test
+          for i in {1..60}; do
+            if curl -sf http://localhost:8080/actuator/health | grep -q '"status":"UP"'; then
+              echo "Container healthy"
+              docker rm -f api-smoke
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Container did not become healthy in 60s"
+          docker logs api-smoke
+          docker rm -f api-smoke
+          exit 1

--- a/.github/workflows/container-smoke-test.yml
+++ b/.github/workflows/container-smoke-test.yml
@@ -48,6 +48,8 @@ jobs:
         run: ./gradlew bootBuildImage --imageName=api-smoke:test
 
       # メモリ値は deploy.yml の --memory と揃えること。
+      # docker の `-m 1g` は 1 GiB (= 1024 MiB) を表し、gcloud の `--memory=1Gi` と等価。
+      # 単位表記が異なるため、片方だけを更新しないよう注意する。
       - name: Smoke test container with prod-like memory limit
         run: |
           docker run -d --name api-smoke -m 1g -p 8080:8080 -e PORT=8080 api-smoke:test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,4 +59,4 @@ jobs:
           service: api
           region: asia-northeast1
           image: ${{ vars.IMAGE }}:${{ github.sha }}
-          flags: '--service-account=api-runner@ptiringo-toy-box.iam.gserviceaccount.com --no-allow-unauthenticated --port=8080 --memory=512Mi --cpu=1 --min-instances=0 --max-instances=3'
+          flags: '--service-account=api-runner@ptiringo-toy-box.iam.gserviceaccount.com --no-allow-unauthenticated --port=8080 --memory=1Gi --cpu=1 --cpu-boost --min-instances=0 --max-instances=3'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,9 @@ jobs:
           docker push ${{ vars.IMAGE }}:${{ github.sha }}
           docker push ${{ vars.IMAGE }}:latest
 
+      # --memory: container-smoke-test.yml の docker run -m と揃えること。
+      # gcloud の `--memory=1Gi` は 1 GiB (= 1024 MiB) を表し、docker の `-m 1g` と等価。
+      # 単位表記が異なるため、片方だけを更新しないよう注意する。
       - name: Deploy to Cloud Run
         uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3.0.1
         with:


### PR DESCRIPTION
## 概要

Closes #213

PR #210 (Spring WebFlux → MVC + Virtual Thread 移行) のマージ後に Cloud Run デプロイが失敗していた問題の修正と、同種の事故を main マージ前に検知する CI を追加します。

## 根本原因

実際の Cloud Run ログを確認したところ、issue で想定されていた startup probe timeout ではなく、**Paketo buildpack の memory-calculator がコンテナ起動前に exit していた** ことが判明しました。

```
fixed memory regions require 607098K which is greater than 512M available for allocation:
-XX:MaxDirectMemorySize=10M, -XX:MaxMetaspaceSize=95098K,
-XX:ReservedCodeCacheSize=240M, -Xss1M * 250 threads
ERROR: failed to launch: ... memory-calculator: exit status 1
Container called exit(82).
```

heap 以前の話で、JVM 非ヒープ領域 (DirectMemory + Metaspace + CodeCache + Stack ×250 threads) だけで 593 MiB 必要なのに、Cloud Run のメモリが 512Mi しかないため Paketo が事前計算で起動を諦めていました。

WebFlux → MVC への切替で **ロードクラス数が増えて Metaspace 要求が膨らんだ** のが直接の引き金です。

## 変更内容

### 1. `fix: Cloud Run のメモリ設定を 1Gi に増やし cpu-boost を有効化` (149cb30)

`.github/workflows/deploy.yml`:
- `--memory=512Mi` → `--memory=1Gi` に増やし、非ヒープ領域 + heap 余裕を確保
- `--cpu-boost` を追加し、Tomcat + Spring context のコールドスタートを短縮

### 2. `chore: コンテナ起動を PR 段階で検証する smoke test を追加` (12f2f9e)

`.github/workflows/container-smoke-test.yml` (新規):
- `bootBuildImage` でイメージを生成し、`docker run -m 1g` で本番相当のメモリ制約下で起動
- `/actuator/health` が `UP` を返すまでヘルスチェック (最大 60 秒)
- これにより Paketo memory-calculator の事前計算エラー、Spring context の bean 初期化失敗、起動タイムアウトのいずれも本番デプロイ前に検知可能になる

PR チェック全体の所要時間が伸びすぎないよう、`infra/` / `.claude/` / `src/test/` / `*.md` のみを変更する PR ではトリガしない `paths-ignore` を設定しています (`deploy.yml` の `paths-ignore` と同じ思想)。

## 動作確認

- [x] ローカルで `./gradlew bootBuildImage --imageName=api-smoke:test` 成功
- [x] `docker run -d -m 1g -p 8080:8080 -e PORT=8080 api-smoke:test` でコンテナが起動し `/actuator/health` が `{"status":"UP"}` を返すことを確認
- [x] このブランチに対して `Container Smoke Test` workflow が走り success することを確認 ([run #25601593117](https://github.com/ptiringo/toy-box/actions/runs/25601593117/job/75156343404), 1m08s)
  - これにより、修正後のメモリ設定 (`-m 1g`) でコンテナが実際に起動・ヘルスチェック成功することが確認できており、マージ後の Cloud Run デプロイも成功する見込みが高い
- [ ] **マージ後** の `Deploy API` workflow が成功する → main マージ後に確認
- [ ] **マージ後** に `https://api-***.a.run.app/actuator/health` が `{"status":"UP"}` を返す → 上記 deploy 成功後に確認

## レビュー時の注意

- メモリ値は `deploy.yml` の `--memory` と `container-smoke-test.yml` の `docker run -m` を揃える必要があります。両方を同時に変更するときは片方だけにならないよう注意してください (workflow 内にコメントを記載済み)
- `--cpu-boost` は起動時のみ CPU を一時的に増強する Cloud Run の機能で、定常運用コストには影響しません