### PR TITLE
feat: ktlint を ktfmt に置き換える (#211)

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -1,4 +1,4 @@
-# Pull Request 時にテストとktlintチェックを自動実行し、mainブランチへの壊れたコードのマージを防止します。
+# Pull Request 時にテストと ktfmt チェックを自動実行し、mainブランチへの壊れたコードのマージを防止します。
 name: API Tests
 run-name: API Tests for ${{ github.ref }}
 
@@ -32,8 +32,8 @@ jobs:
         with:
           cache-provider: basic
 
-      - name: Run ktlint check
-        run: ./gradlew ktlintCheck --stacktrace
+      - name: Run ktfmt check
+        run: ./gradlew ktfmtCheck --stacktrace
 
       - name: Run API tests
         run: ./gradlew test --stacktrace

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
           languages: java-kotlin
 
       - name: Build with Gradle
-        run: ./gradlew build -x test -x ktlintCheck --stacktrace
+        run: ./gradlew build -x test -x ktfmtCheck --stacktrace
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,11 +45,11 @@ mise exec -- ./gradlew build
 ### コード品質チェック
 
 ```bash
-# ktlint チェック
-./gradlew ktlintCheck
+# ktfmt フォーマットチェック
+./gradlew ktfmtCheck
 
-# ktlint 自動フォーマット
-./gradlew ktlintFormat
+# ktfmt 自動フォーマット
+./gradlew ktfmtFormat
 
 # 全チェック実行
 ./gradlew check
@@ -213,10 +213,11 @@ mise list
 
 現在管理されているツール（`mise.toml` 参照）：
 - `editorconfig-checker`: EditorConfig 準拠チェック
+- `java` (Temurin 21): Gradle / Kotlin のビルドおよびテスト実行用 JDK
 - `lefthook`: Git フック管理
 - `terraform`: インフラ構成管理
 
-**注意**: Java（JDK 21）は mise ではなく Gradle toolchain で管理されています。
+**Java バージョン管理について**: JDK のバージョン要件は `build.gradle.kts` の Gradle toolchain で宣言しています（`languageVersion = 21`）。実体の JDK は mise が提供し、Gradle の toolchain auto-detection が `JAVA_HOME` / `PATH` 経由で検出します。
 
 ### Lefthook
 
@@ -230,7 +231,7 @@ lefthook install
 
 #### 実行されるフック
 
-- **pre-commit**（並列実行）: EditorConfig チェック、ktlint チェック、Terraform fmt チェック、Terraform validate
+- **pre-commit**（並列実行）: EditorConfig チェック、ktfmt チェック、Terraform fmt チェック、Terraform validate
 - **pre-push**: 全テスト実行
 - **commit-msg**: Conventional Commits 形式のチェック
 
@@ -241,7 +242,7 @@ lefthook install
 lefthook run pre-commit
 
 # 特定のコマンドのみスキップ
-LEFTHOOK_EXCLUDE=ktlint-check git commit -m "メッセージ"
+LEFTHOOK_EXCLUDE=ktfmt-check git commit -m "メッセージ"
 ```
 
 ## OpenAPI/Swagger
@@ -309,4 +310,4 @@ terraform fmt -recursive
 
 - このプロジェクトは現在、永続化層（データベース、リポジトリ）を持ちません
 - ドメインモデルは探索的な実装であり、TODO コメントが含まれています
-- コード品質を重視しており、CI で ktlint と EditorConfig のチェックが自動実行されます
+- コード品質を重視しており、CI で ktfmt と EditorConfig のチェックが自動実行されます

--- a/README.md
+++ b/README.md
@@ -4,19 +4,21 @@
 
 ### コードスタイルとフォーマット
 
-このプロジェクトでは、Kotlin コードの品質とスタイルの統一のために **ktlint** を使用しています。
+このプロジェクトでは、Kotlin コードのフォーマット統一のために **ktfmt** を使用しています。
+ktfmt は Kotlin 公式コーディング規約（`kotlinlang-style`、4 space indent / 100 char limit）に準拠した
+フォーマッタで、設定項目を持たず常に同じ結果を出力します。
 
-#### ktlint の使い方
+#### ktfmt の使い方
 
-以下のGradleタスクが利用可能です：
+以下の Gradle タスクが利用可能です：
 
-- **`./gradlew ktlintCheck`** - コードスタイルの違反をチェックします
-- **`./gradlew ktlintFormat`** - コードを自動フォーマットします
+- **`./gradlew ktfmtCheck`** - フォーマット違反をチェックします
+- **`./gradlew ktfmtFormat`** - コードを自動フォーマットします
 
 #### CI での自動チェック
 
-Pull Request を作成すると、GitHub Actions で自動的に ktlint チェックが実行されます。
-スタイル違反がある場合、CI は失敗します。
+Pull Request を作成すると、GitHub Actions で自動的に ktfmt チェックが実行されます。
+フォーマット違反がある場合、CI は失敗します。
 
 #### pre-commit フック
 
@@ -30,12 +32,12 @@ lefthook install
 
 これにより、以下のフックが自動的に有効化されます：
 
-- **pre-commit**: コミット前に ktlint チェックと EditorConfig チェックを実行
+- **pre-commit**: コミット前に ktfmt チェックと EditorConfig チェックを実行
 - **pre-push**: プッシュ前に全テストを実行
 - **commit-msg**: コミットメッセージの形式をチェック
 
 特定のフックをスキップしたい場合：
 
 ```bash
-LEFTHOOK_EXCLUDE=ktlint-check git commit -m "メッセージ"
+LEFTHOOK_EXCLUDE=ktfmt-check git commit -m "メッセージ"
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,21 +5,16 @@ plugins {
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.spring.dependency.management)
     alias(libs.plugins.springdoc.openapi.gradle)
-    alias(libs.plugins.ktlint)
+    alias(libs.plugins.ktfmt)
 }
 
 group = "com.example"
+
 version = "0.0.1-SNAPSHOT"
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
-}
+java { toolchain { languageVersion = JavaLanguageVersion.of(21) } }
 
-repositories {
-    mavenCentral()
-}
+repositories { mavenCentral() }
 
 dependencies {
     @Suppress("VulnerableLibrariesLocal", "RedundantSuppression")
@@ -38,42 +33,11 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
-kotlin {
-    compilerOptions {
-        freeCompilerArgs.addAll("-Xjsr305=strict")
-    }
-}
+kotlin { compilerOptions { freeCompilerArgs.addAll("-Xjsr305=strict") } }
 
-tasks.withType<Test> {
-    useJUnitPlatform()
-}
+tasks.withType<Test> { useJUnitPlatform() }
 
-configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
-    // ktlint のバージョン（プラグインが管理）
-    version.set("1.8.0")
-
-    // デバッグモードの有効化（必要に応じて）
-    debug.set(false)
-
-    // 詳細なログ出力
-    verbose.set(true)
-
-    // Android用のルールセットを使用しない
-    android.set(false)
-
-    // 出力形式の設定
-    outputToConsole.set(true)
-
-    // エラー時にビルドを失敗させる
-    ignoreFailures.set(false)
-
-    // EditorConfig の設定を尊重
-    enableExperimentalRules.set(false)
-
-    // フィルター設定
-    filter {
-        exclude("**/generated/**")
-        include("**/kotlin/**")
-        include("**/*.kts")
-    }
+ktfmt {
+    // Kotlin 公式コーディング規約準拠（4 space indent / 100 char limit）
+    kotlinLangStyle()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlin = "2.3.21"
 spring-boot = "4.0.6"
 spring-dependency-management = "1.1.7"
 springdoc-openapi-gradle = "1.9.0"
-ktlint = "14.2.0"
+ktfmt = "0.26.0"
 
 # ライブラリのバージョン
 springdoc-openapi-bom = "3.0.3"
@@ -33,5 +33,5 @@ spring-dependency-management = { id = "io.spring.dependency-management", version
 # SpringDoc OpenAPI プラグイン
 springdoc-openapi-gradle = { id = "org.springdoc.openapi-gradle-plugin", version.ref = "springdoc-openapi-gradle" }
 
-# ktlint プラグイン
-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+# ktfmt プラグイン
+ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,11 +9,11 @@ pre-commit:
       run: ec
       tags: format
 
-    # ktlint によるコードスタイルチェック
-    ktlint-check:
+    # ktfmt によるフォーマットチェック
+    ktfmt-check:
       glob: "**/*.{kt,kts}"
-      run: mise exec -- ./gradlew ktlintCheck --daemon
-      tags: format lint
+      run: mise exec -- ./gradlew ktfmtCheck --daemon
+      tags: format
 
     # Terraform フォーマットチェック
     terraform-fmt-check:

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
 [tools]
 editorconfig-checker = "3.3.0"
+java = "temurin-21.0.0+35.0.LTS"
 lefthook = "1.12.2"
 terraform = "1.12.2"

--- a/src/main/kotlin/com/example/api/ApiApplication.kt
+++ b/src/main/kotlin/com/example/api/ApiApplication.kt
@@ -9,9 +9,7 @@ import org.springframework.boot.runApplication
 @SpringBootApplication
 @OpenAPIDefinition(
     info = Info(title = "toy-box", summary = "toy-box の API 定義です。"),
-    tags = [
-        Tag(name = "Hello", description = "サンプル"),
-    ],
+    tags = [Tag(name = "Hello", description = "サンプル")],
 )
 class ApiApplication
 

--- a/src/main/kotlin/com/example/api/controller/HelloController.kt
+++ b/src/main/kotlin/com/example/api/controller/HelloController.kt
@@ -9,21 +9,26 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class HelloController {
-    data class HelloResponse(
-        val message: String,
-    )
+    data class HelloResponse(val message: String)
 
     @Operation(
         summary = "Hello World エンドポイント",
         description = "簡単な Hello World メッセージを返すエンドポイント",
         tags = ["Hello"],
-        responses = [
-            ApiResponse(
-                responseCode = "200",
-                description = "OK",
-                content = [Content(schema = Schema(implementation = HelloResponse::class), mediaType = "application/json")],
-            ),
-        ],
+        responses =
+            [
+                ApiResponse(
+                    responseCode = "200",
+                    description = "OK",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = HelloResponse::class),
+                                mediaType = "application/json",
+                            )
+                        ],
+                )
+            ],
     )
     @GetMapping("/api/hello")
     fun hello(): HelloResponse = HelloResponse("Hello World")

--- a/src/main/kotlin/com/example/api/domain/Command.kt
+++ b/src/main/kotlin/com/example/api/domain/Command.kt
@@ -2,8 +2,4 @@ package com.example.api.domain
 
 import java.time.LocalDateTime
 
-@Suppress("unused")
-class Command<T>(
-    val t: T,
-    val timestamp: LocalDateTime,
-)
+@Suppress("unused") class Command<T>(val t: T, val timestamp: LocalDateTime)

--- a/src/main/kotlin/com/example/api/domain/horseracing/breeding/Breeding.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/breeding/Breeding.kt
@@ -3,10 +3,7 @@ package com.example.api.domain.horseracing.breeding
 import java.util.UUID
 
 /** 繁殖ID */
-@JvmInline
-value class BreedingId(
-    val value: UUID,
-)
+@JvmInline value class BreedingId(val value: UUID)
 
 /** 繁殖 */
 @Suppress("unused")

--- a/src/main/kotlin/com/example/api/domain/horseracing/horse/bloodhorse/BloodHorse.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/horse/bloodhorse/BloodHorse.kt
@@ -3,10 +3,7 @@ package com.example.api.domain.horseracing.horse.bloodhorse
 import java.util.UUID
 
 /** 軽種馬ID */
-@JvmInline
-value class BloodHorseId(
-    val value: UUID,
-)
+@JvmInline value class BloodHorseId(val value: UUID)
 
 /** 性 */
 @Suppress("unused")
@@ -19,9 +16,10 @@ enum class Sex {
 }
 
 /** 軽種馬 */
-class BloodHorse private constructor(
+class BloodHorse
+private constructor(
     /** 性 */
-    @Suppress("unused") val sex: Sex,
+    @Suppress("unused") val sex: Sex
 ) {
     /** 軽種馬ID */
     val id = BloodHorseId(UUID.randomUUID())

--- a/src/main/kotlin/com/example/api/domain/horseracing/horse/bloodhorse/RegisterInStudBook.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/horse/bloodhorse/RegisterInStudBook.kt
@@ -3,8 +3,6 @@ package com.example.api.domain.horseracing.horse.bloodhorse
 import com.example.api.domain.Command
 
 /** 血統登録を行う */
-@Suppress("unused")
-fun registerInStudBook(command: Command<StudBook>) {
-}
+@Suppress("unused") fun registerInStudBook(command: Command<StudBook>) {}
 
 class StudBook

--- a/src/main/kotlin/com/example/api/domain/horseracing/horse/racehorse/Racehorse.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/horse/racehorse/Racehorse.kt
@@ -3,7 +3,4 @@ package com.example.api.domain.horseracing.horse.racehorse
 import com.example.api.domain.horseracing.horse.bloodhorse.BloodHorseId
 
 /** 競走馬 */
-@Suppress("unused")
-data class Racehorse(
-    val bloodHorseId: BloodHorseId,
-)
+@Suppress("unused") data class Racehorse(val bloodHorseId: BloodHorseId)

--- a/src/main/kotlin/com/example/api/domain/horseracing/horse/stallion/Stallion.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/horse/stallion/Stallion.kt
@@ -3,7 +3,4 @@ package com.example.api.domain.horseracing.horse.stallion
 import com.example.api.domain.horseracing.horse.bloodhorse.BloodHorseId
 
 /** 種牡馬 */
-@Suppress("unused")
-data class Stallion(
-    val bloodHorseId: BloodHorseId,
-)
+@Suppress("unused") data class Stallion(val bloodHorseId: BloodHorseId)

--- a/src/main/kotlin/com/example/api/domain/horseracing/jockey/Jockey.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/jockey/Jockey.kt
@@ -8,10 +8,7 @@ import java.util.UUID
  *
  * @property value UUID形式のID値
  */
-@JvmInline
-value class JockeyId(
-    val value: UUID,
-)
+@JvmInline value class JockeyId(val value: UUID)
 
 /**
  * 騎手（ジョッキー）を表すデータクラス
@@ -26,15 +23,11 @@ class Jockey(
     /** 姓 */
     val lastName: String,
 ) {
-    /**
-     * ジョッキーID
-     * インスタンス生成時に一意なIDを自動生成する
-     */
+    /** ジョッキーID インスタンス生成時に一意なIDを自動生成する */
     val id = JockeyId(Generators.timeBasedEpochRandomGenerator().generate())
 
     /**
-     * 等価判定
-     * 同じ型かつIDが一致する場合のみ等価とみなす
+     * 等価判定 同じ型かつIDが一致する場合のみ等価とみなす
      *
      * @param other 比較対象
      * @return 等価ならtrue
@@ -50,8 +43,7 @@ class Jockey(
     }
 
     /**
-     * ハッシュコード生成
-     * ジョッキーIDに基づいてハッシュ値を返す
+     * ハッシュコード生成 ジョッキーIDに基づいてハッシュ値を返す
      *
      * @return ハッシュ値
      */

--- a/src/main/kotlin/com/example/api/domain/horseracing/race/ConfirmResult.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/race/ConfirmResult.kt
@@ -17,11 +17,11 @@ data class RaceResult(
 /** 到達順位 */
 data class OrderOfFinish(
     // TODO: 正しい型を設計する
-    val something: Nothing,
+    val something: Nothing
 )
 
 /** レース確定イベント */
 data class ConfirmRaceResultEvent(
     // TODO: 正しい型を設計する
-    val confirmedRaceResult: Nothing,
+    val confirmedRaceResult: Nothing
 )

--- a/src/main/kotlin/com/example/api/domain/horseracing/race/Race.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/race/Race.kt
@@ -4,15 +4,12 @@ import com.fasterxml.uuid.Generators
 import java.util.UUID
 
 /** レースID */
-@JvmInline
-value class RaceId(
-    val value: UUID,
-)
+@JvmInline value class RaceId(val value: UUID)
 
 /** レース */
 class Race(
     /** レース名 */
-    val name: String,
+    val name: String
 ) {
     /** レースID */
     val id = RaceId(Generators.timeBasedEpochRandomGenerator().generate())

--- a/src/main/kotlin/com/example/api/domain/sakamichi/Member.kt
+++ b/src/main/kotlin/com/example/api/domain/sakamichi/Member.kt
@@ -4,10 +4,7 @@ import com.fasterxml.uuid.Generators
 import java.util.UUID
 
 /** メンバーID */
-@JvmInline
-value class MemberId(
-    val value: UUID,
-)
+@JvmInline value class MemberId(val value: UUID)
 
 /** メンバー */
 class Member(

--- a/src/main/kotlin/com/example/api/domain/tennis/Player.kt
+++ b/src/main/kotlin/com/example/api/domain/tennis/Player.kt
@@ -4,10 +4,7 @@ import com.fasterxml.uuid.Generators
 import java.util.UUID
 
 /** 選手ID */
-@JvmInline
-value class PlayerId(
-    val value: UUID,
-)
+@JvmInline value class PlayerId(val value: UUID)
 
 /** 選手 */
 class Player(

--- a/src/test/kotlin/com/example/api/ApiApplicationTests.kt
+++ b/src/test/kotlin/com/example/api/ApiApplicationTests.kt
@@ -5,7 +5,5 @@ import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
 class ApiApplicationTests {
-    @Test
-    fun contextLoads() {
-    }
+    @Test fun contextLoads() {}
 }

--- a/src/test/kotlin/com/example/api/OpenApiTest.kt
+++ b/src/test/kotlin/com/example/api/OpenApiTest.kt
@@ -15,9 +15,7 @@ import org.springframework.test.web.servlet.client.RestTestClient
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureRestTestClient
 @TestConstructor(autowireMode = AutowireMode.ALL)
-class OpenApiTest(
-    private val restTestClient: RestTestClient,
-) {
+class OpenApiTest(private val restTestClient: RestTestClient) {
     @Test
     fun `OpenAPI の JSON ドキュメントが取得できること`() {
         restTestClient

--- a/src/test/kotlin/com/example/api/actuator/HealthEndpointTest.kt
+++ b/src/test/kotlin/com/example/api/actuator/HealthEndpointTest.kt
@@ -10,9 +10,7 @@ import org.springframework.test.web.servlet.client.RestTestClient
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureRestTestClient
 @TestConstructor(autowireMode = AutowireMode.ALL)
-class HealthEndpointTest(
-    val restTestClient: RestTestClient,
-) {
+class HealthEndpointTest(val restTestClient: RestTestClient) {
     @Test
     fun `ヘルスエンドポイントを呼び出すとUPステータスが返される`() {
         restTestClient

--- a/src/test/kotlin/com/example/api/controller/HelloControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/HelloControllerTest.kt
@@ -9,9 +9,7 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester
 
 @WebMvcTest(HelloController::class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
-class HelloControllerTest(
-    val mockMvc: MockMvc,
-) {
+class HelloControllerTest(val mockMvc: MockMvc) {
     private val tester = MockMvcTester.create(mockMvc)
 
     @Test

--- a/src/test/kotlin/com/example/api/domain/horseracing/jockey/JockeyTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/jockey/JockeyTest.kt
@@ -3,9 +3,7 @@ package com.example.api.domain.horseracing.jockey
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-/**
- * Jockey クラスのユニットテスト
- */
+/** Jockey クラスのユニットテスト */
 class JockeyTest {
     @Nested
     inner class ConstructorTest {


### PR DESCRIPTION
## 概要

Closes #211

Kotlin コードのフォーマット管理を **ktlint** から **ktfmt** に置き換えます。

- ktlint は `.editorconfig` 経由の挙動差や設定議論の余地が残るのに対し、ktfmt は "1 つの正解" を強制する哲学のフォーマッタで、設定の bikeshedding が発生しません。
- ktfmt はルール評価エンジンを持たないため高速で、決定的なフォーマット結果が得られます。
- スタイルは Kotlin 公式コーディング規約準拠の `kotlinlangStyle` (4 space indent / 100 char limit) を採用しました。

ktlint が副次的にカバーしていた命名規則チェック・未使用 import 検出・コードスメル検出は失われるため、後続の #212 (detekt 導入) で補完する予定です。

## 変更内容

- `build.gradle.kts`
  - `ktlint` プラグインと `KtlintExtension` 設定ブロックを削除します。
  - `com.ncorti.ktfmt.gradle` プラグインを追加し、`ktfmt { kotlinLangStyle() }` を設定します。
- `gradle/libs.versions.toml`
  - `ktlint` のバージョンおよびプラグイン定義を削除します。
  - `ktfmt = "0.26.0"` をバージョン定義および `[plugins]` セクションに追加します。
- `mise.toml`
  - Gradle toolchain (JDK 21) 検出のため `java = "temurin-21.0.0+35.0.LTS"` を追加します。
  - これに伴い CLAUDE.md の "Java は mise ではなく Gradle toolchain で管理" という注記を、"バージョン要件は toolchain で宣言、実体 JDK は mise が提供" という構成に書き換えています。
- `lefthook.yml`
  - `pre-commit` の `ktlint-check` を `ktfmt-check` (`./gradlew ktfmtCheck`) に置換します。
- `.github/workflows/api-tests.yml`
  - `ktlintCheck` ステップを `ktfmtCheck` に置換します。
- `.github/workflows/codeql.yml`
  - Build with Gradle ステップの除外タスクを `-x ktlintCheck` から `-x ktfmtCheck` に変更します。
- `CLAUDE.md` / `README.md`
  - コード品質チェック、pre-commit、CI 自動チェックの説明を ktfmt 中心に更新します。
- 既存 `*.kt` / `build.gradle.kts`
  - `./gradlew ktfmtFormat` を一度実行し、`kotlinlangStyle` で再フォーマットしています。

## 動作確認

- [x] `./gradlew ktfmtCheck` がローカルで成功することを確認しました。
- [x] `./gradlew test` がローカル (JDK 21 / mise 経由) で成功することを確認しました。
- [x] `lefthook` の `pre-commit` (editorconfig-check + ktfmt-check) がコミット時に成功することを確認しました。
- [ ] GitHub Actions の `API Tests` (ktfmtCheck + test) ワークフローが緑になることを確認します。
- [ ] GitHub Actions の `CodeQL Analysis` (ktfmtCheck を除外したビルド) が緑になることを確認します。

## 備考

- ktfmt は `.editorconfig` を読まない設計ですが、`kotlinlangStyle` のインデント幅 (4) はリポジトリの想定と一致しているため実害はありません。
- ktfmt 単体ではフォーマット以外の静的解析を行わないため、命名規則やコードスメル検出は #212 (detekt 導入) で補います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)