### PR TITLE
chore: Stop hook で ktfmt と detekt を自動実行

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,24 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./gradlew ktfmtFormat --daemon",
+            "timeout": 120,
+            "statusMessage": "ktfmt フォーマット適用中..."
+          },
+          {
+            "type": "command",
+            "command": "./gradlew detekt --daemon",
+            "timeout": 120,
+            "statusMessage": "detekt 静的解析実行中..."
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## 概要

Claude Code のターン終了 (Stop イベント) 時に Kotlin コードのフォーマットと静的解析を自動で走らせる hook を `.claude/settings.json` に追加します。

#211 (ktfmt) と #212 (detekt) で導入したツール群を Claude Code のセッション内でも即時フィードバックさせるための運用追加です。Issue 化はせず、運用改善 PR としてマージ可能です。

## 設計方針

- フォーマット系の `ktfmtFormat` は決定的かつ高速のため、ターン終了時に **自動整形** してしまう。Claude は整形を気にせず編集できる。
- 静的解析の `detekt` はターン終了時に走らせ、違反があればコマンドが非ゼロで終わるためターン終了時にエラーとして表示される。Claude にフィードバックさせて修正させたい場合は将来 `decision: \"block\"` JSON を返すラッパーに差し替え可能。
- `PostToolUse` は採用しません。Edit/Write のたびに Gradle を起動するのは体感が悪く、`#212` issue でも同様の見解が出ているためです。

## 変更内容

- `.claude/settings.json`
  - `Stop` イベントに 2 つの command フックを順次登録します。
    1. `./gradlew ktfmtFormat --daemon` (`statusMessage`: "ktfmt フォーマット適用中...")
    2. `./gradlew detekt --daemon` (`statusMessage`: "detekt 静的解析実行中...")
  - どちらも `timeout: 120` 秒。
  - 既存の `SessionStart` hook (`.claude/hooks/session-start-mise.sh`) はそのまま保持します。

## `mise exec --` を付けない理由

`.claude/hooks/session-start-mise.sh` が `mise hook-env` の出力を `$CLAUDE_ENV_FILE` に書き出し、Claude Code セッション全体の `PATH` / `JAVA_HOME` に mise 管理ツールが反映されています。Stop hook の子プロセスもこの環境を継承するため、`mise exec --` プレフィックスは不要です。lefthook と異なり Claude Code セッション内では mise が暗黙に活性化されているという理解です。

## 動作確認

- [x] `jq -e '.hooks.Stop[].hooks[].command' .claude/settings.json` で JSON とスキーマが妥当であることを確認しました。
- [x] `./gradlew ktfmtFormat --daemon` がローカルで `mise exec --` 無しに成功することを確認しました。
- [x] `./gradlew detekt --daemon` がローカルで `mise exec --` 無しに成功することを確認しました。
- [ ] hook を実際に有効化するには `/hooks` メニューを一度開くか Claude Code を再起動して watcher に拾わせる必要があります（既存セッションのみ）。新規セッションでは起動時に読み込まれます。

## 今後の改善余地 (本 PR 範囲外)

- detekt が違反を出した際に Claude にフィードバックして同ターン内で自動修正させたい場合は、`decision: "block"` を含む JSON を出力するラッパースクリプトに差し替える。
- Kotlin 関連ファイルが編集されていないターンでもフックが走るため、git diff で `.kt` / `.kts` の変更有無を確認してスキップするゲートを追加するとさらに軽くなる（現状は Gradle の up-to-date 判定で実質的には数百 ms で抜ける）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)