### PR TITLE
feat: Claude Code hooks に pre-commit 相当のチェック群を追加 (#209)

### DIFF
--- a/.claude/hooks/post-edit-editorconfig.sh
+++ b/.claude/hooks/post-edit-editorconfig.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# PostToolUse hook: 編集ファイルに対して EditorConfig 違反を検査する。
+#
+# Claude Code から渡される stdin JSON の tool_input.file_path / tool_response.filePath
+# を読み取り、対象ファイルが実在する場合のみ ec (editorconfig-checker) を実行する。
+#
+# - 違反があれば exit 2 を返し、stderr を Claude へフィードバックする。
+# - file_path が空 / ファイル未存在 / ec 未インストールの場合は黙って exit 0 で抜ける。
+
+set -uo pipefail
+
+# stdin の JSON は 1 度しか読めないので変数化する。jq が無い環境ではスキップ。
+if ! command -v jq >/dev/null 2>&1; then
+    exit 0
+fi
+payload="$(cat)"
+
+file_path="$(printf '%s' "$payload" | jq -r '.tool_input.file_path // .tool_response.filePath // empty')"
+[ -z "$file_path" ] && exit 0
+[ -f "$file_path" ] || exit 0
+
+# ec はリポジトリ直下の .editorconfig を起点にチェックするため repo root に移動する。
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root" || exit 0
+# macOS の /tmp -> /private/tmp などシンボリックリンク差異を吸収する。
+abs_file="$(/usr/bin/env python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$file_path" 2>/dev/null || echo "$file_path")"
+abs_root="$(/usr/bin/env python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$repo_root" 2>/dev/null || echo "$repo_root")"
+rel_path="${abs_file#"$abs_root"/}"
+
+if ! command -v ec >/dev/null 2>&1; then
+    exit 0
+fi
+
+output="$(ec "$rel_path" 2>&1)"
+status=$?
+if [ "$status" -ne 0 ]; then
+    printf 'EditorConfig 違反が検出されました (%s):\n%s\n' "$rel_path" "$output" >&2
+    exit 2
+fi
+exit 0

--- a/.claude/hooks/post-edit-terraform-fmt.sh
+++ b/.claude/hooks/post-edit-terraform-fmt.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# PostToolUse hook: 編集ファイルが infra/ 配下の Terraform ソースであれば
+# `terraform fmt -check` でフォーマット違反を検査する。
+#
+# - 違反があれば exit 2 を返し、Claude にフィードバックして自動整形を促す。
+# - 対象外ファイル / terraform 未インストールの場合は exit 0 で黙って抜ける。
+
+set -uo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+    exit 0
+fi
+payload="$(cat)"
+
+file_path="$(printf '%s' "$payload" | jq -r '.tool_input.file_path // .tool_response.filePath // empty')"
+[ -z "$file_path" ] && exit 0
+[ -f "$file_path" ] || exit 0
+
+# macOS の /tmp -> /private/tmp などシンボリックリンク差異を吸収するため
+# 両方を realpath で正規化してから prefix を取り除く。
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+abs_file="$(/usr/bin/env python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$file_path" 2>/dev/null || echo "$file_path")"
+abs_root="$(/usr/bin/env python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$repo_root" 2>/dev/null || echo "$repo_root")"
+rel_path="${abs_file#"$abs_root"/}"
+
+# infra/ 配下の *.tf のみ対象（モジュール配下も含む）
+case "$rel_path" in
+    infra/*.tf) ;;
+    infra/*/*.tf) ;;
+    infra/*/*/*.tf) ;;
+    *) exit 0 ;;
+esac
+
+if ! command -v terraform >/dev/null 2>&1; then
+    exit 0
+fi
+
+output="$(cd "$repo_root" && terraform fmt -check -recursive infra/ 2>&1)"
+status=$?
+if [ "$status" -ne 0 ]; then
+    printf 'terraform fmt 違反が検出されました:\n%s\n`terraform fmt -recursive infra/` で整形してください。\n' "$output" >&2
+    exit 2
+fi
+exit 0

--- a/.claude/hooks/stop-gradle-test.sh
+++ b/.claude/hooks/stop-gradle-test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Stop hook: 直近の未コミット変更に Kotlin / Java ソースが含まれているとき、
+# `./gradlew test --daemon` を実行してテストの破壊を検知する。
+#
+# - HEAD との差分で *.kt / *.kts / *.java の変更が無いターンはスキップする。
+# - 失敗時は exit 2 で Claude にフィードバックして修正を促す。
+
+set -uo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root" || exit 0
+
+if ! git diff HEAD --name-only 2>/dev/null | grep -qE '\.(kt|kts|java)$'; then
+    exit 0
+fi
+
+if [ ! -x ./gradlew ]; then
+    exit 0
+fi
+
+output="$(./gradlew test --daemon --console=plain 2>&1)"
+status=$?
+if [ "$status" -ne 0 ]; then
+    printf './gradlew test に失敗しました:\n%s\n' "$output" >&2
+    exit 2
+fi
+exit 0

--- a/.claude/hooks/stop-terraform-validate.sh
+++ b/.claude/hooks/stop-terraform-validate.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Stop hook: 直近の未コミット変更に infra/*.tf が含まれているとき、
+# `terraform validate` で構文エラー / 参照エラー / リソース定義不整合を検査する。
+#
+# - HEAD との差分で .tf 変更が無いターンは何もしない。
+# - 違反があれば exit 2 を返し、Claude にフィードバックする。
+# - terraform 未インストール時は exit 0 で黙って抜ける。
+
+set -uo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root" || exit 0
+
+# HEAD との差分に infra/*.tf が含まれない場合はスキップ
+if ! git diff HEAD --name-only 2>/dev/null | grep -qE '^infra/.*\.tf$'; then
+    exit 0
+fi
+
+if ! command -v terraform >/dev/null 2>&1; then
+    exit 0
+fi
+
+# init が走っていない場合のみ backend 無効で init する（terraform validate の前提）
+if [ ! -d infra/.terraform ]; then
+    if ! init_output="$(cd infra && terraform init -backend=false -no-color 2>&1)"; then
+        printf 'terraform init に失敗しました:\n%s\n' "$init_output" >&2
+        exit 2
+    fi
+fi
+
+output="$(cd infra && terraform validate -no-color 2>&1)"
+status=$?
+if [ "$status" -ne 0 ]; then
+    printf 'terraform validate に失敗しました:\n%s\n' "$output" >&2
+    exit 2
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,25 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/post-edit-editorconfig.sh",
+            "timeout": 15,
+            "statusMessage": "EditorConfig チェック中..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/post-edit-terraform-fmt.sh",
+            "timeout": 30,
+            "statusMessage": "terraform fmt チェック中..."
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
@@ -24,6 +43,18 @@
             "command": "./gradlew detekt --daemon",
             "timeout": 120,
             "statusMessage": "detekt 静的解析実行中..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/stop-gradle-test.sh",
+            "timeout": 180,
+            "statusMessage": "gradle test 実行中 (Kotlin/Java 変更時のみ)..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/stop-terraform-validate.sh",
+            "timeout": 60,
+            "statusMessage": "terraform validate 実行中 (Terraform 変更時のみ)..."
           }
         ]
       }


### PR DESCRIPTION
## 概要

Closes #209

Lefthook の pre-commit / pre-push で実行している品質チェック群を、Claude Code の hooks (PostToolUse / Stop) でも実行するように設定します。Claude が編集したコードが lint / format / test に違反していた場合、コミット前に Claude 自身がその場で気づいて修正できるようにフィードバックループを短縮します。

既にマージ済みの PR で `Stop` に `ktfmtFormat` / `detekt` を登録済みです (#211 / #212 / #223)。本 PR はそこに残りのチェック (EditorConfig / terraform fmt / gradle test / terraform validate) を追加します。

## 設計方針

- **PostToolUse**: 軽量で「編集直後に検知して即修正」が活きるチェック (`ec`、`terraform fmt -check`) を担当します。
- **Stop**: Gradle / Terraform の比較的重いチェック (`./gradlew test`、`terraform validate`) を担当します。
- Stop の test / validate は `git diff HEAD` で **当該言語のファイル変更があるターンのみ** 走らせ、無関係なターンでは即座にスキップさせます。
- 違反検出時は `exit 2` + stderr 出力で Claude にフィードバックし、その場で修正させる動作になります (`exit 0` 以外で stderr に出力するとそのまま Claude へ流れる Stop hook 仕様)。
- `mise exec --` は不要です (`SessionStart` hook が `mise hook-env` の出力を `$CLAUDE_ENV_FILE` に流し込んでセッション全体に PATH / JAVA_HOME を反映しているため)。

## 変更内容

### 新規スクリプト

| パス | イベント | 役割 |
|---|---|---|
| `.claude/hooks/post-edit-editorconfig.sh` | PostToolUse (Edit/Write/MultiEdit) | 編集ファイルに `ec` を実行 |
| `.claude/hooks/post-edit-terraform-fmt.sh` | PostToolUse (Edit/Write/MultiEdit) | 編集ファイルが `infra/**/*.tf` なら `terraform fmt -check -recursive infra/` を実行 |
| `.claude/hooks/stop-gradle-test.sh` | Stop | `git diff HEAD` に `*.kt` / `*.kts` / `*.java` が含まれていれば `./gradlew test --daemon` を実行 |
| `.claude/hooks/stop-terraform-validate.sh` | Stop | `git diff HEAD` に `infra/*.tf` が含まれていれば必要に応じて backend 無効で init してから `terraform validate` を実行 |

各スクリプトとも:
- `jq` で stdin JSON から `tool_input.file_path` / `tool_response.filePath` を取り出します。
- macOS の `/tmp -> /private/tmp` 等のシンボリックリンクで `git rev-parse --show-toplevel` と `file_path` の prefix が一致しないケースに対応するため、両パスを `realpath` で正規化してから glob 判定します。
- 違反 / 失敗時は **exit 2** + stderr 出力で Claude にフィードバックします。

### `.claude/settings.json`

- `PostToolUse` hook (matcher: `Edit|Write|MultiEdit`) を新規追加し、2 つのスクリプトを登録します (timeout 15s / 30s、`statusMessage` 付き)。
- 既存 `Stop` hook に `stop-gradle-test.sh` (timeout 180s) と `stop-terraform-validate.sh` (timeout 60s) を追加します。
- 既存の `SessionStart` mise hook、`Stop` の `ktfmtFormat` / `detekt` はそのまま保持します。

## 動作確認

- [x] `jq -e '.hooks.PostToolUse[].hooks[].command'` および `.hooks.Stop[]` で JSON 構造とスキーマを検証しました。
- [x] PostToolUse の `ec` ハック: 違反 (trailing whitespace) を仕込んだファイルで `exit 2` + 日本語エラーメッセージが返ることを確認しました。
- [x] PostToolUse の `terraform fmt`: フォーマット崩れた `infra/test.tf` で `exit 2`、整形済み `infra/main.tf` で `exit 0` を確認しました。
- [x] Stop の `gradle test` / `terraform validate`: 対象ファイル diff が無い状態で即座に `exit 0` でスキップされることを確認しました。
- [x] lefthook (`pre-commit`) のコミットチェックが通ることを確認しました。
- [ ] 既存セッションで hook を有効化するには `/hooks` メニューを一度開くか Claude Code を再起動して watcher に拾わせる必要があります（新規セッションでは起動時に読み込まれます）。

## 設定の単一ソース化について (#209 備考)

issue 末尾に「同じチェックを lefthook と Claude hooks の 2 か所で定義することになる。将来的には共通スクリプトに切り出して両方から呼び出す形が望ましい」とあります。本 PR では取り扱わず、運用してみて重複コストが顕在化したら別 issue として切り出す想定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)