### PR TITLE
feat: kotlin-result を導入してドメイン/アプリケーション層のエラーを型化

### DIFF
--- a/.claude/rules/api-design.md
+++ b/.claude/rules/api-design.md
@@ -1,0 +1,30 @@
+---
+paths:
+  - "src/main/kotlin/com/example/api/controller/**/*.kt"
+  - "src/test/kotlin/com/example/api/controller/**/*.kt"
+---
+
+# API 設計規約
+
+REST API は以下のスタイルガイドに準拠する。
+
+## リソース設計
+
+[Google AIP](https://google.aip.dev/) 準拠とする。
+
+- リソース指向設計（[AIP-121](https://google.aip.dev/121)）
+- リソース名 / コレクション名は複数形・小文字スネークケース（[AIP-122](https://google.aip.dev/122)）
+- 標準メソッド `List / Get / Create / Update / Delete`（[AIP-131](https://google.aip.dev/131) ～ [AIP-135](https://google.aip.dev/135)）
+- Create は `POST /{collection}` でコレクションに対して行い、作成された resource 全体を `201 Created` で返す（[AIP-133](https://google.aip.dev/133)）
+
+## エラーレスポンス
+
+[RFC 9457 Problem Details for HTTP APIs](https://www.rfc-editor.org/rfc/rfc9457) に準拠する。
+
+- `Content-Type: application/problem+json` で返す
+- Spring の `org.springframework.http.ProblemDetail` を使う
+- 標準フィールド: `type` (URI) / `title` / `status` / `detail` / `instance`
+- 業務エラー固有の追加情報は拡張プロパティで保持する（例: `errorCode` / `existingId` 等）
+- `type` は当面 `urn:problem-type:{kebab-case-code}` 形式を用い、HTTP で公開する Resolvable URI ができたら差し替える
+
+> AIP-193 (Errors) はレスポンスボディの形（`google.rpc.Status`）を規定するが、本プロジェクトでは REST 寄りの RFC 9457 を採用する。リソース設計など構造系のみ AIP を適用する。

--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -1,0 +1,52 @@
+---
+paths:
+  - "src/main/kotlin/com/example/api/controller/**/*.kt"
+  - "src/main/kotlin/com/example/api/application/**/*.kt"
+  - "src/main/kotlin/com/example/api/domain/**/*.kt"
+  - "src/test/kotlin/com/example/api/**/*.kt"
+---
+
+# エラーハンドリング規約
+
+ドメイン / アプリケーション層の失敗ハンドリングは [`kotlin-result`](https://github.com/michaelbull/kotlin-result) の `Result<V, E>` を用いて型として表現する。例外は「インフラ障害」「プログラミングエラー」など、業務的に想定しないものに限定する。
+
+## 例外 vs `Result<V, E>` の使い分け
+
+| 観点 | 方針 |
+|------|------|
+| 業務ルール違反（重複登録、状態遷移違反、バリデーション NG 等） | `Result.Err` で表現する |
+| インフラ障害（DB 切断 / タイムアウト等） | 例外を throw して `@ControllerAdvice` で処理 |
+| プログラミングエラー（NPE、不正な前提条件等） | 例外。`@ControllerAdvice` で 500 |
+| Repository の単純な lookup（`findById` 等） | `T?` で可。Result を強制しない |
+
+## エラー型の設計
+
+- ドメイン操作の失敗のしかたが **1 種類** なら単一の `data class` をエラー型として持つ
+- 失敗のしかたが **2 種類以上** なら `sealed interface` に昇格し、`when` の網羅性チェックで漏れを防ぐ
+- 共通親 `interface`（`DomainError` 等）は **当面導入しない**。Controller 境界で横串のハンドリングが重複し始めた段階で初めて切り出す
+- エラーバリアントの `Throwable` 保持は、外部 API / ファイル I/O など **例外起因のバリアントだけ** に持たせる。共通 interface に `cause: Throwable?` を強制しない
+- ドメインオブジェクトの不変条件違反（例: 名前のブランク）は、そのドメインオブジェクトの `companion object.create()` ファクトリで `Result<T, ValidationError>` を返して表現する。application 層は受けたエラーを必要に応じて自分のエラー型に wrap する
+
+## Controller 境界での変換
+
+ドメイン / アプリケーション層に Spring 依存を持ち込まないため、`Result` から `ResponseEntity` への変換は Controller 境界で `mapBoth` を用いて行う。レスポンスは [api-design.md](api-design.md) に従い RFC 9457 形式の `ProblemDetail` で返す。
+
+```kotlin
+@PostMapping("/api/jockeys")
+fun register(@RequestBody request: RegisterJockeyRequest): ResponseEntity<Any> =
+    registerJockey(command).mapBoth(
+        success = { jockey ->
+            ResponseEntity.status(HttpStatus.CREATED).body<Any>(jockey.toResponse())
+        },
+        failure = { error ->
+            val problem = error.toProblemDetail()
+            ResponseEntity.status(problem.status)
+                .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .body<Any>(problem)
+        },
+    )
+```
+
+## 段階的導入
+
+サンドボックスプロジェクトであることを踏まえ、最初から全面適用はしない。`horseracing` ドメインを参考実装として整備し、`sakamichi` / `tennis` 等の他ドメインへは段階的に展開していく。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,5 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## プロジェクト概要
 
 Kotlin Spring Boot (Spring MVC + Virtual Thread) を使用した API プロジェクトです。複数のドメインモデル（競馬、エンターテイメント、テニス）を探索する sandbox プロジェクトとして開発されています。
@@ -140,13 +138,24 @@ fun registerInStudBook(command: Command<StudBook>)
 com.example.api/
 ├── ApiApplication.kt    # エントリーポイント（@OpenAPIDefinition もここ）
 ├── controller/          # @RestController（HTTP エンドポイント）
-└── domain/              # ドメインロジック（Spring に依存しない）
-    ├── horseracing/     # 競馬ドメイン
-    ├── sakamichi/       # エンターテイメントドメイン
-    └── tennis/          # スポーツドメイン
+├── application/         # ユースケース（フレームワーク非依存）
+│   └── horseracing/
+├── domain/              # ドメインロジック（フレームワーク非依存）
+│   ├── horseracing/     # 競馬ドメイン
+│   ├── sakamichi/       # エンターテイメントドメイン
+│   └── tennis/          # スポーツドメイン
+└── infrastructure/      # ポートの具象実装（@Repository 等の Spring 依存可）
+    └── horseracing/
 ```
 
-**設計原則**: ドメインパッケージはフレームワーク非依存。コントローラーは HTTP とドメインロジックの薄いアダプター層として機能。
+**設計原則**:
+
+- **domain**: Entity / Value Object / Repository ポート（interface） / ドメインオブジェクト同士で完結するロジック。Spring に依存しない
+- **application**: ユースケース（コマンド DTO + ユースケースクラス + そのユースケースに紐づく失敗バリアント）。ドメインを組み合わせて業務シナリオを構築する。ユースケースを DI 経由で公開するための `@Service` / `@Component` のみ Spring 依存を許容し、ロジック本体は Plain Kotlin で書く
+- **controller**: HTTP アダプター。`Result` から `ResponseEntity` への変換のみを担う
+- **infrastructure**: Repository ポートの具体実装、外部システム連携などのアダプター。Spring 依存可
+
+ユースケース関数の命名は `動詞 + リソース名` を基本とし、入力 DTO は `〜Command`（書き込み系）／ `〜Query`（読み取り系）サフィックスを付ける。
 
 ## コーディング規約
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,12 +25,15 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation(libs.java.uuid.generator)
+    implementation(libs.kotlin.result)
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation(libs.springdoc.openapi.starter.webmvc.ui)
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     testImplementation("org.springframework.boot:spring-boot-resttestclient")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation(libs.mockk)
+    testImplementation(libs.springmockk)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,9 @@ detekt = "2.0.0-alpha.3"
 # ライブラリのバージョン
 springdoc-openapi-bom = "3.0.3"
 java-uuid-generator = "5.2.0"
+kotlin-result = "2.3.1"
+mockk = "1.14.9"
+springmockk = "5.0.1"
 
 [libraries]
 # SpringDoc OpenAPI
@@ -20,6 +23,13 @@ springdoc-openapi-starter-webmvc-ui = { module = "org.springdoc:springdoc-openap
 
 # UUID Generator
 java-uuid-generator = { module = "com.fasterxml.uuid:java-uuid-generator", version.ref = "java-uuid-generator" }
+
+# kotlin-result（業務エラーを Result<V, E> で表現する）
+kotlin-result = { module = "com.michael-bull.kotlin-result:kotlin-result", version.ref = "kotlin-result" }
+
+# mockk（Kotlin 向けモックライブラリ）
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+springmockk = { module = "com.ninja-squad:springmockk", version.ref = "springmockk" }
 
 [plugins]
 # Kotlin プラグイン

--- a/src/main/kotlin/com/example/api/application/horseracing/jockey/JockeyRegistrationUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/horseracing/jockey/JockeyRegistrationUseCase.kt
@@ -1,0 +1,64 @@
+package com.example.api.application.horseracing.jockey
+
+import com.example.api.domain.Command
+import com.example.api.domain.horseracing.jockey.Jockey
+import com.example.api.domain.horseracing.jockey.JockeyId
+import com.example.api.domain.horseracing.jockey.JockeyRepository
+import com.example.api.domain.horseracing.jockey.JockeyValidationError
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.andThen
+import com.github.michaelbull.result.mapError
+import org.springframework.stereotype.Service
+
+/**
+ * ジョッキー登録ユースケースの入力コマンド。
+ *
+ * @property firstName 名
+ * @property lastName 姓
+ */
+data class RegisterJockeyCommand(val firstName: String, val lastName: String)
+
+/** ジョッキー登録時に発生しうる業務ルール違反。 */
+sealed interface JockeyRegistrationError {
+    /**
+     * Jockey 不変条件違反を application 層エラーに wrap したもの。
+     *
+     * 個別バリアントは [JockeyValidationError] を参照する。
+     */
+    data class InvalidJockey(val cause: JockeyValidationError) : JockeyRegistrationError
+
+    /** 同姓同名のジョッキーが既に登録済み。 */
+    data class DuplicateJockey(val existingId: JockeyId) : JockeyRegistrationError
+}
+
+/**
+ * ジョッキー登録ユースケース。
+ *
+ * 業務ルール:
+ * - Jockey の不変条件を満たす（[Jockey.create] で検証）
+ * - 同姓同名のジョッキーが既に存在してはならない
+ *
+ * Controller 層は本クラスのみに依存し、[JockeyRepository] 等のポートは知らない。
+ *
+ * @return 登録された [Jockey]、または業務ルール違反を表す [JockeyRegistrationError]
+ */
+@Service
+class JockeyRegistrationUseCase(private val jockeyRepository: JockeyRepository) {
+    operator fun invoke(
+        command: Command<RegisterJockeyCommand>
+    ): Result<Jockey, JockeyRegistrationError> {
+        val input = command.t
+        return Jockey.create(input.firstName, input.lastName)
+            .mapError { JockeyRegistrationError.InvalidJockey(it) }
+            .andThen { jockey ->
+                val duplicate = jockeyRepository.findByFullName(input.firstName, input.lastName)
+                if (duplicate != null) {
+                    Err(JockeyRegistrationError.DuplicateJockey(duplicate.id))
+                } else {
+                    Ok(jockeyRepository.save(jockey))
+                }
+            }
+    }
+}

--- a/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
@@ -1,0 +1,93 @@
+package com.example.api.controller.jockey
+
+import com.example.api.application.horseracing.jockey.JockeyRegistrationUseCase
+import com.example.api.application.horseracing.jockey.RegisterJockeyCommand
+import com.example.api.domain.Command
+import com.github.michaelbull.result.mapBoth
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import java.time.LocalDateTime
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ProblemDetail
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * ジョッキーリソースの HTTP アダプター。
+ *
+ * Google AIP のリソース指向設計に従い、コレクション `/api/jockeys` に対する Create を提供する。 エラーレスポンスは RFC 9457 (Problem
+ * Details) 形式で返す。
+ */
+@RestController
+class JockeyController(private val registerJockey: JockeyRegistrationUseCase) {
+    @Operation(
+        summary = "ジョッキーを登録する",
+        description = "ジョッキーを新規登録する。業務ルール違反時は RFC 9457 形式の problem+json を返す。",
+        tags = ["Jockey"],
+        responses =
+            [
+                ApiResponse(
+                    responseCode = "201",
+                    description = "登録成功",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = RegisterJockeyResponse::class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "400",
+                    description = "氏名がブランク",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "409",
+                    description = "同姓同名のジョッキーが既に登録済み",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+            ],
+    )
+    @PostMapping("/api/jockeys")
+    fun register(@RequestBody request: RegisterJockeyRequest): ResponseEntity<Any> {
+        val command =
+            Command(RegisterJockeyCommand(request.firstName, request.lastName), LocalDateTime.now())
+        return registerJockey(command)
+            .mapBoth(
+                success = { jockey ->
+                    ResponseEntity.status(HttpStatus.CREATED)
+                        .body<Any>(
+                            RegisterJockeyResponse(
+                                id = jockey.id.value,
+                                firstName = jockey.firstName,
+                                lastName = jockey.lastName,
+                            )
+                        )
+                },
+                failure = { error ->
+                    val problem = error.toProblemDetail()
+                    ResponseEntity.status(problem.status)
+                        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                        .body<Any>(problem)
+                },
+            )
+    }
+}

--- a/src/main/kotlin/com/example/api/controller/jockey/RegisterJockeyRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/RegisterJockeyRequest.kt
@@ -1,0 +1,9 @@
+package com.example.api.controller.jockey
+
+/**
+ * `POST /api/jockeys` のリクエストボディ。
+ *
+ * @property firstName 名
+ * @property lastName 姓
+ */
+data class RegisterJockeyRequest(val firstName: String, val lastName: String)

--- a/src/main/kotlin/com/example/api/controller/jockey/RegisterJockeyResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/RegisterJockeyResponse.kt
@@ -1,0 +1,70 @@
+package com.example.api.controller.jockey
+
+import com.example.api.application.horseracing.jockey.JockeyRegistrationError
+import com.example.api.domain.horseracing.jockey.JockeyValidationError
+import java.net.URI
+import java.util.UUID
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+
+/**
+ * `POST /api/jockeys` の成功レスポンスボディ。
+ *
+ * @property id 登録された [com.example.api.domain.horseracing.jockey.JockeyId] の生 UUID
+ * @property firstName 名
+ * @property lastName 姓
+ */
+data class RegisterJockeyResponse(val id: UUID, val firstName: String, val lastName: String)
+
+/**
+ * [JockeyRegistrationError] を RFC 9457 (`application/problem+json`) 形式の [ProblemDetail] に 変換する。
+ *
+ * - `type`: `urn:problem-type:{kebab-case-code}` 形式の暫定 URI
+ * - `title`: 人間可読の短い説明
+ * - `status`: 業務ルール違反の意味に応じた HTTP ステータス
+ * - `detail`: 個別の事象に応じた追加の説明
+ * - 拡張プロパティ `errorCode`: アプリケーション固有のエラーコード
+ */
+fun JockeyRegistrationError.toProblemDetail(): ProblemDetail =
+    when (this) {
+        is JockeyRegistrationError.InvalidJockey -> cause.toProblemDetail()
+        is JockeyRegistrationError.DuplicateJockey ->
+            problem(
+                    status = HttpStatus.CONFLICT,
+                    code = "duplicate-jockey",
+                    title = "Duplicate jockey",
+                    detail = "同姓同名のジョッキーが既に登録されています。",
+                )
+                .apply { setProperty("existingId", existingId.value) }
+    }
+
+private fun JockeyValidationError.toProblemDetail(): ProblemDetail =
+    when (this) {
+        JockeyValidationError.BlankFirstName ->
+            problem(
+                status = HttpStatus.BAD_REQUEST,
+                code = "blank-first-name",
+                title = "First name is blank",
+                detail = "firstName は空であってはいけません。",
+            )
+        JockeyValidationError.BlankLastName ->
+            problem(
+                status = HttpStatus.BAD_REQUEST,
+                code = "blank-last-name",
+                title = "Last name is blank",
+                detail = "lastName は空であってはいけません。",
+            )
+    }
+
+private fun problem(
+    status: HttpStatus,
+    code: String,
+    title: String,
+    detail: String,
+): ProblemDetail =
+    ProblemDetail.forStatus(status).apply {
+        type = URI.create("urn:problem-type:$code")
+        this.title = title
+        this.detail = detail
+        setProperty("errorCode", code)
+    }

--- a/src/main/kotlin/com/example/api/domain/horseracing/jockey/Jockey.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/jockey/Jockey.kt
@@ -1,6 +1,9 @@
 package com.example.api.domain.horseracing.jockey
 
 import com.fasterxml.uuid.Generators
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import java.util.UUID
 
 /**
@@ -10,14 +13,29 @@ import java.util.UUID
  */
 @JvmInline value class JockeyId(val value: UUID)
 
+/** ジョッキー生成時に発生しうる不変条件違反。 */
+sealed interface JockeyValidationError {
+    /** 名がブランク。 */
+    data object BlankFirstName : JockeyValidationError
+
+    /** 姓がブランク。 */
+    data object BlankLastName : JockeyValidationError
+}
+
 /**
- * 騎手（ジョッキー）を表すデータクラス
+ * 騎手（ジョッキー）を表すエンティティ。
+ *
+ * 不変条件:
+ * - `firstName` / `lastName` のいずれもブランクではない
+ *
+ * 不変条件を満たした上で生成するために、コンストラクタは private にして [Jockey.create] でのみ生成する。
  *
  * @property firstName 名
  * @property lastName 姓
  * @property id ジョッキーID（自動生成）
  */
-class Jockey(
+class Jockey
+private constructor(
     /** 名 */
     val firstName: String,
     /** 姓 */
@@ -26,12 +44,7 @@ class Jockey(
     /** ジョッキーID インスタンス生成時に一意なIDを自動生成する */
     val id = JockeyId(Generators.timeBasedEpochRandomGenerator().generate())
 
-    /**
-     * 等価判定 同じ型かつIDが一致する場合のみ等価とみなす
-     *
-     * @param other 比較対象
-     * @return 等価ならtrue
-     */
+    /** 等価判定 同じ型かつIDが一致する場合のみ等価とみなす */
     override fun equals(other: Any?): Boolean {
         if (this === other) {
             return true
@@ -42,10 +55,20 @@ class Jockey(
         return id == (other as Jockey).id
     }
 
-    /**
-     * ハッシュコード生成 ジョッキーIDに基づいてハッシュ値を返す
-     *
-     * @return ハッシュ値
-     */
+    /** ハッシュコード生成 ジョッキーIDに基づいてハッシュ値を返す */
     override fun hashCode(): Int = id.hashCode()
+
+    companion object {
+        /**
+         * 不変条件を検証してから [Jockey] を生成する。
+         *
+         * @return 生成された [Jockey]、または不変条件違反を表す [JockeyValidationError]
+         */
+        fun create(firstName: String, lastName: String): Result<Jockey, JockeyValidationError> =
+            when {
+                firstName.isBlank() -> Err(JockeyValidationError.BlankFirstName)
+                lastName.isBlank() -> Err(JockeyValidationError.BlankLastName)
+                else -> Ok(Jockey(firstName, lastName))
+            }
+    }
 }

--- a/src/main/kotlin/com/example/api/domain/horseracing/jockey/JockeyRepository.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/jockey/JockeyRepository.kt
@@ -1,0 +1,14 @@
+package com.example.api.domain.horseracing.jockey
+
+/**
+ * ジョッキーの永続化を担うポート
+ *
+ * ドメイン層はこのインターフェースのみを参照する。実装は infrastructure 層に置く。
+ */
+interface JockeyRepository {
+    /** 同姓同名のジョッキーを検索する。存在しなければ null。 */
+    fun findByFullName(firstName: String, lastName: String): Jockey?
+
+    /** ジョッキーを永続化する */
+    fun save(jockey: Jockey): Jockey
+}

--- a/src/main/kotlin/com/example/api/domain/horseracing/race/ConfirmResult.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/race/ConfirmResult.kt
@@ -1,9 +1,22 @@
 package com.example.api.domain.horseracing.race
 
+import com.github.michaelbull.result.Result
+
 /** レースの確定 */
 @Suppress("unused")
-fun confirmRaceResult(raceResult: RaceResult): Result<ConfirmRaceResultEvent> {
+fun confirmRaceResult(
+    raceResult: RaceResult
+): Result<ConfirmRaceResultEvent, ConfirmRaceResultError> {
     TODO()
+}
+
+/** レース確定時に発生しうる業務ルール違反 */
+sealed interface ConfirmRaceResultError {
+    /** 当該レースの結果が既に確定済み */
+    data class AlreadyConfirmed(val raceId: RaceId) : ConfirmRaceResultError
+
+    /** 到達順位がレースのルール上不正 */
+    data class InvalidOrderOfFinish(val reason: String) : ConfirmRaceResultError
 }
 
 /** レース結果 */

--- a/src/main/kotlin/com/example/api/infrastructure/horseracing/jockey/InMemoryJockeyRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/horseracing/jockey/InMemoryJockeyRepository.kt
@@ -1,0 +1,25 @@
+package com.example.api.infrastructure.horseracing.jockey
+
+import com.example.api.domain.horseracing.jockey.Jockey
+import com.example.api.domain.horseracing.jockey.JockeyId
+import com.example.api.domain.horseracing.jockey.JockeyRepository
+import java.util.concurrent.ConcurrentHashMap
+import org.springframework.stereotype.Repository
+
+/**
+ * In-Memory な JockeyRepository 実装。PoC 用途。
+ *
+ * 永続化層の代わりとして ConcurrentHashMap で保持する。アプリ再起動でデータは消える。
+ */
+@Repository
+class InMemoryJockeyRepository : JockeyRepository {
+    private val store = ConcurrentHashMap<JockeyId, Jockey>()
+
+    override fun findByFullName(firstName: String, lastName: String): Jockey? =
+        store.values.firstOrNull { it.firstName == firstName && it.lastName == lastName }
+
+    override fun save(jockey: Jockey): Jockey {
+        store[jockey.id] = jockey
+        return jockey
+    }
+}

--- a/src/test/kotlin/com/example/api/application/horseracing/jockey/JockeyRegistrationUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/horseracing/jockey/JockeyRegistrationUseCaseTest.kt
@@ -1,0 +1,81 @@
+package com.example.api.application.horseracing.jockey
+
+import com.example.api.domain.Command
+import com.example.api.domain.horseracing.jockey.Jockey
+import com.example.api.domain.horseracing.jockey.JockeyRepository
+import com.example.api.domain.horseracing.jockey.JockeyValidationError
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDateTime
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class JockeyRegistrationUseCaseTest {
+
+    private fun command(firstName: String, lastName: String): Command<RegisterJockeyCommand> =
+        Command(RegisterJockeyCommand(firstName, lastName), LocalDateTime.now())
+
+    @Nested
+    inner class SuccessCase {
+        @Test
+        fun `名と姓が正しく既存ジョッキーと衝突しないとき登録に成功する`() {
+            val repository = mockk<JockeyRepository>()
+            every { repository.findByFullName("武", "豊") } returns null
+            every { repository.save(any()) } answers { firstArg() }
+            val useCase = JockeyRegistrationUseCase(repository)
+
+            val jockey = useCase(command("武", "豊")).unwrap()
+
+            assert(jockey.firstName == "武")
+            assert(jockey.lastName == "豊")
+            verify(exactly = 1) { repository.save(any()) }
+        }
+    }
+
+    @Nested
+    inner class FailureCase {
+        @Test
+        fun `名がブランクのとき InvalidJockey(BlankFirstName) を返し永続化されない`() {
+            val repository = mockk<JockeyRepository>()
+            val useCase = JockeyRegistrationUseCase(repository)
+
+            val result = useCase(command("", "豊"))
+
+            assert(
+                result.getError() ==
+                    JockeyRegistrationError.InvalidJockey(JockeyValidationError.BlankFirstName)
+            )
+            verify(exactly = 0) { repository.save(any()) }
+        }
+
+        @Test
+        fun `姓がブランクのとき InvalidJockey(BlankLastName) を返し永続化されない`() {
+            val repository = mockk<JockeyRepository>()
+            val useCase = JockeyRegistrationUseCase(repository)
+
+            val result = useCase(command("武", ""))
+
+            assert(
+                result.getError() ==
+                    JockeyRegistrationError.InvalidJockey(JockeyValidationError.BlankLastName)
+            )
+            verify(exactly = 0) { repository.save(any()) }
+        }
+
+        @Test
+        fun `同姓同名のジョッキーが既に存在するとき DuplicateJockey を返し永続化されない`() {
+            val existing = Jockey.create("武", "豊").unwrap()
+            val repository = mockk<JockeyRepository>()
+            every { repository.findByFullName("武", "豊") } returns existing
+            val useCase = JockeyRegistrationUseCase(repository)
+
+            val result = useCase(command("武", "豊"))
+
+            assert(result.getError() == JockeyRegistrationError.DuplicateJockey(existing.id))
+            verify(exactly = 0) { repository.save(any()) }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
@@ -1,0 +1,108 @@
+package com.example.api.controller.jockey
+
+import com.example.api.application.horseracing.jockey.JockeyRegistrationError
+import com.example.api.application.horseracing.jockey.JockeyRegistrationUseCase
+import com.example.api.application.horseracing.jockey.RegisterJockeyCommand
+import com.example.api.domain.Command
+import com.example.api.domain.horseracing.jockey.Jockey
+import com.example.api.domain.horseracing.jockey.JockeyValidationError
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.unwrap
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.context.TestConstructor.AutowireMode
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.assertj.MockMvcTester
+
+@WebMvcTest(JockeyController::class)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class JockeyControllerTest(val mockMvc: MockMvc) {
+    @MockkBean private lateinit var registerJockey: JockeyRegistrationUseCase
+
+    private val tester = MockMvcTester.create(mockMvc)
+
+    @Nested
+    inner class SuccessCase {
+        @Test
+        fun `正常な入力で 201 Created と登録結果が返ること`() {
+            val savedJockey = Jockey.create("武", "豊").unwrap()
+            every { registerJockey(any<Command<RegisterJockeyCommand>>()) } returns Ok(savedJockey)
+
+            tester
+                .post()
+                .uri("/api/jockeys")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"firstName":"武","lastName":"豊"}""")
+                .assertThat()
+                .hasStatus(HttpStatus.CREATED)
+                .bodyJson()
+                .extractingPath("$.firstName")
+                .isEqualTo("武")
+        }
+    }
+
+    @Nested
+    inner class FailureCase {
+        @Test
+        fun `InvalidJockey(BlankFirstName) で 400 と problem+json が返ること`() {
+            every { registerJockey(any<Command<RegisterJockeyCommand>>()) } returns
+                Err(JockeyRegistrationError.InvalidJockey(JockeyValidationError.BlankFirstName))
+
+            tester
+                .post()
+                .uri("/api/jockeys")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"firstName":"","lastName":"豊"}""")
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.errorCode")
+                .isEqualTo("blank-first-name")
+        }
+
+        @Test
+        fun `InvalidJockey(BlankLastName) で 400 と problem+json が返ること`() {
+            every { registerJockey(any<Command<RegisterJockeyCommand>>()) } returns
+                Err(JockeyRegistrationError.InvalidJockey(JockeyValidationError.BlankLastName))
+
+            tester
+                .post()
+                .uri("/api/jockeys")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"firstName":"武","lastName":""}""")
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.errorCode")
+                .isEqualTo("blank-last-name")
+        }
+
+        @Test
+        fun `DuplicateJockey で 409 と existingId 付きの problem+json が返ること`() {
+            val existing = Jockey.create("武", "豊").unwrap()
+            every { registerJockey(any<Command<RegisterJockeyCommand>>()) } returns
+                Err(JockeyRegistrationError.DuplicateJockey(existing.id))
+
+            tester
+                .post()
+                .uri("/api/jockeys")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"firstName":"武","lastName":"豊"}""")
+                .assertThat()
+                .hasStatus(HttpStatus.CONFLICT)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.existingId")
+                .isEqualTo(existing.id.value.toString())
+        }
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/horseracing/jockey/JockeyTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/jockey/JockeyTest.kt
@@ -1,17 +1,37 @@
 package com.example.api.domain.horseracing.jockey
 
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 /** Jockey クラスのユニットテスト */
 class JockeyTest {
     @Nested
-    inner class ConstructorTest {
+    inner class CreateTest {
         @Test
-        fun `コンストラクタでプロパティが正しく設定されること`() {
-            val jockey = Jockey("武", "豊")
+        fun `正しい名前で create するとプロパティが正しく設定されること`() {
+            val jockey = Jockey.create("武", "豊").unwrap()
             assert(jockey.firstName == "武")
             assert(jockey.lastName == "豊")
+        }
+
+        @Test
+        fun `firstName がブランクのとき BlankFirstName を返すこと`() {
+            val result = Jockey.create("", "豊")
+            assert(result.getError() == JockeyValidationError.BlankFirstName)
+        }
+
+        @Test
+        fun `firstName が空白文字のみのとき BlankFirstName を返すこと`() {
+            val result = Jockey.create("   ", "豊")
+            assert(result.getError() == JockeyValidationError.BlankFirstName)
+        }
+
+        @Test
+        fun `lastName がブランクのとき BlankLastName を返すこと`() {
+            val result = Jockey.create("武", "")
+            assert(result.getError() == JockeyValidationError.BlankLastName)
         }
     }
 
@@ -19,14 +39,14 @@ class JockeyTest {
     inner class EqualsTest {
         @Test
         fun `同じ名前でもIDが異なれば等価でない`() {
-            val jockey1 = Jockey(firstName = "太郎", lastName = "山田")
-            val jockey2 = Jockey(firstName = "太郎", lastName = "山田")
+            val jockey1 = Jockey.create("太郎", "山田").unwrap()
+            val jockey2 = Jockey.create("太郎", "山田").unwrap()
             assert(jockey1 != jockey2)
         }
 
         @Test
         fun `同じインスタンスは等価である`() {
-            val jockey = Jockey(firstName = "次郎", lastName = "佐藤")
+            val jockey = Jockey.create("次郎", "佐藤").unwrap()
             assert(jockey == jockey)
         }
     }
@@ -35,8 +55,8 @@ class JockeyTest {
     inner class HashCodeTest {
         @Test
         fun `hashCodeがIDに依存していることを検証する`() {
-            val jockey1 = Jockey(firstName = "四郎", lastName = "田中")
-            val jockey2 = Jockey(firstName = "四郎", lastName = "田中")
+            val jockey1 = Jockey.create("四郎", "田中").unwrap()
+            val jockey2 = Jockey.create("四郎", "田中").unwrap()
             assert(jockey1.hashCode() != jockey2.hashCode())
         }
     }


### PR DESCRIPTION
## 概要

issue #217 の対応です。`kotlin-result` を導入し、ドメイン / アプリケーション層の業務ルール違反を `Result<V, E>` 型として表現する方針に切り替えました。`horseracing` ドメインのジョッキー登録ユースケースを PoC として実装しています。

あわせて、エラーハンドリング規約と REST API 設計規約（Google AIP + RFC 9457）を `.claude/rules/` 配下に切り出し、対象パス配下を編集するときに Claude Code へ自動でロードされる構成にしました。

Closes #217

## 変更内容

- **依存追加**: `kotlin-result 2.3.1` に加え、テスト用に `mockk 1.14.9` と `springmockk 5.0.1` を追加しました。
- **規約整備**: `.claude/rules/api-design.md` と `.claude/rules/error-handling.md` を追加し、CLAUDE.md にはパッケージ構成（`application` / `infrastructure` 層）を追記しました。
- **既存コードの置換**: `ConfirmResult.kt` の戻り値を標準ライブラリ `Result` から `kotlin-result` の `Result<V, E>` に置換し、`ConfirmRaceResultError` を `sealed interface` で仮置きしました。
- **PoC: ジョッキー登録ユースケース**
  - `Jockey` を `private constructor` + `companion Jockey.create(): Result<Jockey, JockeyValidationError>` でファクトリ化し、不変条件（名／姓のブランク禁止）をドメイン側に閉じました。
  - `application/horseracing/jockey/JockeyRegistrationUseCase` を `@Service` で公開し、`registerJockey(command)` の中身を `operator fun invoke` 内に直接記述しています。`JockeyRepository` はこのクラスのみが知ります。
  - `controller/jockey/JockeyController` は `JockeyRegistrationUseCase` だけに依存し、`mapBoth` で `Result` を `ResponseEntity` に変換します。
  - エラーレスポンスは Spring の `ProblemDetail` を使い、RFC 9457 (`application/problem+json`) で返します。`errorCode` や `existingId` などのアプリ固有情報は拡張プロパティで付与しています。
  - リクエスト DTO / レスポンス DTO は `controller/jockey/` 配下に別ファイルで切り出し、`RegisterJockeyResponse.kt` には成功 DTO と `JockeyRegistrationError → ProblemDetail` の変換を同居させました。
- **インフラ層追加**: `infrastructure/horseracing/jockey/InMemoryJockeyRepository` を `@Repository` で追加しました（PoC 用、`ConcurrentHashMap` 保持）。
- **テスト**: `mockk` / `@MockkBean` (springmockk) ベースに統一し、`JockeyTest` / `JockeyRegistrationUseCaseTest` / `JockeyControllerTest` で成功 / 各失敗バリアントを網羅しました。Controller の slice テストでは `201` / `400` / `409` と `problem+json` の拡張プロパティを検証しています。

## 動作確認

- [x] `./gradlew check` がローカルで成功すること
- [x] `JockeyRegistrationUseCaseTest` で成功 / `InvalidJockey(BlankFirstName)` / `InvalidJockey(BlankLastName)` / `DuplicateJockey` を網羅していること
- [x] `JockeyControllerTest` で `201 Created` / `400 BAD_REQUEST` + `problem+json` / `409 CONFLICT` + `existingId` 拡張プロパティを検証していること
- [ ] `./gradlew bootRun` で起動し、`POST /api/jockeys` に対して期待した HTTP ステータス（`201` / `400` / `409`）が返ることを手動で確認すること