### PR TITLE
feat: 横断的例外ハンドラを追加し標準例外を RFC 9457 形式に統一

### DIFF
--- a/src/main/kotlin/com/example/api/controller/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/example/api/controller/GlobalExceptionHandler.kt
@@ -1,0 +1,42 @@
+package com.example.api.controller
+
+import java.net.URI
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+
+/**
+ * 横断的な例外ハンドラ。
+ *
+ * - Spring MVC 標準例外（リクエストボディ不正・媒体型不一致等）は親クラス [ResponseEntityExceptionHandler]
+ *   に委譲する。`spring.mvc.problemdetails.enabled=true` により RFC 9457 (`application/problem+json`)
+ *   形式へ変換される。
+ * - 上記以外の想定外例外（インフラ障害・プログラミングエラー）は 500 + problem+json で返す。
+ *
+ * 業務ルール違反は各 Controller 境界で `Result` から `ProblemDetail` に変換するため、ここでは扱わない。
+ */
+@RestControllerAdvice
+class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
+    /**
+     * 想定外の例外を 500 (`application/problem+json`) として返す。
+     *
+     * 例外メッセージはセキュリティのためレスポンスに含めず、ログにのみ記録する。
+     */
+    @ExceptionHandler(Exception::class)
+    fun handleUnexpectedException(ex: Exception): ProblemDetail {
+        log.error("想定外の例外が発生しました", ex)
+        return ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR).apply {
+            type = URI.create("urn:problem-type:internal-server-error")
+            title = "Internal server error"
+            detail = "サーバー内部でエラーが発生しました。"
+            setProperty("errorCode", "internal-server-error")
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
   threads:
     virtual:
       enabled: true
+  mvc:
+    problemdetails:
+      # Spring MVC 標準例外（リクエストボディ不正・媒体型不一致等）を RFC 9457 形式に変換する
+      enabled: true
 
 springdoc:
   show-actuator: true

--- a/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,60 @@
+package com.example.api.controller
+
+import com.example.api.application.horseracing.jockey.JockeyRegistrationUseCase
+import com.example.api.application.horseracing.jockey.RegisterJockeyCommand
+import com.example.api.controller.jockey.JockeyController
+import com.example.api.domain.Command
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.junit.jupiter.api.Test
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.context.TestConstructor.AutowireMode
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.assertj.MockMvcTester
+
+/**
+ * [GlobalExceptionHandler] の検証。
+ *
+ * 業務ルール違反ではない例外（リクエストボディ不正・想定外例外）が RFC 9457 形式で返ることを、 [JockeyController] を踏み台にして確認する。
+ */
+@WebMvcTest(JockeyController::class)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class GlobalExceptionHandlerTest(val mockMvc: MockMvc) {
+    @MockkBean private lateinit var registerJockey: JockeyRegistrationUseCase
+
+    private val tester = MockMvcTester.create(mockMvc)
+
+    @Test
+    fun `必須フィールド欠落のリクエストボディで 400 と problem+json が返ること`() {
+        // lastName が欠落しており Jackson のデシリアライズに失敗する
+        tester
+            .post()
+            .uri("/api/jockeys")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""{"firstName":"武"}""")
+            .assertThat()
+            .hasStatus(HttpStatus.BAD_REQUEST)
+            .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+    }
+
+    @Test
+    fun `想定外の例外発生時に 500 と problem+json が返ること`() {
+        every { registerJockey(any<Command<RegisterJockeyCommand>>()) } throws
+            RuntimeException("予期しない障害")
+
+        tester
+            .post()
+            .uri("/api/jockeys")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""{"firstName":"武","lastName":"豊"}""")
+            .assertThat()
+            .hasStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+            .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+            .bodyJson()
+            .extractingPath("$.errorCode")
+            .isEqualTo("internal-server-error")
+    }
+}


### PR DESCRIPTION
## 概要

`.claude/rules/error-handling.md` の規約に記載がありながら未実装だった `@RestControllerAdvice` による横断的エラーハンドリングを追加し、Spring MVC 標準例外の RFC 9457 (`application/problem+json`) 変換を有効化します。規約と実装の乖離を解消します。

Closes #232

## 変更内容

- **`application.yml`**: `spring.mvc.problemdetails.enabled: true` を追加。リクエストボディ不正・媒体型不一致などの Spring MVC 標準例外が RFC 9457 形式で返るようになります。
- **`GlobalExceptionHandler.kt`**: `ResponseEntityExceptionHandler` を継承した `@RestControllerAdvice` を新規追加。
  - 標準例外は親クラスに委譲（problemdetails により problem+json 化）
  - 想定外例外（インフラ障害・プログラミングエラー）は 500 + problem+json で返却
  - 例外メッセージはセキュリティのためレスポンスに含めず、ログにのみ記録
- **`GlobalExceptionHandlerTest.kt`**: 必須フィールド欠落時の 400、想定外例外時の 500 がいずれも `application/problem+json` で返ることを検証。

## 設計メモ

- 業務ルール違反は従来どおり各 Controller 境界で `Result` → `ProblemDetail` に変換する責務分担を維持（本 advice では扱いません）。
- `type` は規約に従い暫定の `urn:problem-type:{kebab-case-code}` 形式を採用。

## 確認

- `./gradlew ktfmtCheck detekt test` 全パス
- pre-commit フック（editorconfig / ktfmt / detekt）全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
