### PR TITLE
chore: Spring Boot を 4.0.6 から 4.0.7 にアップデート

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 kotlin = "2.3.21"
 
 # プラグインのバージョン
-spring-boot = "4.0.6"
+spring-boot = "4.0.7"
 spring-dependency-management = "1.1.7"
 springdoc-openapi-gradle = "1.9.0"
 ktfmt = "0.26.0"


### PR DESCRIPTION
## 概要

Spring Boot を 4.0.6 → 4.0.7（2026-06-10 リリース）にパッチアップデートします。

## 目的

`tomcat-embed-core` の Dependabot アラート 7 件（critical 3 / high 3 / low 1）の解消が目的です。Spring Boot 4.0.7 は Tomcat **11.0.22** を固定しており、これは全 7 件の修正バージョンと一致します。

| アラート | 深刻度 | 概要 |
|---|---|---|
| #16 | critical | Security constraints not correctly applied |
| #14 | critical | Digest authenticator will authenticate any unknown user |
| #11 | critical | HTTP/2 request headers not validated |
| #13 | high | LockOutRealm treats user names as case-sensitive |
| #12 | high | WebSocket authentication header exposure |
| #10 | high | Unbounded read in WebDAV LOCK and PROPFIND handling |
| #15 | low | AJP secret compared in non-constant time |

※ 残る moderate 1 件（commons-lang3）は Gradle プラグインの buildscript classpath 限定の依存で、本アップデートでは解消されないため別途 dismiss 対応します。

## 確認内容

- `./gradlew dependencyInsight` で `tomcat-embed-core:11.0.22` への解決を確認
- `./gradlew check`（ktfmtCheck + detekt + test）が成功することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)