### PR TITLE
chore: kotlin.test の誤 import を detekt で機械的に禁止

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     testImplementation("org.springframework.boot:spring-boot-resttestclient")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation(libs.mockk)
     testImplementation(libs.springmockk)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -19,3 +19,13 @@ style:
   # 個別の TODO 解消は別 issue で扱うため検出対象から外す。
   ForbiddenComment:
     active: false
+  # テスト規約（CLAUDE.md 参照）: JUnit 5 の org.junit.jupiter.api.Test と
+  # Power Assert（stdlib の kotlin.assert）を使用する。マルチプラットフォーム対応は
+  # 不要なため kotlin.test の誤 import を機械的に禁止する。
+  ForbiddenImport:
+    active: true
+    forbiddenImports:
+      - reason:
+          'kotlin.test は使用禁止。テストには org.junit.jupiter.api.Test と
+          Power Assert (kotlin.assert) を使用すること（CLAUDE.md テスト規約参照）。'
+        value: 'kotlin.test.*'


### PR DESCRIPTION
## 概要

Closes #233

`build.gradle.kts` の `kotlin-test-junit5` 依存と CLAUDE.md の「kotlin.test.Test は使用禁止」規約の衝突を解消し、誤 import を機械的に防ぐ仕組みを整えました。

## 変更内容

- **`build.gradle.kts`**: `kotlin-test-junit5` 依存を削除
  - ソース内で `kotlin.test` は一切使用されていないことを確認済み
  - Power Assert プラグインはデフォルト設定で stdlib の `kotlin.assert` を変換対象とするため、`kotlin-test` は不要
- **`config/detekt/detekt.yml`**: `ForbiddenImport` ルールで `kotlin.test.*` を禁止
  - 誤 import 時には CLAUDE.md のテスト規約を参照する日本語メッセージを表示

## テスト・確認内容

- `kotlin.test.Test` を import した一時テストを作成し、`./gradlew detekt` が `ForbiddenImport` で検出して失敗することを確認（確認後に削除）
- `./gradlew check`（ktfmtCheck + detekt + test）が依存削除後もパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
