### PR TITLE
chore: Claude Code のローカル専用ファイルを .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ out/
 
 ### Claude Code ###
 .claude/settings.local.json
+.claude/worktrees/
+CLAUDE.local.md
 
 ### Terraform ###
 **/.terraform/*


### PR DESCRIPTION
## 概要

Claude Code がプロジェクト内に生成するローカル専用ファイルを .gitignore に追加します。

## 変更内容

- `.claude/worktrees/`: Claude Code がセッション中に作成する一時的な git worktree。ローカル作業用のためコミット対象外
- `CLAUDE.local.md`: 個人用のローカル指示ファイル。誤コミット防止のため予防的に追加

なお、`.claude/hooks/`・`.claude/rules/`・`.claude/settings.json` はチーム共有が前提のファイルのため、引き続き git 管理対象のままです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)