### PR TITLE
chore: Gradle configuration cache を有効化

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+# Gradle ビルド設定
+
+# configuration cache: 設定フェーズ（ビルドスクリプト評価・タスクグラフ構築）の結果をキャッシュし、
+# ビルドスクリプトに変更がない場合は設定フェーズをスキップして起動を高速化する
+org.gradle.configuration-cache=true


### PR DESCRIPTION
## 概要

`gradle.properties` を新規追加し、Gradle の configuration cache を有効化します。

## 背景

このプロジェクトは短い Gradle 起動が頻発する構成です：

- lefthook pre-commit: `ktfmtCheck` + `detekt`
- lefthook pre-push: `test`
- Claude Code Stop フック: `ktfmtFormat` → `detekt` → `test`
- CI (api-tests.yml): `ktfmtCheck` → `detekt` → `test` の 3 連続起動

configuration cache により、ビルドスクリプトに変更がない限り設定フェーズ（1〜3 秒）がスキップされ、これらすべてが恩恵を受けます。

## 検証

- `./gradlew check`: 成功。2 回目は「Configuration cache entry reused.」が出て全体 1.5 秒に短縮
- `./gradlew ktfmtFormat`: 成功
- Spring Boot / ktfmt / detekt プラグインいずれも非互換の問題報告なし（Gradle 9.5.1）

🤖 Generated with [Claude Code](https://claude.com/claude-code)