### PR TITLE
refactor: UUID 生成戦略をタイムベース(UUIDv7)に統一し generateId() へ集約

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,9 +118,7 @@ class HelloController {
 エンティティは UUID ベースの同一性を持ちます：
 
 - **ID による等価性**: `equals()` と `hashCode()` は ID のみで実装
-- **UUID 生成戦略**:
-  - `UUID.randomUUID()`: シンプルなランダム生成
-  - `Generators.timeBasedEpochRandomGenerator()`: タイムベース生成（`java-uuid-generator` ライブラリ使用）
+- **UUID 生成戦略**: タイムベース（UUIDv7 相当の `Generators.timeBasedEpochRandomGenerator()`、`java-uuid-generator` ライブラリ使用）に統一する。生成値が時刻順にソート可能で永続化時のインデックス局所性に優れるため、ランダム（`UUID.randomUUID()`）ではなくこちらを標準とする。生成ロジックは `domain.shared.generateId()` に集約しており、各 ID 値クラスは `JockeyId(generateId())` のようにこの関数を介して生成する（エンティティごとに生成方法を書き分けない）
 - **役割の表明**: 集約ルートには `@AggregateRoot`、識別子プロパティには `@field:Identity` を付与（`@Identity` は FIELD ターゲットのため use-site target の明示が必要）
 
 #### Command パターン

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/Breeding.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/Breeding.kt
@@ -1,5 +1,6 @@
 package com.example.api.domain.horseracing.model.breeding
 
+import com.example.api.domain.shared.generateId
 import java.util.UUID
 import org.jmolecules.ddd.annotation.AggregateRoot
 import org.jmolecules.ddd.annotation.Identity
@@ -13,5 +14,5 @@ import org.jmolecules.ddd.annotation.ValueObject
 @AggregateRoot
 class Breeding {
     /** 繁殖ID */
-    @field:Identity val id = BreedingId(UUID.randomUUID())
+    @field:Identity val id = BreedingId(generateId())
 }

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/BloodHorse.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/BloodHorse.kt
@@ -1,6 +1,7 @@
 package com.example.api.domain.horseracing.model.horse.bloodhorse
 
 import com.example.api.domain.shared.Entity
+import com.example.api.domain.shared.generateId
 import java.util.UUID
 import org.jmolecules.ddd.annotation.AggregateRoot
 import org.jmolecules.ddd.annotation.Identity
@@ -27,5 +28,5 @@ private constructor(
     @Suppress("unused") val sex: Sex
 ) : Entity<BloodHorseId>() {
     /** 軽種馬ID */
-    @field:Identity override val id = BloodHorseId(UUID.randomUUID())
+    @field:Identity override val id = BloodHorseId(generateId())
 }

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/jockey/Jockey.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/jockey/Jockey.kt
@@ -1,7 +1,7 @@
 package com.example.api.domain.horseracing.model.jockey
 
 import com.example.api.domain.shared.Entity
-import com.fasterxml.uuid.Generators
+import com.example.api.domain.shared.generateId
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
@@ -47,8 +47,7 @@ private constructor(
     val lastName: String,
 ) : Entity<JockeyId>() {
     /** ジョッキーID インスタンス生成時に一意なIDを自動生成する */
-    @field:Identity
-    override val id = JockeyId(Generators.timeBasedEpochRandomGenerator().generate())
+    @field:Identity override val id = JockeyId(generateId())
 
     companion object {
         /**

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/race/Race.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/race/Race.kt
@@ -1,7 +1,7 @@
 package com.example.api.domain.horseracing.model.race
 
 import com.example.api.domain.shared.Entity
-import com.fasterxml.uuid.Generators
+import com.example.api.domain.shared.generateId
 import java.util.UUID
 import org.jmolecules.ddd.annotation.AggregateRoot
 import org.jmolecules.ddd.annotation.Identity
@@ -17,5 +17,5 @@ class Race(
     val name: String
 ) : Entity<RaceId>() {
     /** レースID */
-    @field:Identity override val id = RaceId(Generators.timeBasedEpochRandomGenerator().generate())
+    @field:Identity override val id = RaceId(generateId())
 }

--- a/src/main/kotlin/com/example/api/domain/sakamichi/model/Member.kt
+++ b/src/main/kotlin/com/example/api/domain/sakamichi/model/Member.kt
@@ -1,7 +1,7 @@
 package com.example.api.domain.sakamichi.model
 
 import com.example.api.domain.shared.Entity
-import com.fasterxml.uuid.Generators
+import com.example.api.domain.shared.generateId
 import java.util.UUID
 import org.jmolecules.ddd.annotation.AggregateRoot
 import org.jmolecules.ddd.annotation.Identity
@@ -19,6 +19,5 @@ class Member(
     @Suppress("unused") val lastName: String,
 ) : Entity<MemberId>() {
     /** メンバーID */
-    @field:Identity
-    override val id = MemberId(Generators.timeBasedEpochRandomGenerator().generate())
+    @field:Identity override val id = MemberId(generateId())
 }

--- a/src/main/kotlin/com/example/api/domain/shared/Identifiers.kt
+++ b/src/main/kotlin/com/example/api/domain/shared/Identifiers.kt
@@ -1,0 +1,17 @@
+package com.example.api.domain.shared
+
+import com.fasterxml.uuid.Generators
+import java.util.UUID
+
+/**
+ * エンティティ識別子用の UUID を生成する。
+ *
+ * 生成方式はタイムベース（UUIDv7 相当の [Generators.timeBasedEpochRandomGenerator]）に統一する。生成値が時刻順にソート可能で、永続化時の
+ * B-Tree インデックスの局所性に優れるため、ランダム（UUIDv4）ではなくこちらを標準とする。
+ *
+ * UUID 生成戦略をエンティティごとに書き分けると意図が読み取れなくなるため、全エンティティの ID 生成はこの関数に集約する。新しいエンティティの ID
+ * 値クラスもこの関数を用いて生成すること。
+ *
+ * @return タイムベースで生成された [UUID]
+ */
+fun generateId(): UUID = Generators.timeBasedEpochRandomGenerator().generate()

--- a/src/main/kotlin/com/example/api/domain/tennis/model/Player.kt
+++ b/src/main/kotlin/com/example/api/domain/tennis/model/Player.kt
@@ -1,6 +1,6 @@
 package com.example.api.domain.tennis.model
 
-import com.fasterxml.uuid.Generators
+import com.example.api.domain.shared.generateId
 import java.util.UUID
 import org.jmolecules.ddd.annotation.AggregateRoot
 import org.jmolecules.ddd.annotation.Identity
@@ -17,7 +17,7 @@ class Player(
     /** 姓 */
     @Suppress("unused") val lastName: String,
 ) {
-    @field:Identity val id = PlayerId(Generators.timeBasedEpochRandomGenerator().generate())
+    @field:Identity val id = PlayerId(generateId())
 
     override fun equals(other: Any?): Boolean {
         if (this === other) {


### PR DESCRIPTION
## 概要

Closes #234

エンティティ間で UUID 生成方法がばらついており、差異が意図的なのか書き分けミスなのかが読み手に伝わらない問題を解消する。生成方式を **タイムベース（UUIDv7 相当の `timeBasedEpochRandomGenerator`）に統一** し、生成ロジックを 1 箇所へ集約した。

## 背景

| エンティティ | 変更前 | 変更後 |
|---|---|---|
| Jockey / Race / Player / Member | タイムベース | `generateId()` |
| BloodHorse / Breeding | ランダム (`UUID.randomUUID()`) | `generateId()`（タイムベースへ統一） |

## 変更内容

- **`domain/shared/Identifiers.kt`（新規）**: トップレベル関数 `generateId(): UUID` を追加。全エンティティの ID 生成をこの関数に集約する。
- **各エンティティ**: ID 値クラスの生成を `XxxId(generateId())` 形式に統一。
- **`CLAUDE.md`**: UUID 生成戦略を「タイムベースに統一・`generateId()` に集約」と明文化。統一の根拠（時系列ソート性・永続化時のインデックス局所性）を記載。

## 統一の根拠

UUIDv7 は生成値が時刻順にソート可能で、永続化を見据えた際の B-Tree インデックス局所性に優れる。ランダムである必要のあるエンティティが存在しないため、全エンティティをタイムベースに揃えた。これにより新規エンティティ追加時も `XxxId(generateId())` と書くだけで迷わずに済む。

## 確認

- `./gradlew ktfmtCheck detekt test` グリーン（ArchUnit のドメイン層依存ルールにも適合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
