### PR TITLE
refactor: Command<T> の責務を明確化し timestamp を Instant 化する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,12 +125,12 @@ class HelloController {
 
 #### Command パターン
 
-`Command<T>` でドメインコマンドをラップ：
+`Command<T>` はドメインコマンドのペイロードに**発生時刻メタデータを添える封筒**。ペイロード（何をしたいか）と、それがいつ発生したかという横断的メタデータを分離する。発生時刻はタイムゾーン非依存のドメインイベント時刻として `Instant` で保持する：
 
 ```kotlin
 class Command<T>(
-    val t: T,
-    val timestamp: LocalDateTime,
+    val payload: T,
+    val issuedAt: Instant,
 )
 
 // 使用例

--- a/src/main/kotlin/com/example/api/application/horseracing/jockey/JockeyRegistrationUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/horseracing/jockey/JockeyRegistrationUseCase.kt
@@ -49,7 +49,7 @@ class JockeyRegistrationUseCase(private val jockeyRepository: JockeyRepository) 
     operator fun invoke(
         command: Command<RegisterJockeyCommand>
     ): Result<Jockey, JockeyRegistrationError> {
-        val input = command.t
+        val input = command.payload
         return Jockey.create(input.firstName, input.lastName)
             .mapError { JockeyRegistrationError.InvalidJockey(it) }
             .andThen { jockey ->

--- a/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import java.time.LocalDateTime
+import java.time.Instant
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ProblemDetail
@@ -69,7 +69,7 @@ class JockeyController(private val registerJockey: JockeyRegistrationUseCase) {
     @PostMapping("/api/jockeys")
     fun register(@RequestBody request: RegisterJockeyRequest): ResponseEntity<Any> {
         val command =
-            Command(RegisterJockeyCommand(request.firstName, request.lastName), LocalDateTime.now())
+            Command(RegisterJockeyCommand(request.firstName, request.lastName), Instant.now())
         return registerJockey(command)
             .mapBoth(
                 success = { jockey ->

--- a/src/main/kotlin/com/example/api/domain/shared/Command.kt
+++ b/src/main/kotlin/com/example/api/domain/shared/Command.kt
@@ -1,5 +1,15 @@
 package com.example.api.domain.shared
 
-import java.time.LocalDateTime
+import java.time.Instant
 
-@Suppress("unused") class Command<T>(val t: T, val timestamp: LocalDateTime)
+/**
+ * ドメインコマンドのペイロードに発生時刻メタデータを添える封筒。
+ *
+ * ペイロード（何をしたいか）と、それがいつ発生したかという横断的メタデータを分離するための薄いラッパー。 各ユースケースの入力 DTO（`〜Command`）をそのまま [payload]
+ * に載せ、`Command` 自体はコンテキストに依存しない。
+ *
+ * @param T 包むドメインコマンドの型
+ * @property payload 実行したいドメインコマンド
+ * @property issuedAt コマンドが発生した時刻。タイムゾーンに依存しないドメインイベント時刻として [Instant] で保持する
+ */
+class Command<T>(val payload: T, val issuedAt: Instant)

--- a/src/test/kotlin/com/example/api/application/horseracing/jockey/JockeyRegistrationUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/horseracing/jockey/JockeyRegistrationUseCaseTest.kt
@@ -9,14 +9,14 @@ import com.github.michaelbull.result.unwrap
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import java.time.LocalDateTime
+import java.time.Instant
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class JockeyRegistrationUseCaseTest {
 
     private fun command(firstName: String, lastName: String): Command<RegisterJockeyCommand> =
-        Command(RegisterJockeyCommand(firstName, lastName), LocalDateTime.now())
+        Command(RegisterJockeyCommand(firstName, lastName), Instant.now())
 
     @Nested
     inner class SuccessCase {


### PR DESCRIPTION
## 概要

`Command<T>` の責務を明確化し、イベント時刻を `LocalDateTime` から `Instant` に変更しました。

Closes #235

## 背景

`Command<T>` は責務が定義されないまま `@Suppress("unused")` で警告を黙らせた状態で、`timestamp` はどこからも参照されていませんでした。また Controller でイベント時刻に `LocalDateTime.now()` を使っており、ドメインイベント時刻としてはタイムゾーン非依存の `Instant` が望ましい状態でした。

## 変更内容

- **`domain/shared/Command.kt`**: 責務を「ドメインコマンドのペイロードに発生時刻メタデータを添える封筒」と KDoc で明文化。プロパティを `t` → `payload`、`timestamp: LocalDateTime` → `issuedAt: Instant` に変更。`@Suppress("unused")` を除去
- **`controller/jockey/JockeyController.kt`**: コマンド生成を `LocalDateTime.now()` → `Instant.now()` に変更
- **`application/horseracing/jockey/JockeyRegistrationUseCase.kt`**: `command.t` → `command.payload` に追従
- **テスト**: `JockeyRegistrationUseCaseTest` のコマンド生成を `Instant.now()` に追従
- **`CLAUDE.md`**: Command パターンの記述を `payload` / `issuedAt` / `Instant` と封筒の意図に更新

## 設計判断

issue で挙がった「廃止 / 意図づけ+Instant化 / 実消費」の 3 案のうち、**意図づけ + Instant 化**を採用しました。`issuedAt` は現状まだ consumer がいないメタデータですが、issue の「過剰設計を避けつつ最小限の意図づけ」方針に沿い、実消費（モデルへの時刻記録等）は導入していません。

## 確認

- `./gradlew ktfmtCheck detekt test` green（`@Suppress` 除去後も detekt 警告は再燃せず）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
