### PR TITLE
chore: mise + fnox + 1Password でシークレットを暗号化保管し必要時のみ env へ展開する仕組みを整備

### DIFF
--- a/.claude/rules/secrets.md
+++ b/.claude/rules/secrets.md
@@ -1,0 +1,82 @@
+# シークレット管理規約（mise + fnox）
+
+ローカル開発で必要なシークレットは、平文で `~/.zshrc` 等に `export` せず、**暗号化保管／外部参照＋必要時だけ環境変数へ展開**する。仕組みは mise で管理する [fnox](https://fnox.jdx.dev/)（mise 作者 jdx 製）で統一する。
+
+当面の対象は GitHub MCP（`https://api.githubcopilot.com/mcp/`）用の `GITHUB_PERSONAL_ACCESS_TOKEN`。将来的に GCP 認証情報など他シークレットも同じ仕組みへ寄せる。
+
+## バックエンド: 1Password（案C）
+
+シークレットの実体は 1Password の Vault に保管し、`fnox.toml` には **`op://` 参照のみ**を書く（平文も暗号化値も置かない）。fnox は値の解決時に 1Password CLI (`op`) を `op inject` 経由で呼び出す。
+
+- **サービスアカウントトークンは不要**: `op` がサインイン済み（デスクトップアプリ連携 or `op signin`）であれば、`OP_SERVICE_ACCOUNT_TOKEN` なしで解決できる。これにより「トークンのブートストラップ（鶏卵問題）」と「個人プランでのサービスアカウント可用性」の懸念を回避している。
+- `fnox.toml` は参照のみのため **git にコミットしてよい**（チーム共有時も各自の `op` セッションで解決される）。
+
+## 前提セットアップ（初回のみ）
+
+1. **1Password デスクトップアプリの CLI 連携を有効化**
+   - 1Password アプリ → 設定 → 開発者 →「1Password CLI と連携」をオン（生体認証で `op` が解錠される）。
+   - 確認: `op whoami`（サインイン済みアカウントが表示されること）。
+2. **1Password に GitHub PAT を保管**
+   - 任意の Vault に PAT を保存し、その参照を `fnox.toml` の `value`（`op://<vault>/<item>/<field>`）に設定する。
+   - 例: `op://Personal/GitHub PAT/credential`
+   - PAT に必要なスコープは利用する GitHub MCP のツールに依存（最小権限で発行する）。
+
+## 日常運用
+
+### シークレットの確認・追加
+
+```bash
+# 定義済みシークレットの一覧（値は解決せず参照のみ表示）
+fnox list
+
+# 値が解決できるか確認（op サインインが必要）
+fnox get GITHUB_PERSONAL_ACCESS_TOKEN
+
+# 設定の健全性チェック
+fnox doctor
+
+# 新しいシークレット参照を追加（実トークンは 1Password 側に保存済みにしておく）
+fnox set <ENV_NAME> "op://<vault>/<item>/<field>" --provider onepass
+```
+
+> Claude Code の Bash サンドボックス内からは `op` がデスクトップアプリのソケットに到達できずエラーになる。`fnox` / `op` をローカルで実行・検証する際はサンドボックスを無効化して実行する（Claude Code では当該コマンドをサンドボックス無効で実行する）。
+
+### Claude Code（MCP）への env 供給
+
+GitHub MCP は HTTP 接続で `Authorization: Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}` を要求する（`.mcp.json` 参照）。`${...}` は **`claude` を起動したプロセスの環境変数**から補間されるため、トークンを `claude` の環境に注入した状態で起動する。
+
+**推奨: 起動時のみ注入（永続化しない）**
+
+```bash
+# このセッションの間だけ env に展開され、終了後は環境に残らない
+fnox exec -- claude
+```
+
+エイリアス化しておくと楽:
+
+```bash
+# ~/.zshrc など
+alias claude='fnox exec -- claude'
+```
+
+**代替: cd 時の自動ロード（`fnox activate`）**
+
+```bash
+# ~/.zshrc
+eval "$(fnox activate zsh)"
+```
+
+プロジェクトディレクトリに `cd` した時点で env が自動ロードされる。ただし対話シェルの環境にトークンが載るため、「必要時だけ展開し永続化しない」方針には `fnox exec` のほうが忠実。
+
+## git / gitleaks との整合
+
+- `fnox.toml` は **コミット対象**（`op://` 参照のみで秘密情報を含まない）。`.gitignore` で除外しない。
+- gitleaks は `op://` 参照を秘密として誤検知しない（pre-commit の gitleaks スキャンと整合）。
+- 実トークンを誤って `fnox.toml` や `.mcp.json` に直接書かないこと（必ず参照 / env 補間を使う）。
+
+## 関連ファイル
+
+- `mise.toml` — fnox をツールとして管理
+- `fnox.toml` — プロバイダ定義とシークレット参照（`op://`）
+- `.mcp.json` — GitHub MCP 定義（`${GITHUB_PERSONAL_ACCESS_TOKEN}` を env 補間）
+- `.claude/settings.local.json` — サンドボックス設定

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,7 @@ mise list
 現在管理されているツール（`mise.toml` 参照）：
 - `actionlint`: GitHub Actions ワークフローの lint
 - `editorconfig-checker`: EditorConfig 準拠チェック
+- `fnox`: シークレット管理（暗号化保管／外部参照＋必要時だけ env へ展開）
 - `gitleaks`: シークレット混入スキャン
 - `java` (Temurin 21): Gradle / Kotlin のビルドおよびテスト実行用 JDK
 - `lefthook`: Git フック管理
@@ -273,6 +274,16 @@ lefthook run pre-commit
 # 特定のコマンドのみスキップ
 LEFTHOOK_EXCLUDE=ktfmt-check git commit -m "メッセージ"
 ```
+
+## シークレット管理（fnox + 1Password）
+
+ローカル開発で必要なシークレット（当面は GitHub MCP 用の `GITHUB_PERSONAL_ACCESS_TOKEN`）は、平文で shell profile に `export` せず、**1Password に保管＋必要時だけ env へ展開**する。仕組みは mise 管理の [fnox](https://fnox.jdx.dev/) で統一する。
+
+- `fnox.toml` には `op://` 参照のみを書き（秘密情報を含まない）、**git にコミットしてよい**
+- 値の解決は 1Password CLI (`op`) 経由。`op` がサインイン済み（デスクトップアプリ連携）なら**サービスアカウントトークンは不要**
+- MCP への供給は `fnox exec -- claude` で起動し、`.mcp.json` の `${GITHUB_PERSONAL_ACCESS_TOKEN}` を env 補間する
+
+運用手順・前提セットアップの詳細は **`.claude/rules/secrets.md`** を参照。
 
 ## OpenAPI/Swagger
 

--- a/fnox.toml
+++ b/fnox.toml
@@ -1,0 +1,16 @@
+# fnox によるシークレット管理設定
+#
+# このファイルには「暗号化済みの値」または「外部参照（op:// など）」のみを記載し、
+# 平文のシークレットは決して書かない。そのため git にコミットしてよい。
+#
+# 値の解決には 1Password CLI (op) を使う。op がデスクトップアプリ連携または
+# `op signin` でサインイン済みであれば、サービスアカウントトークンは不要。
+# 詳細な運用手順は .claude/rules/secrets.md を参照。
+
+[providers.onepass]
+type = "1password"
+
+[secrets]
+# GitHub MCP (https://api.githubcopilot.com/mcp/) の Authorization ヘッダで使う PAT。
+# value は 1Password の op:// 参照 (op://<vault>/<item>/<field>)。実トークンはここには入らない。
+GITHUB_PERSONAL_ACCESS_TOKEN = { provider = "onepass", value = "op://Private/toy-box GitHub MCP/credential", description = "GitHub MCP (api.githubcopilot.com) 用 PAT" }

--- a/mise.lock
+++ b/mise.lock
@@ -71,6 +71,52 @@ url = "https://github.com/editorconfig-checker/editorconfig-checker/releases/dow
 checksum = "sha256:6234197229170c9b956c244c821e09082a95c507e22159e0b2bce6562fd82a22"
 url = "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.3.0/ec-windows-amd64.zip"
 
+[[tools.fnox]]
+version = "1.26.0"
+backend = "github:jdx/fnox"
+
+[tools.fnox."platforms.linux-arm64"]
+checksum = "sha256:25f2628f54113685338322fc6c485d3f899ce0e1a926046c641a323a81806879"
+url = "https://github.com/jdx/fnox/releases/download/v1.26.0/fnox-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/fnox/releases/assets/445847393"
+provenance = "github-attestations"
+
+[tools.fnox."platforms.linux-arm64-musl"]
+checksum = "sha256:dca289095fcd009094a745e2e6c664e3691087d0e02e0c305abef59c3903ef61"
+url = "https://github.com/jdx/fnox/releases/download/v1.26.0/fnox-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/fnox/releases/assets/445847389"
+provenance = "github-attestations"
+
+[tools.fnox."platforms.linux-x64"]
+checksum = "sha256:6e2a359357223d83f235523eb21e7402c5a84b5471aeff6d4d0ea6cb4bc6abc2"
+url = "https://github.com/jdx/fnox/releases/download/v1.26.0/fnox-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/fnox/releases/assets/445847488"
+provenance = "github-attestations"
+
+[tools.fnox."platforms.linux-x64-musl"]
+checksum = "sha256:c6d3d8efeb942b6d3ee4383c6c68c53bd7e625bd1a6f632def203bfaac98089c"
+url = "https://github.com/jdx/fnox/releases/download/v1.26.0/fnox-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/fnox/releases/assets/445847496"
+provenance = "github-attestations"
+
+[tools.fnox."platforms.macos-arm64"]
+checksum = "sha256:65295b6cf9a345240967f3fd73db4645d7e4ec3ef4f20f735bd41802c92896f7"
+url = "https://github.com/jdx/fnox/releases/download/v1.26.0/fnox-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/fnox/releases/assets/445847391"
+provenance = "github-attestations"
+
+[tools.fnox."platforms.macos-x64"]
+checksum = "sha256:6a621920c16ee27dd32a7063664082f321cb9362369e96c40098eba5769532df"
+url = "https://github.com/jdx/fnox/releases/download/v1.26.0/fnox-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/fnox/releases/assets/445847388"
+provenance = "github-attestations"
+
+[tools.fnox."platforms.windows-x64"]
+checksum = "sha256:ba7ac2eb4ce18178f711d40428431ff20da334c8d61302bca1edae5980e151c8"
+url = "https://github.com/jdx/fnox/releases/download/v1.26.0/fnox-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/fnox/releases/assets/445847435"
+provenance = "github-attestations"
+
 [[tools.gitleaks]]
 version = "8.30.1"
 backend = "aqua:gitleaks/gitleaks"

--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,7 @@ lockfile = true
 [tools]
 actionlint = "1.7.12"
 editorconfig-checker = "3.3.0"
+fnox = "1.26.0"
 gitleaks = "8.30.1"
 java = "temurin-21.0.0+35.0.LTS"
 lefthook = "1.12.2"


### PR DESCRIPTION
## 概要

ローカル開発で必要なシークレット（当面は GitHub MCP 用の `GITHUB_PERSONAL_ACCESS_TOKEN`）を、平文で shell profile に `export` せず、**1Password に保管＋必要時だけ env へ展開**する仕組みを mise + [fnox](https://github.com/jdx/fnox) で整備しました。

Closes #256（※ `.mcp.json`（GitHub MCP 本体の定義）は別イシューで対応するため本 PR には含みません）

## バックエンド選定: 案C（1Password）

Issue の比較表のうち **案C（1Password）** を採用しました。調査の結果、fnox の 1Password プロバイダは `op inject` を呼ぶ実装で、`op` がデスクトップアプリ連携でサインイン済みなら **`OP_SERVICE_ACCOUNT_TOKEN` は不要**でした。これにより Issue が懸念していた以下を回避できます。

- サービスアカウントトークンのブートストラップ（鶏卵問題）
- 個人/ファミリープランでのサービスアカウント可用性

## 変更内容

| ファイル | 変更 |
|---|---|
| `mise.toml` / `mise.lock` | fnox 1.26.0 をツールとして追加 |
| `fnox.toml`（新規） | 1Password プロバイダと `GITHUB_PERSONAL_ACCESS_TOKEN` の `op://` 参照を定義。実トークンは含まず参照のみ |
| `.claude/rules/secrets.md`（新規） | シークレット管理規約（選定理由・前提セットアップ・運用・MCP への env 供給・gitleaks 整合・sandbox 注意点） |
| `CLAUDE.md` | ツール一覧に fnox 追加 + シークレット管理セクション新設 |

## セキュリティ / 整合性

- `fnox.toml` は `op://` 参照のみで秘密情報を含まないため **git にコミット可**
- gitleaks は `op://` 参照を誤検知しない（作業ツリー全体スキャンでクリーン）
- pre-commit（gitleaks / EditorConfig / commitizen）と pre-push（全テスト）をパス

## 動作確認

fnox → op（生体認証）→ 1Password のオンデマンド解決をローカルで検証済み:

```
$ fnox exec -- sh -c '[ -n "$GITHUB_PERSONAL_ACCESS_TOKEN" ] && echo "OK: ${#GITHUB_PERSONAL_ACCESS_TOKEN} 文字"'
OK: 93 文字
```

トークンは平文でファイルに残らず、実行時のみ env に展開される（永続化しない）ことを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
