### PR TITLE
test: テスト戦略を明文化し Kover カバレッジハーネスを導入

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,62 @@
+# テスト戦略
+
+オニオンアーキテクチャの 4 リングに、テストピラミッドをそのまま写像する。**内側ほど数多く・速く・隔離して、外側ほど少数・統合寄りに**テストする。リングごとに手法が決まっているので、新しいコードはそのリングの流儀に従う。
+
+## リング × テスト手法
+
+| リング | パッケージ | テスト手法 | 参考実装 |
+|-------|-----------|-----------|---------|
+| domainModel | `domain.*.model` / `domain.shared` | 純粋ユニット（DI なし・Power Assert）。VO の不変条件は `create()` の `Result` を検証 | `MicrochipNumberTest` / `JockeyTest` / `EntityTest` |
+| domainService | `domain.*.service` | 純粋ユニット。集約はテスト用 Fixture で組む（モック不要） | `RegisterInStudBookTest` |
+| applicationService | `application` | ユニット。Repository ポートを mockk でスタブし、ユースケースの分岐と失敗バリアントを検証 | `RegisterInStudBookUseCaseTest` / `JockeyRegistrationUseCaseTest` |
+| adapter (rest) | `controller` | `@WebMvcTest` + `MockMvcTester` の slice テスト。HTTP 入出力と ProblemDetail 描画を検証 | `BloodHorseControllerTest` / `GlobalExceptionHandlerTest` |
+| 横断 | — | ArchUnit（規約）／ OpenAPI 契約／ `@SpringBootTest` 統合（最小限） | `ArchitectureTest` / `OpenApiTest` / `HealthEndpointTest` |
+
+方針:
+
+- **モックは applicationService の Repository ポート境界に限る**。ドメイン層は Fixture で実物を組み、モックしない（純粋関数なので隔離コスト不要）。
+- ドメインサービスのテスト用 Fixture は対象コンテキストの `model` パッケージ配下にテストコードとして置く（例: `BloodHorseFixture`）。
+- 統合テスト（`@SpringBootTest`）は配線確認の最小限に留める。ロジックの網羅は内側のリングで済ませる（ピラミッドの底を厚く）。
+- テスト規約（JUnit 5 / Power Assert / `@WebMvcTest` / 日本語ケース名）の詳細は CLAUDE.md「テスト規約」を参照。
+
+## カバレッジハーネス（Kover）
+
+カバレッジは [Kover](https://github.com/Kotlin/kotlinx-kover) で計測する（JaCoCo ではない。理由は [ADR-0006](../../docs/adr/0006-kover-over-jacoco.md)）。設定は `build.gradle.kts` の `kover {}` ブロック。
+
+### 2 つのレポート variant
+
+| variant | 目的 | 対象 | タスク |
+|---------|------|------|-------|
+| `total` | **穴の可視化**。探索領域も含めた全体像を見せる | 全 main コード（エントリーポイント除く） | `koverHtmlReport` / `koverXmlReport` / `koverLog` |
+| `mature` | **リグレッション防止ゲート**。成熟領域だけを検証 | 下記「ゲート対象」のみ | `koverVerifyMature` / `koverLogMature` |
+
+Kover 0.9 の検証ルールはパッケージ単位のフィルタを持てないため、`copyVariant` で `total` を複製した `mature` variant に includes フィルタを掛けてゲート対象を絞っている。
+
+### ゲートの考え方（ラチェット）
+
+- **成熟パッケージのみゲート**: レイヤーごとのテストが揃った領域だけに行カバレッジ下限を課す。探索段階のモデル（`tennis` / `sakamichi` / `breeding` / `race` / `racehorse` / `stallion` 等）は `total` レポートには出すが、ゲートからは外して CI をノイズで赤くしない。
+- **現状の下限は行 85%**（実測 88.3% を少し下げてロック）。これは**ラチェット**であり、カバレッジが上がったら下限も引き上げて後戻りを防ぐ。下げるのは設計判断を伴うときだけ。
+- ゲート対象に新コードを足すなら、テストも添えて 85% を割らないこと。割ると `./gradlew check`（および CI の `koverVerifyMature`）が失敗する。
+
+ゲート対象パッケージ（`build.gradle.kts` の `variant("mature")` の includes が唯一の出所。ここは要約）:
+`domain.shared` / `domain.horseracing.model.jockey` / `model.horse.bloodhorse` / `service.horse` / `application.horseracing` / `controller`。
+
+### 実行
+
+```bash
+./gradlew koverHtmlReport      # build/reports/kover/html/index.html で穴を目視（total）
+./gradlew koverVerifyMature    # 成熟ゲートの検証（check にも組み込み済み）
+./gradlew check                # ktfmt + detekt + test + koverVerifyMature を一括実行
+```
+
+CI（`api-tests.yml`）は test 後に `koverVerifyMature` でゲートを掛け、`koverLog` / `koverLogMature` の数値を PR の Job Summary に出す（外部サービス不使用）。
+
+## 当面の宿題（カバレッジの穴）
+
+`total` レポートで 0% に見える領域は、成熟させるときにテストを添える。優先度は実装の成熟度に従う:
+
+- `infrastructure.*`（InMemory リポジトリ）: ポート実装の契約テストが未整備
+- `domain.horseracing.service`（`ConfirmRaceResult` / `RegisterForBreeding`）: サービスだがテスト無し
+- `domain.horseracing.model`（`breeding` / `race` / `racehorse` / `stallion`）・`sakamichi` / `tennis`: 探索段階のモデル
+
+これらは成熟してゲート対象に昇格する時点で `variant("mature")` の includes に追加する。

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -42,3 +42,19 @@ jobs:
 
       - name: Run API tests
         run: ./gradlew test --stacktrace
+
+      # 成熟パッケージの行カバレッジ下限（ラチェット）を検証する。下回るとここで失敗する。
+      - name: Verify coverage gate
+        run: ./gradlew koverVerifyMature --stacktrace
+
+      # 全体／成熟ゲートの行カバレッジを PR の Job Summary に出す（外部サービス不要）。
+      # ゲートが落ちても数値が見えるよう always() で実行する。
+      - name: Report coverage
+        if: always()
+        run: |
+          {
+            echo '## 🧪 テストカバレッジ'
+            echo ''
+            ./gradlew koverLog koverLogMature --console=plain 2>&1 \
+              | grep 'カバレッジ' | sed 's/^/- /'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,8 +44,11 @@ jobs:
         with:
           languages: java-kotlin
 
+      # CodeQL は解析用に production コードがコンパイルできれば十分。
+      # assemble は check 配下（test / ktfmt / detekt / koverVerify）を一切呼ばないため、
+      # 検証タスクの個別除外が不要で、check に検証が増えてもメンテ不要。
       - name: Build with Gradle
-        run: ./gradlew build -x test -x ktfmtCheck -x detekt --stacktrace
+        run: ./gradlew assemble --stacktrace
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,8 @@ com.example.api/
 
 ### テスト規約
 
+テスト戦略（オニオン各リング × テストピラミッドの対応、どの層で何を・どうテストするか）とカバレッジハーネス（Kover の `total` / `mature` 2 variant 構成・成熟領域のみゲートするラチェット運用）は `.claude/rules/testing.md` を参照。本節は個別の記法（アノテーション・アサーション・命名）を定める。
+
 #### アノテーション
 
 - **JUnit 5 を使用**: `org.junit.jupiter.api.Test` アノテーションを使用

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.springdoc.openapi.gradle)
     alias(libs.plugins.ktfmt)
     alias(libs.plugins.detekt)
+    alias(libs.plugins.kover)
 }
 
 group = "com.example"
@@ -66,5 +67,82 @@ tasks.withType<dev.detekt.gradle.Detekt>().configureEach {
         checkstyle.required.set(true)
         sarif.required.set(true)
         markdown.required.set(true)
+    }
+}
+
+kover {
+    // 検証ゲート専用に total と同一内容の variant を複製する。
+    // Kover 0.9 の検証ルールはパッケージ単位のフィルタを持てないため、
+    // 「全体を見せるレポート（total）」と「成熟パッケージだけを検証する variant（mature）」を分ける。
+    currentProject { copyVariant("mature", "jvm") }
+
+    reports {
+        // 全レポート共通の除外。カバレッジ対象として意味を持たないものだけを外す。
+        filters {
+            excludes {
+                // エントリーポイント（main / Spring ブートストラップ）はカバレッジ対象外
+                classes("com.example.api.ApiApplication*")
+            }
+        }
+
+        // total: コードの全体像を見せるレポート（穴の可視化が目的なので絞り込まない）。
+        total {
+            xml {
+                // CI で集計するため XML を常に生成する
+                onCheck = false
+            }
+            html {
+                title = "toy-box カバレッジ"
+                onCheck = false
+            }
+            // koverLog: CI の Job Summary に流すための 1 行集計（外部 Action 不要）
+            log {
+                groupBy = kotlinx.kover.gradle.plugin.dsl.GroupingEntityType.APPLICATION
+                coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
+                aggregationForGroup =
+                    kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
+                format = "全体（探索領域含む）の行カバレッジ: <value>%"
+            }
+        }
+
+        // mature: 検証ゲートを「成熟パッケージのみ」に絞る。
+        // 探索段階のモデル（tennis / sakamichi / breeding / race / racehorse / stallion 等）は
+        // total レポートには出すが、ゲートからは外してノイズで CI を赤くしない。
+        variant("mature") {
+            // 共通の除外に加え、成熟＝レイヤーごとのテストが揃っている領域だけを includes で残す
+            filtersAppend {
+                includes {
+                    packages(
+                        "com.example.api.domain.shared",
+                        "com.example.api.domain.horseracing.model.jockey",
+                        "com.example.api.domain.horseracing.model.horse.bloodhorse",
+                        "com.example.api.domain.horseracing.service.horse",
+                        "com.example.api.application.horseracing",
+                        "com.example.api.controller",
+                    )
+                }
+            }
+            log {
+                groupBy = kotlinx.kover.gradle.plugin.dsl.GroupingEntityType.APPLICATION
+                coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
+                aggregationForGroup =
+                    kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
+                format = "成熟ゲート対象の行カバレッジ: <value>%"
+            }
+            verify {
+                // check 実行時に検証も走らせる
+                onCheck = true
+                rule("成熟パッケージの行カバレッジ（リグレッション防止のラチェット）") {
+                    bound {
+                        // 現状実測 88.3%（302/342 行）を 85% に固定し、以後の低下を検出するラチェット。
+                        // 成熟領域に新コードを足すならテストも添えること、という圧をかける。
+                        minValue = 85
+                        coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
+                        aggregationForGroup =
+                            kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
+                    }
+                }
+            }
+        }
     }
 }

--- a/docs/adr/0006-kover-over-jacoco.md
+++ b/docs/adr/0006-kover-over-jacoco.md
@@ -1,0 +1,43 @@
+# 0006. カバレッジ計測に Kover を採用し、成熟領域のみゲートする
+
+- Status: Accepted
+- Date: 2026-06-16
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+テスト戦略を明文化するにあたり、カバレッジを機械的に計測し回帰を検出するハーネスを用意したくなった。検討した論点は 2 つ。
+
+### ツール選定: Kover か JaCoCo か
+
+JVM のカバレッジでは JaCoCo が定番だが、本プロジェクトは型安全な ID のために `@JvmInline value class`（`JockeyId` / `BloodHorseId` 等）を多用している（CLAUDE.md「Value Object パターン」参照）。
+
+- **JaCoCo は Kotlin の合成バイトコード（inline class のボクシング/アンボクシング、`Companion`、data class 生成メンバ等）をそのまま数える**ため、inline class を多用するコードでは「書いていない行」が未到達としてカウントされ、数値が実態とずれる。除外設定で抑えることはできるが、value class が増えるたびに調整が要る。
+- [Kover](https://github.com/Kotlin/kotlinx-kover) は JetBrains 製で Kotlin コンパイラの事情を理解しており、こうした合成要素を既定で適切に扱う。Gradle プラグインで version catalog 管理でき、HTML / XML レポートと検証ルールを標準で持つ。
+
+inline class が設計の中核にある以上、Kotlin ネイティブの Kover が素直と判断した。
+
+### ゲートの単位: 全体一律か領域ごとか
+
+このリポジトリは sandbox であり、成熟度に温度差がある。`horseracing` の血統・騎手まわりはレイヤーごとにテストが揃っている一方、`tennis` / `sakamichi` や `breeding` / `race` 等は TODO を含む探索段階のモデルで、テストがほぼ無い。
+
+全体に一律の閾値を課すと、探索コードを書くたびにゲートが赤くなり、カバレッジ計測がノイズ源になる。かといってゲートを置かないと、成熟領域の回帰を見逃す。
+
+## Decision（決定）
+
+- カバレッジ計測ツールに **Kover** を採用する（JaCoCo は使わない）。
+- レポートを 2 つの variant に分ける:
+  - **`total`**: エントリーポイントのみ除外した全体。穴の可視化が目的で、絞り込まない。
+  - **`mature`**: `copyVariant` で `total` を複製し、includes フィルタで**成熟パッケージだけ**に絞った検証ゲート。
+- ゲートは**成熟パッケージのみ**に行カバレッジ下限を課す。探索段階のモデルは `total` には出すがゲート対象から外す。
+- 下限は**ラチェット運用**とする。現状実測（行 88.3%）を少し下げた **85%** でロックし、上がったら下限も引き上げて後戻りを防ぐ。下げるのは設計判断を伴うときのみ。
+- ゲート（`koverVerifyMature`）を `check` に組み込み、CI（`api-tests.yml`）でも検証する。PR の Job Summary には `koverLog` の数値を出す（外部サービスは使わない）。
+
+設定の実体は `build.gradle.kts` の `kover {}` ブロック、運用ルールは [.claude/rules/testing.md](../../.claude/rules/testing.md) に置く。
+
+## Consequences（結果・影響）
+
+- inline class を増やしてもカバレッジ数値が実態とずれにくく、除外設定のメンテが不要になった。
+- 探索コードを書いてもゲートが赤くならず、成熟領域の回帰だけを捕まえられる。可視化（`total`）と強制（`mature`）を分離した分、`build.gradle.kts` の設定はやや込み入る（Kover 0.9 の検証ルールがパッケージ単位フィルタを持たないため `copyVariant` で迂回している）。
+- ゲート対象は `variant("mature")` の includes が唯一の出所。**領域が成熟したら includes に追加して昇格させる**運用が必要。追加を忘れると、テストを書いてもゲートに反映されない点に注意。
+- 探索領域に残るカバレッジの穴（`infrastructure` の契約テスト、`ConfirmRaceResult` / `RegisterForBreeding` 等）は当面の宿題として testing.md に記載した。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,3 +15,4 @@
 | [0003](0003-consolidate-mcp-config-in-repo.md) | MCP サーバー設定をリポジトリ管理ファイルに集約する | Accepted |
 | [0004](0004-secrets-fnox-1password.md) | シークレット管理を fnox + 1Password（参照のみ）で行う | Accepted |
 | [0005](0005-time-based-uuid-generation.md) | エンティティ識別子をタイムベース UUID（UUIDv7 相当）に統一する | Accepted |
+| [0006](0006-kover-over-jacoco.md) | カバレッジ計測に Kover を採用し、成熟領域のみゲートする | Accepted |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ spring-dependency-management = "1.1.7"
 springdoc-openapi-gradle = "1.9.0"
 ktfmt = "0.26.0"
 detekt = "2.0.0-alpha.3"
+kover = "0.9.8"
 
 # ライブラリのバージョン
 springdoc-openapi-bom = "3.0.3"
@@ -59,3 +60,6 @@ ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 
 # detekt プラグイン
 detekt = { id = "dev.detekt", version.ref = "detekt" }
+
+# Kover プラグイン（Kotlin ネイティブのカバレッジ計測。inline value class を正しく数えられる）
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }


### PR DESCRIPTION
## 概要

テスト戦略を明文化し、Kover によるカバレッジ計測ハーネスを導入する。既存テストはオニオン4リングにテストピラミッドが綺麗に写像できていたため、それを戦略として言語化したうえで、計測・ゲート・CI 集計を整備した。**穴埋めテストの追加は本 PR の対象外**（穴の可視化と回帰防止のハーネスまで）。

## やったこと

### カバレッジハーネス（Kover）
- **JaCoCo ではなく Kover** を採用。`@JvmInline value class` を多用するため、合成バイトコードを誤カウントしない Kotlin ネイティブの Kover が適切（→ ADR-0006）
- **2 variant 構成**
  - `total`: エントリーポイントのみ除外した全体。穴の可視化が目的（HTML/XML/log）
  - `mature`: `copyVariant` で `total` を複製し、成熟パッケージのみ includes した検証ゲート
- **ラチェットゲート**: 成熟領域の行カバレッジ実測 88.3% を **85%** でロック。`koverVerifyMature` を `check` に組み込み

### CI（`api-tests.yml`）
- test 後に `koverVerifyMature` でゲートを掛ける
- `koverLog` / `koverLogMature` の数値を PR の Job Summary に出力（外部サービス不使用）

```
- 全体（探索領域含む）の行カバレッジ: 76.69%
- 成熟ゲート対象の行カバレッジ: 88.30%
```

### 文書
- `.claude/rules/testing.md`: リング別テスト手法・Kover 運用・当面の宿題（カバレッジの穴）を明文化
- `docs/adr/0006-kover-over-jacoco.md`: Kover 採用と成熟領域のみゲートする方針の経緯
- `CLAUDE.md`: テスト規約から testing.md へ参照を追加

## テストの確認

- `./gradlew check`（ktfmt + detekt + test + `koverVerifyMature` ゲート）green
- pre-push の全テスト green
- actionlint / zizmor / editorconfig green

## レビュー観点

- ゲート対象パッケージ（`build.gradle.kts` の `variant("mature")` の includes）の線引きが妥当か
- 閾値 85% の置き方（実測 88.3% に対するマージン）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
