### PR TITLE
refactor: blank-check 系 VO の create() 重複を共有述語にまとめる

### DIFF
--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingRegistrationNumber.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingRegistrationNumber.kt
@@ -1,7 +1,6 @@
 package com.example.api.domain.horseracing.model.breeding
 
-import com.github.michaelbull.result.Err
-import com.github.michaelbull.result.Ok
+import com.example.api.domain.shared.createNonBlank
 import com.github.michaelbull.result.Result
 import org.jmolecules.ddd.annotation.ValueObject
 
@@ -24,10 +23,6 @@ value class BreedingRegistrationNumber private constructor(val value: String) {
         fun create(
             value: String
         ): Result<BreedingRegistrationNumber, BlankBreedingRegistrationNumber> =
-            if (value.isBlank()) {
-                Err(BlankBreedingRegistrationNumber)
-            } else {
-                Ok(BreedingRegistrationNumber(value.trim()))
-            }
+            createNonBlank(value, BlankBreedingRegistrationNumber, ::BreedingRegistrationNumber)
     }
 }

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/Breeder.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/Breeder.kt
@@ -1,7 +1,6 @@
 package com.example.api.domain.horseracing.model.horse.bloodhorse
 
-import com.github.michaelbull.result.Err
-import com.github.michaelbull.result.Ok
+import com.example.api.domain.shared.createNonBlank
 import com.github.michaelbull.result.Result
 import org.jmolecules.ddd.annotation.ValueObject
 
@@ -22,10 +21,6 @@ value class Breeder private constructor(val name: String) {
     companion object {
         /** ブランクでないことを検証して [Breeder] を生成する。 */
         fun create(name: String): Result<Breeder, BlankBreeder> =
-            if (name.isBlank()) {
-                Err(BlankBreeder)
-            } else {
-                Ok(Breeder(name.trim()))
-            }
+            createNonBlank(name, BlankBreeder, ::Breeder)
     }
 }

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/PedigreeRegistrationNumber.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/PedigreeRegistrationNumber.kt
@@ -1,7 +1,6 @@
 package com.example.api.domain.horseracing.model.horse.bloodhorse
 
-import com.github.michaelbull.result.Err
-import com.github.michaelbull.result.Ok
+import com.example.api.domain.shared.createNonBlank
 import com.github.michaelbull.result.Result
 import org.jmolecules.ddd.annotation.ValueObject
 
@@ -23,10 +22,6 @@ value class PedigreeRegistrationNumber private constructor(val value: String) {
         fun create(
             value: String
         ): Result<PedigreeRegistrationNumber, BlankPedigreeRegistrationNumber> =
-            if (value.isBlank()) {
-                Err(BlankPedigreeRegistrationNumber)
-            } else {
-                Ok(PedigreeRegistrationNumber(value.trim()))
-            }
+            createNonBlank(value, BlankPedigreeRegistrationNumber, ::PedigreeRegistrationNumber)
     }
 }

--- a/src/main/kotlin/com/example/api/domain/shared/StringValueObjects.kt
+++ b/src/main/kotlin/com/example/api/domain/shared/StringValueObjects.kt
@@ -1,0 +1,23 @@
+package com.example.api.domain.shared
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+
+/**
+ * 単一文字列を値とする値オブジェクトの「ブランクでないこと」検証を共有するコンビネータ。
+ *
+ * [raw] がブランク（空文字・空白のみ）なら値オブジェクトを構築せず [blank] を [Err] で返し、ブランクでなければ trim した値を [create] に渡して構築し [Ok]
+ * で返す。複数の文字列 VO が同じ blank 検証と trim 正規化を個別実装すると正規化方針がドリフトしうるため、ここに一元化する。
+ *
+ * 各 VO は自身の `companion object.create()` からこのコンビネータを呼び、固有のエラー型 [E] と private constructor を [create]
+ * に渡す（「VO ごとに create() で Result を返す」方針は維持する）。
+ *
+ * @param T 構築する値オブジェクトの型
+ * @param E ブランク時に返すエラー型
+ * @param raw 検証対象の生文字列
+ * @param blank ブランクだった場合に返すエラー値
+ * @param create trim 済み文字列から値オブジェクトを構築するファクトリ（private constructor 参照など）
+ */
+inline fun <T, E> createNonBlank(raw: String, blank: E, create: (String) -> T): Result<T, E> =
+    if (raw.isBlank()) Err(blank) else Ok(create(raw.trim()))

--- a/src/test/kotlin/com/example/api/domain/shared/StringValueObjectsTest.kt
+++ b/src/test/kotlin/com/example/api/domain/shared/StringValueObjectsTest.kt
@@ -1,0 +1,35 @@
+package com.example.api.domain.shared
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import org.junit.jupiter.api.Test
+
+/** createNonBlank コンビネータのユニットテスト */
+class StringValueObjectsTest {
+    /** ブランク時に返すエラー型 */
+    private data object Blank
+
+    @Test
+    fun `ブランクでなければtrim済みの値でファクトリが呼ばれOkを返すこと`() {
+        val result = createNonBlank("  abc  ", Blank) { it }
+        assert(result.unwrap() == "abc")
+    }
+
+    @Test
+    fun `空文字ならファクトリを呼ばずErrを返すこと`() {
+        var called = false
+        val result =
+            createNonBlank("", Blank) {
+                called = true
+                it
+            }
+        assert(result.getError() == Blank)
+        assert(!called)
+    }
+
+    @Test
+    fun `空白のみでもブランクとして弾かれること`() {
+        val result = createNonBlank("   ", Blank) { it }
+        assert(result.getError() == Blank)
+    }
+}


### PR DESCRIPTION
## 概要

Closes #270

単一文字列 VO の「ブランクでないこと」検証 + trim 正規化が、`Breeder` / `PedigreeRegistrationNumber` / `BreedingRegistrationNumber` の 3 箇所で同型に重複していた（/code-review の指摘 #6）。`domain.shared` に共有コンビネータ `createNonBlank` を切り出し、各 `create()` から呼ぶ形に統一した。正規化方針（trim）が VO ごとにドリフトするのを防ぐ。

## 変更内容

- **`domain/shared/StringValueObjects.kt`（新規）**: `createNonBlank(raw, blank, create)` コンビネータ。ブランク（空文字・空白のみ）なら VO を構築せず指定エラーを `Err`、非ブランクなら trim 済み値で `create`（private constructor 参照）を呼び `Ok` を返す。`inline` 関数のため private constructor は companion スコープから参照可能。
- **`Breeder.kt` / `PedigreeRegistrationNumber.kt` / `BreedingRegistrationNumber.kt`**: 手書きの `isBlank()`/`trim()` 分岐を `createNonBlank` 呼び出しに置換（各 1 行に短縮）。
- **`StringValueObjectsTest.kt`（新規）**: コンビネータのユニットテスト（trim・ブランク判定・ブランク時はファクトリ未呼出し）。

「VO ごとに `create()` で `Result` を返す」方針（`error-handling.md`）は維持している。

## 確認

- `./gradlew ktfmtFormat detekt test` 緑
- `./gradlew koverVerifyMature` 緑（成熟ゲート行カバレッジ 88.79%）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
