### PR TITLE
docs: PR のマージ方式を merge commit に統一するルールを明文化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,7 @@ com.example.api/
 - **コメントとドキュメント**: 日本語で記述
 - **変数名、関数名、クラス名**: 英語で記述（意味を明確に）
 - **コミットメッセージ**: 日本語で記述、Conventional Commits 形式に準拠。最初に Conventional Commits ヘッダー（例: `feat: 新機能を追加`）を記述し、その後ファイルごとの詳細な変更内容を記述
+- **PR のマージ方式**: 必ず **merge commit**（`gh pr merge --merge`）を使う。squash / rebase は使わない（個々のコミット履歴を main に残す方針）。CLI でマージする場合はセルフ PR の BLOCKED 表示回避のため `--admin` を付ける
 
 ### 命名規則
 


### PR DESCRIPTION
## 概要

PR マージは squash ではなく **merge commit** を使う方針をチームルールとして確定したため、CLAUDE.md に明文化する。

## 変更内容

- **CLAUDE.md**（コーディング規約 > 言語とスタイル）: 「PR のマージ方式」を追記。`gh pr merge --merge` を使い squash / rebase は使わない（個々のコミット履歴を main に残す）。CLI マージ時はセルフ PR の BLOCKED 表示回避のため `--admin` を付ける旨も併記。

## 備考

GitHub リポジトリ側のマージボタン設定（squash / rebase を無効化し merge commit のみ許可）での強制は、別途オーナー操作で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
