### PR TITLE
refactor: エラー funnel の規約判定を型ベースに堅牢化する (#269)

### DIFF
--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -49,7 +49,7 @@ fun register(@RequestBody request: RegisterJockeyRequest): RegisterJockeyRespons
 
 > **Controller 境界に限った例外条項**: 「業務エラー＝`Result` / 例外＝インフラ」の原則は維持する。ただし**描画のためだけ**に、Controller 境界で業務エラーを `ErrorResponseException` へ再送出することを許す。ドメイン / アプリケーション層は一切例外を投げず、例外化は `orThrowProblem()` の一手に限定する（中央 funnel で problem 形を一元統制するための割り切り）。
 
-problem 形の統一は `GlobalExceptionHandler.handleExceptionInternal` が担い、`errorCode` 未設定の `ProblemDetail`（フレームワーク標準例外由来）に `type` / `errorCode` 規約を一律付与する。業務エラーは `toProblemDetail()` で既に規約済みのため二重付与しない。
+problem 形の統一は `GlobalExceptionHandler.handleExceptionInternal` が担い、規約未適用の `ProblemDetail`（フレームワーク標準例外由来）に `type` / `errorCode` 規約を一律付与する。規約済みかは `errorCode` プロパティ名の有無ではなく **`ConventionalProblemDetail` 型かどうか**で判定する（業務エラーは `problem()` ビルダ経由でこの型になり規約済み、二重付与しない）。プロパティ名一致を単一の弱点にしないための型ベース判定。
 
 ## 段階的導入
 

--- a/src/main/kotlin/com/example/api/controller/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/example/api/controller/GlobalExceptionHandler.kt
@@ -23,7 +23,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
  * - 上記以外の想定外例外（インフラ障害・プログラミングエラー）は 500 + problem+json で返す。
  *
  * problem 形の一元化のため、[handleExceptionInternal] で `type` / `errorCode` 規約を未設定の ProblemDetail に
- * 一律で付与する（業務エラーは既に規約済みのため二重付与しない）。
+ * 一律で付与する（業務エラーは [ConventionalProblemDetail] 型で規約済みのため二重付与しない）。
  */
 @RestControllerAdvice
 class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
@@ -46,7 +46,7 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
     /**
      * 基底クラスが組み立てた標準例外の応答に、本プロジェクトの RFC 9457 規約（`type` / `errorCode`）を付与する。
      *
-     * `errorCode` を既に持つ ProblemDetail（業務エラー由来）は規約済みとみなして触らない。
+     * [ConventionalProblemDetail] 型の ProblemDetail（業務エラー由来）は規約済みとみなして触らない。
      */
     override fun handleExceptionInternal(
         ex: Exception,
@@ -61,7 +61,8 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
     }
 
     private fun applyConvention(problem: ProblemDetail) {
-        if (problem.properties?.containsKey("errorCode") == true) {
+        // 規約済みかは errorCode プロパティ名ではなく型で判定する（プロパティ名一致を単一の弱点にしない）
+        if (problem is ConventionalProblemDetail) {
             return
         }
         // 標準ステータスは enum 名から、非標準コードは数値からコードを導く（funnel 内で valueOf 例外を出さない）

--- a/src/main/kotlin/com/example/api/controller/ProblemResponses.kt
+++ b/src/main/kotlin/com/example/api/controller/ProblemResponses.kt
@@ -28,7 +28,20 @@ fun <T> Result<T, ProblemDetail>.orThrowProblem(): T = getOrElse { problem ->
 }
 
 /**
- * RFC 9457 規約に従って [ProblemDetail] を組み立てる唯一のビルダ。
+ * RFC 9457 規約（`type` / `errorCode`）が適用済みであることを **型で** 表明する [ProblemDetail]。
+ *
+ * [problem] ビルダだけがこの型を生成し、funnel（[GlobalExceptionHandler.handleExceptionInternal]）は
+ * 「この型かどうか」で規約付与済みかを判定する。 `errorCode` プロパティ名の有無に依存しないため、
+ * 業務エラーが偶然コードを付け忘れても（規約付与が補完として走る）、フレームワーク応答が偶然 `errorCode` を持っていても （型が異なるので規約付与される）、判定が崩れない。
+ *
+ * `ProblemDetail.forStatus()` は `ProblemDetail(rawStatusCode)` を呼ぶだけの薄いファクトリのため、
+ * 親コンストラクタを直接呼んでも生成結果は同じ（`type` の `about:blank` デフォルトはフィールド初期化子由来）。 Jackson のシリアライズも親
+ * [ProblemDetail] 向けの mixin が型階層を辿って適用されるため、出力 JSON の形は変わらない。
+ */
+internal class ConventionalProblemDetail(status: HttpStatus) : ProblemDetail(status.value())
+
+/**
+ * RFC 9457 規約に従って [ConventionalProblemDetail] を組み立てる唯一のビルダ。
  *
  * `type` は暫定の `urn:problem-type:{code}` 形式、拡張プロパティ `errorCode` にアプリ固有のエラーコードを持たせる。 各 Controller の
  * `toProblemDetail()` 群と [GlobalExceptionHandler] の 500 応答が共有し、problem の形を変えるときは ここだけを直せばよい（例:
@@ -45,7 +58,7 @@ internal fun problem(
     title: String,
     detail: String,
 ): ProblemDetail =
-    ProblemDetail.forStatus(status).apply {
+    ConventionalProblemDetail(status).apply {
         type = URI.create("urn:problem-type:$code")
         this.title = title
         this.detail = detail

--- a/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
@@ -1,9 +1,13 @@
 package com.example.api.controller
 
+import com.example.api.application.horseracing.jockey.JockeyRegistrationError
 import com.example.api.application.horseracing.jockey.JockeyRegistrationUseCase
 import com.example.api.application.horseracing.jockey.RegisterJockeyCommand
 import com.example.api.controller.jockey.JockeyController
+import com.example.api.domain.horseracing.model.jockey.JockeyId
 import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.generateId
+import com.github.michaelbull.result.Err
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.junit.jupiter.api.Test
@@ -42,6 +46,26 @@ class GlobalExceptionHandlerTest(val mockMvc: MockMvc) {
             .bodyJson()
             .extractingPath("$.errorCode")
             .isEqualTo("bad-request")
+    }
+
+    @Test
+    fun `業務エラー由来の problem が funnel を通っても自前の errorCode を保持し status 由来コードで上書きされないこと`() {
+        // DuplicateJockey は problem() ＝ ConventionalProblemDetail で errorCode=duplicate-jockey を持つ。
+        // funnel は型で規約済みと判定して触らないため、status(409) 由来の "conflict" に上書きされない。
+        every { registerJockey(any<Command<RegisterJockeyCommand>>()) } returns
+            Err(JockeyRegistrationError.DuplicateJockey(JockeyId(generateId())))
+
+        tester
+            .post()
+            .uri("/api/jockeys")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""{"firstName":"武","lastName":"豊"}""")
+            .assertThat()
+            .hasStatus(HttpStatus.CONFLICT)
+            .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+            .bodyJson()
+            .extractingPath("$.errorCode")
+            .isEqualTo("duplicate-jockey")
     }
 
     @Test


### PR DESCRIPTION
## 概要

closes #269

エラー描画 funnel（`GlobalExceptionHandler.applyConvention`）が「規約済みか」を `errorCode` プロパティ名の有無で判定していたのを、**`ConventionalProblemDetail` 型かどうか**で判定するよう堅牢化する（/code-review high 指摘 #5・PR #263 起点）。

## 背景の弱点

プロパティ名一致での識別は単一の弱点だった:
- 業務エラーが `errorCode` を付け忘れると、status 由来コードで静かに上書きされる
- 逆に偶然 `errorCode` を持つフレームワーク応答は規約付与をスキップしてしまう

## やったこと

- **`ProblemResponses.kt`**: `problem()` ビルダだけが生成する `internal class ConventionalProblemDetail` を追加し、「規約適用済み」を型で表明。`ProblemDetail.forStatus()` と等価な生成のため出力 JSON の形は不変。
- **`GlobalExceptionHandler.kt`**: 判定を `problem is ConventionalProblemDetail` に変更。業務エラーがコードを付け忘れても規約付与が補完として走り、フレームワーク応答が偶然 `errorCode` を持っても型が違えば規約付与される。
- **`GlobalExceptionHandlerTest.kt`**: 業務エラー由来 problem（`DuplicateJockey` → 409 / `duplicate-jockey`）が funnel を通っても自前の `errorCode` を保持し、status 由来コードで上書きされない回帰テストを追加。
- **`error-handling.md`**: 判定方式の説明を型ベースに追従。

## 確認

`./gradlew check` 通過（ktfmt / detekt / test / koverVerifyMature）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
