### PR TITLE
refactor: Command の発生時刻を注入 Clock 経由に一元化する (#272)

### DIFF
--- a/src/main/kotlin/com/example/api/config/ClockConfiguration.kt
+++ b/src/main/kotlin/com/example/api/config/ClockConfiguration.kt
@@ -1,0 +1,17 @@
+package com.example.api.config
+
+import java.time.Clock
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * 時刻源（[Clock]）の DI 定義。
+ *
+ * アダプター（Controller 等）が発生時刻を採取する際の時刻源を Bean として一元供給する。 本番は UTC のシステムクロックを使い、テストでは固定 [Clock] を差し替えて
+ * 時刻を決定的にできるようにするための注入点。
+ */
+@Configuration
+class ClockConfiguration {
+    /** 本番用の時刻源。タイムゾーン非依存のドメインイベント時刻に合わせて UTC を用いる。 */
+    @Bean fun clock(): Clock = Clock.systemUTC()
+}

--- a/src/main/kotlin/com/example/api/controller/horse/BloodHorseController.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/BloodHorseController.kt
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import java.time.Instant
+import java.time.Clock
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ProblemDetail
@@ -24,7 +24,10 @@ import org.springframework.web.bind.annotation.RestController
  * (Problem Details) 形式で返す。
  */
 @RestController
-class BloodHorseController(private val registerInStudBook: RegisterInStudBookUseCase) {
+class BloodHorseController(
+    private val registerInStudBook: RegisterInStudBookUseCase,
+    private val clock: Clock,
+) {
     @Operation(
         summary = "軽種馬を血統登録する",
         description = "父母を指定して血統登録を行い、誕生した軽種馬を返す。業務ルール違反時は RFC 9457 形式の problem+json を返す。",
@@ -69,7 +72,7 @@ class BloodHorseController(private val registerInStudBook: RegisterInStudBookUse
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/blood_horses")
     fun register(@RequestBody request: RegisterBloodHorseRequest): RegisterBloodHorseResponse =
-        registerInStudBook(Command(request.toCommand(), Instant.now()))
+        registerInStudBook(Command.now(request.toCommand(), clock))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()
             .toRegisterResponse()

--- a/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import java.time.Instant
+import java.time.Clock
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ProblemDetail
@@ -25,7 +25,10 @@ import org.springframework.web.bind.annotation.RestController
  * Details) 形式で返す。
  */
 @RestController
-class JockeyController(private val registerJockey: JockeyRegistrationUseCase) {
+class JockeyController(
+    private val registerJockey: JockeyRegistrationUseCase,
+    private val clock: Clock,
+) {
     @Operation(
         summary = "ジョッキーを登録する",
         description = "ジョッキーを新規登録する。業務ルール違反時は RFC 9457 形式の problem+json を返す。",
@@ -70,8 +73,7 @@ class JockeyController(private val registerJockey: JockeyRegistrationUseCase) {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/jockeys")
     fun register(@RequestBody request: RegisterJockeyRequest): RegisterJockeyResponse {
-        val command =
-            Command(RegisterJockeyCommand(request.firstName, request.lastName), Instant.now())
+        val command = Command.now(RegisterJockeyCommand(request.firstName, request.lastName), clock)
         val jockey = registerJockey(command).mapError { it.toProblemDetail() }.orThrowProblem()
         return RegisterJockeyResponse(
             id = jockey.id.value,

--- a/src/main/kotlin/com/example/api/domain/shared/Command.kt
+++ b/src/main/kotlin/com/example/api/domain/shared/Command.kt
@@ -1,5 +1,6 @@
 package com.example.api.domain.shared
 
+import java.time.Clock
 import java.time.Instant
 
 /**
@@ -12,4 +13,14 @@ import java.time.Instant
  * @property payload 実行したいドメインコマンド
  * @property issuedAt コマンドが発生した時刻。タイムゾーンに依存しないドメインイベント時刻として [Instant] で保持する
  */
-class Command<T>(val payload: T, val issuedAt: Instant)
+class Command<T>(val payload: T, val issuedAt: Instant) {
+    companion object {
+        /**
+         * 時刻源 [clock] から発生時刻を採取して [payload] を封筒に詰める。
+         *
+         * `Instant.now()` の直書きを各アダプターに散らさず、注入された [Clock] 経由に一元化するためのファクトリ。 テストでは固定 [Clock] を渡すことで
+         * [issuedAt] を決定的にできる。
+         */
+        fun <T> now(payload: T, clock: Clock): Command<T> = Command(payload, Instant.now(clock))
+    }
+}

--- a/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
@@ -2,12 +2,14 @@ package com.example.api.controller
 
 import com.example.api.application.horseracing.jockey.JockeyRegistrationUseCase
 import com.example.api.application.horseracing.jockey.RegisterJockeyCommand
+import com.example.api.config.ClockConfiguration
 import com.example.api.controller.jockey.JockeyController
 import com.example.api.domain.shared.Command
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.junit.jupiter.api.Test
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.context.TestConstructor
@@ -21,6 +23,7 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester
  * 業務ルール違反ではない例外（リクエストボディ不正・想定外例外）が RFC 9457 形式で返ることを、 [JockeyController] を踏み台にして確認する。
  */
 @WebMvcTest(JockeyController::class)
+@Import(ClockConfiguration::class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class GlobalExceptionHandlerTest(val mockMvc: MockMvc) {
     @MockkBean private lateinit var registerJockey: JockeyRegistrationUseCase

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -3,6 +3,7 @@ package com.example.api.controller.horse
 import com.example.api.application.horseracing.horse.RegisterInStudBookCommand
 import com.example.api.application.horseracing.horse.RegisterInStudBookUseCase
 import com.example.api.application.horseracing.horse.RegisterInStudBookUseCaseError
+import com.example.api.config.ClockConfiguration
 import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseFixture
 import com.example.api.domain.horseracing.model.horse.bloodhorse.Sex
 import com.example.api.domain.horseracing.service.horse.RegisterInStudBookError
@@ -15,6 +16,7 @@ import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.context.TestConstructor
@@ -23,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 
 @WebMvcTest(BloodHorseController::class)
+@Import(ClockConfiguration::class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class BloodHorseControllerTest(val mockMvc: MockMvc) {
     @MockkBean private lateinit var registerInStudBook: RegisterInStudBookUseCase

--- a/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
@@ -3,6 +3,7 @@ package com.example.api.controller.jockey
 import com.example.api.application.horseracing.jockey.JockeyRegistrationError
 import com.example.api.application.horseracing.jockey.JockeyRegistrationUseCase
 import com.example.api.application.horseracing.jockey.RegisterJockeyCommand
+import com.example.api.config.ClockConfiguration
 import com.example.api.domain.horseracing.model.jockey.Jockey
 import com.example.api.domain.horseracing.model.jockey.JockeyValidationError
 import com.example.api.domain.shared.Command
@@ -14,6 +15,7 @@ import io.mockk.every
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.context.TestConstructor
@@ -22,6 +24,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 
 @WebMvcTest(JockeyController::class)
+@Import(ClockConfiguration::class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class JockeyControllerTest(val mockMvc: MockMvc) {
     @MockkBean private lateinit var registerJockey: JockeyRegistrationUseCase


### PR DESCRIPTION
## 概要

Closes #272

Controller が `Command(payload, Instant.now())` を直書きしており、時刻源が各アダプターに散在してテストで固定できなかった（/code-review の指摘 #8）。時刻源を `Clock` Bean として注入可能にし、`Command.now()` ファクトリに採取ロジックを集約する。

## 変更内容

- **`domain/shared/Command.kt`**: `Command.now(payload, clock)` ファクトリを追加し、`Instant.now(clock)` の呼び出しを集約。`java.time.Clock` は純粋 JDK のため domain 層に置ける（ArchUnit のフレームワーク非依存ルールに抵触しない）
- **`config/ClockConfiguration.kt`**（新規）: `Clock` Bean（`systemUTC`）を供給する `@Configuration`。本番は UTC のシステムクロック、テストでは固定 `Clock` を差し替え可能
- **`controller/horse/BloodHorseController.kt` / `controller/jockey/JockeyController.kt`**: `Clock` を注入し `Command.now()` を使用、`Instant.now()` 直書きを除去
- **test**: 3 つの `@WebMvcTest` slice（`BloodHorseControllerTest` / `JockeyControllerTest` / `GlobalExceptionHandlerTest`）に `@Import(ClockConfiguration::class)` を追加し、Controller が要求する `Clock` Bean を slice コンテキストに供給

## 設計判断

- `Clock` 注入 + `Command.now()` ファクトリの併用とした。Controller は adapter のため Spring DI 可（規約上問題なし）。`Instant.now(clock)` の呼び出しは `Command.now()` に一元化し、直書きを根絶
- `Clock` Bean は専用の `ClockConfiguration` に切り出した。`@WebMvcTest` slice から `@Import` 単独で取り込めるようにするため（`ApiApplication` の `@Bean` だと slice で拾えない）
- `config` パッケージは新設だが、ArchUnit の `onionArchitecture()` は containment を強制していないため抵触しない

## 確認

- `./gradlew check` green（test / detekt / ktfmt / koverVerifyMature）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
