### PR TITLE
chore: UUID.randomUUID() の直接呼び出しを ArchUnit で禁止する (#292)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -91,6 +91,7 @@ domain/
 
 - 標準出力・標準エラーへの直接書き込み禁止（ロガーを使う）
 - フィールドインジェクション禁止（コンストラクタインジェクションを使う）
+- `UUID.randomUUID()` の直接呼び出し禁止。ID は `domain.shared.generateId()`（UUIDv7 相当のタイムベース生成）経由で生成する（永続化時のインデックス局所性のため。[ADR-0005](../../docs/adr/0005-time-based-uuid-generation.md)）。main コードのみ対象（テストの fixture は対象外）
 
 ## ルールの変更・追加
 

--- a/src/test/kotlin/com/example/api/architecture/ArchitectureTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/ArchitectureTest.kt
@@ -14,6 +14,7 @@ import com.tngtech.archunit.library.GeneralCodingRules
 import com.tngtech.archunit.library.dependencies.SliceAssignment
 import com.tngtech.archunit.library.dependencies.SliceIdentifier
 import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices
+import java.util.UUID
 import org.jmolecules.archunit.JMoleculesDddRules
 import org.jmolecules.ddd.annotation.AggregateRoot
 import org.jmolecules.ddd.annotation.Entity as DddEntity
@@ -164,4 +165,19 @@ class ArchitectureTest {
 
     /** フィールドインジェクションを使わずコンストラクタインジェクションを使うこと。 */
     @ArchTest val noFieldInjection = GeneralCodingRules.NO_CLASSES_SHOULD_USE_FIELD_INJECTION
+
+    /**
+     * ID は `UUID.randomUUID()` を直接呼ばず `domain.shared.generateId()`（UUIDv7 相当のタイムベース生成）経由で生成すること。
+     *
+     * 生成値が時刻順にソート可能で永続化時のインデックス局所性に優れるため、全 ID をタイムベース生成に統一する（ADR-0005）。
+     */
+    @ArchTest
+    val idsAreGeneratedViaGenerateId =
+        noClasses()
+            .should()
+            .callMethod(UUID::class.java, "randomUUID")
+            .because(
+                "ID は domain.shared.generateId()（UUIDv7 相当のタイムベース生成）経由で生成する。" +
+                    "永続化時のインデックス局所性のため UUID.randomUUID() の直接呼び出しは禁止（ADR-0005）"
+            )
 }


### PR DESCRIPTION
## 概要

文章のみだった規約「ID は `domain.shared.generateId()`（UUIDv7 相当のタイムベース生成）経由で生成する」を ArchUnit で機械強制する。親 #291 のサブ issue #292 に対応。

永続化時のインデックス局所性（時刻順ソート可能性）を全 ID で担保するための規約で、根拠は [ADR-0005](docs/adr/0005-time-based-uuid-generation.md)。

Closes #292

## 実装方針: Detekt ではなく ArchUnit

issue では Detekt `ForbiddenMethodCall` が第一候補だったが、**同ルールは type resolution が必須**。lefthook / CI が回す `detekt` タスクは type resolution を持たない（`detektMain` / `detektTest` のみ持つ）ため、設定を足しても**発火しない**。

そこで issue 記載の代替「ArchUnit」を採用した。既存のテストハーネス（`./gradlew test` / pre-push / CI）でそのまま走り、追加のタスク配線も不要。

## 変更点

- **`ArchitectureTest.kt`**: `noClasses().should().callMethod(UUID, "randomUUID")` ルールを追加。`.because(...)` に generateId 経由の旨と ADR-0005 参照を明記
  - `ArchitectureTest` は `ImportOption.DoNotIncludeTests` のため **main コードのみ対象**。テスト fixture の `UUID.randomUUID()` は intent（本番 ID の永続化局所性）どおり対象外
- **`.claude/rules/architecture.md`**: 「その他の強制ルール」に本ルールを追記

## 検証

- `./gradlew test --tests ArchitectureTest` 緑
- **vacuous でないことを確認**: 一時的に `generateId()` を `UUID.randomUUID()` に差し替えると `idsAreGeneratedViaGenerateId` が FAILED になることを確認後、復元
- `./gradlew ktfmtCheck detekt` 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)
