### PR TITLE
feat: 開発環境の devcontainer を整備する (#302)

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,51 @@
+# Dev Container
+
+再現可能な開発環境を [Dev Container](https://containers.dev/) で提供する。**IntelliJ IDEA を第一優先**のクライアントとし、VS Code / GitHub Codespaces からも利用できる（仕様自体はポータブル）。
+
+## 構成
+
+| ファイル | 役割 |
+|---------|------|
+| `devcontainer.json` | コンテナ定義。base image + features + エディタ設定 |
+| `post-create.sh` | 作成後の一度きりセットアップ（mise trust / install、lefthook install） |
+
+- **base image**: `mcr.microsoft.com/devcontainers/base:bookworm`（Debian 系。非 root の `vscode` ユーザー同梱）
+- **features**:
+  - `ghcr.io/devcontainers-extra/features/mise:1` — [mise](https://mise.jdx.dev/) 本体
+  - `ghcr.io/anthropics/devcontainer-features/claude-code:1.0` — Claude Code CLI（node 依存は feature が自動解決）
+
+### ツールバージョンの出所は `mise.toml` のみ
+
+devcontainer はバージョンを二重管理しない。mise feature は **mise 本体だけ**を入れ、ツール実体（java(temurin-21) / actionlint / editorconfig-checker / fnox / gitleaks / lefthook / terraform / zizmor）は `post-create.sh` の `mise install` が `mise.toml` に従って導入する。バージョンを変えたいときは `mise.toml` だけを編集する。
+
+### PATH への載り方
+
+- **対話シェル**: `post-create.sh` が `~/.bashrc` に `mise activate bash` を仕込む（`JAVA_HOME` 等も注入）。
+- **非対話プロセス（IntelliJ の Gradle 実行など）**: `devcontainer.json` の `remoteEnv` で mise の shims（`~/.local/share/mise/shims`）を `PATH` に追加する。
+- **Claude Code セッション**: 既存の `.claude/hooks/session-start-mise.sh`（SessionStart hook）が `mise hook-env` を流し込むため、`mise exec --` プレフィックス無しで `./gradlew` 等を実行できる。
+
+## 使い方
+
+### IntelliJ IDEA（主シナリオ）
+
+JetBrains Gateway もしくは IntelliJ 内蔵の Dev Containers サポートからリポジトリを開く。Gradle JVM はコンテナ内 JDK（mise が提供する temurin-21）を指すように設定する。`customizations.jetbrains.plugins` で ktfmt / detekt プラグインを宣言済み。
+
+### VS Code / Codespaces
+
+"Reopen in Container" で開く。`customizations.vscode.extensions` で Java / Kotlin / Gradle / EditorConfig / mise の拡張を最小限宣言している。
+
+### 動作確認
+
+```bash
+./gradlew check     # ktfmt + detekt + test + カバレッジゲート
+claude --version    # Claude Code CLI が入っていること
+mise list           # mise.toml のツールが解決されていること
+```
+
+## 既知の制約（スコープ外）
+
+本 devcontainer は「Java/Gradle 開発 + Claude Code」の土台を優先しており、以下は別途検討する（[issue #302](https://github.com/ptiringo/toy-box/issues/302) のスコープ外）。
+
+- **terraform MCP サーバーの Docker 依存**: `.mcp.json` の `terraform` サーバーは `docker run hashicorp/terraform-mcp-server` を前提とするため、コンテナ内から使うには Docker-in-Docker / Docker-outside-of-Docker が必要。`context7`（http）はコンテナ内でもそのまま使える。
+- **ネットワーク firewall サンドボックス**（`init-firewall.sh` 相当）は導入しない。
+- **シークレット（fnox + 1Password）**: `op` のデスクトップアプリ連携はコンテナから到達できない。現状 `fnox.toml` の `[secrets]` は空のため当面の支障はない。

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {
+      "version": "1.0.5",
+      "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
+      "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
+    },
+    "ghcr.io/devcontainers-extra/features/mise:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/devcontainers-extra/features/mise@sha256:5c389ab1e3c8e44e5e0ff119f6868d54dbb781bc860bd8587dc66209cb8c4a8c",
+      "integrity": "sha256:5c389ab1e3c8e44e5e0ff119f6868d54dbb781bc860bd8587dc66209cb8c4a8c"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,58 @@
+// Dev Container 定義（仕様: https://containers.dev/）。
+//
+// 方針:
+// - ツールバージョンの唯一の出所は mise.toml。devcontainer 側ではバージョンを二重管理せず、
+//   mise feature で mise 本体だけを入れ、実体は postCreate の `mise install` が解決する。
+// - 主シナリオは IntelliJ IDEA（JetBrains Gateway / Dev Containers 連携）。VS Code /
+//   Codespaces からも開ける状態は維持する。
+// - Claude Code を同梱し、既存の SessionStart hook（.claude/hooks/session-start-mise.sh）で
+//   mise 管理ツールがセッションの PATH に載る。
+{
+  "name": "toy-box",
+  // Debian (bookworm) 系の Dev Containers 公式イメージ。非 root の vscode ユーザー、git、
+  // curl 等を同梱。Dockerfile を持たず features の合成で構成する。
+  "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+
+  "features": {
+    // mise 本体を導入（実体のツールは postCreate の `mise install` が mise.toml に従って入れる）。
+    "ghcr.io/devcontainers-extra/features/mise:1": {},
+    // Claude Code CLI を導入（node 依存は feature 側が自動で解決する）。
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
+  },
+
+  // mise 管理ツールを「mise exec --」プレフィックス無しで実行できるよう、shims を PATH に通す。
+  // 対話シェルでは post-create.sh が仕込む `mise activate` が JAVA_HOME 等も含めて注入するが、
+  // IntelliJ の Gradle 実行など非対話プロセスからも java/terraform を解決できるよう shims も足す。
+  "remoteEnv": {
+    "PATH": "${containerEnv:PATH}:/home/vscode/.local/share/mise/shims"
+  },
+
+  // コンテナ作成後に一度だけ実行: mise trust → mise install（全ツール）→ lefthook install。
+  "postCreateCommand": ".devcontainer/post-create.sh",
+
+  "remoteUser": "vscode",
+
+  "customizations": {
+    // 主対象。Kotlin/Gradle は IntelliJ に同梱のため、プロジェクトの品質ツールに対応する
+    // プラグインのみ宣言する。Gradle JVM はコンテナ内 JDK（mise 提供の temurin-21）を指す。
+    "jetbrains": {
+      "backend": "IntelliJ",
+      "plugins": [
+        // ktfmt（フォーマッタ）
+        "com.facebook.ktfmt_idea_plugin",
+        // detekt（静的解析）
+        "io.gitlab.arturbosch.detekt"
+      ]
+    },
+    // VS Code / Codespaces でも開ける状態を維持するため最小限の拡張を宣言する。
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack",
+        "fwcd.kotlin",
+        "vscjava.vscode-gradle",
+        "EditorConfig.EditorConfig",
+        "hverlin.mise-vscode"
+      ]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Dev Container 作成後に一度だけ実行されるセットアップ。
+#
+# 役割:
+#   1. 対話シェルで mise を有効化（PATH / JAVA_HOME 等を注入）
+#   2. mise.toml に従って全ツールを導入（バージョンの出所は mise.toml のみ）
+#   3. lefthook で git フックを設定
+#
+# mise feature は mise バイナリを入れるだけで activate / `mise install` は行わないため、
+# それらを本スクリプトで担う。
+set -euo pipefail
+
+# 対話 bash 起動時に mise を有効化する（重複追記を避ける）。
+if ! grep -qs 'mise activate bash' "${HOME}/.bashrc"; then
+  echo 'eval "$(mise activate bash)"' >> "${HOME}/.bashrc"
+fi
+
+# このリポジトリの mise.toml を信頼してからツールを導入する。
+# （信頼しないと mise が設定を読まずツールが入らない）
+mise trust
+mise install
+
+# git フック（pre-commit / pre-push / commit-msg）をインストールする。
+# lefthook は mise 管理ツールのため mise exec 経由で呼ぶ。
+# git worktree 上のコンテナなど .git が解決できない環境では失敗しうるが、
+# それでコンテナ作成全体を止めないよう警告にとどめる（後から手動で再実行できる）。
+if ! mise exec -- lefthook install; then
+  echo "warn: lefthook install に失敗しました。コンテナ内で git が利用可能になったら 'mise exec -- lefthook install' を再実行してください。" >&2
+fi

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ lefthook install    # Git フックを有効化
 
 mise を活性化済みのシェル（または Claude Code セッション）では Gradle を直接実行できます。詳細は CLAUDE.md「ツール管理」を参照。
 
+### Dev Container（再現可能な開発環境）
+
+ローカルへの個別セットアップの代わりに、[Dev Container](https://containers.dev/)（`.devcontainer/`）でも開発環境を立ち上げられます。**IntelliJ IDEA（JetBrains Gateway / Dev Containers 連携）を主シナリオ**とし、VS Code / GitHub Codespaces からも利用できます。
+
+- JDK 21 + mise 管理ツール一式が揃った状態でコンテナが起動し、`./gradlew check` まで通ります。
+- ツールバージョンの出所は引き続き `mise.toml`（devcontainer 側で二重管理しません）。コンテナ作成時に `mise install` / `lefthook install` が自動実行されます。
+- Claude Code CLI を同梱しており、コンテナ内でもそのまま利用できます（mise 管理ツールは PATH に通ります）。
+
+詳細・既知の制約（terraform MCP の Docker 依存、シークレット連携など）は [.devcontainer/README.md](.devcontainer/README.md) を参照。
+
 ### ビルド・テスト・起動
 
 ```bash

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,6 +103,12 @@ kover {
                     kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
                 format = "全体（探索領域含む）の行カバレッジ: <value>%"
             }
+            // total はルールを持たない可視化専用レポート。検証ゲートは mature variant が担うため、
+            // total の verify を check から外す。これを残すと check 実行時に koverVerify(total) と
+            // koverVerifyMature が並列で走り、copyVariant で複製した両 variant が中間成果物を共有する
+            // 結果、total が先に走ると mature の検証がフィルタ前（全体）の値を掴んで誤検知する
+            // （Linux 等でタスク順が入れ替わると顕在化するレース）。
+            verify { onCheck = false }
         }
 
         // mature: 検証ゲートを「成熟パッケージのみ」に絞る。


### PR DESCRIPTION
## 概要

開発環境の Dev Container を整備する（#302）。検証の過程で炙り出した kover ゲートのレースバグ修正（#310）を別コミットで同梱する。

## コミット

1. **fix: koverVerifyMature 誤検知（total verify とのレース）を解消する (#310)**
   `./gradlew check` 時に `koverVerify`(total) と `koverVerifyMature`(mature) が並列で走り、`copyVariant` 複製の両 variant が verify 中間成果物を共有するレース。total が先に走ると mature の検証がフィルタ前（全体 80.35%）を掴みゲート 85% を割って誤検知していた（OS スケジューラ依存で Linux 上 ~50%）。total はルール無しの可視化専用なので `verify { onCheck = false }` で `check` のゲートから外し、レースを構造的に解消。
2. **feat: 開発環境の devcontainer を整備する (#302)**
   `.devcontainer/` 一式と README 追記。

## devcontainer の構成

- base: `mcr.microsoft.com/devcontainers/base:bookworm`（Debian / 非 root vscode ユーザー）
- features: `devcontainers-extra/mise`（mise 本体）+ `anthropics/claude-code`（Claude Code CLI）
- ツールバージョンの唯一の出所は **`mise.toml` のまま**。mise 本体だけ feature で入れ、実体は postCreate の `mise install` が解決
- `post-create.sh`: `mise activate` 仕込み → `mise trust` → `mise install` → `lefthook install`（worktree 等での lefthook 失敗は警告に留めコンテナ作成を止めない）
- `remoteEnv` で mise shims を PATH に追加（IntelliJ の Gradle 等の非対話プロセス対応）
- `devcontainer-lock.json` で feature digest を pin（再現性）

## 動作確認

devcontainer CLI でコンテナを作成し、コンテナ内で検証済み:

- `mise list` … `mise.toml` の 8 ツールすべて解決
- `claude --version` … `2.1.181 (Claude Code)` 同梱確認
- `./gradlew check` … **3 回連続グリーン**（mise 提供の JDK 21 / Gradle 9.5.1、ktfmt + detekt + test + カバレッジゲート通過）
- ホスト `clean check` グリーン、`check --dry-run` で `check` グラフから `koverVerify` が消えることを確認

IntelliJ IDEA（JetBrains Gateway / Dev Containers）での Gradle 同期・テスト実行は手元で別途確認する想定（CLI では代替不可）。

## スコープ外（issue 記載どおり）

terraform MCP の Docker 依存 / ネットワーク firewall / シークレット連携は別途検討。

Closes #302
Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)
