### PR TITLE
feat: 繁殖成績報告（種付〜分娩）のドメインモデルとサービスを実装する (#265)

### DIFF
--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResult.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResult.kt
@@ -1,0 +1,101 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.example.api.domain.shared.Entity
+import com.example.api.domain.shared.generateId
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import java.time.Year
+import java.util.UUID
+import org.jmolecules.ddd.annotation.AggregateRoot
+import org.jmolecules.ddd.annotation.Identity
+import org.jmolecules.ddd.annotation.ValueObject
+
+/** 繁殖成績ID */
+@ValueObject @JvmInline value class BreedingResultId(val value: UUID)
+
+/**
+ * 既に分娩結果が報告済みの繁殖成績へ重ねて報告しようとした。
+ *
+ * 分娩結果の報告は種付年ごとに一度だけ行えるドメインイベントであり、二重報告は不変条件違反。
+ *
+ * @property current 既に報告されている分娩結果
+ */
+data class FoalingAlreadyRecorded(val current: FoalingOutcome)
+
+/**
+ * 繁殖成績を表す集約ルート。種付年ごとの「種付〜分娩」の年次レコード。
+ *
+ * 繁殖登録済みの牝馬（[BreedingRegistration]）について、その年の種付（[Covering]）と分娩結果
+ * （[FoalingOutcome]）を記録する。「繁殖成績報告書」（様式第14号）が報告する 1 行ぶんの年次成績に対応する。 繁殖登録は別集約であり、参照は
+ * [BreedingRegistrationId] 経由で表す。種付年は種付日から導出する。
+ *
+ * 状態はイミュータブルに扱う。種付の記録で生成され（[outcome] は null＝分娩結果は未報告）、後日の分娩結果報告 で一度だけ [outcome] が確定する。報告は
+ * [recordFoaling] が分娩結果を持つ新しい [BreedingResult] を返す ことで表し、同一性（[id]）は引き継ぐ。元のインスタンスは変更しない。
+ *
+ * 種牡馬が雄であることなど集約をまたぐ前提条件の検証はドメインサービス recordCovering の責務とする。検証を経た 生成のみを許すため、コンストラクタは private とし、生成口
+ * [of] は同モジュールのドメインサービスからのみ呼べる よう internal とする。
+ *
+ * @property id 繁殖成績ID（生成時に自動採番し、以後の写像でも引き継ぐ）
+ * @property breedingRegistrationId この成績が紐づく繁殖登録（繁殖牝馬のロール）のID
+ * @property covering その年の種付
+ * @property outcome その年の分娩結果。未報告なら null。報告は [recordFoaling] でのみ行う
+ */
+@AggregateRoot
+class BreedingResult
+private constructor(
+    @field:Identity override val id: BreedingResultId,
+    val breedingRegistrationId: BreedingRegistrationId,
+    val covering: Covering,
+    val outcome: FoalingOutcome?,
+) : Entity<BreedingResultId>() {
+    /** 種付年。種付日から導出する（繁殖成績はこの年単位で集計・報告される）。 */
+    val coveringYear: Year
+        get() = Year.of(covering.coveringDate.year)
+
+    /**
+     * 分娩結果を報告した新しい [BreedingResult] を返す。
+     *
+     * 分娩結果の報告は種付年ごとに一度だけ行えるドメインイベント。既に報告済みの成績への再報告は 不変条件違反として [FoalingAlreadyRecorded]
+     * を返し、写像を行わない（元の [BreedingResult] も不変）。 成功時は [outcome] のみ差し替え、[id] を含む他の属性は引き継ぐ。
+     *
+     * @param outcome 報告する分娩結果
+     * @return 報告済みの新しい [BreedingResult]、既に報告済みなら [FoalingAlreadyRecorded]
+     */
+    fun recordFoaling(outcome: FoalingOutcome): Result<BreedingResult, FoalingAlreadyRecorded> {
+        val current = this.outcome
+        return if (current != null) {
+            Err(FoalingAlreadyRecorded(current))
+        } else {
+            Ok(copy(outcome = outcome))
+        }
+    }
+
+    /** [id] と未指定の属性を引き継ぎ、指定された属性だけを差し替えた新しい [BreedingResult] を返す。 */
+    private fun copy(outcome: FoalingOutcome? = this.outcome): BreedingResult =
+        BreedingResult(
+            id = id,
+            breedingRegistrationId = breedingRegistrationId,
+            covering = covering,
+            outcome = outcome,
+        )
+
+    companion object {
+        /**
+         * 種付を記録した [BreedingResult] を生成する。
+         *
+         * 種牡馬が雄であることなどの前提条件はドメインサービス recordCovering が検証済みである前提のため、 この生成口は同モジュールのドメインサービスからのみ呼べるよう
+         * internal とする。生成直後は分娩結果が 未報告（[outcome] は null）。
+         */
+        internal fun of(
+            breedingRegistrationId: BreedingRegistrationId,
+            covering: Covering,
+        ): BreedingResult =
+            BreedingResult(
+                id = BreedingResultId(generateId()),
+                breedingRegistrationId = breedingRegistrationId,
+                covering = covering,
+                outcome = null,
+            )
+    }
+}

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/Covering.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/Covering.kt
@@ -1,0 +1,22 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseId
+import java.time.LocalDate
+import org.jmolecules.ddd.annotation.ValueObject
+
+/**
+ * 種付（種牡馬を繁殖牝馬に交配したという事実）を表す値オブジェクト。
+ *
+ * 繁殖成績の年次レコード（[BreedingResult]）における最初の節目で、どの種牡馬と・いつ交配し・その事実を どの種付証明書で証明するかを束ねる。種牡馬は別個体（別集約）であり、参照は
+ * [BloodHorseId] 経由で表す。 種牡馬が雄であることなど集約をまたぐ前提条件の検証はドメインサービス recordCovering の責務とし、 検証を経た記録のみを許す。
+ *
+ * @property stallionId 種牡馬（雄の軽種馬）の軽種馬ID
+ * @property coveringDate 種付日
+ * @property certificateNumber 種付の事実を証明する種付証明書の番号
+ */
+@ValueObject
+data class Covering(
+    val stallionId: BloodHorseId,
+    val coveringDate: LocalDate,
+    val certificateNumber: CoveringCertificateNumber,
+)

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/CoveringCertificateNumber.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/CoveringCertificateNumber.kt
@@ -1,0 +1,28 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.example.api.domain.shared.createNonBlank
+import com.github.michaelbull.result.Result
+import org.jmolecules.ddd.annotation.ValueObject
+
+/** 種付証明書番号がブランク。 */
+data object BlankCoveringCertificateNumber
+
+/**
+ * 種付証明書番号。
+ *
+ * 種付の事実は種牡馬の管理者が発行する「種付証明書」で証明され、産駒の血統登録申込時の必須準備物となる（登録規程実施基準・血統登録のながれ）。
+ * 種付という節目（イベント）が確かに行われたことの証憑を識別する。具体的な桁数・形式は未確認のため、現時点では ブランクでないことのみを不変条件とする （形式が判明したら桁数検証を加える）。
+ *
+ * @property value 種付証明書番号
+ */
+@ValueObject
+@JvmInline
+value class CoveringCertificateNumber private constructor(val value: String) {
+    companion object {
+        /** ブランクでないことを検証して [CoveringCertificateNumber] を生成する。 */
+        fun create(
+            value: String
+        ): Result<CoveringCertificateNumber, BlankCoveringCertificateNumber> =
+            createNonBlank(value, BlankCoveringCertificateNumber, ::CoveringCertificateNumber)
+    }
+}

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/FoalingOutcome.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/FoalingOutcome.kt
@@ -1,0 +1,49 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import java.time.LocalDate
+import org.jmolecules.ddd.annotation.ValueObject
+
+/**
+ * 分娩結果。種付を行った繁殖牝馬がその年に迎えた帰結を表す。
+ *
+ * 「繁殖成績報告書」（様式第14号）が報告する分娩の帰結を sealed なドメイン語彙として表す。生産（産駒あり） の [LiveFoal]
+ * と、産駒なしに終わった各区分（様式第14号裏「子馬のない母の繁殖成績」のうち**種付後に生じる もの**）に分かれる。帰結は相互排他であり、`when` の網羅性で漏れを防ぐため sealed
+ * interface とする。
+ *
+ * 「種付せず」（その年に種付しなかった区分）は種付（[Covering]）が存在しない帰結であり、種付を起点とする本モデル
+ * の対象外として今回は表現しない（別途モデル化を検討）。妊娠期間・生後日数の閾値（例: 流産と死産の境、生後直死 の判定日数）は様式の OCR
+ * が不鮮明なため数値としては保持せず、報告者の区分判断をそのまま受け取る分類として扱う。
+ */
+sealed interface FoalingOutcome {
+    /**
+     * 生産（産駒あり）。分娩により生存産駒を得た帰結。
+     *
+     * ここで生じた産駒は、母（繁殖登録証明書）と父（[Covering] の種付証明書）を添えて血統登録 （registerInStudBook）される入力に接続する。産駒は血統登録の成立まで
+     * [com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorse] として実体化しない
+     * ため、本帰結は分娩日のみを保持する。
+     *
+     * @property foalingDate 分娩日（産駒の出生年月日）
+     */
+    @ValueObject data class LiveFoal(val foalingDate: LocalDate) : FoalingOutcome
+
+    /** 不受胎。種付したが受胎が確認できなかった。 */
+    @ValueObject data object NotConceived : FoalingOutcome
+
+    /** 流産。妊娠期間の途中で胎子が死亡または死んで娩出された。 */
+    @ValueObject data object Abortion : FoalingOutcome
+
+    /** 双子流産。双子の流産。 */
+    @ValueObject data object TwinAbortion : FoalingOutcome
+
+    /** 死産。妊娠後期に胎子が死亡または死んで娩出された。 */
+    @ValueObject data object Stillbirth : FoalingOutcome
+
+    /** 双子死産。双子の死産。 */
+    @ValueObject data object TwinStillbirth : FoalingOutcome
+
+    /** 生後直死。出生直後（ごく短期間）に死亡した。 */
+    @ValueObject data object NeonatalDeath : FoalingOutcome
+
+    /** 双子生後直死。双子の生後直死。 */
+    @ValueObject data object TwinNeonatalDeath : FoalingOutcome
+}

--- a/src/main/kotlin/com/example/api/domain/horseracing/service/breeding/RecordCovering.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/service/breeding/RecordCovering.kt
@@ -1,0 +1,52 @@
+package com.example.api.domain.horseracing.service.breeding
+
+import com.example.api.domain.horseracing.model.breeding.BreedingRegistration
+import com.example.api.domain.horseracing.model.breeding.BreedingResult
+import com.example.api.domain.horseracing.model.breeding.Covering
+import com.example.api.domain.horseracing.model.breeding.CoveringCertificateNumber
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorse
+import com.example.api.domain.horseracing.model.horse.bloodhorse.Sex
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import java.time.LocalDate
+
+/**
+ * 繁殖牝馬に対するその年の種付を記録し、繁殖成績（[BreedingResult]）の年次レコードを起こす。
+ *
+ * 繁殖登録（[BreedingRegistration]）により対象が繁殖牝馬であることは担保される。本サービスは集約をまたぐ前提条件 として、配合相手の種牡馬が雄であることを検証してから
+ * [BreedingResult] を生成する。種牡馬は別個体（別集約） であり、生成物は種牡馬を ID（`BloodHorseId`）経由で参照する。
+ *
+ * @param breedingRegistration 種付対象の繁殖牝馬の繁殖登録
+ * @param stallion 配合相手の種牡馬（雄の [BloodHorse]）
+ * @param coveringDate 種付日
+ * @param certificateNumber 種付の事実を証明する種付証明書の番号
+ * @return 種付を記録した [BreedingResult]、または前提条件違反を表す [RecordCoveringError]
+ */
+fun recordCovering(
+    breedingRegistration: BreedingRegistration,
+    stallion: BloodHorse,
+    coveringDate: LocalDate,
+    certificateNumber: CoveringCertificateNumber,
+): Result<BreedingResult, RecordCoveringError> =
+    if (stallion.sex != Sex.MALE) {
+        Err(RecordCoveringError.StallionNotMale)
+    } else {
+        Ok(
+            BreedingResult.of(
+                breedingRegistrationId = breedingRegistration.id,
+                covering = Covering(stallion.id, coveringDate, certificateNumber),
+            )
+        )
+    }
+
+/**
+ * 種付記録の前提条件違反。
+ *
+ * 現時点では種牡馬が雄であることのみを検証するが、制度上は他の前提条件もありうる（例: 同一種付年の重複記録の禁止、 種牡馬の種牡馬登録の確認）。集約が揃い次第バリアントを追加できるよう
+ * sealed interface としておく。
+ */
+sealed interface RecordCoveringError {
+    /** 配合相手は種牡馬（雄）に限られるが、指定された馬が雄でない。 */
+    data object StallionNotMale : RecordCoveringError
+}

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingFixture.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingFixture.kt
@@ -1,0 +1,41 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseId
+import com.example.api.domain.shared.generateId
+import com.github.michaelbull.result.unwrap
+import java.time.LocalDate
+
+/**
+ * テスト用に繁殖コンテキストの集約・値オブジェクトを組み立てる Object Mother。
+ *
+ * [BreedingRegistration] / [BreedingResult] の生成口は本番ではドメインサービスに封じ込められている（`of` は
+ * internal）。テストでは前提条件検証を経ずに任意の状態を用意したいため、internal 可視性がモジュール内（test も同一 モジュール）から見えることを利用してここで直接組み立てる。
+ */
+object BreedingFixture {
+    /** 既定値を持つ [BreedingRegistration] を生成する。必要な属性のみ上書きする。 */
+    fun breedingRegistration(
+        broodmareId: BloodHorseId = BloodHorseId(generateId())
+    ): BreedingRegistration =
+        BreedingRegistration.of(
+            registrationNumber = BreedingRegistrationNumber.create("B-2024-0001").unwrap(),
+            broodmareId = broodmareId,
+        )
+
+    /** 既定値を持つ [Covering] を生成する。必要な属性のみ上書きする。 */
+    fun covering(
+        stallionId: BloodHorseId = BloodHorseId(generateId()),
+        coveringDate: LocalDate = LocalDate.of(2024, 4, 1),
+    ): Covering =
+        Covering(
+            stallionId = stallionId,
+            coveringDate = coveringDate,
+            certificateNumber = CoveringCertificateNumber.create("C-2024-0001").unwrap(),
+        )
+
+    /** 既定値を持つ、分娩結果未報告の [BreedingResult] を生成する。必要な属性のみ上書きする。 */
+    fun breedingResult(
+        breedingRegistrationId: BreedingRegistrationId = breedingRegistration().id,
+        covering: Covering = covering(),
+    ): BreedingResult =
+        BreedingResult.of(breedingRegistrationId = breedingRegistrationId, covering = covering)
+}

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultTest.kt
@@ -1,0 +1,59 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import java.time.LocalDate
+import java.time.Year
+import org.junit.jupiter.api.Test
+
+/** BreedingResult 集約のユニットテスト */
+class BreedingResultTest {
+    @Test
+    fun `種付日からその年が種付年として導出されること`() {
+        val result =
+            BreedingFixture.breedingResult(
+                covering = BreedingFixture.covering(coveringDate = LocalDate.of(2024, 4, 1))
+            )
+
+        assert(result.coveringYear == Year.of(2024))
+    }
+
+    @Test
+    fun `生成直後は分娩結果が未報告であること`() {
+        val result = BreedingFixture.breedingResult()
+
+        assert(result.outcome == null)
+    }
+
+    @Test
+    fun `分娩結果を報告すると outcome を持つ新インスタンスが返り同一性が引き継がれること`() {
+        val result = BreedingFixture.breedingResult()
+        val outcome = FoalingOutcome.LiveFoal(LocalDate.of(2025, 3, 20))
+
+        val reported = result.recordFoaling(outcome).unwrap()
+
+        assert(reported.outcome == outcome)
+        assert(reported.id == result.id)
+        // 元のインスタンスは不変
+        assert(result.outcome == null)
+    }
+
+    @Test
+    fun `産駒なしの帰結も分娩結果として報告できること`() {
+        val result = BreedingFixture.breedingResult()
+
+        val reported = result.recordFoaling(FoalingOutcome.NotConceived).unwrap()
+
+        assert(reported.outcome == FoalingOutcome.NotConceived)
+    }
+
+    @Test
+    fun `既に報告済みの成績へ再報告すると FoalingAlreadyRecorded を返すこと`() {
+        val first = FoalingOutcome.LiveFoal(LocalDate.of(2025, 3, 20))
+        val reported = BreedingFixture.breedingResult().recordFoaling(first).unwrap()
+
+        val error = reported.recordFoaling(FoalingOutcome.NotConceived).getError()
+
+        assert(error == FoalingAlreadyRecorded(first))
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/CoveringCertificateNumberTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/CoveringCertificateNumberTest.kt
@@ -1,0 +1,36 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import org.junit.jupiter.api.Test
+
+/** CoveringCertificateNumber 値オブジェクトのユニットテスト */
+class CoveringCertificateNumberTest {
+    @Test
+    fun `ブランクでない値なら生成できること`() {
+        val number = CoveringCertificateNumber.create("C-2024-0001").unwrap()
+
+        assert(number.value == "C-2024-0001")
+    }
+
+    @Test
+    fun `前後の空白は trim されること`() {
+        val number = CoveringCertificateNumber.create("  C-2024-0001  ").unwrap()
+
+        assert(number.value == "C-2024-0001")
+    }
+
+    @Test
+    fun `空文字ならブランクエラーを返すこと`() {
+        val result = CoveringCertificateNumber.create("")
+
+        assert(result.getError() == BlankCoveringCertificateNumber)
+    }
+
+    @Test
+    fun `空白のみならブランクエラーを返すこと`() {
+        val result = CoveringCertificateNumber.create("   ")
+
+        assert(result.getError() == BlankCoveringCertificateNumber)
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/horseracing/service/breeding/RecordCoveringTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/service/breeding/RecordCoveringTest.kt
@@ -1,0 +1,41 @@
+package com.example.api.domain.horseracing.service.breeding
+
+import com.example.api.domain.horseracing.model.breeding.BreedingFixture
+import com.example.api.domain.horseracing.model.breeding.CoveringCertificateNumber
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseFixture
+import com.example.api.domain.horseracing.model.horse.bloodhorse.Sex
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import java.time.LocalDate
+import org.junit.jupiter.api.Test
+
+/** recordCovering ドメインサービスのユニットテスト */
+class RecordCoveringTest {
+    private val coveringDate = LocalDate.of(2024, 4, 1)
+    private val certificateNumber = CoveringCertificateNumber.create("C-2024-0001").unwrap()
+
+    @Test
+    fun `配合相手が種牡馬なら種付が記録され種牡馬を ID で参照する繁殖成績が生成されること`() {
+        val registration = BreedingFixture.breedingRegistration()
+        val stallion = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
+
+        val result =
+            recordCovering(registration, stallion, coveringDate, certificateNumber).unwrap()
+
+        assert(result.breedingRegistrationId == registration.id)
+        assert(result.covering.stallionId == stallion.id)
+        assert(result.covering.coveringDate == coveringDate)
+        assert(result.covering.certificateNumber == certificateNumber)
+        assert(result.outcome == null)
+    }
+
+    @Test
+    fun `配合相手が雄でないと StallionNotMale を返すこと`() {
+        val registration = BreedingFixture.breedingRegistration()
+        val mare = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+
+        val result = recordCovering(registration, mare, coveringDate, certificateNumber)
+
+        assert(result.getError() == RecordCoveringError.StallionNotMale)
+    }
+}


### PR DESCRIPTION
## 概要

#265 繁殖成績報告（種付〜分娩）を**ドメイン層（model + service + テスト）**として実装する。旧 `Breeding.kt`（空スタブ、PR #263 で削除）の正統な作り直し。

`BreedingRegistration`（繁殖牝馬のロール）に対し、種付年ごとの「種付 → 分娩結果」の年次レコードを記録するモデルとドメインサービスを追加する。

スコープは既存の `registerForBreeding` と同じ粒度（ドメイン層止まり、application / REST は別 issue）。

## 典拠

JAIRS「登録規程実施基準」様式第14号（繁殖成績報告書）・血統登録のながれ。分娩結果の8区分は様式第14号裏「子馬のない母の繁殖成績」に基づく（issue #265 のコメント参照）。

## 変更点

### model（`domain/horseracing/model/breeding/`）
- **`BreedingResult`**: 繁殖成績の集約ルート。種付年ごとの年次レコード。種付で生成（`outcome = null`）し、`recordFoaling` で分娩結果を**一度だけ**確定するイミュータブルな状態遷移（ADR-0009）。種付年は種付日から導出。繁殖登録は `BreedingRegistrationId` 経由で参照。生成口 `of` は internal（検証はドメインサービスに封じ込め）。
- **`Covering`**: 種付 VO。種牡馬（`BloodHorseId` 経由）・種付日・種付証明書番号を束ねる。
- **`CoveringCertificateNumber`**: 種付証明書番号 VO。ブランク非許可。
- **`FoalingOutcome`**: 分娩結果の sealed ドメイン語彙。生産（`LiveFoal`）＋ 種付後の産駒なし7区分（不受胎/流産/双子流産/死産/双子死産/生後直死/双子生後直死）。

### service（`domain/horseracing/service/breeding/`）
- **`recordCovering`**: 配合相手が種牡馬（雄）であることを検証して `BreedingResult` を起こすドメインサービス。失敗は `RecordCoveringError`（sealed）。
- 分娩結果の報告（`recordFoaling`）は集約内で完結する状態遷移のため `BreedingResult` のメソッドとした（`BloodHorse.assignName` と同じ流儀）。

### test
- `BreedingFixture`（Object Mother）、種付年導出・分娩結果報告・二重報告ガード・種牡馬性別検証のユニットテスト。

## 設計判断

- **「種付せず」区分は今回除外**: 種付（covering）が存在しない年次成績は本モデル（種付起点）の対象外とし、`BreedingResult` は covering 必須でモデル化。→ 別 issue へ。
- **産駒 → 血統登録の接続はドキュメントのみ**: `LiveFoal` から `registerInStudBook` への接続点を KDoc で示すに留め、実配線は別 issue（#267 と境界共有）。
- 妊娠期間・生後日数の閾値は様式 OCR が不鮮明なため数値として保持せず、報告者の区分判断を受け取る分類として扱う。

## 未対応（別 issue 起票予定）

- 「種付せず」区分のモデル化
- application 層ユースケース ＋ REST IF
- 生産産駒（`LiveFoal`）→ `registerInStudBook` の接続配線
- 年次集計（受胎率・生産率・登録率／様式第2号）と提出期限（5/31）制約

## 確認

`./gradlew check` 通過（ktfmt / detekt / ArchUnit / kover ゲート）。

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)
