### PR TITLE
feat: devcontainer に Docker-in-Docker を追加して terraform MCP をコンテナ内で使えるようにする

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -13,6 +13,7 @@
 - **features**:
   - `ghcr.io/devcontainers-extra/features/mise:1` — [mise](https://mise.jdx.dev/) 本体
   - `ghcr.io/anthropics/devcontainer-features/claude-code:1.0` — Claude Code CLI（node 依存は feature が自動解決）
+  - `ghcr.io/devcontainers/features/docker-in-docker:2` — Docker-in-Docker（terraform MCP の `docker run` 用）
 
 ### ツールバージョンの出所は `mise.toml` のみ
 
@@ -46,6 +47,5 @@ mise list           # mise.toml のツールが解決されていること
 
 本 devcontainer は「Java/Gradle 開発 + Claude Code」の土台を優先しており、以下は別途検討する（[issue #302](https://github.com/ptiringo/toy-box/issues/302) のスコープ外）。
 
-- **terraform MCP サーバーの Docker 依存**: `.mcp.json` の `terraform` サーバーは `docker run hashicorp/terraform-mcp-server` を前提とするため、コンテナ内から使うには Docker-in-Docker / Docker-outside-of-Docker が必要。`context7`（http）はコンテナ内でもそのまま使える。
 - **ネットワーク firewall サンドボックス**（`init-firewall.sh` 相当）は導入しない。
 - **シークレット（fnox + 1Password）**: `op` のデスクトップアプリ連携はコンテナから到達できない。現状 `fnox.toml` の `[secrets]` は空のため当面の支障はない。

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -9,6 +9,11 @@
       "version": "1.0.0",
       "resolved": "ghcr.io/devcontainers-extra/features/mise@sha256:5c389ab1e3c8e44e5e0ff119f6868d54dbb781bc860bd8587dc66209cb8c4a8c",
       "integrity": "sha256:5c389ab1e3c8e44e5e0ff119f6868d54dbb781bc860bd8587dc66209cb8c4a8c"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.17.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c",
+      "integrity": "sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,10 @@
     // mise 本体を導入（実体のツールは postCreate の `mise install` が mise.toml に従って入れる）。
     "ghcr.io/devcontainers-extra/features/mise:1": {},
     // Claude Code CLI を導入（node 依存は feature 側が自動で解決する）。
-    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
+    // Docker-in-Docker。`.mcp.json` の terraform MCP（`docker run hashicorp/terraform-mcp-server`）を
+    // コンテナ内からも起動できるようにする。
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
   },
 
   // mise 管理ツールを「mise exec --」プレフィックス無しで実行できるよう、shims を PATH に通す。


### PR DESCRIPTION
## 概要

devcontainer 内で `/doctor` を実行すると terraform MCP サーバーが `Executable not found in $PATH: "docker"` で失敗していた。原因は devcontainer に docker が存在しないこと（features は mise と claude-code のみ）。`.mcp.json` の terraform MCP は `docker run hashicorp/terraform-mcp-server` を前提とするため、コンテナ内では起動できなかった。

Docker-in-Docker feature を追加してコンテナ内でも terraform MCP を起動できるようにする。#302（devcontainer 整備）のフォローアップ。

## 変更内容

- **`.devcontainer/devcontainer.json`**: features に `ghcr.io/devcontainers/features/docker-in-docker:2` を追加
- **`.devcontainer/devcontainer-lock.json`**: `devcontainer up` による lock 再生成で docker-in-docker 2.17.0 を digest 付きで pin
- **`.devcontainer/README.md`**: features 一覧に追記し、「既知の制約」から terraform MCP の Docker 依存の項目を削除（本変更で解消）

## 確認

- `devcontainer up --remove-existing-container` でコンテナを再ビルドし、claude を起動できることを確認済み
- 再ビルド後、コンテナ内の docker で terraform MCP が起動できる想定（`context7` は http のため従来どおり利用可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
