### PR TITLE
test: 集約のイミュータブル性（var 禁止）を ArchUnit で機械強制する (#307)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -92,6 +92,7 @@ domain/
 - 標準出力・標準エラーへの直接書き込み禁止（ロガーを使う）
 - フィールドインジェクション禁止（コンストラクタインジェクションを使う）
 - `UUID.randomUUID()` の直接呼び出し禁止。ID は `domain.shared.generateId()`（UUIDv7 相当のタイムベース生成）経由で生成する（永続化時のインデックス局所性のため。[ADR-0005](../../docs/adr/0005-time-based-uuid-generation.md)）。main コードのみ対象（テストの fixture は対象外）
+- **集約（`@AggregateRoot` / `@Entity`）はイミュータブル**（`val` のみ・`var` 禁止）。状態遷移は対象を書き換えず、同一性（ID）を引き継いだ新インスタンスを返すメソッドで表す（[ADR-0009](../../docs/adr/0009-immutable-aggregates.md)）。`val` は final フィールド・`var` は非 final フィールドへコンパイルされるため、集約クラスが直接宣言するフィールドが全て final であることを ArchUnit で検証して `var` を排除する
 
 ## ルールの変更・追加
 

--- a/src/test/kotlin/com/example/api/architecture/ArchitectureTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/ArchitectureTest.kt
@@ -8,6 +8,7 @@ import com.tngtech.archunit.core.importer.ImportOption
 import com.tngtech.archunit.junit.AnalyzeClasses
 import com.tngtech.archunit.junit.ArchTest
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
 import com.tngtech.archunit.library.Architectures.onionArchitecture
 import com.tngtech.archunit.library.GeneralCodingRules
@@ -132,6 +133,26 @@ class ArchitectureTest {
             .areAnnotatedWith(DddRepository::class.java)
             .should()
             .resideInAPackage(DOMAIN_MODEL)
+
+    /**
+     * 集約（@AggregateRoot / @Entity）はイミュータブルに保つこと（val のみ・var 禁止）。
+     *
+     * 状態遷移は対象を書き換えず、同一性（ID）を引き継いだ新インスタンスを返すメソッドで表す（ADR-0009）。 Kotlin の `val` プロパティは final
+     * フィールドへ、`var` は非 final フィールド（＋ setter）へコンパイルされるため、 集約クラスが直接宣言するフィールドが全て final であることを検証することで
+     * `var` を排除する。
+     */
+    @ArchTest
+    val aggregatesAreImmutable =
+        fields()
+            .that()
+            .areDeclaredInClassesThat()
+            .areAnnotatedWith(AggregateRoot::class.java)
+            .or()
+            .areDeclaredInClassesThat()
+            .areAnnotatedWith(DddEntity::class.java)
+            .should()
+            .beFinal()
+            .because("集約はイミュータブルに保ち、状態遷移は新インスタンスで表す（ADR-0009）。var は禁止")
 
     /** HTTP アダプター（@RestController）は controller 層に置くこと。 */
     @ArchTest


### PR DESCRIPTION
## 概要

ADR-0009 で定めた「集約（`@AggregateRoot` / `@Entity`）はイミュータブルに保ち、状態遷移は対象を書き換えず同一性（ID）を引き継いだ新インスタンスで表す（`val` のみ・`var` 禁止）」規約を、**文章規定から ArchUnit による機械強制へ昇格**する。#307（規約強制化 7）の ADR-0009 部分に対応。

## やったこと

- `ArchitectureTest.kt` に `aggregatesAreImmutable` ルールを追加
  - `@AggregateRoot` / `@Entity` 付きクラスが**直接宣言するフィールドが全て `final` であること**（`beFinal`）を検証
  - Kotlin の `val` は final フィールド・`var` は非 final フィールド（＋ setter）へコンパイルされるため、これにより `var` を排除できる
- `.claude/rules/architecture.md` の「その他の強制ルール」に本ルールを追記

## ルールに歯があることの確認

対象 0 件のバキューム（常に成功）でないことを確認するため、一時的に集約（`Player`）へ `var mutableProbe` を追加して当該テストが落ちる（`aggregatesAreImmutable FAILED`）ことを確認済み。確認後に元へ戻している。

## 検証

- `./gradlew check` グリーン（test + `koverVerifyMature` ゲート含む）
- 既存集約（`Jockey` / `Race` / `BloodHorse` / `BreedingResult` / `BreedingRegistration` / `Player` / `Member`）はすべて `val` のみのため即グリーン

## スコープ外

- ADR-0008（馬名の値オブジェクト化）の機械強制可否検討は #307 に残し、別途対応する

## 関連

- #307（規約強制化 7）/ #291（トラッキング）
- [ADR-0009](docs/adr/0009-immutable-aggregates.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
