### PR TITLE
feat: 繁殖成績報告の application 層ユースケースと REST IF を実装する (#323)

### DIFF
--- a/src/main/kotlin/com/example/api/application/horseracing/breeding/RecordCoveringUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/horseracing/breeding/RecordCoveringUseCase.kt
@@ -1,0 +1,107 @@
+package com.example.api.application.horseracing.breeding
+
+import com.example.api.domain.horseracing.model.breeding.BreedingRegistrationId
+import com.example.api.domain.horseracing.model.breeding.BreedingRegistrationRepository
+import com.example.api.domain.horseracing.model.breeding.BreedingResult
+import com.example.api.domain.horseracing.model.breeding.BreedingResultRepository
+import com.example.api.domain.horseracing.model.breeding.CoveringCertificateNumber
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseId
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.horseracing.service.breeding.RecordCoveringError
+import com.example.api.domain.horseracing.service.breeding.recordCovering
+import com.example.api.domain.shared.Command
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import com.github.michaelbull.result.mapError
+import com.github.michaelbull.result.toResultOr
+import java.time.LocalDate
+import java.util.UUID
+import org.springframework.stereotype.Service
+
+/**
+ * 種付記録ユースケースの入力コマンド。
+ *
+ * 繁殖成績報告書の「種付」欄に相当する境界の生入力。種付証明書番号は素の文字列で受け取り、ユースケース内で VO の `create`
+ * を通して検証する。繁殖登録・種牡馬は既存の登録IDで参照する。
+ *
+ * @property breedingRegistrationId 種付対象の繁殖牝馬の繁殖登録ID
+ * @property stallionId 配合相手の種牡馬（雄の軽種馬）の軽種馬ID
+ * @property coveringDate 種付日
+ * @property certificateNumber 種付の事実を証明する種付証明書の番号
+ */
+data class RecordCoveringCommand(
+    val breedingRegistrationId: UUID,
+    val stallionId: UUID,
+    val coveringDate: LocalDate,
+    val certificateNumber: String,
+)
+
+/** 種付記録時に発生しうる業務ルール違反。 */
+sealed interface RecordCoveringUseCaseError {
+    /** 種付証明書番号がブランク。 */
+    data object InvalidCertificateNumber : RecordCoveringUseCaseError
+
+    /** 種付対象として指定された繁殖登録が存在しない。 */
+    data class BreedingRegistrationNotFound(val breedingRegistrationId: UUID) :
+        RecordCoveringUseCaseError
+
+    /** 配合相手として指定された種牡馬（軽種馬）が存在しない。 */
+    data class StallionNotFound(val stallionId: UUID) : RecordCoveringUseCaseError
+
+    /**
+     * ドメインサービス recordCovering の前提条件違反を application 層エラーに wrap したもの。
+     *
+     * 個別バリアント（種牡馬が雄でない等）は [RecordCoveringError] を参照する。
+     */
+    data class PreconditionViolated(val cause: RecordCoveringError) : RecordCoveringUseCaseError
+}
+
+/**
+ * 種付記録ユースケース。
+ *
+ * 境界の生入力を VO に変換し（不正なら検証エラー）、繁殖登録と種牡馬を Repository で引き当て、ドメインサービス recordCovering
+ * で前提条件（種牡馬が雄であること）を検証してから、起こした繁殖成績（[BreedingResult]）の年次 レコードを永続化する。Controller
+ * 層は本クラスのみに依存し、ポートやドメインサービスは知らない。
+ *
+ * @return 起こされた [BreedingResult]、または業務ルール違反を表す [RecordCoveringUseCaseError]
+ */
+@Service
+class RecordCoveringUseCase(
+    private val breedingRegistrationRepository: BreedingRegistrationRepository,
+    private val bloodHorseRepository: BloodHorseRepository,
+    private val breedingResultRepository: BreedingResultRepository,
+) {
+    operator fun invoke(
+        command: Command<RecordCoveringCommand>
+    ): Result<BreedingResult, RecordCoveringUseCaseError> = binding {
+        val input = command.payload
+
+        val certificateNumber =
+            CoveringCertificateNumber.create(input.certificateNumber)
+                .mapError { RecordCoveringUseCaseError.InvalidCertificateNumber }
+                .bind()
+
+        val breedingRegistration =
+            breedingRegistrationRepository
+                .findById(BreedingRegistrationId(input.breedingRegistrationId))
+                .toResultOr {
+                    RecordCoveringUseCaseError.BreedingRegistrationNotFound(
+                        input.breedingRegistrationId
+                    )
+                }
+                .bind()
+
+        val stallion =
+            bloodHorseRepository
+                .findById(BloodHorseId(input.stallionId))
+                .toResultOr { RecordCoveringUseCaseError.StallionNotFound(input.stallionId) }
+                .bind()
+
+        val breedingResult =
+            recordCovering(breedingRegistration, stallion, input.coveringDate, certificateNumber)
+                .mapError { RecordCoveringUseCaseError.PreconditionViolated(it) }
+                .bind()
+
+        breedingResultRepository.save(breedingResult)
+    }
+}

--- a/src/main/kotlin/com/example/api/application/horseracing/breeding/ReportFoalingUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/horseracing/breeding/ReportFoalingUseCase.kt
@@ -1,0 +1,72 @@
+package com.example.api.application.horseracing.breeding
+
+import com.example.api.domain.horseracing.model.breeding.BreedingResult
+import com.example.api.domain.horseracing.model.breeding.BreedingResultId
+import com.example.api.domain.horseracing.model.breeding.BreedingResultRepository
+import com.example.api.domain.horseracing.model.breeding.FoalingOutcome
+import com.example.api.domain.shared.Command
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import com.github.michaelbull.result.mapError
+import com.github.michaelbull.result.toResultOr
+import java.util.UUID
+import org.springframework.stereotype.Service
+
+/**
+ * 分娩結果報告ユースケースの入力コマンド。
+ *
+ * 繁殖成績報告書の「分娩結果」欄に相当する境界の入力。報告対象の繁殖成績を ID で参照し、報告する帰結を ドメインの [FoalingOutcome]
+ * で受け取る（生産＝産駒ありか、産駒なしの各区分か）。
+ *
+ * @property breedingResultId 報告対象の繁殖成績ID
+ * @property outcome 報告する分娩結果
+ */
+data class ReportFoalingCommand(val breedingResultId: UUID, val outcome: FoalingOutcome)
+
+/** 分娩結果報告時に発生しうる業務ルール違反。 */
+sealed interface ReportFoalingUseCaseError {
+    /** 報告対象として指定された繁殖成績が存在しない。 */
+    data class BreedingResultNotFound(val breedingResultId: UUID) : ReportFoalingUseCaseError
+
+    /**
+     * 既に分娩結果が報告済みの繁殖成績へ重ねて報告しようとした。
+     *
+     * 分娩結果の報告は種付年ごとに一度だけ行えるドメインイベントであり、二重報告は不変条件違反。
+     *
+     * @property current 既に報告されている分娩結果
+     */
+    data class AlreadyReported(val current: FoalingOutcome) : ReportFoalingUseCaseError
+}
+
+/**
+ * 分娩結果報告ユースケース。
+ *
+ * 報告対象の繁殖成績を [BreedingResultRepository] で引き当て、集約の [BreedingResult.recordFoaling] で
+ * 分娩結果を確定（二重報告は不変条件違反）してから、報告済みの新インスタンスを永続化する。Controller 層は 本クラスのみに依存する。
+ *
+ * @return 報告済みの [BreedingResult]、または業務ルール違反を表す [ReportFoalingUseCaseError]
+ */
+@Service
+class ReportFoalingUseCase(private val breedingResultRepository: BreedingResultRepository) {
+    operator fun invoke(
+        command: Command<ReportFoalingCommand>
+    ): Result<BreedingResult, ReportFoalingUseCaseError> = binding {
+        val input = command.payload
+
+        val breedingResult =
+            breedingResultRepository
+                .findById(BreedingResultId(input.breedingResultId))
+                .toResultOr {
+                    ReportFoalingUseCaseError.BreedingResultNotFound(input.breedingResultId)
+                }
+                .bind()
+
+        val reported =
+            breedingResult
+                .recordFoaling(input.outcome)
+                .mapError { ReportFoalingUseCaseError.AlreadyReported(it.current) }
+                .bind()
+
+        breedingResultRepository.save(reported)
+    }
+}

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultController.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultController.kt
@@ -1,0 +1,153 @@
+package com.example.api.controller.breeding
+
+import com.example.api.application.horseracing.breeding.RecordCoveringUseCase
+import com.example.api.application.horseracing.breeding.ReportFoalingCommand
+import com.example.api.application.horseracing.breeding.ReportFoalingUseCase
+import com.example.api.controller.orThrowProblem
+import com.example.api.domain.shared.Command
+import com.github.michaelbull.result.mapError
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import java.time.Clock
+import java.util.UUID
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ProblemDetail
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 繁殖成績リソースの HTTP アダプター。
+ *
+ * Google AIP のリソース指向設計に従い、コレクション `/api/breeding_results` に対する Create（種付記録による年次 レコードの起票）と、個体への
+ * カスタムメソッド `:reportFoaling`（分娩結果報告、[AIP-136](https://google.aip.dev/136)） を提供する。エラーレスポンスは RFC 9457
+ * (Problem Details) 形式で返す。
+ */
+@RestController
+class BreedingResultController(
+    private val recordCovering: RecordCoveringUseCase,
+    private val reportFoaling: ReportFoalingUseCase,
+    private val clock: Clock,
+) {
+    @Operation(
+        summary = "種付を記録して繁殖成績を起こす",
+        description =
+            "繁殖登録済みの牝馬への種付を記録し、その年の繁殖成績（分娩結果は未報告）を返す。" + "業務ルール違反時は RFC 9457 形式の problem+json を返す。",
+        tags = ["BreedingResult"],
+        responses =
+            [
+                ApiResponse(
+                    responseCode = "201",
+                    description = "種付記録成功（起票された繁殖成績リソースを返す）",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = BreedingResultResponse::class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "400",
+                    description = "入力値が不正（種付証明書番号がブランクなど）",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "422",
+                    description = "繁殖登録・種牡馬が存在しない、または前提条件（種牡馬が雄）を満たさない",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+            ],
+    )
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/api/breeding_results")
+    fun record(@RequestBody request: RecordCoveringRequest): BreedingResultResponse =
+        recordCovering(Command.now(request.toCommand(), clock))
+            .mapError { it.toProblemDetail() }
+            .orThrowProblem()
+            .toResponse()
+
+    @Operation(
+        summary = "分娩結果を報告する",
+        description =
+            "種付済みの繁殖成績に分娩結果（生産または産駒なしの各区分）を報告し、更新後の繁殖成績リソースを返す。" +
+                "二重報告や対象不在などの業務ルール違反時は RFC 9457 形式の problem+json を返す。",
+        tags = ["BreedingResult"],
+        responses =
+            [
+                ApiResponse(
+                    responseCode = "200",
+                    description = "分娩結果報告成功（更新後の繁殖成績リソースを返す）",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = BreedingResultResponse::class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "400",
+                    description = "入力値が不正（生産なのに分娩日が欠けているなど）",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "404",
+                    description = "報告対象の繁殖成績が存在しない",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "409",
+                    description = "既に分娩結果が報告済み（二重報告）",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+            ],
+    )
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/api/breeding_results/{breedingResultId}:reportFoaling")
+    fun reportFoaling(
+        @PathVariable breedingResultId: UUID,
+        @RequestBody request: ReportFoalingRequest,
+    ): BreedingResultResponse {
+        val outcome = request.toOutcome().orThrowProblem()
+        return reportFoaling(Command.now(ReportFoalingCommand(breedingResultId, outcome), clock))
+            .mapError { it.toProblemDetail() }
+            .orThrowProblem()
+            .toResponse()
+    }
+}

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
@@ -1,0 +1,118 @@
+package com.example.api.controller.breeding
+
+import com.example.api.application.horseracing.breeding.RecordCoveringUseCaseError
+import com.example.api.application.horseracing.breeding.ReportFoalingUseCaseError
+import com.example.api.controller.problem
+import com.example.api.domain.horseracing.model.breeding.BreedingResult
+import com.example.api.domain.horseracing.service.breeding.RecordCoveringError
+import java.time.LocalDate
+import java.util.UUID
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+
+/**
+ * 繁殖成績リソースの表現（HTTP 契約）。
+ *
+ * 繁殖成績に対する操作（種付記録の Create、分娩結果報告の `:reportFoaling` カスタムメソッド）は、
+ * [AIP-133](https://google.aip.dev/133) / [AIP-136](https://google.aip.dev/136) に倣い一律で
+ * このリソース表現全体を返す。種付年は種付日から導出した値を持つ。分娩結果は未報告なら null。
+ *
+ * @property id 繁殖成績の生 UUID
+ * @property breedingRegistrationId 紐づく繁殖登録（繁殖牝馬のロール）の生 UUID
+ * @property coveringYear 種付年
+ * @property stallionId 種牡馬の生 UUID
+ * @property coveringDate 種付日
+ * @property certificateNumber 種付証明書番号
+ * @property outcome 分娩結果。未報告なら null
+ */
+data class BreedingResultResponse(
+    val id: UUID,
+    val breedingRegistrationId: UUID,
+    val coveringYear: Int,
+    val stallionId: UUID,
+    val coveringDate: LocalDate,
+    val certificateNumber: String,
+    val outcome: FoalingOutcomeResponse?,
+)
+
+/** [BreedingResult] を繁殖成績リソースの表現へ変換する。各操作の成功レスポンスはこのリソース表現を一律で返す。 */
+fun BreedingResult.toResponse(): BreedingResultResponse =
+    BreedingResultResponse(
+        id = id.value,
+        breedingRegistrationId = breedingRegistrationId.value,
+        coveringYear = coveringYear.value,
+        stallionId = covering.stallionId.value,
+        coveringDate = covering.coveringDate,
+        certificateNumber = covering.certificateNumber.value,
+        outcome = outcome?.toResponse(),
+    )
+
+/**
+ * [RecordCoveringUseCaseError] を RFC 9457 (`application/problem+json`) の [ProblemDetail] に変換する。
+ *
+ * - VO 検証エラーは入力不正として 400 Bad Request
+ * - 繁殖登録・種牡馬の不在やドメイン前提条件違反は、整った入力だが意味的に処理できないため 422 Unprocessable Entity
+ */
+fun RecordCoveringUseCaseError.toProblemDetail(): ProblemDetail =
+    when (this) {
+        RecordCoveringUseCaseError.InvalidCertificateNumber ->
+            problem(
+                status = HttpStatus.BAD_REQUEST,
+                code = "invalid-covering-certificate-number",
+                title = "Invalid covering certificate number",
+                detail = "certificateNumber は空であってはいけません。",
+            )
+        is RecordCoveringUseCaseError.BreedingRegistrationNotFound ->
+            problem(
+                    status = HttpStatus.UNPROCESSABLE_ENTITY,
+                    code = "breeding-registration-not-found",
+                    title = "Breeding registration not found",
+                    detail = "種付対象として指定された繁殖登録が存在しません。",
+                )
+                .apply { setProperty("breedingRegistrationId", breedingRegistrationId) }
+        is RecordCoveringUseCaseError.StallionNotFound ->
+            problem(
+                    status = HttpStatus.UNPROCESSABLE_ENTITY,
+                    code = "stallion-not-found",
+                    title = "Stallion not found",
+                    detail = "配合相手として指定された種牡馬が存在しません。",
+                )
+                .apply { setProperty("stallionId", stallionId) }
+        is RecordCoveringUseCaseError.PreconditionViolated -> cause.toProblemDetail()
+    }
+
+private fun RecordCoveringError.toProblemDetail(): ProblemDetail =
+    when (this) {
+        RecordCoveringError.StallionNotMale ->
+            problem(
+                status = HttpStatus.UNPROCESSABLE_ENTITY,
+                code = "stallion-not-male",
+                title = "Stallion is not male",
+                detail = "配合相手として指定された軽種馬が雄ではありません。",
+            )
+    }
+
+/**
+ * [ReportFoalingUseCaseError] を RFC 9457 (`application/problem+json`) の [ProblemDetail] に変換する。
+ *
+ * - 報告対象（URL パスの繁殖成績）の不在は 404 Not Found
+ * - 二重報告（既に分娩結果が報告済み）は状態の競合として 409 Conflict
+ */
+fun ReportFoalingUseCaseError.toProblemDetail(): ProblemDetail =
+    when (this) {
+        is ReportFoalingUseCaseError.BreedingResultNotFound ->
+            problem(
+                    status = HttpStatus.NOT_FOUND,
+                    code = "breeding-result-not-found",
+                    title = "Breeding result not found",
+                    detail = "報告対象として指定された繁殖成績が存在しません。",
+                )
+                .apply { setProperty("breedingResultId", breedingResultId) }
+        is ReportFoalingUseCaseError.AlreadyReported ->
+            problem(
+                status = HttpStatus.CONFLICT,
+                code = "foaling-already-recorded",
+                title = "Foaling already recorded",
+                detail = "この繁殖成績には既に分娩結果が報告されています。",
+            )
+    }

--- a/src/main/kotlin/com/example/api/controller/breeding/FoalingOutcomeWire.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/FoalingOutcomeWire.kt
@@ -1,0 +1,66 @@
+package com.example.api.controller.breeding
+
+import com.example.api.domain.horseracing.model.breeding.FoalingOutcome
+import java.time.LocalDate
+
+/*
+ * 分娩結果（[FoalingOutcome]）の HTTP 契約で用いる区分 enum と、ドメインとの相互変換。
+ *
+ * ドメインの [FoalingOutcome] は sealed interface（生産＝[FoalingOutcome.LiveFoal] と産駒なしの各 data object）で
+ * 表すが、これをそのまま wire に晒すと、ドメイン側の構造変更が HTTP 契約（および生成クライアント）を無言で破壊する。
+ * これを避けるため adapter 層に契約専用の区分 enum [FoalingOutcomeDto] を置き、網羅 when で domain と往復させる
+ * （区分の増減を compile エラーで検知できる）。生産（[FoalingOutcome.LiveFoal]）のみ分娩日を伴うため、wire 形は
+ * 区分 + 任意の分娩日（[FoalingOutcomeResponse]）で表す。
+ */
+
+/** 分娩結果の区分（HTTP 契約）。 */
+enum class FoalingOutcomeDto {
+    /** 生産（産駒あり）。分娩日を伴う。 */
+    LIVE_FOAL,
+
+    /** 不受胎。 */
+    NOT_CONCEIVED,
+
+    /** 流産。 */
+    ABORTION,
+
+    /** 双子流産。 */
+    TWIN_ABORTION,
+
+    /** 死産。 */
+    STILLBIRTH,
+
+    /** 双子死産。 */
+    TWIN_STILLBIRTH,
+
+    /** 生後直死。 */
+    NEONATAL_DEATH,
+
+    /** 双子生後直死。 */
+    TWIN_NEONATAL_DEATH,
+}
+
+/**
+ * 分娩結果のリソース表現（HTTP 契約）。
+ *
+ * @property kind 分娩結果の区分
+ * @property foalingDate 分娩日。生産（[FoalingOutcomeDto.LIVE_FOAL]）のときのみ非 null
+ */
+data class FoalingOutcomeResponse(val kind: FoalingOutcomeDto, val foalingDate: LocalDate?)
+
+/** ドメインの分娩結果を HTTP 契約のリソース表現へ変換する。 */
+fun FoalingOutcome.toResponse(): FoalingOutcomeResponse =
+    when (this) {
+        is FoalingOutcome.LiveFoal ->
+            FoalingOutcomeResponse(FoalingOutcomeDto.LIVE_FOAL, foalingDate)
+        FoalingOutcome.NotConceived -> FoalingOutcomeResponse(FoalingOutcomeDto.NOT_CONCEIVED, null)
+        FoalingOutcome.Abortion -> FoalingOutcomeResponse(FoalingOutcomeDto.ABORTION, null)
+        FoalingOutcome.TwinAbortion -> FoalingOutcomeResponse(FoalingOutcomeDto.TWIN_ABORTION, null)
+        FoalingOutcome.Stillbirth -> FoalingOutcomeResponse(FoalingOutcomeDto.STILLBIRTH, null)
+        FoalingOutcome.TwinStillbirth ->
+            FoalingOutcomeResponse(FoalingOutcomeDto.TWIN_STILLBIRTH, null)
+        FoalingOutcome.NeonatalDeath ->
+            FoalingOutcomeResponse(FoalingOutcomeDto.NEONATAL_DEATH, null)
+        FoalingOutcome.TwinNeonatalDeath ->
+            FoalingOutcomeResponse(FoalingOutcomeDto.TWIN_NEONATAL_DEATH, null)
+    }

--- a/src/main/kotlin/com/example/api/controller/breeding/RecordCoveringRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/RecordCoveringRequest.kt
@@ -1,0 +1,31 @@
+package com.example.api.controller.breeding
+
+import com.example.api.application.horseracing.breeding.RecordCoveringCommand
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * `POST /api/breeding_results` のリクエストボディ。
+ *
+ * 繁殖成績報告書の「種付」欄に相当する。繁殖登録・種牡馬は登録済みのIDで参照する。VO で表す種付証明書番号は 素の文字列で受け取り、ユースケースで検証する。
+ *
+ * @property breedingRegistrationId 種付対象の繁殖牝馬の繁殖登録ID
+ * @property stallionId 配合相手の種牡馬の軽種馬ID
+ * @property coveringDate 種付日
+ * @property certificateNumber 種付証明書番号
+ */
+data class RecordCoveringRequest(
+    val breedingRegistrationId: UUID,
+    val stallionId: UUID,
+    val coveringDate: LocalDate,
+    val certificateNumber: String,
+)
+
+/** リクエストボディを種付記録ユースケースの入力コマンドへ変換する。 */
+fun RecordCoveringRequest.toCommand(): RecordCoveringCommand =
+    RecordCoveringCommand(
+        breedingRegistrationId = breedingRegistrationId,
+        stallionId = stallionId,
+        coveringDate = coveringDate,
+        certificateNumber = certificateNumber,
+    )

--- a/src/main/kotlin/com/example/api/controller/breeding/ReportFoalingRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/ReportFoalingRequest.kt
@@ -1,0 +1,52 @@
+package com.example.api.controller.breeding
+
+import com.example.api.controller.problem
+import com.example.api.domain.horseracing.model.breeding.FoalingOutcome
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import java.time.LocalDate
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+
+/**
+ * `POST /api/breeding_results/{breedingResultId}:reportFoaling` のリクエストボディ。
+ *
+ * 繁殖成績報告書の「分娩結果」欄に相当する。区分は HTTP 契約専用の [FoalingOutcomeDto] で受け取り（未知の値は Jackson のデシリアライズで弾かれ
+ * 400）、ドメインの [FoalingOutcome] へは [toOutcome] で変換する。生産
+ * （[FoalingOutcomeDto.LIVE_FOAL]）のみ分娩日を伴うため、区分と分娩日の整合は [toOutcome] が検証する。
+ *
+ * @property outcome 分娩結果の区分
+ * @property foalingDate 分娩日。生産のときは必須、それ以外は無視される
+ */
+data class ReportFoalingRequest(val outcome: FoalingOutcomeDto, val foalingDate: LocalDate?)
+
+/**
+ * リクエストボディをドメインの分娩結果へ変換する。
+ *
+ * 生産（[FoalingOutcomeDto.LIVE_FOAL]）は分娩日が必須であり、欠けている場合は入力不正として 400 を表す [ProblemDetail]
+ * を返す。産駒なしの各区分は分娩日を持たない（指定されても無視する）。
+ */
+fun ReportFoalingRequest.toOutcome(): Result<FoalingOutcome, ProblemDetail> =
+    when (outcome) {
+        FoalingOutcomeDto.LIVE_FOAL ->
+            if (foalingDate == null) {
+                Err(
+                    problem(
+                        status = HttpStatus.BAD_REQUEST,
+                        code = "missing-foaling-date",
+                        title = "Missing foaling date",
+                        detail = "生産（LIVE_FOAL）のときは foalingDate が必須です。",
+                    )
+                )
+            } else {
+                Ok(FoalingOutcome.LiveFoal(foalingDate))
+            }
+        FoalingOutcomeDto.NOT_CONCEIVED -> Ok(FoalingOutcome.NotConceived)
+        FoalingOutcomeDto.ABORTION -> Ok(FoalingOutcome.Abortion)
+        FoalingOutcomeDto.TWIN_ABORTION -> Ok(FoalingOutcome.TwinAbortion)
+        FoalingOutcomeDto.STILLBIRTH -> Ok(FoalingOutcome.Stillbirth)
+        FoalingOutcomeDto.TWIN_STILLBIRTH -> Ok(FoalingOutcome.TwinStillbirth)
+        FoalingOutcomeDto.NEONATAL_DEATH -> Ok(FoalingOutcome.NeonatalDeath)
+        FoalingOutcomeDto.TWIN_NEONATAL_DEATH -> Ok(FoalingOutcome.TwinNeonatalDeath)
+    }

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingRegistrationRepository.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingRegistrationRepository.kt
@@ -1,0 +1,18 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import org.jmolecules.ddd.annotation.Repository
+
+/**
+ * 繁殖登録（[BreedingRegistration]）の永続化を担うポート。
+ *
+ * ドメイン層はこのインターフェースのみを参照する。実装は infrastructure 層に置く。 種付記録（recordCovering）の入力となる繁殖登録の取得や、繁殖登録の成立時の保存に
+ * 用いる。
+ */
+@Repository
+interface BreedingRegistrationRepository {
+    /** 繁殖登録IDで検索する。存在しなければ null。 */
+    fun findById(id: BreedingRegistrationId): BreedingRegistration?
+
+    /** 繁殖登録を永続化する。 */
+    fun save(breedingRegistration: BreedingRegistration): BreedingRegistration
+}

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultRepository.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultRepository.kt
@@ -1,0 +1,17 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import org.jmolecules.ddd.annotation.Repository
+
+/**
+ * 繁殖成績（[BreedingResult]）の永続化を担うポート。
+ *
+ * ドメイン層はこのインターフェースのみを参照する。実装は infrastructure 層に置く。 種付記録で起こした年次レコードの保存や、分娩結果報告のために対象成績を取得するのに用いる。
+ */
+@Repository
+interface BreedingResultRepository {
+    /** 繁殖成績IDで検索する。存在しなければ null。 */
+    fun findById(id: BreedingResultId): BreedingResult?
+
+    /** 繁殖成績を永続化する。 */
+    fun save(breedingResult: BreedingResult): BreedingResult
+}

--- a/src/main/kotlin/com/example/api/infrastructure/horseracing/breeding/InMemoryBreedingRegistrationRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/horseracing/breeding/InMemoryBreedingRegistrationRepository.kt
@@ -1,0 +1,24 @@
+package com.example.api.infrastructure.horseracing.breeding
+
+import com.example.api.domain.horseracing.model.breeding.BreedingRegistration
+import com.example.api.domain.horseracing.model.breeding.BreedingRegistrationId
+import com.example.api.domain.horseracing.model.breeding.BreedingRegistrationRepository
+import java.util.concurrent.ConcurrentHashMap
+import org.springframework.stereotype.Repository
+
+/**
+ * In-Memory な BreedingRegistrationRepository 実装。PoC 用途。
+ *
+ * 永続化層の代わりとして ConcurrentHashMap で保持する。アプリ再起動でデータは消える。
+ */
+@Repository
+class InMemoryBreedingRegistrationRepository : BreedingRegistrationRepository {
+    private val store = ConcurrentHashMap<BreedingRegistrationId, BreedingRegistration>()
+
+    override fun findById(id: BreedingRegistrationId): BreedingRegistration? = store[id]
+
+    override fun save(breedingRegistration: BreedingRegistration): BreedingRegistration {
+        store[breedingRegistration.id] = breedingRegistration
+        return breedingRegistration
+    }
+}

--- a/src/main/kotlin/com/example/api/infrastructure/horseracing/breeding/InMemoryBreedingResultRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/horseracing/breeding/InMemoryBreedingResultRepository.kt
@@ -1,0 +1,24 @@
+package com.example.api.infrastructure.horseracing.breeding
+
+import com.example.api.domain.horseracing.model.breeding.BreedingResult
+import com.example.api.domain.horseracing.model.breeding.BreedingResultId
+import com.example.api.domain.horseracing.model.breeding.BreedingResultRepository
+import java.util.concurrent.ConcurrentHashMap
+import org.springframework.stereotype.Repository
+
+/**
+ * In-Memory な BreedingResultRepository 実装。PoC 用途。
+ *
+ * 永続化層の代わりとして ConcurrentHashMap で保持する。アプリ再起動でデータは消える。
+ */
+@Repository
+class InMemoryBreedingResultRepository : BreedingResultRepository {
+    private val store = ConcurrentHashMap<BreedingResultId, BreedingResult>()
+
+    override fun findById(id: BreedingResultId): BreedingResult? = store[id]
+
+    override fun save(breedingResult: BreedingResult): BreedingResult {
+        store[breedingResult.id] = breedingResult
+        return breedingResult
+    }
+}

--- a/src/test/kotlin/com/example/api/application/horseracing/breeding/RecordCoveringUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/horseracing/breeding/RecordCoveringUseCaseTest.kt
@@ -1,0 +1,177 @@
+package com.example.api.application.horseracing.breeding
+
+import com.example.api.domain.horseracing.model.breeding.BreedingFixture
+import com.example.api.domain.horseracing.model.breeding.BreedingRegistrationId
+import com.example.api.domain.horseracing.model.breeding.BreedingRegistrationRepository
+import com.example.api.domain.horseracing.model.breeding.BreedingResultRepository
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseFixture
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseId
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.horseracing.model.horse.bloodhorse.Sex
+import com.example.api.domain.horseracing.service.breeding.RecordCoveringError
+import com.example.api.domain.shared.Command
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class RecordCoveringUseCaseTest {
+
+    /** すべて正しい既定のペイロード。変種は `copy` で 1 項目だけ差し替える。 */
+    private fun validPayload(breedingRegistrationId: UUID, stallionId: UUID) =
+        RecordCoveringCommand(
+            breedingRegistrationId = breedingRegistrationId,
+            stallionId = stallionId,
+            coveringDate = LocalDate.of(2024, 4, 1),
+            certificateNumber = "C-2024-0001",
+        )
+
+    private fun command(payload: RecordCoveringCommand): Command<RecordCoveringCommand> =
+        Command(payload, Instant.now())
+
+    @Nested
+    inner class SuccessCase {
+        @Test
+        fun `前提条件を満たすとき種付が記録され分娩結果未報告の繁殖成績が永続化される`() {
+            val registration = BreedingFixture.breedingRegistration()
+            val stallion = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
+            val registrationRepository =
+                mockk<BreedingRegistrationRepository> {
+                    every { findById(registration.id) } returns registration
+                }
+            val bloodHorseRepository =
+                mockk<BloodHorseRepository> { every { findById(stallion.id) } returns stallion }
+            val breedingResultRepository =
+                mockk<BreedingResultRepository> { every { save(any()) } answers { firstArg() } }
+            val useCase =
+                RecordCoveringUseCase(
+                    registrationRepository,
+                    bloodHorseRepository,
+                    breedingResultRepository,
+                )
+
+            val result =
+                useCase(command(validPayload(registration.id.value, stallion.id.value))).unwrap()
+
+            assert(result.breedingRegistrationId == registration.id)
+            assert(result.covering.stallionId == stallion.id)
+            assert(result.covering.coveringDate == LocalDate.of(2024, 4, 1))
+            assert(result.covering.certificateNumber.value == "C-2024-0001")
+            assert(result.outcome == null)
+            verify(exactly = 1) { breedingResultRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    inner class FailureCase {
+        @Test
+        fun `種付証明書番号がブランクのとき InvalidCertificateNumber を返し永続化されない`() {
+            val registrationRepository = mockk<BreedingRegistrationRepository>()
+            val bloodHorseRepository = mockk<BloodHorseRepository>()
+            val breedingResultRepository = mockk<BreedingResultRepository>()
+            val useCase =
+                RecordCoveringUseCase(
+                    registrationRepository,
+                    bloodHorseRepository,
+                    breedingResultRepository,
+                )
+
+            val result =
+                useCase(
+                    command(
+                        validPayload(UUID.randomUUID(), UUID.randomUUID())
+                            .copy(certificateNumber = "")
+                    )
+                )
+
+            assert(result.getError() == RecordCoveringUseCaseError.InvalidCertificateNumber)
+            verify(exactly = 0) { breedingResultRepository.save(any()) }
+        }
+
+        @Test
+        fun `繁殖登録が見つからないとき BreedingRegistrationNotFound を返し永続化されない`() {
+            val breedingRegistrationId = UUID.randomUUID()
+            val registrationRepository =
+                mockk<BreedingRegistrationRepository> {
+                    every { findById(BreedingRegistrationId(breedingRegistrationId)) } returns null
+                }
+            val bloodHorseRepository = mockk<BloodHorseRepository>()
+            val breedingResultRepository = mockk<BreedingResultRepository>()
+            val useCase =
+                RecordCoveringUseCase(
+                    registrationRepository,
+                    bloodHorseRepository,
+                    breedingResultRepository,
+                )
+
+            val result = useCase(command(validPayload(breedingRegistrationId, UUID.randomUUID())))
+
+            assert(
+                result.getError() ==
+                    RecordCoveringUseCaseError.BreedingRegistrationNotFound(breedingRegistrationId)
+            )
+            verify(exactly = 0) { breedingResultRepository.save(any()) }
+        }
+
+        @Test
+        fun `種牡馬が見つからないとき StallionNotFound を返し永続化されない`() {
+            val registration = BreedingFixture.breedingRegistration()
+            val stallionId = UUID.randomUUID()
+            val registrationRepository =
+                mockk<BreedingRegistrationRepository> {
+                    every { findById(registration.id) } returns registration
+                }
+            val bloodHorseRepository =
+                mockk<BloodHorseRepository> {
+                    every { findById(BloodHorseId(stallionId)) } returns null
+                }
+            val breedingResultRepository = mockk<BreedingResultRepository>()
+            val useCase =
+                RecordCoveringUseCase(
+                    registrationRepository,
+                    bloodHorseRepository,
+                    breedingResultRepository,
+                )
+
+            val result = useCase(command(validPayload(registration.id.value, stallionId)))
+
+            assert(result.getError() == RecordCoveringUseCaseError.StallionNotFound(stallionId))
+            verify(exactly = 0) { breedingResultRepository.save(any()) }
+        }
+
+        @Test
+        fun `種牡馬が雄でないときドメイン検証違反を PreconditionViolated に wrap して返す`() {
+            val registration = BreedingFixture.breedingRegistration()
+            val stallion = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+            val registrationRepository =
+                mockk<BreedingRegistrationRepository> {
+                    every { findById(registration.id) } returns registration
+                }
+            val bloodHorseRepository =
+                mockk<BloodHorseRepository> { every { findById(stallion.id) } returns stallion }
+            val breedingResultRepository = mockk<BreedingResultRepository>()
+            val useCase =
+                RecordCoveringUseCase(
+                    registrationRepository,
+                    bloodHorseRepository,
+                    breedingResultRepository,
+                )
+
+            val result = useCase(command(validPayload(registration.id.value, stallion.id.value)))
+
+            assert(
+                result.getError() ==
+                    RecordCoveringUseCaseError.PreconditionViolated(
+                        RecordCoveringError.StallionNotMale
+                    )
+            )
+            verify(exactly = 0) { breedingResultRepository.save(any()) }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/api/application/horseracing/breeding/ReportFoalingUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/horseracing/breeding/ReportFoalingUseCaseTest.kt
@@ -1,0 +1,86 @@
+package com.example.api.application.horseracing.breeding
+
+import com.example.api.domain.horseracing.model.breeding.BreedingFixture
+import com.example.api.domain.horseracing.model.breeding.BreedingResultId
+import com.example.api.domain.horseracing.model.breeding.BreedingResultRepository
+import com.example.api.domain.horseracing.model.breeding.FoalingOutcome
+import com.example.api.domain.shared.Command
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ReportFoalingUseCaseTest {
+
+    private fun command(payload: ReportFoalingCommand): Command<ReportFoalingCommand> =
+        Command(payload, Instant.now())
+
+    @Nested
+    inner class SuccessCase {
+        @Test
+        fun `対象成績が未報告のとき分娩結果が確定し報告済みの成績が永続化される`() {
+            val breedingResult = BreedingFixture.breedingResult()
+            val outcome = FoalingOutcome.LiveFoal(LocalDate.of(2025, 3, 20))
+            val repository =
+                mockk<BreedingResultRepository> {
+                    every { findById(breedingResult.id) } returns breedingResult
+                    every { save(any()) } answers { firstArg() }
+                }
+            val useCase = ReportFoalingUseCase(repository)
+
+            val result =
+                useCase(command(ReportFoalingCommand(breedingResult.id.value, outcome))).unwrap()
+
+            assert(result.outcome == outcome)
+            assert(result.id == breedingResult.id)
+            verify(exactly = 1) { repository.save(any()) }
+        }
+    }
+
+    @Nested
+    inner class FailureCase {
+        @Test
+        fun `対象成績が見つからないとき BreedingResultNotFound を返し永続化されない`() {
+            val breedingResultId = UUID.randomUUID()
+            val repository =
+                mockk<BreedingResultRepository> {
+                    every { findById(BreedingResultId(breedingResultId)) } returns null
+                }
+            val useCase = ReportFoalingUseCase(repository)
+
+            val result =
+                useCase(
+                    command(ReportFoalingCommand(breedingResultId, FoalingOutcome.NotConceived))
+                )
+
+            assert(
+                result.getError() ==
+                    ReportFoalingUseCaseError.BreedingResultNotFound(breedingResultId)
+            )
+            verify(exactly = 0) { repository.save(any()) }
+        }
+
+        @Test
+        fun `既に報告済みの成績へ再報告すると AlreadyReported を返し永続化されない`() {
+            val first = FoalingOutcome.LiveFoal(LocalDate.of(2025, 3, 20))
+            val reported = BreedingFixture.breedingResult().recordFoaling(first).unwrap()
+            val repository =
+                mockk<BreedingResultRepository> { every { findById(reported.id) } returns reported }
+            val useCase = ReportFoalingUseCase(repository)
+
+            val result =
+                useCase(
+                    command(ReportFoalingCommand(reported.id.value, FoalingOutcome.NotConceived))
+                )
+
+            assert(result.getError() == ReportFoalingUseCaseError.AlreadyReported(first))
+            verify(exactly = 0) { repository.save(any()) }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
@@ -1,0 +1,235 @@
+package com.example.api.controller.breeding
+
+import com.example.api.application.horseracing.breeding.RecordCoveringCommand
+import com.example.api.application.horseracing.breeding.RecordCoveringUseCase
+import com.example.api.application.horseracing.breeding.RecordCoveringUseCaseError
+import com.example.api.application.horseracing.breeding.ReportFoalingCommand
+import com.example.api.application.horseracing.breeding.ReportFoalingUseCase
+import com.example.api.application.horseracing.breeding.ReportFoalingUseCaseError
+import com.example.api.config.ClockConfiguration
+import com.example.api.domain.horseracing.model.breeding.BreedingFixture
+import com.example.api.domain.horseracing.model.breeding.FoalingOutcome
+import com.example.api.domain.horseracing.service.breeding.RecordCoveringError
+import com.example.api.domain.shared.Command
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.unwrap
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import java.time.LocalDate
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.context.TestConstructor.AutowireMode
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.assertj.MockMvcTester
+
+@WebMvcTest(BreedingResultController::class)
+@Import(ClockConfiguration::class)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class BreedingResultControllerTest(val mockMvc: MockMvc) {
+    @MockkBean private lateinit var recordCovering: RecordCoveringUseCase
+    @MockkBean private lateinit var reportFoaling: ReportFoalingUseCase
+
+    private val tester = MockMvcTester.create(mockMvc)
+
+    @Nested
+    inner class RecordCoveringCase {
+        private val uri = "/api/breeding_results"
+
+        /** デシリアライズに通る正しいリクエストボディ。ユースケースはモックのため中身の整合は問われない。 */
+        private val validBody =
+            """
+            {
+                "breedingRegistrationId": "11111111-1111-1111-1111-111111111111",
+                "stallionId": "22222222-2222-2222-2222-222222222222",
+                "coveringDate": "2024-04-01",
+                "certificateNumber": "C-2024-0001"
+            }
+            """
+                .trimIndent()
+
+        @Test
+        fun `正常な入力で 201 Created と起票された繁殖成績が返ること`() {
+            val saved = BreedingFixture.breedingResult()
+            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns Ok(saved)
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.CREATED)
+                .bodyJson()
+                .extractingPath("$.coveringYear")
+                .isEqualTo(2024)
+        }
+
+        @Test
+        fun `InvalidCertificateNumber で 400 と problem+json が返ること`() {
+            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+                Err(RecordCoveringUseCaseError.InvalidCertificateNumber)
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.errorCode")
+                .isEqualTo("invalid-covering-certificate-number")
+        }
+
+        @Test
+        fun `BreedingRegistrationNotFound で 422 と breedingRegistrationId 付きの problem+json が返ること`() {
+            val id = UUID.fromString("11111111-1111-1111-1111-111111111111")
+            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+                Err(RecordCoveringUseCaseError.BreedingRegistrationNotFound(id))
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.breedingRegistrationId")
+                .isEqualTo(id.toString())
+        }
+
+        @Test
+        fun `StallionNotFound で 422 と stallionId 付きの problem+json が返ること`() {
+            val id = UUID.fromString("22222222-2222-2222-2222-222222222222")
+            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+                Err(RecordCoveringUseCaseError.StallionNotFound(id))
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.stallionId")
+                .isEqualTo(id.toString())
+        }
+
+        @Test
+        fun `前提条件違反（StallionNotMale）が 422 と problem+json に変換されること`() {
+            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+                Err(
+                    RecordCoveringUseCaseError.PreconditionViolated(
+                        RecordCoveringError.StallionNotMale
+                    )
+                )
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.errorCode")
+                .isEqualTo("stallion-not-male")
+        }
+    }
+
+    @Nested
+    inner class ReportFoalingCase {
+        private val breedingResultId = "33333333-3333-3333-3333-333333333333"
+        private val uri = "/api/breeding_results/$breedingResultId:reportFoaling"
+        private val liveFoalBody = """{ "outcome": "LIVE_FOAL", "foalingDate": "2025-03-20" }"""
+
+        @Test
+        fun `正常な入力で 200 OK と更新後の繁殖成績が返ること`() {
+            val reported =
+                BreedingFixture.breedingResult()
+                    .recordFoaling(FoalingOutcome.LiveFoal(LocalDate.of(2025, 3, 20)))
+                    .unwrap()
+            every { reportFoaling(any<Command<ReportFoalingCommand>>()) } returns Ok(reported)
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(liveFoalBody)
+                .assertThat()
+                .hasStatus(HttpStatus.OK)
+                .bodyJson()
+                .extractingPath("$.outcome.kind")
+                .isEqualTo("LIVE_FOAL")
+        }
+
+        @Test
+        fun `生産なのに分娩日が欠けていると 400 と problem+json が返ること`() {
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{ "outcome": "LIVE_FOAL" }""")
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.errorCode")
+                .isEqualTo("missing-foaling-date")
+        }
+
+        @Test
+        fun `BreedingResultNotFound で 404 と breedingResultId 付きの problem+json が返ること`() {
+            val id = UUID.fromString(breedingResultId)
+            every { reportFoaling(any<Command<ReportFoalingCommand>>()) } returns
+                Err(ReportFoalingUseCaseError.BreedingResultNotFound(id))
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(liveFoalBody)
+                .assertThat()
+                .hasStatus(HttpStatus.NOT_FOUND)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.breedingResultId")
+                .isEqualTo(id.toString())
+        }
+
+        @Test
+        fun `AlreadyReported で 409 と problem+json が返ること`() {
+            every { reportFoaling(any<Command<ReportFoalingCommand>>()) } returns
+                Err(
+                    ReportFoalingUseCaseError.AlreadyReported(
+                        FoalingOutcome.LiveFoal(LocalDate.of(2025, 3, 20))
+                    )
+                )
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{ "outcome": "NOT_CONCEIVED" }""")
+                .assertThat()
+                .hasStatus(HttpStatus.CONFLICT)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.errorCode")
+                .isEqualTo("foaling-already-recorded")
+        }
+    }
+}

--- a/src/test/kotlin/com/example/api/controller/breeding/FoalingOutcomeWireTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/FoalingOutcomeWireTest.kt
@@ -1,0 +1,65 @@
+package com.example.api.controller.breeding
+
+import com.example.api.domain.horseracing.model.breeding.FoalingOutcome
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import java.time.LocalDate
+import org.junit.jupiter.api.Test
+
+/** 分娩結果（[FoalingOutcome]）の wire ↔ domain マッピングのユニットテスト。全区分を網羅する。 */
+class FoalingOutcomeWireTest {
+
+    @Test
+    fun `ドメインの全区分が wire 表現へ変換でき生産のみ分娩日を伴うこと`() {
+        val foalingDate = LocalDate.of(2025, 3, 20)
+        val cases: List<Pair<FoalingOutcome, FoalingOutcomeResponse>> =
+            listOf(
+                FoalingOutcome.LiveFoal(foalingDate) to
+                    FoalingOutcomeResponse(FoalingOutcomeDto.LIVE_FOAL, foalingDate),
+                FoalingOutcome.NotConceived to
+                    FoalingOutcomeResponse(FoalingOutcomeDto.NOT_CONCEIVED, null),
+                FoalingOutcome.Abortion to FoalingOutcomeResponse(FoalingOutcomeDto.ABORTION, null),
+                FoalingOutcome.TwinAbortion to
+                    FoalingOutcomeResponse(FoalingOutcomeDto.TWIN_ABORTION, null),
+                FoalingOutcome.Stillbirth to
+                    FoalingOutcomeResponse(FoalingOutcomeDto.STILLBIRTH, null),
+                FoalingOutcome.TwinStillbirth to
+                    FoalingOutcomeResponse(FoalingOutcomeDto.TWIN_STILLBIRTH, null),
+                FoalingOutcome.NeonatalDeath to
+                    FoalingOutcomeResponse(FoalingOutcomeDto.NEONATAL_DEATH, null),
+                FoalingOutcome.TwinNeonatalDeath to
+                    FoalingOutcomeResponse(FoalingOutcomeDto.TWIN_NEONATAL_DEATH, null),
+            )
+
+        cases.forEach { (domain, expected) -> assert(domain.toResponse() == expected) }
+    }
+
+    @Test
+    fun `wire の全区分がドメインへ変換でき産駒なしは分娩日を無視すること`() {
+        val foalingDate = LocalDate.of(2025, 3, 20)
+        val cases: List<Pair<FoalingOutcomeDto, FoalingOutcome>> =
+            listOf(
+                FoalingOutcomeDto.LIVE_FOAL to FoalingOutcome.LiveFoal(foalingDate),
+                FoalingOutcomeDto.NOT_CONCEIVED to FoalingOutcome.NotConceived,
+                FoalingOutcomeDto.ABORTION to FoalingOutcome.Abortion,
+                FoalingOutcomeDto.TWIN_ABORTION to FoalingOutcome.TwinAbortion,
+                FoalingOutcomeDto.STILLBIRTH to FoalingOutcome.Stillbirth,
+                FoalingOutcomeDto.TWIN_STILLBIRTH to FoalingOutcome.TwinStillbirth,
+                FoalingOutcomeDto.NEONATAL_DEATH to FoalingOutcome.NeonatalDeath,
+                FoalingOutcomeDto.TWIN_NEONATAL_DEATH to FoalingOutcome.TwinNeonatalDeath,
+            )
+
+        cases.forEach { (dto, expected) ->
+            val outcome = ReportFoalingRequest(dto, foalingDate).toOutcome().get()
+            assert(outcome == expected)
+        }
+    }
+
+    @Test
+    fun `生産で分娩日が欠けていると入力不正の ProblemDetail を返すこと`() {
+        val problem = ReportFoalingRequest(FoalingOutcomeDto.LIVE_FOAL, null).toOutcome().getError()
+
+        assert(problem != null)
+        assert(problem?.properties?.get("errorCode") == "missing-foaling-date")
+    }
+}


### PR DESCRIPTION
## 概要

Closes #323

#321（PR）で繁殖成績報告の**ドメイン層**（`recordCovering` ドメインサービス、`BreedingResult.recordFoaling`）まで実装したが、`registerForBreeding` 同様にドメイン層止まりだった。本 PR で **application 層ユースケース・Repository ポート・REST アダプター**へ縦スライスとして接続する。

繁殖成績リソースに対し、種付記録（Create）と分娩結果報告（カスタムメソッド）を提供する。

## 変更点

### domain（model/breeding）
- `BreedingResultRepository` ポート（`findById` / `save`、jMolecules `@Repository`）
- `BreedingRegistrationRepository` ポート（`findById` / `save`）

### infrastructure
- `InMemoryBreedingResultRepository` / `InMemoryBreedingRegistrationRepository`（PoC 用途）

### application（application/horseracing/breeding）
- `RecordCoveringUseCase`: 証明書番号 VO 検証 → 繁殖登録・種牡馬を lookup → `recordCovering` → 繁殖成績を save
  - 失敗バリアント: `InvalidCertificateNumber`(400) / `BreedingRegistrationNotFound`(422) / `StallionNotFound`(422) / `PreconditionViolated`(422)
- `ReportFoalingUseCase`: 繁殖成績を lookup → `recordFoaling`（二重報告は不変条件違反）→ save
  - 失敗バリアント: `BreedingResultNotFound`(404) / `AlreadyReported`(409)

### controller（controller/breeding）
- `BreedingResultController`
  - `POST /api/breeding_results`（種付記録 → 201）
  - `POST /api/breeding_results/{breedingResultId}:reportFoaling`（分娩結果報告 → 200、[AIP-136](https://google.aip.dev/136)）
- `FoalingOutcomeWire`: 分娩結果の wire enum `FoalingOutcomeDto` ↔ ドメイン sealed `FoalingOutcome` を網羅 `when` で相互変換（ADR-0007 準拠）。生産（`LIVE_FOAL`）のみ分娩日を伴う wire 形
- リクエスト/レスポンス DTO と `ProblemDetail`（RFC 9457）変換

## 設計上の判断

- **`BreedingRegistrationRepository` を追加**: ドメインサービス `recordCovering` は `BreedingRegistration` 集約を入力に要求するため、種付記録ユースケースは繁殖登録を lookup する必要がある。issue では infrastructure に `BreedingResultRepository` のみ明記されていたが、lookup に不可欠なため追加した。
- **分娩日の必須検証は wire→domain 変換（`toOutcome`）で 400**: 生産（`LIVE_FOAL`）に分娩日が欠ける入力は controller 境界で `missing-foaling-date` として弾く。産駒なしの各区分は分娩日を持たない。
- **分娩結果報告は集約メソッドを直接呼ぶ**: `recordFoaling` は `BreedingResult` の集約メソッドのため、application から直接呼ぶ（ドメインサービスを介さない）。

## 既知の制約（フォローアップ）

- `BreedingRegistration` を永続化する経路（`registerForBreeding` の application 層化）が未実装のため、種付記録エンドポイントは**現状エンドツーエンドでは繁殖登録が引けず 422 に倒れる**。繁殖登録の永続化は #271 等の別 issue で扱う。本 PR のユニット/slice テストは Repository ポートを mock して各分岐を検証している。

## テスト

- `RecordCoveringUseCaseTest` / `ReportFoalingUseCaseTest`: 成功・各失敗バリアントを mockk で検証
- `BreedingResultControllerTest`: `@WebMvcTest` slice。HTTP 入出力と ProblemDetail 描画（400/404/409/422）
- `FoalingOutcomeWireTest`: wire ↔ domain マッピングを全区分網羅で検証
- `./gradlew check` 通過（ktfmt / detekt / test / koverVerifyMature）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
