### PR TITLE
test: ドメインサービスのトップレベル関数性と RestController の ResponseEntity 不使用を ArchUnit で機械強制する (#295, #296)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -93,6 +93,8 @@ domain/
 - フィールドインジェクション禁止（コンストラクタインジェクションを使う）
 - `UUID.randomUUID()` の直接呼び出し禁止。ID は `domain.shared.generateId()`（UUIDv7 相当のタイムベース生成）経由で生成する（永続化時のインデックス局所性のため。[ADR-0005](../../docs/adr/0005-time-based-uuid-generation.md)）。main コードのみ対象（テストの fixture は対象外）
 - **集約（`@AggregateRoot` / `@Entity`）はイミュータブル**（`val` のみ・`var` 禁止）。状態遷移は対象を書き換えず、同一性（ID）を引き継いだ新インスタンスを返すメソッドで表す（[ADR-0009](../../docs/adr/0009-immutable-aggregates.md)）。`val` は final フィールド・`var` は非 final フィールドへコンパイルされるため、集約クラスが直接宣言するフィールドが全て final であることを ArchUnit で検証して `var` を排除する
+- **ドメインサービス（`domain.*.service`）はトップレベル関数で書く**（`object` / `class` でラップしない）。トップレベル関数はファイルごとのファサードクラス（`〜Kt`）へコンパイルされるため、service パッケージ内のクラスが `Kt` で終わることを ArchUnit で検証して `object` / `class` 宣言を排除する。ただしサービスの戻り値（`Result<_, 〜Error>`）の失敗側を表す失敗バリアント型（`〜Error`）はサービスと同居させてよく、対象から除外する
+- **`@RestController` のハンドラは成功レスポンスで `ResponseEntity` を返さない**。成功は `@ResponseStatus` ＋戻り値で resource を返す（[error-handling.md](error-handling.md) / [api-design.md](api-design.md)）。エラー描画 funnel の `GlobalExceptionHandler` は `@RestController` ではない（`ResponseEntityExceptionHandler` 継承）ため誤検出されない
 
 ## ルールの変更・追加
 

--- a/src/test/kotlin/com/example/api/architecture/ArchitectureTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/ArchitectureTest.kt
@@ -1,6 +1,7 @@
 package com.example.api.architecture
 
 import com.example.api.ApiApplication
+import com.tngtech.archunit.base.DescribedPredicate
 import com.tngtech.archunit.base.DescribedPredicate.not
 import com.tngtech.archunit.core.domain.JavaClass
 import com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage
@@ -10,6 +11,7 @@ import com.tngtech.archunit.junit.ArchTest
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods
 import com.tngtech.archunit.library.Architectures.onionArchitecture
 import com.tngtech.archunit.library.GeneralCodingRules
 import com.tngtech.archunit.library.dependencies.SliceAssignment
@@ -21,6 +23,7 @@ import org.jmolecules.ddd.annotation.AggregateRoot
 import org.jmolecules.ddd.annotation.Entity as DddEntity
 import org.jmolecules.ddd.annotation.Repository as DddRepository
 import org.jmolecules.ddd.annotation.ValueObject
+import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Repository
 import org.springframework.stereotype.Service
 import org.springframework.web.bind.annotation.RestController
@@ -35,6 +38,18 @@ private const val DOMAIN_SERVICE = "com.example.api.domain..service.."
 private const val APPLICATION = "com.example.api.application.."
 private const val CONTROLLER = "com.example.api.controller.."
 private const val INFRASTRUCTURE = "com.example.api.infrastructure.."
+
+/**
+ * ドメインサービスの失敗バリアント型（`〜Error` の sealed interface とその variant）であること。
+ *
+ * サービスの戻り値（`Result<_, 〜Error>`）の失敗側を表す型はサービスと同じパッケージに同居させており、 これは `object` / `class`
+ * によるサービスのラップではないため [domainServicesAreTopLevelFunctions] の対象から除外する。ネストした variant も囲みクラスを辿って判定する。
+ */
+private val isFailureVariantType =
+    DescribedPredicate.describe<JavaClass>("ドメインサービスの失敗バリアント型（〜Error）") { javaClass ->
+        generateSequence(javaClass) { it.enclosingClass.orElse(null) }
+            .any { it.simpleName.endsWith("Error") }
+    }
 
 /**
  * 境界づけられたコンテキスト（horseracing / sakamichi / tennis 等）へのスライス割り当て。
@@ -93,6 +108,24 @@ class ArchitectureTest {
             .should()
             .dependOnClassesThat()
             .resideInAnyPackage("org.springframework..", "jakarta..", "com.fasterxml.jackson..")
+
+    /**
+     * ドメインサービス（`domain.*.service`）は Kotlin のトップレベル関数で書くこと。
+     *
+     * `object` / `class` でラップせず、`service/` パッケージへの配置でドメインサービスを表現する
+     * （`.claude/rules/architecture.md`）。Kotlin のトップレベル関数はファイルごとのファサードクラス（`〜Kt`）へ コンパイルされるため、service
+     * パッケージ内のクラスが `Kt` で終わることを検証して `object` / `class` 宣言を排除する。
+     * ただしサービスの戻り値の失敗側を表す失敗バリアント型（`〜Error`）はサービスと同居させてよく、対象から除外する。
+     */
+    @ArchTest
+    val domainServicesAreTopLevelFunctions =
+        classes()
+            .that()
+            .resideInAPackage(DOMAIN_SERVICE)
+            .and(not(isFailureVariantType))
+            .should()
+            .haveSimpleNameEndingWith("Kt")
+            .because("ドメインサービスは object / class でラップせずトップレベル関数で書く。" + "service/ への配置でドメインサービスを表現する")
 
     /** application 層の Spring 依存は DI 用 stereotype アノテーションのみに留めること。 */
     @ArchTest
@@ -162,6 +195,23 @@ class ArchitectureTest {
             .areAnnotatedWith(RestController::class.java)
             .should()
             .resideInAPackage(CONTROLLER)
+
+    /**
+     * `@RestController` のハンドラは成功レスポンスで `ResponseEntity` を返さないこと。
+     *
+     * 成功レスポンスは `@ResponseStatus` ＋戻り値で resource を返す（`.claude/rules/error-handling.md` /
+     * `.claude/rules/api-design.md`）。エラー描画 funnel の `GlobalExceptionHandler` は `@RestController`
+     * ではない（`ResponseEntityExceptionHandler` 継承）ため、本ルールでは誤検出されない。
+     */
+    @ArchTest
+    val restControllersDoNotReturnResponseEntity =
+        noMethods()
+            .that()
+            .areDeclaredInClassesThat()
+            .areAnnotatedWith(RestController::class.java)
+            .should()
+            .haveRawReturnType(ResponseEntity::class.java)
+            .because("成功レスポンスは @ResponseStatus ＋戻り値で resource を返す。ResponseEntity は使わない")
 
     /** ユースケース（@Service）は application 層に置くこと。 */
     @ArchTest


### PR DESCRIPTION
## 概要

文章のみだった 2 つの規約（親 #291）を ArchUnit へ落として機械強制する。いずれも既存違反 0 件で、テスト追加が主。

## #295 ドメインサービスはトップレベル関数で書く

`domainServicesAreTopLevelFunctions` を追加。`domain.*.service` のクラスが Kotlin ファイルファサード（`〜Kt`）で終わることを検証し、`object` / `class` でのラップを排除する。

- 失敗バリアント型（`〜Error` の sealed interface とネスト variant）はサービスの戻り値（`Result<_, 〜Error>`）の失敗側を表すためサービスと同居が正当。囲みクラスを辿って判定する `isFailureVariantType` 述語で対象から除外している。
- イシュー本文は「型宣言を置くと失敗」を想定していたが、PR #321 で失敗バリアント型が service 同居になった現状に合わせ、サービス本体の object/class ラップだけを禁止するよう精緻化した。

## #296 RestController は成功レスポンスで ResponseEntity を返さない

`restControllersDoNotReturnResponseEntity` を追加。成功は `@ResponseStatus` ＋戻り値で resource を返す方針（error-handling.md / api-design.md）を強制。`GlobalExceptionHandler` は `@RestController` ではない（`ResponseEntityExceptionHandler` 継承）ため自然に除外される。

## 検証

- `./gradlew check` 通過。
- 両ルールとも、わざと違反（service に `object` ラッパ／RestController に `ResponseEntity` 戻り値）を入れると失敗することを確認済み。

Closes #295
Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)
