### PR TITLE
docs: ADR-0010 集約をまたぐ前提条件を持つ生成口のドメインサービス封じ込めを記録 (#268)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ class HelloController {
 - **UUID 生成戦略**: タイムベース（UUIDv7 相当の `Generators.timeBasedEpochRandomGenerator()`、`java-uuid-generator` ライブラリ使用）に統一する。生成値が時刻順にソート可能で永続化時のインデックス局所性に優れるため、ランダム（`UUID.randomUUID()`）ではなくこちらを標準とする。生成ロジックは `domain.shared.generateId()` に集約しており、各 ID 値クラスは `JockeyId(generateId())` のようにこの関数を介して生成する（エンティティごとに生成方法を書き分けない）。選定理由（インデックス局所性）の詳細は [ADR-0005](docs/adr/0005-time-based-uuid-generation.md) を参照
 - **役割の表明**: 集約ルートには `@AggregateRoot`、識別子プロパティには `@field:Identity` を付与（`@Identity` は FIELD ターゲットのため use-site target の明示が必要）
 - **イミュータブル**: 集約はイミュータブルに保つ。プロパティは `val` のみとし `var` を持たせない。状態遷移は対象を書き換えず、同一性（ID）を引き継いだ新インスタンスを返すメソッドで表す（失敗しうるなら `Result<新インスタンス, エラー>`）。例: `BloodHorse.assignName()` は命名済みの新 `BloodHorse` を返す。`data class` は ID ベースの `final equals`/`hashCode` と衝突するため使わず、`private constructor` ＋ 手書き `copy` で写像する。詳細は [ADR-0009](docs/adr/0009-immutable-aggregates.md) を参照
+- **生成口の可視性**: コンストラクタは `private` にし、生成は companion object のファクトリ経由に限る。ファクトリの可視性は不変条件の閉じ方で決める。不変条件が**集約内で完結**するなら検証ファクトリを `public` にする（例: `Jockey.create`）。**集約をまたぐ前提条件**を満たして初めて生成してよいなら生成口（`of` 等）を `internal` にし、前提を検証するドメインサービス（同一モジュールの `service/`）からのみ呼べるよう封じ込める（例: `BloodHorse.of` を `registerInStudBook` に封じ込め、迂回をコンパイル時に不能にする）。`internal` 生成口のテストは Object Mother（`〜Fixture`）に直接呼び出しを一点集約する。詳細は [ADR-0010](docs/adr/0010-confine-aggregate-creation-to-domain-service.md) を参照
 
 #### Command パターン
 

--- a/docs/adr/0010-confine-aggregate-creation-to-domain-service.md
+++ b/docs/adr/0010-confine-aggregate-creation-to-domain-service.md
@@ -1,0 +1,47 @@
+# 0010. 集約をまたぐ前提条件を持つ生成口はドメインサービスに封じ込める（of は internal、テストは Object Mother）
+
+- Status: Accepted
+- Date: 2026-06-20
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+血統登録（issue #266 / PR #263）の実装で、軽種馬集約 `BloodHorse` の生成のしかたが問題になった。
+
+血統登録は「血統及び個体識別を明らかにする登録」であり、`BloodHorse` を生成してよいのは次の前提条件を検証し終えた後に限られる。
+
+- 父が雄であること
+- 母が雌であること
+- 申告された父母との DNA 型による親子判定に矛盾がないこと
+- 仔の品種が父母の品種と整合すること
+
+これらはいずれも**父・母という別集約（別の `BloodHorse`）を参照して初めて検証できる**。つまり前提条件の検証は単一集約内で完結せず、集約をまたぐ。本プロジェクトの規約（[architecture.md](../../.claude/rules/architecture.md)）では、複数の集約をまたぐドメインロジックはドメインサービス（`service/` のトップレベル関数）の責務である。検証は `registerInStudBook` が担う。
+
+ここで「生成口を誰に見せるか」が論点になった。`BloodHorse` のコンストラクタや生成ファクトリ（`of`）を `public` にすると、検証を経ずに `BloodHorse` を直接 `new` できてしまう。すると「血統登録済み（前提条件を満たした）個体」という不変条件が型で守られず、`registerInStudBook` を迂回した不正な生成が文法上可能になる。
+
+対比として、騎手集約 `Jockey` は生成ファクトリ `Jockey.create` を `public` にしている。`Jockey` の不変条件（姓名がブランクでない）は**集約内で完結**するため、ファクトリ自身が検証すれば足り、生成口を隠す必要がない。`BloodHorse` との違いは「不変条件が集約内で閉じるか、集約をまたぐか」にある。
+
+検討した代替案:
+
+- **生成口を public のままにし、規約文書で「直接生成するな」と書く**: 文章のみのルールは強制力がなく、迂回をコンパイラが防げない。却下。
+- **生成口を private にし、ドメインサービスを `BloodHorse` と同じパッケージ（同一ファイル）に置く**: パッケージプライベートで閉じられるが、ドメインサービスは `service/` リング、モデルは `model/` リングという本プロジェクトのパッケージ分割（オニオン 4 リング）と矛盾する。却下。
+- **生成口を internal にする**: Kotlin の `internal` はモジュール（Gradle のソースセット単位）に閉じる。`model/` の `BloodHorse.of` を `internal` にすれば、同一モジュールの `service/` リングにある `registerInStudBook` からは呼べるが、別モジュール（将来切り出すアダプタ等）からは呼べない。採用。
+
+`internal` を採ると、テストから生成口をどう叩くかが次の課題になる。テストでは前提条件検証を経ずに任意の `BloodHorse` を用意したい（例: `registerInStudBook` へ渡す父・母そのもの）。`internal` はモジュール内に見えるため、**test ソースセットも同一モジュールであれば直接 `of` を呼べる**。これを Object Mother パターン（`BloodHorseFixture`）に集約する。
+
+## Decision（決定）
+
+- 集約の生成口の可視性は、その集約の**不変条件が集約内で完結するか、集約をまたぐか**で決める。
+  - **集約内で完結する不変条件のみ**を持つ集約は、検証ファクトリ（`create` 等）を **`public`** にする（例: `Jockey.create`。姓名ブランク検証は集約内で閉じる）。
+  - **集約をまたぐ前提条件**を満たして初めて生成してよい集約は、生成口（`of` 等）を **`internal`** にし、前提条件を検証するドメインサービス（同一モジュールの `service/`）からのみ呼べるよう封じ込める（例: `BloodHorse.of` を `registerInStudBook` に封じ込める）。これにより「検証済みでなければ生成できない」を**型と可視性で**担保し、サービスの迂回を文法的に不能にする。
+- `internal` 生成口を持つ集約のテストは、生成口を直接叩く責務を **Object Mother（`〜Fixture`）に一点集約**する。test は同一モジュールなので `internal` が見え、`BloodHorseFixture` が `BloodHorse.of` を直接呼んで任意の馬を組み立てる。個々のテストはモックを使わず、Fixture が返す実物の集約で検証する（[testing.md](../../.claude/rules/testing.md) の Fixture 方針に沿う）。Fixture は対象コンテキストの `model` パッケージ配下に test コードとして置く。
+
+守るべきルールの結論は [CLAUDE.md](../../CLAUDE.md)「Entity パターン」「Value Object パターン」および [architecture.md](../../.claude/rules/architecture.md) に置く。参考実装は `domain/horseracing/model/horse/bloodhorse/BloodHorse.kt`（`of` が internal）、`service/horse/RegisterInStudBook.kt`（唯一の正規生成経路）、`test` の `BloodHorseFixture`。経緯は issue #268 / #266、PR #263。生成口の封じ込めは [ADR-0009](0009-immutable-aggregates.md)（イミュータブル集約・private constructor）と組み合わさり、`BloodHorse` の生成・写像経路を完全に統制する。
+
+## Consequences（結果・影響）
+
+- 「血統登録済みの `BloodHorse`」という不変条件が、文章ルールではなく**型と `internal` 可視性**で守られる。`registerInStudBook` を迂回した生成はコンパイル時に不能になる。
+- 生成口を隠すか公開するかの判断基準が「不変条件が集約内で完結するか」に統一され、新しい集約（種牡馬・繁殖牝馬・競走馬などのロール統一: issue #266）を追加するときも同じ基準で判断できる。集約内で閉じるなら `public create`、集約をまたぐ前提が要るなら `internal of` ＋ ドメインサービス封じ込め。
+- `internal` はモジュール（ソースセット）境界でしか閉じないため、**将来アダプタ等を別モジュールに切り出すと自然に生成口が隠れる**一方、現状は test を含む同一モジュール全体から見える。テストが生成口を叩けるのはこの可視性に依存しており、Object Mother に集約することで「どこから internal を叩いているか」を一箇所に局所化している。Fixture 以外から直接 `of` を呼ばないこと。
+- Object Mother 経由のテスト構築は、Fixture にデフォルト値を集約することでテストの記述量を抑えられる反面、Fixture が肥大化しうる。Fixture の置き場・ソースセット方針の確定は issue #326 で別途扱う。
+- 父母不明個体（輸入馬・基礎輸入馬）の登録経路（issue #267）では「父母 `BloodHorse` を必須とする」前提が崩れるため、生成口の引数（現状 `sireId` / `damId` 必須）の見直しが必要になる。その際も「生成口は検証済みドメインサービスからのみ」という本決定の骨子は維持する。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,3 +19,4 @@
 | [0007](0007-wire-enum-dto-decoupling.md) | HTTP 契約の enum をドメインから分離し Dto enum + マッパーで往復する | Accepted |
 | [0008](0008-uniform-resource-representation-response.md) | REST リソース操作の成功レスポンスは一律でリソース表現を返す | Accepted |
 | [0009](0009-immutable-aggregates.md) | ドメイン集約はイミュータブルに保ち、状態遷移は新インスタンスで表す | Accepted |
+| [0010](0010-confine-aggregate-creation-to-domain-service.md) | 集約をまたぐ前提条件を持つ生成口はドメインサービスに封じ込める | Accepted |


### PR DESCRIPTION
## 概要

#268 の対応。PR #263 で実装済みの「`BloodHorse` 生成口封じ込め」（`of` は internal、テストは `BloodHorseFixture` が直接叩く）の設計判断を **ADR-0010** に昇格する。ドキュメントのみの変更でコードは無変更。

## 背景

`BloodHorse` の生成可否は父・母（別集約）を参照して検証する前提条件（父=雄/母=雌/DNA 親子整合/品種整合）に依存し、検証は集約をまたぐドメインサービス `registerInStudBook` の責務。生成口を public にすると検証を迂回した生成が文法上可能になるため、`of` を internal にしてサービスに封じ込めている。この判断を ADR として残す。

## 決定（ADR-0010 の核心）

生成口の可視性を **「不変条件が集約内で完結するか／集約をまたぐか」** という一本の基準で決める。

| 集約 | 不変条件 | 生成口 | 封じ込め先 |
|------|---------|--------|-----------|
| `Jockey` | 集約内で完結（姓名ブランク） | `create` を public | ファクトリ自身が検証 |
| `BloodHorse` | 集約をまたぐ（父母参照） | `of` を internal | ドメインサービス `registerInStudBook` |

`internal` 生成口のテストは Object Mother（`BloodHorseFixture`）に直接呼び出しを一点集約する方針も明文化。

## 変更

- `docs/adr/0010-confine-aggregate-creation-to-domain-service.md`: 新規 ADR。検討した代替案・却下理由、ADR-0009（イミュータブル）との組み合わせ、#266/#267 への波及を記載
- `docs/adr/README.md`: 索引に ADR-0010 を追加
- `CLAUDE.md`: Entity パターンに「生成口の可視性」の結論を追記し ADR-0010 へリンク

## 関連

- Closes #268
- 関連: #266（ロール統一）/ #267（父母不明個体）/ #326（Object Mother 置き場）/ #307（ADR-0009 機械強制）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
