### PR TITLE
feat: 生産産駒(LiveFoal)から血統登録への接続をドメインサービスで実装する (#324)

### DIFF
--- a/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/FoalIdentity.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/FoalIdentity.kt
@@ -1,0 +1,40 @@
+package com.example.api.domain.horseracing.model.horse.bloodhorse
+
+import org.jmolecules.ddd.annotation.ValueObject
+
+/**
+ * 生産産駒の血統登録に際して申請者が持ち込む、仔馬自身の個体識別情報の束。
+ *
+ * [StudBookEntry] のうち、生産（分娩）から導出できる **生年月日（[DateOfBirth]）を除いた** 属性をまとめる。
+ * 生産産駒の血統登録（registerFoal）では、出生日は繁殖成績の分娩結果（`FoalingOutcome.LiveFoal.foalingDate`）
+ * から確定するため申請者入力に含めず、本束と分娩日を合わせて [StudBookEntry] を組み立てる。父・母（[BloodHorse]）は
+ * 集約をまたぐ参照のため本束には含めず、ドメインサービスに別途渡す。
+ *
+ * @property sex 性
+ * @property coatColor 毛色
+ * @property breedType 品種
+ * @property breeder 生産者
+ * @property microchipNumber マイクロチップ番号
+ * @property dnaParentage 申告された父母との DNA 型による親子判定結果
+ */
+@ValueObject
+data class FoalIdentity(
+    val sex: Sex,
+    val coatColor: CoatColor,
+    val breedType: BreedType,
+    val breeder: Breeder,
+    val microchipNumber: MicrochipNumber,
+    val dnaParentage: DnaParentageResult,
+) {
+    /** [foalingDate] を生年月日として補い、血統登録の入力となる [StudBookEntry] を組み立てる。 */
+    fun toStudBookEntry(foalingDate: DateOfBirth): StudBookEntry =
+        StudBookEntry(
+            sex = sex,
+            coatColor = coatColor,
+            breedType = breedType,
+            dateOfBirth = foalingDate,
+            breeder = breeder,
+            microchipNumber = microchipNumber,
+            dnaParentage = dnaParentage,
+        )
+}

--- a/src/main/kotlin/com/example/api/domain/horseracing/service/horse/RegisterFoal.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/service/horse/RegisterFoal.kt
@@ -1,0 +1,70 @@
+package com.example.api.domain.horseracing.service.horse
+
+import com.example.api.domain.horseracing.model.breeding.BreedingResult
+import com.example.api.domain.horseracing.model.breeding.FoalingOutcome
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorse
+import com.example.api.domain.horseracing.model.horse.bloodhorse.DateOfBirth
+import com.example.api.domain.horseracing.model.horse.bloodhorse.FoalIdentity
+import com.example.api.domain.horseracing.model.horse.bloodhorse.PedigreeRegistrationNumber
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.mapError
+
+/**
+ * 生産産駒（生まれた仔馬）を血統登録し、軽種馬（[BloodHorse]）を誕生させる。
+ *
+ * 繁殖成績（[BreedingResult]）の分娩結果が生産（[FoalingOutcome.LiveFoal]＝産駒あり）である場合に、その産駒を
+ * 血統登録する入口。父・母は繁殖記録から定まり、registerInStudBook へ橋渡しする:
+ * - 父（[sire]）= 種付（`covering.stallionId`）の種牡馬
+ * - 母（[dam]）= 繁殖登録（`breedingRegistration.broodmareId`）の繁殖牝馬
+ * - 出生日 = 分娩結果（[FoalingOutcome.LiveFoal.foalingDate]）。申請者入力ではなく繁殖記録から確定する
+ *
+ * 産駒が生まれていない帰結（不受胎・流産・死産など [FoalingOutcome.LiveFoal] 以外）からは登録できず [RegisterFoalError.NotLiveFoal]
+ * を返す。父=雄・母=雌・DNA 親子整合・親仔の品種整合といった前提条件の検証は委譲先の registerInStudBook が担う。
+ *
+ * 父母が当システムに存在しない輸入馬・基礎輸入馬の登録経路は本サービスの対象外であり、別途設計する（#267）。
+ *
+ * @param breedingResult 産駒が生じた繁殖成績（分娩結果が報告済みであること）
+ * @param sire 父（雄）の軽種馬。`breedingResult.covering.stallionId` に対応する個体を上位で解決して渡す
+ * @param dam 母（雌）の軽種馬。繁殖登録の `broodmareId` に対応する個体を上位で解決して渡す
+ * @param foalIdentity 申請者が持ち込む仔馬自身の個体識別情報（生年月日を除く）
+ * @param registrationNumber 交付される血統登録番号
+ * @return 生成された [BloodHorse]、または前提条件違反を表す [RegisterFoalError]
+ */
+fun registerFoal(
+    breedingResult: BreedingResult,
+    sire: BloodHorse,
+    dam: BloodHorse,
+    foalIdentity: FoalIdentity,
+    registrationNumber: PedigreeRegistrationNumber,
+): Result<BloodHorse, RegisterFoalError> {
+    val outcome = breedingResult.outcome
+    if (outcome !is FoalingOutcome.LiveFoal) {
+        return Err(RegisterFoalError.NotLiveFoal(outcome))
+    }
+    val entry = foalIdentity.toStudBookEntry(DateOfBirth(outcome.foalingDate))
+    return registerInStudBook(sire, dam, entry, registrationNumber).mapError {
+        RegisterFoalError.RegistrationFailed(it)
+    }
+}
+
+/**
+ * 生産産駒の血統登録の前提条件違反。
+ *
+ * 失敗のしかたが複数あるため sealed interface とし、`when` の網羅性で漏れを防ぐ。
+ */
+sealed interface RegisterFoalError {
+    /**
+     * 繁殖成績の分娩結果が生産（[FoalingOutcome.LiveFoal]）でない、または未報告（null）であり、登録できる産駒が存在しない。
+     *
+     * @property current 報告されている分娩結果。未報告なら null
+     */
+    data class NotLiveFoal(val current: FoalingOutcome?) : RegisterFoalError
+
+    /**
+     * 委譲先の血統登録（registerInStudBook）の前提条件違反を wrap したもの。
+     *
+     * 個別バリアント（父が雄でない・品種不整合など）は [RegisterInStudBookError] を参照する。
+     */
+    data class RegistrationFailed(val cause: RegisterInStudBookError) : RegisterFoalError
+}

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/BloodHorseFixture.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/BloodHorseFixture.kt
@@ -29,6 +29,22 @@ object BloodHorseFixture {
             dnaParentage = dnaParentage,
         )
 
+    /** 既定値を持つ [FoalIdentity] を生成する。必要な属性のみ上書きする。 */
+    fun foalIdentity(
+        sex: Sex = Sex.MALE,
+        coatColor: CoatColor = CoatColor.BAY,
+        breedType: BreedType = BreedType.THOROUGHBRED,
+        dnaParentage: DnaParentageResult = DnaParentageResult.CONSISTENT,
+    ): FoalIdentity =
+        FoalIdentity(
+            sex = sex,
+            coatColor = coatColor,
+            breedType = breedType,
+            breeder = Breeder.create("ノーザンファーム").unwrap(),
+            microchipNumber = MicrochipNumber.create("392140000000001").unwrap(),
+            dnaParentage = dnaParentage,
+        )
+
     /** 既定値を持つ [BloodHorse] を生成する。性・品種など必要な属性のみ上書きする。 */
     fun bloodHorse(sex: Sex = Sex.MALE, breedType: BreedType = BreedType.THOROUGHBRED): BloodHorse =
         BloodHorse.of(

--- a/src/test/kotlin/com/example/api/domain/horseracing/service/horse/RegisterFoalTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/service/horse/RegisterFoalTest.kt
@@ -1,0 +1,94 @@
+package com.example.api.domain.horseracing.service.horse
+
+import com.example.api.domain.horseracing.model.breeding.BreedingFixture
+import com.example.api.domain.horseracing.model.breeding.FoalingOutcome
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseFixture
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BreedType
+import com.example.api.domain.horseracing.model.horse.bloodhorse.PedigreeRegistrationNumber
+import com.example.api.domain.horseracing.model.horse.bloodhorse.Sex
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import java.time.LocalDate
+import org.junit.jupiter.api.Test
+
+/** registerFoal ドメインサービスのユニットテスト */
+class RegisterFoalTest {
+    private val registrationNumber = PedigreeRegistrationNumber.create("2024104567").unwrap()
+    private val foalingDate = LocalDate.of(2024, 3, 20)
+
+    private fun liveFoalResult() =
+        BreedingFixture.breedingResult()
+            .recordFoaling(FoalingOutcome.LiveFoal(foalingDate))
+            .unwrap()
+
+    @Test
+    fun `生産産駒は血統登録され父母を ID で参照し出生日が分娩日になること`() {
+        val sire = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
+        val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        val foalIdentity = BloodHorseFixture.foalIdentity(breedType = BreedType.THOROUGHBRED)
+
+        val bloodHorse =
+            registerFoal(liveFoalResult(), sire, dam, foalIdentity, registrationNumber).unwrap()
+
+        assert(bloodHorse.sireId == sire.id)
+        assert(bloodHorse.damId == dam.id)
+        assert(bloodHorse.dateOfBirth.value == foalingDate)
+        assert(bloodHorse.registrationNumber == registrationNumber)
+    }
+
+    @Test
+    fun `分娩結果が未報告だと NotLiveFoal を返すこと`() {
+        val sire = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
+        val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+
+        val result =
+            registerFoal(
+                BreedingFixture.breedingResult(),
+                sire,
+                dam,
+                BloodHorseFixture.foalIdentity(),
+                registrationNumber,
+            )
+
+        assert(result.getError() == RegisterFoalError.NotLiveFoal(null))
+    }
+
+    @Test
+    fun `分娩結果が生産以外だと現在の帰結を添えて NotLiveFoal を返すこと`() {
+        val sire = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
+        val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        val notConceived =
+            BreedingFixture.breedingResult().recordFoaling(FoalingOutcome.NotConceived).unwrap()
+
+        val result =
+            registerFoal(
+                notConceived,
+                sire,
+                dam,
+                BloodHorseFixture.foalIdentity(),
+                registrationNumber,
+            )
+
+        assert(result.getError() == RegisterFoalError.NotLiveFoal(FoalingOutcome.NotConceived))
+    }
+
+    @Test
+    fun `委譲先の前提条件違反は RegistrationFailed に wrap して返すこと`() {
+        val sire = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+
+        val result =
+            registerFoal(
+                liveFoalResult(),
+                sire,
+                dam,
+                BloodHorseFixture.foalIdentity(),
+                registrationNumber,
+            )
+
+        assert(
+            result.getError() ==
+                RegisterFoalError.RegistrationFailed(RegisterInStudBookError.SireNotMale)
+        )
+    }
+}


### PR DESCRIPTION
## 概要

#324（生産産駒 `FoalingOutcome.LiveFoal` → 血統登録 `registerInStudBook` への接続配線）を、**ドメイン層スコープ**で実装する。接続の核心である `registerFoal` ドメインサービスを追加し、`LiveFoal` で生じた産駒を `registerInStudBook` の入力（父・母・個体識別）へ橋渡しする。

## 背景・スコープ判断

着手中、breeding コンテキストの **application 層・永続化ポート（`BreedingResultRepository` 等）・InMemory 実装が未整備**であることが判明した（breeding は現状「ドメインモデル + ドメインサービス」止まり）。そのため:

- 本 PR は #324 が本来求める「**接続経路**」の核心 = `registerFoal` ドメインサービスに絞る
- これを駆動する application ユースケースと breeding 永続化ポートの整備は **#343** に切り出した
- #267（父母不明個体の登録経路）とは `registerInStudBook` という**同じ入口を共有**する形に整理した

## 変更内容

**main**
- `domain/horseracing/model/horse/bloodhorse/FoalIdentity.kt`: 申請者が持ち込む個体識別 VO（`StudBookEntry` から生年月日を除いた束）。`toStudBookEntry(foalingDate)` で出生日を補い `StudBookEntry` を組み立てる
- `domain/horseracing/service/horse/RegisterFoal.kt`: `registerFoal` ドメインサービス + `RegisterFoalError`。分娩結果が `LiveFoal` であることを検証し、**出生日を `foalingDate` から導出**して `registerInStudBook` へ委譲する（父=雄/母=雌/DNA/品種の検証は委譲先が担当）

**test**
- `service/horse/RegisterFoalTest.kt`: 成功（父母 ID 参照・出生日=分娩日）/ `NotLiveFoal`（未報告・生産以外）/ `RegistrationFailed` のユニットテスト
- `model/horse/bloodhorse/BloodHorseFixture.kt`: `foalIdentity()` ヘルパーを追加

## 確認

- `./gradlew check` 通過（ktfmt / detekt / test / koverVerifyMature）
- ゲート対象パッケージ `service.horse` / `model.horse.bloodhorse` をテストでカバー

## 関連

- Closes #324
- Follow-up: #343（application 配線 + breeding 永続化ポート）
- 入口共有: #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)
