### PR TITLE
feat: Issue 優先度を GitHub Projects のカスタムフィールドへ移行する (#335)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,27 @@ class HelloControllerTest(val mockMvc: MockMvc) {
 - `trim_trailing_whitespace = true`: 行末空白を削除（マークダウンを除く）
 - `charset = utf-8`: UTF-8 エンコーディング
 
+## 優先度管理
+
+Issue の優先度は **GitHub Projects（`toy-box` = Project #4）の `Priority` single-select カスタムフィールド**で管理する。優先度ラベル（`P1〜P4`）は廃止済み（採否の経緯は [ADR-0011](docs/adr/0011-priority-via-projects-custom-field.md)）。
+
+- **出所は Project の Priority フィールド 1 つ**。ラベルとの併用はしない（二重管理を避ける）。
+- オプションは `P1: 今すぐ` / `P2: 近いうち` / `P3: いずれ` / `P4: 探索・保留` の 4 段階。
+- 優先度を付けたい Issue は **Project に追加してからフィールドを設定**する（Project に入れた Issue だけが優先度を持つ）。
+- 優先度順に眺める・束ねる・絞るときは Project のビューを使う（`gh issue list` のラベル列には優先度は出ない）。
+- CLI からの確認・設定:
+
+```bash
+# 優先度付きで一覧（Web ビューが基本だが CLI でも確認可）
+gh project item-list 4 --owner ptiringo
+
+# Issue を Project に追加して優先度を設定（field-id / option-id は field-list で確認）
+gh project item-add 4 --owner ptiringo --url <issue-url>
+gh project field-list 4 --owner ptiringo --format json   # フィールド/オプション ID の確認
+```
+
+- フィールド定義と既存ラベルからの移行はスクリプト化してある（`scripts/migrate-priority-to-project.sh`、`gh project` CLI で再現可能）。Project スコープが要るので事前に `gh auth refresh -s project`。
+
 ## ツール管理
 
 ### mise

--- a/docs/adr/0011-priority-via-projects-custom-field.md
+++ b/docs/adr/0011-priority-via-projects-custom-field.md
@@ -1,0 +1,42 @@
+# 0011. Issue 優先度を GitHub Projects のカスタムフィールドで管理する（ラベル運用を廃止）
+
+- Status: Accepted
+- Date: 2026-06-20
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+これまで Issue の優先度は `P1: 今すぐ`〜`P4: 探索・保留` の **ラベル**で運用していた（issue #335）。ラベルはリポジトリ横断で検索でき、Issue 本体に直接ぶら下がり、`gh issue list` でも見える利点がある。一方で「優先度を軸にした見方」——ソート・グルーピング・ビューでの絞り込み——がしづらい。優先度順に並べたい、P1 だけ束ねて眺めたい、といった操作がラベルでは弱い。
+
+GitHub には優先度管理に使える機能が複数あり、用語が紛らわしいので整理した。
+
+| 機能 | 付与対象 | 優先度用途 |
+|------|---------|-----------|
+| Custom properties（カスタムプロパティ） | **リポジトリ**（Org 単位のメタデータ） | ✗ Issue には付かない。リポジトリ分類用 |
+| **Projects のカスタムフィールド** | Project に追加した Issue/PR | ◎ 優先度の定番。single-select（P1/P2…）でソート・グルーピング・フィルタ可 |
+| Issue Types | Issue（Org 単位、Bug/Feature/Task 等） | △ 「種別」であって優先度ではない |
+| ラベル | Issue / PR | ○ 可視・検索・横断に強いが、ビューでのソート/グルーピングが弱い |
+
+「カスタムプロパティ」はリポジトリ分類用で Issue 優先度には使えない。Issue Types は種別であって優先度ではない。優先度に向くのは **Projects V2 の single-select カスタムフィールド**で、公式 Project テンプレートにも `Priority` フィールドが標準で入る。
+
+論点は「ラベル継続 / Projects 移行 / 併用」のどれを採るか。併用は両機能の長所を取れるが、優先度の出所が 2 つになり手動同期の二重管理が生じる（ラベルを変えたらフィールドも、の往復が必要で、必ずズレる）。個人リポジトリ（toy-box）であり、出所は 1 つに保ちたい。
+
+## Decision（決定）
+
+**Issue 優先度は GitHub Projects のカスタムフィールド（single-select）を唯一の出所とし、`P1〜P4` ラベルは廃止する（完全移行）。**
+
+- 優先度フィールドは toy-box リポジトリの Project #4（`toy-box`）に `Priority` single-select フィールドとして定義する。オプションは従来のラベルと同じ語彙 `P1: 今すぐ` / `P2: 近いうち` / `P3: いずれ` / `P4: 探索・保留` を踏襲し、語彙の継続性を保つ。
+- 既存の open issue は移行スクリプト（`scripts/migrate-priority-to-project.sh`）で Project へ投入し、ラベルの優先度を Priority フィールドへ写像したうえで、`P1〜P4` ラベル定義をリポジトリから削除する。
+- 以後の優先度設定は Project のビュー（または `gh project item-edit`）で行う。`gh issue list` の出力からは優先度が見えなくなるため、優先度順に眺めたいときは Project のビューを使う。
+- Issue Types（Bug/Feature/Task 等の種別）は優先度とは直交する別軸であり、本決定の対象外（必要になれば別途検討）。
+
+採否の結論と日常運用は [CLAUDE.md](../../CLAUDE.md)「優先度管理」に置く。
+
+## Consequences（結果・影響）
+
+- 優先度の出所が Project の Priority フィールド 1 つに一本化され、ラベルとの二重管理・手動同期のズレが消える。
+- Project のビューで優先度ソート・グルーピング・フィルタが使えるようになり、「P1 だけ束ねて見る」「優先度順に並べる」が容易になる。
+- 引き換えに、`gh issue list` や Issue 一覧画面のラベル列からは優先度が見えなくなる。優先度を見るには Project（Web のビュー、または `gh project item-list 4 --owner ptiringo`）を経由する必要がある。CLI で優先度を素早く確認する用途はやや後退する。
+- Project に入れた Issue だけが優先度を持つ。新規 Issue は Project へ追加して初めて優先度を付けられる（運用として、優先度を付けたい Issue は Project に入れる）。
+- ラベル定義の削除により、closed issue も含め全 Issue から `P1〜P4` ラベルが外れる。closed issue の当時の優先度ラベルは失われるが、完了済みのため実害はない。
+- 移行・フィールド定義は `gh project` CLI で再現可能な形にしてある（スクリプト化）。将来 Project を作り直す場合もスクリプトを起点に再構築できる。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,3 +20,4 @@
 | [0008](0008-uniform-resource-representation-response.md) | REST リソース操作の成功レスポンスは一律でリソース表現を返す | Accepted |
 | [0009](0009-immutable-aggregates.md) | ドメイン集約はイミュータブルに保ち、状態遷移は新インスタンスで表す | Accepted |
 | [0010](0010-confine-aggregate-creation-to-domain-service.md) | 集約をまたぐ前提条件を持つ生成口はドメインサービスに封じ込める | Accepted |
+| [0011](0011-priority-via-projects-custom-field.md) | Issue 優先度を GitHub Projects のカスタムフィールドで管理する（ラベル運用を廃止） | Accepted |

--- a/scripts/migrate-priority-to-project.sh
+++ b/scripts/migrate-priority-to-project.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# 優先度ラベル（P1〜P4）を GitHub Projects #4 の Priority フィールドへ移行するスクリプト。
+#
+# 背景・方針は ADR-0011 / CLAUDE.md「優先度管理」を参照。Projects のカスタムフィールドを
+# 優先度の唯一の出所とし、P ラベルは廃止する（完全移行）。処理は 2 段階:
+#   1. open issue を Project に投入し、各 issue の `P1: 今すぐ`〜`P4: 探索・保留` ラベルを
+#      Priority single-select フィールドの対応オプションへ写像する。
+#   2. 写像後、リポジトリから P1〜P4 ラベル定義を削除する（全 issue から一括除去される）。
+#
+# 順序が重要: ラベルを field へ写し終えてから定義を消す。先に消すと写像元が失われる。
+# 冪等: 既に投入済みの issue は item-add が既存アイテムを返すため、再実行しても重複しない。
+#       ラベル削除後の再実行は対象 0 件になるだけで安全（field 値は既に設定済み）。
+#
+# 前提: `gh auth refresh -s project` で project スコープ付与済みであること。
+# 実行: **通常のターミナル（Terminal.app / iTerm 等）で** bash scripts/migrate-priority-to-project.sh
+#   ※ Claude Code の `!` 経由やサンドボックス下で実行すると、スクリプト内の gh が
+#     サンドボックスのプロキシ TLS に阻まれ `OSStatus -26276` で全 API 呼び出しが失敗する
+#     （gh の sandbox 除外は単体コマンドのみ対象で、スクリプト内の gh には効かない）。
+#     必ずサンドボックス外の素のシェルで実行すること。
+# 互換: macOS 標準の bash 3.2 で動くよう連想配列/mapfile を使わない。
+set -euo pipefail
+
+# --- プリフライト: API 到達性を確認（TLS 失敗を黙って素通りさせない）---
+if ! gh api graphql -f query='query{viewer{login}}' >/dev/null 2>&1; then
+  echo "ERROR: GitHub API に到達できません（TLS/認証エラーの可能性）。" >&2
+  echo "  - サンドボックス外の通常ターミナルで実行していますか？（OSStatus -26276 は sandbox TLS 起因）" >&2
+  echo "  - project スコープはありますか？ 必要なら: gh auth refresh -s project" >&2
+  exit 1
+fi
+
+OWNER=ptiringo
+PROJECT_NUMBER=4
+PROJECT_ID=PVT_kwHOAGtZ7c4BbL04
+FIELD_ID=PVTSSF_lAHOAGtZ7c4BbL04zhV-LEM
+
+# P ラベル名 -> Priority オプション ID
+option_id_for() {
+  case "$1" in
+    "P1: 今すぐ") echo e9ce2b26 ;;
+    "P2: 近いうち") echo 61f24689 ;;
+    "P3: いずれ") echo 1d0a06c9 ;;
+    "P4: 探索・保留") echo 12ac3381 ;;
+    *) echo "" ;;
+  esac
+}
+
+# open issue を「URL <TAB> Pラベル」で列挙（P ラベルは最初の 1 件のみ採用）。
+# process substitution（done < <(gh ...)）だと gh の失敗が握りつぶされ「0 件」で
+# 誤完走するため、一旦変数へ取得して set -e で fail-fast させる。
+# jq プログラム内の $i / $p は jq 変数。shell 展開させないため意図的に single quote。
+# shellcheck disable=SC2016
+issues=$(
+  gh issue list --state open --limit 200 --json url,labels \
+    --jq '.[] | . as $i
+          | ([$i.labels[].name | select(test("^P[1-4]:"))] | first) as $p
+          | select($p != null)
+          | "\($i.url)\t\($p)"'
+)
+
+count=0
+# herestring は while をサブシェル化しないため count の加算が親に残る
+while IFS=$'\t' read -r url plabel; do
+  [ -z "$url" ] && continue
+  optid=$(option_id_for "$plabel")
+  if [ -z "$optid" ]; then
+    echo "skip（未知の P ラベル '$plabel'）: $url"
+    continue
+  fi
+  item_id=$(gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "$url" --format json --jq '.id')
+  gh project item-edit \
+    --id "$item_id" \
+    --project-id "$PROJECT_ID" \
+    --field-id "$FIELD_ID" \
+    --single-select-option-id "$optid" >/dev/null
+  count=$((count + 1))
+  echo "set $plabel -> $url"
+done <<< "$issues"
+
+echo "写像完了: $count 件を投入・設定。確認: gh project item-list $PROJECT_NUMBER --owner $OWNER"
+
+# --- 第2段階: P ラベル定義を削除（完全移行）---
+# ラベル定義を消すと open/closed 問わず全 issue から当該ラベルが外れる。
+# 既存ラベル一覧を 1 度だけ取得し、存在するものだけ削除する。削除自体の失敗は
+# set -e で fail-fast させる（TLS/権限エラーを「未存在」と誤魔化さない）。
+existing_labels=$(gh label list --limit 200 --json name --jq '.[].name')
+for label in "P1: 今すぐ" "P2: 近いうち" "P3: いずれ" "P4: 探索・保留"; do
+  if printf '%s\n' "$existing_labels" | grep -qxF "$label"; then
+    gh label delete "$label" --yes >/dev/null
+    echo "delete label: $label"
+  else
+    echo "skip（ラベル既に未存在）: $label"
+  fi
+done
+
+echo "完了: 優先度を Project #$PROJECT_NUMBER の Priority フィールドへ移行し、P ラベルを廃止した。"


### PR DESCRIPTION
## 概要

Issue #335 の検討に決着をつける。優先度ラベル（`P1〜P4`）運用を見直し、**GitHub Projects #4 の `Priority` single-select カスタムフィールドを唯一の出所**とする方針へ完全移行する。ラベルとの併用はせず P ラベルは廃止する（出所を 1 つに保ち、二重管理を避ける）。

## 検討結果

`#335` の整理どおり、優先度に向くのは Projects のカスタムフィールド。選択肢（ラベル継続 / Projects 移行 / 併用）のうち **Projects へ完全移行（ラベル廃止）**を採用した。

- 併用は両機能の長所を取れるが、優先度の出所が 2 つになり手動同期のズレが必ず生じる
- 個人リポジトリで出所は 1 つに保ちたい → ラベル廃止して Projects フィールドへ一本化

トレードオフ: `gh issue list` のラベル列からは優先度が見えなくなる（優先度の確認・並べ替えは Project ビュー / `gh project item-list` 経由になる）。

## 変更内容

- **docs/adr/0011**: 決定を ADR 化（Custom properties / Projects フィールド / Issue Types / ラベルの違いと適用範囲の整理を含む）
- **docs/adr/README.md**: 一覧に 0011 を追加
- **CLAUDE.md**: 「優先度管理」セクションを追加（出所・運用・`gh project` コマンド・移行スクリプト案内）
- **scripts/migrate-priority-to-project.sh**: open issue を Project へ投入 → P ラベルを Priority フィールドへ写像 → P1〜P4 ラベル定義を削除する移行スクリプト（bash 3.2 互換・冪等、サンドボックス外実行のプリフライト付き）

> ℹ️ ADR は当初 0010 で起票したが、main で別 PR (#268) が 0010 を先に取得したため **0011** に振り直した。

## 受け入れ条件

- [x] ラベル / Projects フィールド / Issue Types の違いと適用範囲を整理する（ADR-0011）
- [x] toy-box での優先度管理方針を決める → **Projects 移行（ラベル廃止）**
- [x] 決定した方針を ADR / CLAUDE.md に記録する
- [x] 移行手順（`gh project` 含む）を整備する（migrate-priority-to-project.sh）

## 移行の実行結果

**実行済み**。open issue 42 件を Project #4 の Priority フィールドへ写像し、P1〜P4 ラベル定義を削除した（P1=4 / P2=12 / P3=22 / P4=4、ラベル全削除を確認）。スクリプトは冪等なので再実行可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
