### PR TITLE
feat: 生産産駒登録ユースケース(RegisterFoalUseCase)の application 配線

### DIFF
--- a/src/main/kotlin/com/example/api/application/horseracing/horse/RegisterFoalUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/horseracing/horse/RegisterFoalUseCase.kt
@@ -1,0 +1,169 @@
+package com.example.api.application.horseracing.horse
+
+import com.example.api.domain.horseracing.model.breeding.BreedingRegistrationRepository
+import com.example.api.domain.horseracing.model.breeding.BreedingResultId
+import com.example.api.domain.horseracing.model.breeding.BreedingResultRepository
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorse
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BreedType
+import com.example.api.domain.horseracing.model.horse.bloodhorse.Breeder
+import com.example.api.domain.horseracing.model.horse.bloodhorse.CoatColor
+import com.example.api.domain.horseracing.model.horse.bloodhorse.DnaParentageResult
+import com.example.api.domain.horseracing.model.horse.bloodhorse.FoalIdentity
+import com.example.api.domain.horseracing.model.horse.bloodhorse.MicrochipNumber
+import com.example.api.domain.horseracing.model.horse.bloodhorse.PedigreeRegistrationNumber
+import com.example.api.domain.horseracing.model.horse.bloodhorse.Sex
+import com.example.api.domain.horseracing.service.horse.RegisterFoalError
+import com.example.api.domain.horseracing.service.horse.registerFoal
+import com.example.api.domain.shared.Command
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import com.github.michaelbull.result.mapError
+import com.github.michaelbull.result.toResultOr
+import java.util.UUID
+import org.springframework.stereotype.Service
+
+/**
+ * 生産産駒登録ユースケースの入力コマンド。
+ *
+ * 生産（分娩）された仔馬の血統登録申請に相当する境界の生入力。父・母・出生日は申請者が持ち込まず、報告済みの 繁殖成績（[breedingResultId]）から定まる:
+ * - 父 = 種付（`covering.stallionId`）の種牡馬
+ * - 母 = 繁殖登録（`breedingRegistration.broodmareId`）の繁殖牝馬
+ * - 出生日 = 分娩結果（`FoalingOutcome.LiveFoal.foalingDate`）
+ *
+ * よって本コマンドは繁殖成績IDと、仔馬自身の個体識別（生年月日・父母を除く）のみを受け取る。VO で表す項目（番号・ マイクロチップ・生産者）は素の文字列で受け取り、ユースケース内で各 VO の
+ * `create` を通して検証する。
+ *
+ * @property breedingResultId 産駒が生じた繁殖成績ID（分娩結果が報告済みであること）
+ * @property sex 性
+ * @property coatColor 毛色
+ * @property breedType 品種
+ * @property breeder 生産者名
+ * @property microchipNumber マイクロチップ番号
+ * @property dnaParentage 申告された父母との DNA 型による親子判定結果
+ * @property registrationNumber 交付される血統登録番号
+ */
+data class RegisterFoalCommand(
+    val breedingResultId: UUID,
+    val sex: Sex,
+    val coatColor: CoatColor,
+    val breedType: BreedType,
+    val breeder: String,
+    val microchipNumber: String,
+    val dnaParentage: DnaParentageResult,
+    val registrationNumber: String,
+)
+
+/** 生産産駒登録時に発生しうる業務ルール違反。 */
+sealed interface RegisterFoalUseCaseError {
+    /** 血統登録番号がブランク。 */
+    data object InvalidRegistrationNumber : RegisterFoalUseCaseError
+
+    /** マイクロチップ番号が 15 桁の数字でない。 */
+    data object InvalidMicrochipNumber : RegisterFoalUseCaseError
+
+    /** 生産者名がブランク。 */
+    data object BlankBreeder : RegisterFoalUseCaseError
+
+    /** 登録対象として指定された繁殖成績が存在しない。 */
+    data class BreedingResultNotFound(val breedingResultId: UUID) : RegisterFoalUseCaseError
+
+    /** 繁殖成績が紐づく繁殖登録が存在しない（母＝繁殖牝馬を解決できない）。 */
+    data class BreedingRegistrationNotFound(val breedingRegistrationId: UUID) :
+        RegisterFoalUseCaseError
+
+    /** 父（種付の種牡馬）として参照される軽種馬が存在しない。 */
+    data class SireNotFound(val sireId: UUID) : RegisterFoalUseCaseError
+
+    /** 母（繁殖登録の繁殖牝馬）として参照される軽種馬が存在しない。 */
+    data class DamNotFound(val damId: UUID) : RegisterFoalUseCaseError
+
+    /**
+     * ドメインサービス registerFoal の前提条件違反を application 層エラーに wrap したもの。
+     *
+     * 個別バリアント（分娩結果が生産でない・父が雄でない・品種不整合など）は [RegisterFoalError] を参照する。
+     */
+    data class PreconditionViolated(val cause: RegisterFoalError) : RegisterFoalUseCaseError
+}
+
+/**
+ * 生産産駒登録ユースケース。
+ *
+ * 境界の生入力を VO に変換し（不正なら検証エラー）、繁殖成績・繁殖登録・父（種付の種牡馬）・母（繁殖牝馬）を 各ポートで引き当て、ドメインサービス registerFoal
+ * で前提条件（分娩結果が生産であること、および委譲先 registerInStudBook の父=雄・母=雌・DNA 親子整合・品種整合）を検証してから、誕生した [BloodHorse]
+ * を永続化する。 Controller 層は本クラスのみに依存し、ポートやドメインサービスは知らない。
+ *
+ * @return 登録された [BloodHorse]、または業務ルール違反を表す [RegisterFoalUseCaseError]
+ */
+@Service
+class RegisterFoalUseCase(
+    private val breedingResultRepository: BreedingResultRepository,
+    private val breedingRegistrationRepository: BreedingRegistrationRepository,
+    private val bloodHorseRepository: BloodHorseRepository,
+) {
+    operator fun invoke(
+        command: Command<RegisterFoalCommand>
+    ): Result<BloodHorse, RegisterFoalUseCaseError> = binding {
+        val input = command.payload
+
+        val registrationNumber =
+            PedigreeRegistrationNumber.create(input.registrationNumber)
+                .mapError { RegisterFoalUseCaseError.InvalidRegistrationNumber }
+                .bind()
+        val microchipNumber =
+            MicrochipNumber.create(input.microchipNumber)
+                .mapError { RegisterFoalUseCaseError.InvalidMicrochipNumber }
+                .bind()
+        val breeder =
+            Breeder.create(input.breeder).mapError { RegisterFoalUseCaseError.BlankBreeder }.bind()
+
+        val breedingResult =
+            breedingResultRepository
+                .findById(BreedingResultId(input.breedingResultId))
+                .toResultOr {
+                    RegisterFoalUseCaseError.BreedingResultNotFound(input.breedingResultId)
+                }
+                .bind()
+
+        val breedingRegistration =
+            breedingRegistrationRepository
+                .findById(breedingResult.breedingRegistrationId)
+                .toResultOr {
+                    RegisterFoalUseCaseError.BreedingRegistrationNotFound(
+                        breedingResult.breedingRegistrationId.value
+                    )
+                }
+                .bind()
+
+        val sireId = breedingResult.covering.stallionId
+        val sire =
+            bloodHorseRepository
+                .findById(sireId)
+                .toResultOr { RegisterFoalUseCaseError.SireNotFound(sireId.value) }
+                .bind()
+
+        val damId = breedingRegistration.broodmareId
+        val dam =
+            bloodHorseRepository
+                .findById(damId)
+                .toResultOr { RegisterFoalUseCaseError.DamNotFound(damId.value) }
+                .bind()
+
+        val foalIdentity =
+            FoalIdentity(
+                sex = input.sex,
+                coatColor = input.coatColor,
+                breedType = input.breedType,
+                breeder = breeder,
+                microchipNumber = microchipNumber,
+                dnaParentage = input.dnaParentage,
+            )
+
+        val bloodHorse =
+            registerFoal(breedingResult, sire, dam, foalIdentity, registrationNumber)
+                .mapError { RegisterFoalUseCaseError.PreconditionViolated(it) }
+                .bind()
+
+        bloodHorseRepository.save(bloodHorse)
+    }
+}

--- a/src/test/kotlin/com/example/api/application/horseracing/horse/RegisterFoalUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/horseracing/horse/RegisterFoalUseCaseTest.kt
@@ -1,0 +1,242 @@
+package com.example.api.application.horseracing.horse
+
+import com.example.api.domain.horseracing.model.breeding.BreedingFixture
+import com.example.api.domain.horseracing.model.breeding.BreedingRegistration
+import com.example.api.domain.horseracing.model.breeding.BreedingRegistrationRepository
+import com.example.api.domain.horseracing.model.breeding.BreedingResult
+import com.example.api.domain.horseracing.model.breeding.BreedingResultId
+import com.example.api.domain.horseracing.model.breeding.BreedingResultRepository
+import com.example.api.domain.horseracing.model.breeding.FoalingOutcome
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorse
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseFixture
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BreedType
+import com.example.api.domain.horseracing.model.horse.bloodhorse.CoatColor
+import com.example.api.domain.horseracing.model.horse.bloodhorse.DnaParentageResult
+import com.example.api.domain.horseracing.model.horse.bloodhorse.Sex
+import com.example.api.domain.horseracing.service.horse.RegisterFoalError
+import com.example.api.domain.horseracing.service.horse.RegisterInStudBookError
+import com.example.api.domain.shared.Command
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class RegisterFoalUseCaseTest {
+
+    private val foalingDate = LocalDate.of(2024, 3, 20)
+
+    private fun command(
+        breedingResultId: UUID,
+        sex: Sex = Sex.MALE,
+        breedType: BreedType = BreedType.THOROUGHBRED,
+        microchipNumber: String = "392140000000001",
+        breeder: String = "ノーザンファーム",
+        registrationNumber: String = "2024104567",
+    ): Command<RegisterFoalCommand> =
+        Command(
+            RegisterFoalCommand(
+                breedingResultId = breedingResultId,
+                sex = sex,
+                coatColor = CoatColor.BAY,
+                breedType = breedType,
+                breeder = breeder,
+                microchipNumber = microchipNumber,
+                dnaParentage = DnaParentageResult.CONSISTENT,
+                registrationNumber = registrationNumber,
+            ),
+            Instant.now(),
+        )
+
+    /** 父・母・繁殖登録・繁殖成績（生産済み）が解決できる正常系の土台を組む。 */
+    private class Wiring {
+        val sire: BloodHorse = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
+        val dam: BloodHorse = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        val breedingRegistration: BreedingRegistration =
+            BreedingFixture.breedingRegistration(broodmareId = dam.id)
+        val breedingResult: BreedingResult =
+            BreedingFixture.breedingResult(
+                    breedingRegistrationId = breedingRegistration.id,
+                    covering = BreedingFixture.covering(stallionId = sire.id),
+                )
+                .recordFoaling(FoalingOutcome.LiveFoal(LocalDate.of(2024, 3, 20)))
+                .unwrap()
+
+        val breedingResultRepository =
+            mockk<BreedingResultRepository> {
+                every { findById(breedingResult.id) } returns breedingResult
+            }
+        val breedingRegistrationRepository =
+            mockk<BreedingRegistrationRepository> {
+                every { findById(breedingRegistration.id) } returns breedingRegistration
+            }
+        val bloodHorseRepository =
+            mockk<BloodHorseRepository> {
+                every { findById(sire.id) } returns sire
+                every { findById(dam.id) } returns dam
+                every { save(any()) } answers { firstArg() }
+            }
+
+        fun useCase() =
+            RegisterFoalUseCase(
+                breedingResultRepository,
+                breedingRegistrationRepository,
+                bloodHorseRepository,
+            )
+    }
+
+    @Nested
+    inner class SuccessCase {
+        @Test
+        fun `産駒が血統登録され父母が繁殖記録から解決され出生日が分娩日になる`() {
+            val w = Wiring()
+
+            val bloodHorse = w.useCase()(command(w.breedingResult.id.value)).unwrap()
+
+            assert(bloodHorse.sireId == w.sire.id)
+            assert(bloodHorse.damId == w.dam.id)
+            assert(bloodHorse.dateOfBirth.value == foalingDate)
+            verify(exactly = 1) { w.bloodHorseRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    inner class ValidationFailureCase {
+        @Test
+        fun `血統登録番号がブランクだと InvalidRegistrationNumber を返す`() {
+            val w = Wiring()
+
+            val result = w.useCase()(command(w.breedingResult.id.value, registrationNumber = ""))
+
+            assert(result.getError() == RegisterFoalUseCaseError.InvalidRegistrationNumber)
+            verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
+        }
+
+        @Test
+        fun `マイクロチップ番号が不正だと InvalidMicrochipNumber を返す`() {
+            val w = Wiring()
+
+            val result = w.useCase()(command(w.breedingResult.id.value, microchipNumber = "123"))
+
+            assert(result.getError() == RegisterFoalUseCaseError.InvalidMicrochipNumber)
+            verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
+        }
+
+        @Test
+        fun `生産者名がブランクだと BlankBreeder を返す`() {
+            val w = Wiring()
+
+            val result = w.useCase()(command(w.breedingResult.id.value, breeder = ""))
+
+            assert(result.getError() == RegisterFoalUseCaseError.BlankBreeder)
+            verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    inner class LookupFailureCase {
+        @Test
+        fun `繁殖成績が見つからないと BreedingResultNotFound を返し永続化されない`() {
+            val breedingResultId = UUID.randomUUID()
+            val repository =
+                mockk<BreedingResultRepository> {
+                    every { findById(BreedingResultId(breedingResultId)) } returns null
+                }
+            val useCase = RegisterFoalUseCase(repository, mockk(), mockk(relaxed = true))
+
+            val result = useCase(command(breedingResultId))
+
+            assert(
+                result.getError() ==
+                    RegisterFoalUseCaseError.BreedingResultNotFound(breedingResultId)
+            )
+        }
+
+        @Test
+        fun `繁殖登録が見つからないと BreedingRegistrationNotFound を返し永続化されない`() {
+            val w = Wiring()
+            every { w.breedingRegistrationRepository.findById(w.breedingRegistration.id) } returns
+                null
+
+            val result = w.useCase()(command(w.breedingResult.id.value))
+
+            assert(
+                result.getError() ==
+                    RegisterFoalUseCaseError.BreedingRegistrationNotFound(
+                        w.breedingRegistration.id.value
+                    )
+            )
+            verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
+        }
+
+        @Test
+        fun `父が見つからないと SireNotFound を返し永続化されない`() {
+            val w = Wiring()
+            every { w.bloodHorseRepository.findById(w.sire.id) } returns null
+
+            val result = w.useCase()(command(w.breedingResult.id.value))
+
+            assert(result.getError() == RegisterFoalUseCaseError.SireNotFound(w.sire.id.value))
+            verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
+        }
+
+        @Test
+        fun `母が見つからないと DamNotFound を返し永続化されない`() {
+            val w = Wiring()
+            every { w.bloodHorseRepository.findById(w.dam.id) } returns null
+
+            val result = w.useCase()(command(w.breedingResult.id.value))
+
+            assert(result.getError() == RegisterFoalUseCaseError.DamNotFound(w.dam.id.value))
+            verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    inner class PreconditionFailureCase {
+        @Test
+        fun `分娩結果が未報告だと PreconditionViolated(NotLiveFoal) を返す`() {
+            val w = Wiring()
+            val notReported =
+                BreedingFixture.breedingResult(
+                    breedingRegistrationId = w.breedingRegistration.id,
+                    covering = BreedingFixture.covering(stallionId = w.sire.id),
+                )
+            every { w.breedingResultRepository.findById(notReported.id) } returns notReported
+
+            val result = w.useCase()(command(notReported.id.value))
+
+            assert(
+                result.getError() ==
+                    RegisterFoalUseCaseError.PreconditionViolated(
+                        RegisterFoalError.NotLiveFoal(null)
+                    )
+            )
+            verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
+        }
+
+        @Test
+        fun `委譲先の前提条件違反は PreconditionViolated(RegistrationFailed) に wrap される`() {
+            // 父が雌のため registerInStudBook が SireNotMale を返す
+            val w = Wiring()
+            val female = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+            every { w.bloodHorseRepository.findById(w.sire.id) } returns female
+
+            val result = w.useCase()(command(w.breedingResult.id.value))
+
+            assert(
+                result.getError() ==
+                    RegisterFoalUseCaseError.PreconditionViolated(
+                        RegisterFoalError.RegistrationFailed(RegisterInStudBookError.SireNotMale)
+                    )
+            )
+            verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
+        }
+    }
+}


### PR DESCRIPTION
## 概要

PR #342（issue #324）で実装した接続経路のドメインサービス `registerFoal` を **application 層から駆動する配線**を追加する（#343）。

## 背景の補足（issue との差分）

issue #343 の本文では「`BreedingResultRepository` / `BreedingRegistrationRepository`・その InMemory 実装・`RecordCovering` / `ReportFoaling` ユースケースが未整備」とされていたが、**着手時点でいずれも既に存在**していた（直近のマージで整備済み）。そのため本 PR は未整備だった **`RegisterFoalUseCase` 本体とテスト**に絞る。issue のチェックリストはこれでほぼ消化される。

## 変更点

- **`RegisterFoalUseCase`**（`application/horseracing/horse/`）
  - 入力 `RegisterFoalCommand`: `breedingResultId` ＋ 申請者の個体識別入力（性・毛色・品種・生産者・マイクロチップ・DNA親子判定・登録番号）。父・母・出生日は申請者入力に含めず繁殖記録から確定する
  - フロー: 繁殖成績 → 繁殖登録 → 父（`covering.stallionId`）/母（`broodmareId`）を各ポートで解決し、`registerFoal` を駆動して誕生した `BloodHorse` を永続化
  - 失敗バリアント: `InvalidRegistrationNumber` / `InvalidMicrochipNumber` / `BlankBreeder` / `BreedingResultNotFound` / `BreedingRegistrationNotFound` / `SireNotFound` / `DamNotFound` / `PreconditionViolated(RegisterFoalError)`
- **`RegisterFoalUseCaseTest`**: mockk で 3 ポートをスタブし、正常系と検索／VO検証／前提条件の各失敗系を網羅

## 確認

- `./gradlew check` 通過（ktfmt / detekt / test / koverVerifyMature 85%ゲート含む）

## 関連

- #324 / PR #342（接続経路のドメインサービス `registerFoal`）
- #267（父母不明個体の血統登録経路。`registerInStudBook` の同じ入口を共有）

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)
