### PR TITLE
refactor: REST 命名規約を確定する（URL=camelCase / ボディ=snake_case）+ ADR 化 (#337)

### DIFF
--- a/.claude/rules/api-design.md
+++ b/.claude/rules/api-design.md
@@ -13,11 +13,25 @@ REST API は以下のスタイルガイドに準拠する。
 [Google AIP](https://google.aip.dev/) 準拠とする。
 
 - リソース指向設計（[AIP-121](https://google.aip.dev/121)）
-- リソース名 / コレクション名は複数形・小文字スネークケース（[AIP-122](https://google.aip.dev/122)）
+- リソース名 / コレクション名は複数形・**camelCase**（[AIP-122](https://google.aip.dev/122)）。例: `/api/bloodHorses`、`/api/breedingResults`
 - 標準メソッド `List / Get / Create / Update / Delete`（[AIP-131](https://google.aip.dev/131) ～ [AIP-135](https://google.aip.dev/135)）
 - Create は `POST /{collection}` でコレクションに対して行い、作成された resource 全体を `201 Created` で返す（[AIP-133](https://google.aip.dev/133)）
 - カスタムメソッドは `POST /{resource}:{verb}`（[AIP-136](https://google.aip.dev/136)）で表す。特定リソースを操作するカスタムメソッド（例: 馬名登録 `:registerName`）は、操作後の resource 全体を返す
 - **リソース操作の成功レスポンスは一律でリソース表現を返す**。操作ごとに別レスポンス DTO を作らず、リソース名ベースの単一 DTO（`〜Response`、例 `BloodHorseResponse`）を全操作（Create / カスタムメソッド等）で共用する。操作前は未設定になりうる属性（命名前の `name` 等）は nullable で表す。経緯は [ADR-0008](../../docs/adr/0008-uniform-resource-representation-response.md)
+
+## 命名規約（casing）
+
+URL とボディで casing を使い分ける。AIP の「URL はハードルール、ボディの JSON casing は自由」という非対称をそのまま反映したもの。経緯・却下案は [ADR-0012](../../docs/adr/0012-rest-naming-convention.md)。
+
+| 対象 | casing | 根拠 |
+|---|---|---|
+| URL コレクション識別子 | **camelCase** | [AIP-122](https://google.aip.dev/122) の must（`/api/bloodHorses`、`/api/breedingResults`）。アンダースコア・ハイフン不可 |
+| JSON ボディフィールド | **snake_case** | AIP は JSON casing を縛らない（[AIP-140](https://google.aip.dev/140) が must で縛るのは proto 定義 = snake_case）。意図的に snake_case を採用 |
+| カスタムメソッド動詞 | lowerCamelCase | [AIP-136](https://google.aip.dev/136)（`:registerName` 等） |
+
+- ボディの snake_case は `application.yml` の `spring.jackson.property-naming-strategy: SNAKE_CASE` で request/response bean に一括適用する。
+- **`ProblemDetail.properties` は `Map<String, Object>` で naming strategy が効かない**。problem+json の拡張キー（`error_code` / `sire_id` 等）は各 `toProblemDetail()` 群の `setProperty(...)` リテラルで直接 snake_case を書く。RFC 9457 の標準フィールド（`type` / `title` / `status` / `detail` / `instance`）は不変。
+- enum 値文字列（`MALE` 等）は naming strategy 非対象でそのまま。
 
 ## リクエスト / レスポンス DTO とドメインの分離
 
@@ -38,7 +52,7 @@ VO で表す項目（番号・名前など）は素の文字列で DTO に受け
 - `Content-Type: application/problem+json` で返す
 - Spring の `org.springframework.http.ProblemDetail` を使う
 - 標準フィールド: `type` (URI) / `title` / `status` / `detail` / `instance`
-- 業務エラー固有の追加情報は拡張プロパティで保持する（例: `errorCode` / `existingId` 等）
+- 業務エラー固有の追加情報は拡張プロパティで保持する（例: `error_code` / `existing_id` 等。拡張キーは snake_case。前述「命名規約」を参照）
 - `type` は当面 `urn:problem-type:{kebab-case-code}` 形式を用い、HTTP で公開する Resolvable URI ができたら差し替える
 
 > AIP-193 (Errors) はレスポンスボディの形（`google.rpc.Status`）を規定するが、本プロジェクトでは REST 寄りの RFC 9457 を採用する。リソース設計など構造系のみ AIP を適用する。

--- a/docs/adr/0012-rest-naming-convention.md
+++ b/docs/adr/0012-rest-naming-convention.md
@@ -1,0 +1,51 @@
+# 0012. REST 命名規約を URL=camelCase / ボディ=snake_case に確定する
+
+- Status: Accepted
+- Date: 2026-06-21
+- Deciders: ptiringo
+
+## Context（背景・課題）
+
+REST API の命名（URL とボディの casing）が不揃いで、ドキュメントと実装も食い違っていた。
+
+- **URL コレクション識別子**: snake_case（`/api/blood_horses`、`/api/breeding_results`）
+- **JSON ボディフィールド**: Jackson デフォルトの camelCase（`registrationNumber` / `coveringYear` など）
+- **`.claude/rules/api-design.md` の AIP-122 誤読**: 「コレクション名は小文字スネークケース（AIP-122）」と記載していたが、AIP-122 は camelCase を要求している
+
+### AIP の典拠（原典確認済み）
+
+- **URL（コレクション識別子）— [AIP-122](https://google.aip.dev/122)**: `Collection identifiers **must** be in camelCase`、かつ `/[a-z][a-zA-Z0-9]*/`（アンダースコア・ハイフン不可）、複数形。**現状の snake_case は AIP-122 違反**。kebab-case も非準拠。
+- **ボディ（フィールド名）— [AIP-140](https://google.aip.dev/140)**: must で縛るのは **proto 定義 = `lower_snake_case`**。JSON 表現の casing は明示していない。Google API のボディが camelCase に見えるのは proto3 の JSON マッピング既定（非規範・パーサは両方受理）であって AIP の要求ではない。**本プロジェクトは proto ベースではないため JSON casing は自由**で、snake_case にしても AIP 違反にならない。
+- **カスタムメソッド動詞 — [AIP-136](https://google.aip.dev/136)**: lowerCamelCase。現状の `:registerName` / `:reportFoaling` は準拠済み。
+
+### 検討した代替案
+
+- **全 camelCase（URL も ボディも camelCase）**: AIP-122 は満たすが、ボディを camelCase にする積極的な根拠が「proto3 既定の見た目に合わせる」しかない。本プロジェクトは proto ベースでないためその制約に従う理由がなく、却下。
+- **全 snake_case（URL も ボディも snake_case）**: ボディは妥当だが URL が AIP-122 違反になるため却下。
+- **kebab-case（URL）**: AIP-122 の `/[a-z][a-zA-Z0-9]*/` に反する（ハイフン不可）ため却下。
+
+## Decision（決定）
+
+REST 命名規約を以下に確定する。
+
+| 対象 | casing | 根拠 |
+|---|---|---|
+| URL コレクション識別子 | **camelCase** | AIP-122 の must（`blood_horses` → `bloodHorses`、`breeding_results` → `breedingResults`） |
+| JSON ボディフィールド | **snake_case** | AIP は JSON casing を縛らない。snake_case が AIP-140 の「真の」フィールド名であり、意図的に採用する |
+| カスタムメソッド動詞 | lowerCamelCase | AIP-136（現状維持） |
+
+URL=camelCase / ボディ=snake_case という非対称は、AIP の「URL はハードルール、ボディの JSON casing は自由」をそのまま反映したもの。
+
+実装方針:
+
+- URL は `controller/**` の `@PostMapping` 等のパスを camelCase へ変更する。
+- ボディは `application.yml` の `spring.jackson.property-naming-strategy: SNAKE_CASE` で request/response bean に一括適用する。
+- **`ProblemDetail.properties` は `Map<String, Object>` で naming strategy が効かない**。problem+json の拡張キー（`error_code` / `sire_id` 等）は各 `toProblemDetail()` 群の `setProperty(...)` リテラルで直接 snake_case を書く。RFC 9457 の標準フィールド（`type` / `title` / `status` / `detail` / `instance`）は不変。
+- enum 値文字列（`MALE` 等）は naming strategy 非対象でそのまま。
+
+## Consequences（結果・影響）
+
+- URL が AIP-122 準拠になり、ドキュメント（`.claude/rules/api-design.md`）の誤記も訂正された。命名規約が URL / ボディともに一意に定まり、新規エンドポイントの判断に迷いがなくなる。
+- ボディの snake_case 化は naming strategy で一括適用されるため、新しい DTO はフィールドを camelCase の Kotlin プロパティとして書くだけで自動的に snake_case にシリアライズされる（追加作業不要）。
+- ただし `ProblemDetail` の拡張キーだけは naming strategy の枠外であり、`setProperty(...)` のキー文字列を手で snake_case に保つ必要がある（規約の穴。レビュー時の確認点）。将来 Detekt / ArchUnit での機械強制を検討する余地がある。
+- 結論（守るべきルール）は `.claude/rules/api-design.md` の「命名規約（casing）」節に置く。本 ADR はその経緯・典拠・却下案の記録。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,3 +21,4 @@
 | [0009](0009-immutable-aggregates.md) | ドメイン集約はイミュータブルに保ち、状態遷移は新インスタンスで表す | Accepted |
 | [0010](0010-confine-aggregate-creation-to-domain-service.md) | 集約をまたぐ前提条件を持つ生成口はドメインサービスに封じ込める | Accepted |
 | [0011](0011-priority-via-projects-custom-field.md) | Issue 優先度を GitHub Projects のカスタムフィールドで管理する（ラベル運用を廃止） | Accepted |
+| [0012](0012-rest-naming-convention.md) | REST 命名規約を URL=camelCase / ボディ=snake_case に確定する | Accepted |

--- a/src/main/kotlin/com/example/api/controller/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/example/api/controller/GlobalExceptionHandler.kt
@@ -72,7 +72,7 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
         if (problem.type == BLANK_TYPE) {
             problem.type = URI.create("urn:problem-type:$code")
         }
-        problem.setProperty("errorCode", code)
+        problem.setProperty("error_code", code)
     }
 
     companion object {

--- a/src/main/kotlin/com/example/api/controller/ProblemResponses.kt
+++ b/src/main/kotlin/com/example/api/controller/ProblemResponses.kt
@@ -62,5 +62,5 @@ internal fun problem(
         type = URI.create("urn:problem-type:$code")
         this.title = title
         this.detail = detail
-        setProperty("errorCode", code)
+        setProperty("error_code", code)
     }

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultController.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultController.kt
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController
 /**
  * 繁殖成績リソースの HTTP アダプター。
  *
- * Google AIP のリソース指向設計に従い、コレクション `/api/breeding_results` に対する Create（種付記録による年次 レコードの起票）と、個体への
+ * Google AIP のリソース指向設計に従い、コレクション `/api/breedingResults` に対する Create（種付記録による年次 レコードの起票）と、個体への
  * カスタムメソッド `:reportFoaling`（分娩結果報告、[AIP-136](https://google.aip.dev/136)） を提供する。エラーレスポンスは RFC 9457
  * (Problem Details) 形式で返す。
  */
@@ -77,7 +77,7 @@ class BreedingResultController(
             ],
     )
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/api/breeding_results")
+    @PostMapping("/api/breedingResults")
     fun record(@RequestBody request: RecordCoveringRequest): BreedingResultResponse =
         recordCovering(Command.now(request.toCommand(), clock))
             .mapError { it.toProblemDetail() }
@@ -139,7 +139,7 @@ class BreedingResultController(
             ],
     )
     @ResponseStatus(HttpStatus.OK)
-    @PostMapping("/api/breeding_results/{breedingResultId}:reportFoaling")
+    @PostMapping("/api/breedingResults/{breedingResultId}:reportFoaling")
     fun reportFoaling(
         @PathVariable breedingResultId: UUID,
         @RequestBody request: ReportFoalingRequest,

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
@@ -60,7 +60,7 @@ fun RecordCoveringUseCaseError.toProblemDetail(): ProblemDetail =
                 status = HttpStatus.BAD_REQUEST,
                 code = "invalid-covering-certificate-number",
                 title = "Invalid covering certificate number",
-                detail = "certificateNumber は空であってはいけません。",
+                detail = "certificate_number は空であってはいけません。",
             )
         is RecordCoveringUseCaseError.BreedingRegistrationNotFound ->
             problem(
@@ -69,7 +69,7 @@ fun RecordCoveringUseCaseError.toProblemDetail(): ProblemDetail =
                     title = "Breeding registration not found",
                     detail = "種付対象として指定された繁殖登録が存在しません。",
                 )
-                .apply { setProperty("breedingRegistrationId", breedingRegistrationId) }
+                .apply { setProperty("breeding_registration_id", breedingRegistrationId) }
         is RecordCoveringUseCaseError.StallionNotFound ->
             problem(
                     status = HttpStatus.UNPROCESSABLE_ENTITY,
@@ -77,7 +77,7 @@ fun RecordCoveringUseCaseError.toProblemDetail(): ProblemDetail =
                     title = "Stallion not found",
                     detail = "配合相手として指定された種牡馬が存在しません。",
                 )
-                .apply { setProperty("stallionId", stallionId) }
+                .apply { setProperty("stallion_id", stallionId) }
         is RecordCoveringUseCaseError.PreconditionViolated -> cause.toProblemDetail()
     }
 
@@ -107,7 +107,7 @@ fun ReportFoalingUseCaseError.toProblemDetail(): ProblemDetail =
                     title = "Breeding result not found",
                     detail = "報告対象として指定された繁殖成績が存在しません。",
                 )
-                .apply { setProperty("breedingResultId", breedingResultId) }
+                .apply { setProperty("breeding_result_id", breedingResultId) }
         is ReportFoalingUseCaseError.AlreadyReported ->
             problem(
                 status = HttpStatus.CONFLICT,

--- a/src/main/kotlin/com/example/api/controller/breeding/RecordCoveringRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/RecordCoveringRequest.kt
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 /**
- * `POST /api/breeding_results` のリクエストボディ。
+ * `POST /api/breedingResults` のリクエストボディ。
  *
  * 繁殖成績報告書の「種付」欄に相当する。繁殖登録・種牡馬は登録済みのIDで参照する。VO で表す種付証明書番号は 素の文字列で受け取り、ユースケースで検証する。
  *

--- a/src/main/kotlin/com/example/api/controller/breeding/ReportFoalingRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/ReportFoalingRequest.kt
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 
 /**
- * `POST /api/breeding_results/{breedingResultId}:reportFoaling` のリクエストボディ。
+ * `POST /api/breedingResults/{breedingResultId}:reportFoaling` のリクエストボディ。
  *
  * 繁殖成績報告書の「分娩結果」欄に相当する。区分は HTTP 契約専用の [FoalingOutcomeDto] で受け取り（未知の値は Jackson のデシリアライズで弾かれ
  * 400）、ドメインの [FoalingOutcome] へは [toOutcome] で変換する。生産
@@ -36,7 +36,7 @@ fun ReportFoalingRequest.toOutcome(): Result<FoalingOutcome, ProblemDetail> =
                         status = HttpStatus.BAD_REQUEST,
                         code = "missing-foaling-date",
                         title = "Missing foaling date",
-                        detail = "生産（LIVE_FOAL）のときは foalingDate が必須です。",
+                        detail = "生産（LIVE_FOAL）のときは foaling_date が必須です。",
                     )
                 )
             } else {

--- a/src/main/kotlin/com/example/api/controller/horse/BloodHorseController.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/BloodHorseController.kt
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController
 /**
  * 軽種馬リソースの HTTP アダプター。
  *
- * Google AIP のリソース指向設計に従い、コレクション `/api/blood_horses` に対する Create（血統登録）と、 個体への カスタムメソッド
+ * Google AIP のリソース指向設計に従い、コレクション `/api/bloodHorses` に対する Create（血統登録）と、 個体への カスタムメソッド
  * `:registerName`（馬名登録、[AIP-136](https://google.aip.dev/136)）を提供する。 エラーレスポンスは RFC 9457 (Problem
  * Details) 形式で返す。
  */
@@ -75,7 +75,7 @@ class BloodHorseController(
             ],
     )
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/api/blood_horses")
+    @PostMapping("/api/bloodHorses")
     fun register(@RequestBody request: RegisterBloodHorseRequest): BloodHorseResponse =
         registerInStudBook(Command.now(request.toCommand(), clock))
             .mapError { it.toProblemDetail() }
@@ -135,7 +135,7 @@ class BloodHorseController(
             ],
     )
     @ResponseStatus(HttpStatus.OK)
-    @PostMapping("/api/blood_horses/{bloodHorseId}:registerName")
+    @PostMapping("/api/bloodHorses/{bloodHorseId}:registerName")
     fun registerName(
         @PathVariable bloodHorseId: UUID,
         @RequestBody request: RegisterHorseNameRequest,

--- a/src/main/kotlin/com/example/api/controller/horse/BloodHorseResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/BloodHorseResponse.kt
@@ -72,14 +72,14 @@ fun RegisterInStudBookUseCaseError.toProblemDetail(): ProblemDetail =
                 status = HttpStatus.BAD_REQUEST,
                 code = "invalid-registration-number",
                 title = "Invalid registration number",
-                detail = "registrationNumber は空であってはいけません。",
+                detail = "registration_number は空であってはいけません。",
             )
         RegisterInStudBookUseCaseError.InvalidMicrochipNumber ->
             problem(
                 status = HttpStatus.BAD_REQUEST,
                 code = "invalid-microchip-number",
                 title = "Invalid microchip number",
-                detail = "microchipNumber は 15 桁の数字でなければなりません。",
+                detail = "microchip_number は 15 桁の数字でなければなりません。",
             )
         RegisterInStudBookUseCaseError.BlankBreeder ->
             problem(
@@ -95,7 +95,7 @@ fun RegisterInStudBookUseCaseError.toProblemDetail(): ProblemDetail =
                     title = "Sire not found",
                     detail = "父として指定された軽種馬が存在しません。",
                 )
-                .apply { setProperty("sireId", sireId) }
+                .apply { setProperty("sire_id", sireId) }
         is RegisterInStudBookUseCaseError.DamNotFound ->
             problem(
                     status = HttpStatus.UNPROCESSABLE_ENTITY,
@@ -103,7 +103,7 @@ fun RegisterInStudBookUseCaseError.toProblemDetail(): ProblemDetail =
                     title = "Dam not found",
                     detail = "母として指定された軽種馬が存在しません。",
                 )
-                .apply { setProperty("damId", damId) }
+                .apply { setProperty("dam_id", damId) }
         is RegisterInStudBookUseCaseError.PreconditionViolated -> cause.toProblemDetail()
     }
 

--- a/src/main/kotlin/com/example/api/controller/horse/NameHorseProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/NameHorseProblem.kt
@@ -28,7 +28,7 @@ fun NameHorseUseCaseError.toProblemDetail(): ProblemDetail =
                     title = "Horse not found",
                     detail = "命名対象として指定された軽種馬が存在しません。",
                 )
-                .apply { setProperty("bloodHorseId", bloodHorseId) }
+                .apply { setProperty("blood_horse_id", bloodHorseId) }
         is NameHorseUseCaseError.AlreadyNamed ->
             problem(
                     status = HttpStatus.CONFLICT,
@@ -36,5 +36,5 @@ fun NameHorseUseCaseError.toProblemDetail(): ProblemDetail =
                     title = "Horse already named",
                     detail = "対象の軽種馬は既に命名済みのため、再命名はできません。",
                 )
-                .apply { setProperty("currentName", currentName) }
+                .apply { setProperty("current_name", currentName) }
     }

--- a/src/main/kotlin/com/example/api/controller/horse/RegisterBloodHorseRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/RegisterBloodHorseRequest.kt
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 /**
- * `POST /api/blood_horses` のリクエストボディ。
+ * `POST /api/bloodHorses` のリクエストボディ。
  *
  * 登録申請フォームに相当する。enum 項目（性・毛色・品種・DNA 判定）は HTTP 契約専用の `〜Dto` enum で受け取り、列挙子名で デシリアライズする。未知の値は Jackson
  * のデシリアライズで弾かれ `GlobalExceptionHandler` が 400 を返す。ドメイン enum への 変換は [toCommand] が [toDomain]

--- a/src/main/kotlin/com/example/api/controller/horse/RegisterHorseNameRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/RegisterHorseNameRequest.kt
@@ -4,7 +4,7 @@ import com.example.api.application.horseracing.horse.NameHorseCommand
 import java.util.UUID
 
 /**
- * `POST /api/blood_horses/{bloodHorseId}:registerName` のリクエストボディ。
+ * `POST /api/bloodHorses/{bloodHorseId}:registerName` のリクエストボディ。
  *
  * 馬名登録申請に相当する。命名対象の軽種馬IDは URL パスで指定するため、ボディは付与する馬名のみを持つ。 馬名は VO で検証するため素の文字列で受け取り、ユースケースで
  * [com.example.api.domain.horseracing.model.horse.bloodhorse.HorseName] の検証を通す。

--- a/src/main/kotlin/com/example/api/controller/jockey/RegisterJockeyResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/RegisterJockeyResponse.kt
@@ -35,7 +35,7 @@ fun JockeyRegistrationError.toProblemDetail(): ProblemDetail =
                     title = "Duplicate jockey",
                     detail = "同姓同名のジョッキーが既に登録されています。",
                 )
-                .apply { setProperty("existingId", existingId.value) }
+                .apply { setProperty("existing_id", existingId.value) }
     }
 
 private fun JockeyValidationError.toProblemDetail(): ProblemDetail =
@@ -45,13 +45,13 @@ private fun JockeyValidationError.toProblemDetail(): ProblemDetail =
                 status = HttpStatus.BAD_REQUEST,
                 code = "blank-first-name",
                 title = "First name is blank",
-                detail = "firstName は空であってはいけません。",
+                detail = "first_name は空であってはいけません。",
             )
         JockeyValidationError.BlankLastName ->
             problem(
                 status = HttpStatus.BAD_REQUEST,
                 code = "blank-last-name",
                 title = "Last name is blank",
-                detail = "lastName は空であってはいけません。",
+                detail = "last_name は空であってはいけません。",
             )
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,11 @@ spring:
   threads:
     virtual:
       enabled: true
+  jackson:
+    # JSON ボディのフィールド名を snake_case で表現する（request/response bean に一括適用）。
+    # URL=camelCase / ボディ=snake_case の命名規約は ADR-0012 を参照。
+    # 注: ProblemDetail.properties は Map のため naming strategy が効かず、拡張キーは setProperty で個別に snake_case 指定する。
+    property-naming-strategy: SNAKE_CASE
   mvc:
     problemdetails:
       # Spring MVC 標準例外（リクエストボディ不正・媒体型不一致等）を RFC 9457 形式に変換する

--- a/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
@@ -36,18 +36,18 @@ class GlobalExceptionHandlerTest(val mockMvc: MockMvc) {
 
     @Test
     fun `必須フィールド欠落のリクエストボディで 400 と規約付与済みの problem+json が返ること`() {
-        // lastName が欠落しており Jackson のデシリアライズに失敗する。
-        // フレームワーク標準例外由来でも funnel で errorCode 規約が付与される。
+        // last_name が欠落しており Jackson のデシリアライズに失敗する。
+        // フレームワーク標準例外由来でも funnel で error_code 規約が付与される。
         tester
             .post()
             .uri("/api/jockeys")
             .contentType(MediaType.APPLICATION_JSON)
-            .content("""{"firstName":"武"}""")
+            .content("""{"first_name":"武"}""")
             .assertThat()
             .hasStatus(HttpStatus.BAD_REQUEST)
             .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
             .bodyJson()
-            .extractingPath("$.errorCode")
+            .extractingPath("$.error_code")
             .isEqualTo("bad-request")
     }
 
@@ -62,12 +62,12 @@ class GlobalExceptionHandlerTest(val mockMvc: MockMvc) {
             .post()
             .uri("/api/jockeys")
             .contentType(MediaType.APPLICATION_JSON)
-            .content("""{"firstName":"武","lastName":"豊"}""")
+            .content("""{"first_name":"武","last_name":"豊"}""")
             .assertThat()
             .hasStatus(HttpStatus.CONFLICT)
             .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
             .bodyJson()
-            .extractingPath("$.errorCode")
+            .extractingPath("$.error_code")
             .isEqualTo("duplicate-jockey")
     }
 
@@ -80,12 +80,12 @@ class GlobalExceptionHandlerTest(val mockMvc: MockMvc) {
             .post()
             .uri("/api/jockeys")
             .contentType(MediaType.APPLICATION_JSON)
-            .content("""{"firstName":"武","lastName":"豊"}""")
+            .content("""{"first_name":"武","last_name":"豊"}""")
             .assertThat()
             .hasStatus(HttpStatus.INTERNAL_SERVER_ERROR)
             .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
             .bodyJson()
-            .extractingPath("$.errorCode")
+            .extractingPath("$.error_code")
             .isEqualTo("internal-server-error")
     }
 }

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
@@ -40,16 +40,16 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
 
     @Nested
     inner class RecordCoveringCase {
-        private val uri = "/api/breeding_results"
+        private val uri = "/api/breedingResults"
 
         /** デシリアライズに通る正しいリクエストボディ。ユースケースはモックのため中身の整合は問われない。 */
         private val validBody =
             """
             {
-                "breedingRegistrationId": "11111111-1111-1111-1111-111111111111",
-                "stallionId": "22222222-2222-2222-2222-222222222222",
-                "coveringDate": "2024-04-01",
-                "certificateNumber": "C-2024-0001"
+                "breeding_registration_id": "11111111-1111-1111-1111-111111111111",
+                "stallion_id": "22222222-2222-2222-2222-222222222222",
+                "covering_date": "2024-04-01",
+                "certificate_number": "C-2024-0001"
             }
             """
                 .trimIndent()
@@ -67,7 +67,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 .assertThat()
                 .hasStatus(HttpStatus.CREATED)
                 .bodyJson()
-                .extractingPath("$.coveringYear")
+                .extractingPath("$.covering_year")
                 .isEqualTo(2024)
         }
 
@@ -85,7 +85,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 .hasStatus(HttpStatus.BAD_REQUEST)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.errorCode")
+                .extractingPath("$.error_code")
                 .isEqualTo("invalid-covering-certificate-number")
         }
 
@@ -104,7 +104,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.breedingRegistrationId")
+                .extractingPath("$.breeding_registration_id")
                 .isEqualTo(id.toString())
         }
 
@@ -123,7 +123,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.stallionId")
+                .extractingPath("$.stallion_id")
                 .isEqualTo(id.toString())
         }
 
@@ -145,7 +145,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.errorCode")
+                .extractingPath("$.error_code")
                 .isEqualTo("stallion-not-male")
         }
     }
@@ -153,8 +153,8 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
     @Nested
     inner class ReportFoalingCase {
         private val breedingResultId = "33333333-3333-3333-3333-333333333333"
-        private val uri = "/api/breeding_results/$breedingResultId:reportFoaling"
-        private val liveFoalBody = """{ "outcome": "LIVE_FOAL", "foalingDate": "2025-03-20" }"""
+        private val uri = "/api/breedingResults/$breedingResultId:reportFoaling"
+        private val liveFoalBody = """{ "outcome": "LIVE_FOAL", "foaling_date": "2025-03-20" }"""
 
         @Test
         fun `正常な入力で 200 OK と更新後の繁殖成績が返ること`() {
@@ -187,7 +187,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 .hasStatus(HttpStatus.BAD_REQUEST)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.errorCode")
+                .extractingPath("$.error_code")
                 .isEqualTo("missing-foaling-date")
         }
 
@@ -206,7 +206,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 .hasStatus(HttpStatus.NOT_FOUND)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.breedingResultId")
+                .extractingPath("$.breeding_result_id")
                 .isEqualTo(id.toString())
         }
 
@@ -228,7 +228,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 .hasStatus(HttpStatus.CONFLICT)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.errorCode")
+                .extractingPath("$.error_code")
                 .isEqualTo("foaling-already-recorded")
         }
     }

--- a/src/test/kotlin/com/example/api/controller/breeding/FoalingOutcomeWireTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/FoalingOutcomeWireTest.kt
@@ -60,6 +60,6 @@ class FoalingOutcomeWireTest {
         val problem = ReportFoalingRequest(FoalingOutcomeDto.LIVE_FOAL, null).toOutcome().getError()
 
         assert(problem != null)
-        assert(problem?.properties?.get("errorCode") == "missing-foaling-date")
+        assert(problem?.properties?.get("error_code") == "missing-foaling-date")
     }
 }

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -42,16 +42,16 @@ class BloodHorseControllerTest(val mockMvc: MockMvc) {
     private val validBody =
         """
         {
-            "sireId": "11111111-1111-1111-1111-111111111111",
-            "damId": "22222222-2222-2222-2222-222222222222",
+            "sire_id": "11111111-1111-1111-1111-111111111111",
+            "dam_id": "22222222-2222-2222-2222-222222222222",
             "sex": "MALE",
-            "coatColor": "BAY",
-            "breedType": "THOROUGHBRED",
-            "dateOfBirth": "2023-03-15",
+            "coat_color": "BAY",
+            "breed_type": "THOROUGHBRED",
+            "date_of_birth": "2023-03-15",
             "breeder": "ノーザンファーム",
-            "microchipNumber": "392140000000001",
-            "dnaParentage": "CONSISTENT",
-            "registrationNumber": "2023104567"
+            "microchip_number": "392140000000001",
+            "dna_parentage": "CONSISTENT",
+            "registration_number": "2023104567"
         }
         """
             .trimIndent()
@@ -66,13 +66,13 @@ class BloodHorseControllerTest(val mockMvc: MockMvc) {
 
             tester
                 .post()
-                .uri("/api/blood_horses")
+                .uri("/api/bloodHorses")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(validBody)
                 .assertThat()
                 .hasStatus(HttpStatus.CREATED)
                 .bodyJson()
-                .extractingPath("$.registrationNumber")
+                .extractingPath("$.registration_number")
                 .isEqualTo("2023104567")
         }
     }
@@ -86,14 +86,14 @@ class BloodHorseControllerTest(val mockMvc: MockMvc) {
 
             tester
                 .post()
-                .uri("/api/blood_horses")
+                .uri("/api/bloodHorses")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(validBody)
                 .assertThat()
                 .hasStatus(HttpStatus.BAD_REQUEST)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.errorCode")
+                .extractingPath("$.error_code")
                 .isEqualTo("invalid-microchip-number")
         }
 
@@ -105,14 +105,14 @@ class BloodHorseControllerTest(val mockMvc: MockMvc) {
 
             tester
                 .post()
-                .uri("/api/blood_horses")
+                .uri("/api/bloodHorses")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(validBody)
                 .assertThat()
                 .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.sireId")
+                .extractingPath("$.sire_id")
                 .isEqualTo(sireId.toString())
         }
 
@@ -127,14 +127,14 @@ class BloodHorseControllerTest(val mockMvc: MockMvc) {
 
             tester
                 .post()
-                .uri("/api/blood_horses")
+                .uri("/api/bloodHorses")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(validBody)
                 .assertThat()
                 .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.errorCode")
+                .extractingPath("$.error_code")
                 .isEqualTo("sire-not-male")
         }
     }
@@ -142,7 +142,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc) {
     @Nested
     inner class RegisterNameCase {
         private val bloodHorseId = "33333333-3333-3333-3333-333333333333"
-        private val uri = "/api/blood_horses/$bloodHorseId:registerName"
+        private val uri = "/api/bloodHorses/$bloodHorseId:registerName"
         private val body = """{ "name": "オグリキャップ" }"""
 
         @Test
@@ -179,7 +179,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc) {
                 .hasStatus(HttpStatus.BAD_REQUEST)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.errorCode")
+                .extractingPath("$.error_code")
                 .isEqualTo("invalid-horse-name")
         }
 
@@ -198,7 +198,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc) {
                 .hasStatus(HttpStatus.NOT_FOUND)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.bloodHorseId")
+                .extractingPath("$.blood_horse_id")
                 .isEqualTo(id.toString())
         }
 
@@ -216,7 +216,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc) {
                 .hasStatus(HttpStatus.CONFLICT)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.errorCode")
+                .extractingPath("$.error_code")
                 .isEqualTo("horse-already-named")
         }
     }

--- a/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
@@ -42,11 +42,11 @@ class JockeyControllerTest(val mockMvc: MockMvc) {
                 .post()
                 .uri("/api/jockeys")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"firstName":"武","lastName":"豊"}""")
+                .content("""{"first_name":"武","last_name":"豊"}""")
                 .assertThat()
                 .hasStatus(HttpStatus.CREATED)
                 .bodyJson()
-                .extractingPath("$.firstName")
+                .extractingPath("$.first_name")
                 .isEqualTo("武")
         }
     }
@@ -62,12 +62,12 @@ class JockeyControllerTest(val mockMvc: MockMvc) {
                 .post()
                 .uri("/api/jockeys")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"firstName":"","lastName":"豊"}""")
+                .content("""{"first_name":"","last_name":"豊"}""")
                 .assertThat()
                 .hasStatus(HttpStatus.BAD_REQUEST)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.errorCode")
+                .extractingPath("$.error_code")
                 .isEqualTo("blank-first-name")
         }
 
@@ -80,12 +80,12 @@ class JockeyControllerTest(val mockMvc: MockMvc) {
                 .post()
                 .uri("/api/jockeys")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"firstName":"武","lastName":""}""")
+                .content("""{"first_name":"武","last_name":""}""")
                 .assertThat()
                 .hasStatus(HttpStatus.BAD_REQUEST)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.errorCode")
+                .extractingPath("$.error_code")
                 .isEqualTo("blank-last-name")
         }
 
@@ -99,12 +99,12 @@ class JockeyControllerTest(val mockMvc: MockMvc) {
                 .post()
                 .uri("/api/jockeys")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"firstName":"武","lastName":"豊"}""")
+                .content("""{"first_name":"武","last_name":"豊"}""")
                 .assertThat()
                 .hasStatus(HttpStatus.CONFLICT)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
-                .extractingPath("$.existingId")
+                .extractingPath("$.existing_id")
                 .isEqualTo(existing.id.value.toString())
         }
     }


### PR DESCRIPTION
## 概要

REST の命名規約（URL とボディの casing）を確定し、ドキュメントと実装を整合させる。Closes #337。

現状は URL もボディも不揃いだった:
- URL コレクション識別子: snake_case（`/api/blood_horses`、`/api/breeding_results`）
- JSON ボディフィールド: Jackson デフォルトの camelCase
- `.claude/rules/api-design.md` に AIP-122 の誤読（「小文字スネークケース」と記載）

## 決定（ADR-0012）

| 対象 | casing | 根拠 |
|---|---|---|
| URL コレクション識別子 | **camelCase** | AIP-122 の must |
| JSON ボディフィールド | **snake_case** | AIP は JSON casing を縛らない。意図的に採用 |
| カスタムメソッド動詞 | lowerCamelCase | AIP-136（現状維持） |

URL=camelCase / ボディ=snake_case の非対称は、AIP の「URL はハードルール、ボディの JSON casing は自由」をそのまま反映したもの。

## 変更点

### URL を camelCase へ
- `/api/blood_horses` → `/api/bloodHorses`
- `/api/breeding_results` → `/api/breedingResults`

### ボディを snake_case へ
- `application.yml` に `spring.jackson.property-naming-strategy: SNAKE_CASE` を追加（request/response bean に一括適用）
- **ProblemDetail 拡張キー**は `Map` で naming strategy が効かないため、`setProperty(...)` リテラルを個別に snake_case 化（`error_code` / `sire_id` / `dam_id` / `breeding_registration_id` / `stallion_id` / `breeding_result_id` / `existing_id` / `blood_horse_id` / `current_name`）
- detail メッセージ中のフィールド名参照も整合
- enum 値文字列（`MALE` 等）は naming strategy 非対象でそのまま

### ドキュメント・ADR
- `.claude/rules/api-design.md`：AIP-122 誤記を訂正し命名規約（casing）節を新設
- **ADR-0012** を起票（決定・典拠・却下案=全camelCase/全snake_case/kebab）

### テスト
全 Controller slice テスト・`GlobalExceptionHandlerTest`・`FoalingOutcomeWireTest` の URI / ボディ JSON / `extractingPath` を新 casing に更新

## 完了条件

- [x] URL コレクション識別子が camelCase（AIP-122 準拠）
- [x] JSON ボディフィールドが snake_case
- [x] problem+json 拡張キーが snake_case（標準フィールドは不変）
- [x] 既存テストを更新し `./gradlew check` が green
- [x] api-design.md の AIP-122 誤記を訂正し命名規約を明記
- [x] 決定を ADR 化（docs/adr/0012）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
