### PR TITLE
feat: DTO がドメイン enum をフィールド型に晒さないことを ArchUnit で強制する (#297)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -95,6 +95,7 @@ domain/
 - **集約（`@AggregateRoot` / `@Entity`）はイミュータブル**（`val` のみ・`var` 禁止）。状態遷移は対象を書き換えず、同一性（ID）を引き継いだ新インスタンスを返すメソッドで表す（[ADR-0009](../../docs/adr/0009-immutable-aggregates.md)）。`val` は final フィールド・`var` は非 final フィールドへコンパイルされるため、集約クラスが直接宣言するフィールドが全て final であることを ArchUnit で検証して `var` を排除する
 - **ドメインサービス（`domain.*.service`）はトップレベル関数で書く**（`object` / `class` でラップしない）。トップレベル関数はファイルごとのファサードクラス（`〜Kt`）へコンパイルされるため、service パッケージ内のクラスが `Kt` で終わることを ArchUnit で検証して `object` / `class` 宣言を排除する。ただしサービスの戻り値（`Result<_, 〜Error>`）の失敗側を表す失敗バリアント型（`〜Error`）はサービスと同居させてよく、対象から除外する
 - **`@RestController` のハンドラは成功レスポンスで `ResponseEntity` を返さない**。成功は `@ResponseStatus` ＋戻り値で resource を返す（[error-handling.md](error-handling.md) / [api-design.md](api-design.md)）。エラー描画 funnel の `GlobalExceptionHandler` は `@RestController` ではない（`ResponseEntityExceptionHandler` 継承）ため誤検出されない
+- **HTTP 契約（request / response DTO）はフィールド型にドメイン enum を持たない**。`controller` 層に契約専用の `〜Dto` enum を置き、`toDomain()` / `toApi()` でマッピングする（[api-design.md](api-design.md) / [ADR-0007](../../docs/adr/0007-wire-enum-dto-decoupling.md)）。`controller` 配下のフィールドがドメイン（`domain..`）の enum を raw type に持たないことを ArchUnit で検証する。マッパー関数はドメイン enum を引数・戻り値で扱うが、フィールド型のみを対象とするため誤検出されない（ルールが実際に違反を検出することは `DtoDomainEnumRuleTest` で別途担保）
 
 ## ルールの変更・追加
 

--- a/src/test/kotlin/com/example/api/architecture/ArchitectureTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/ArchitectureTest.kt
@@ -11,6 +11,7 @@ import com.tngtech.archunit.junit.ArchTest
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods
 import com.tngtech.archunit.library.Architectures.onionArchitecture
 import com.tngtech.archunit.library.GeneralCodingRules
@@ -49,6 +50,17 @@ private val isFailureVariantType =
     DescribedPredicate.describe<JavaClass>("ドメインサービスの失敗バリアント型（〜Error）") { javaClass ->
         generateSequence(javaClass) { it.enclosingClass.orElse(null) }
             .any { it.simpleName.endsWith("Error") }
+    }
+
+/**
+ * ドメイン層（`com.example.api.domain..`）に属する enum であること。
+ *
+ * HTTP 契約の DTO がフィールド型にドメイン enum を持つことを禁じる [dtosDoNotExposeDomainEnums] で用いる。 enum
+ * かつドメインパッケージ配下のものだけを対象とし、`controller` 層の契約専用 enum（`〜Dto`）は対象外とする。
+ */
+private val isDomainEnum =
+    DescribedPredicate.describe<JavaClass>("ドメイン層の enum") { javaClass ->
+        javaClass.isEnum && javaClass.packageName.startsWith("com.example.api.domain.")
     }
 
 /**
@@ -212,6 +224,27 @@ class ArchitectureTest {
             .should()
             .haveRawReturnType(ResponseEntity::class.java)
             .because("成功レスポンスは @ResponseStatus ＋戻り値で resource を返す。ResponseEntity は使わない")
+
+    /**
+     * HTTP 契約（request / response DTO）はフィールド型にドメイン enum を持たないこと。
+     *
+     * ドメイン enum を wire に直接晒すと、ドメイン側の列挙子リネームが HTTP 契約（生成クライアント含む）を無言で破壊する。 これを断つため `controller`
+     * 層に契約専用の `〜Dto` enum を置き、`toDomain()` / `toApi()` の網羅 `when`
+     * で相互変換する（`.claude/rules/api-design.md` / ADR-0007）。マッパー関数はドメイン enum をメソッドの引数・戻り値で扱うが、
+     * 本ルールは**フィールド型**のみを対象とするため誤検出されない。
+     */
+    @ArchTest
+    val dtosDoNotExposeDomainEnums =
+        noFields()
+            .that()
+            .areDeclaredInClassesThat()
+            .resideInAPackage(CONTROLLER)
+            .should()
+            .haveRawType(isDomainEnum)
+            .because(
+                "HTTP 契約はドメイン enum を wire に直接晒さず、controller 層の 〜Dto enum へ" +
+                    "マッピングする（ADR-0007）。列挙子リネームによる契約破壊を防ぐ"
+            )
 
     /** ユースケース（@Service）は application 層に置くこと。 */
     @ArchTest

--- a/src/test/kotlin/com/example/api/architecture/DtoDomainEnumRuleTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/DtoDomainEnumRuleTest.kt
@@ -1,0 +1,42 @@
+package com.example.api.architecture
+
+import com.example.api.controller.archfixture.DomainEnumFieldDtoFixture
+import com.example.api.domain.horseracing.model.horse.bloodhorse.CoatColor
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.ImportOption
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * `ArchitectureTest.dtosDoNotExposeDomainEnums`（DTO がドメイン enum をフィールド型に晒さない規約）の
+ * メタテスト。ルールが「違反を検出する」「マッパー関数を誤検出しない」の双方を能動的に検証する（#297 の完了条件）。
+ *
+ * 本番の `@ArchTest` は全クラスに対し現状違反ゼロを保証するが、ルールが**実際に噛む**ことは別途確かめないと
+ * 「常に成功するだけの無力なルール」と区別できない。ここでは違反フィクスチャを与えて失敗することと、実 controller （ドメイン enum
+ * を引数・戻り値で扱うマッパー関数を含む）に対しては成功することを確認する。
+ */
+class DtoDomainEnumRuleTest {
+    private val rule = ArchitectureTest().dtosDoNotExposeDomainEnums
+
+    @Test
+    fun `フィールド型にドメインenumを持つDTOは違反として検出されること`() {
+        // controller 配下でフィールド型にドメイン enum（CoatColor）を持つフィクスチャを与えると違反になる。
+        val classes =
+            ClassFileImporter()
+                .importClasses(DomainEnumFieldDtoFixture::class.java, CoatColor::class.java)
+
+        assertThrows<AssertionError> { rule.check(classes) }
+    }
+
+    @Test
+    fun `実controllerのDTOとマッパー関数は違反しないこと`() {
+        // 実 controller には `〜Dto` enum を使う DTO と、ドメイン enum を引数・戻り値で扱うマッパー関数
+        // （BloodHorseWireEnums 等）が同居する。マッパーは「フィールド」ではないため誤検出されないことを確認する。
+        val classes =
+            ClassFileImporter()
+                .withImportOption(ImportOption.DoNotIncludeTests())
+                .importPackages("com.example.api.controller")
+
+        rule.check(classes)
+    }
+}

--- a/src/test/kotlin/com/example/api/controller/archfixture/DomainEnumFieldDtoFixture.kt
+++ b/src/test/kotlin/com/example/api/controller/archfixture/DomainEnumFieldDtoFixture.kt
@@ -1,0 +1,11 @@
+package com.example.api.controller.archfixture
+
+import com.example.api.domain.horseracing.model.horse.bloodhorse.CoatColor
+
+/**
+ * `dtosDoNotExposeDomainEnums` ルールが違反を検出することを確認するためのフィクスチャ。
+ *
+ * `controller` 配下に置きつつ、フィールド型にドメイン enum（[CoatColor]）を直接持つ「違反 DTO」を意図的に表す。 `ArchitectureTest` 本体は
+ * `DoNotIncludeTests` でテストソースを除外するため、このフィクスチャが本番ルールを汚染することはない。
+ */
+class DomainEnumFieldDtoFixture(val coatColor: CoatColor)


### PR DESCRIPTION
## 概要

Closes #297

HTTP 契約（request / response DTO）がフィールド型にドメイン enum を直接持たないことを **ArchUnit で機械強制**する。ドメイン enum を wire に晒すと、ドメイン側の列挙子リネームが HTTP 契約（生成クライアント含む）を無言で破壊するため、これを `controller` 層の契約専用 `〜Dto` enum へのマッピングで断つ規約（[api-design.md](.claude/rules/api-design.md) / [ADR-0007](docs/adr/0007-wire-enum-dto-decoupling.md)）の機械化。

規約強制化トラッキング #291 の (5)。

## 変更点

- **`ArchitectureTest.kt`**: ルール `dtosDoNotExposeDomainEnums` を追加。`controller` 配下のフィールドが `domain..` の enum を raw type に持つことを禁止する。判定述語 `isDomainEnum`（enum かつドメインパッケージ配下）を追加
- **`DtoDomainEnumRuleTest.kt`（新規・メタテスト）**: ルールが実際に違反を検出すること（違反フィクスチャで `AssertionError`）と、実 controller のマッパー関数を誤検出しないことを能動的に検証
- **`DomainEnumFieldDtoFixture.kt`（新規・フィクスチャ）**: controller 配下にドメイン enum フィールドを持つ違反 DTO
- **`architecture.md`**: 「その他の強制ルール」一覧に追記

## 完了条件

- [x] DTO のフィールド型にドメイン enum を使うとテストが失敗する（メタテストで実証）
- [x] マッパー関数（引数 / 戻り値でドメイン enum を扱う）は誤検出されない（`fields()` 限定 + 実 controller で実証）

## 設計メモ

- `fields()` でフィールド型に限定することで、ドメイン enum を引数・戻り値で扱う `toDomain()` / `toApi()` マッパー（メソッド）は対象外になる
- 本番 `@ArchTest` は「常に成功するだけの無力なルール」になりうるため、ルールが実際に噛むことをメタテスト（`DtoDomainEnumRuleTest`）で別途担保した
- 現状の controller DTO は全て `〜Dto` enum を使っており違反ゼロ。`./gradlew check` グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
