### PR TITLE
feat: ドメイン/アプリ層で throw しないことを detekt カスタムルールで強制する (#298)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -96,6 +96,9 @@ domain/
 - **ドメインサービス（`domain.*.service`）はトップレベル関数で書く**（`object` / `class` でラップしない）。トップレベル関数はファイルごとのファサードクラス（`〜Kt`）へコンパイルされるため、service パッケージ内のクラスが `Kt` で終わることを ArchUnit で検証して `object` / `class` 宣言を排除する。ただしサービスの戻り値（`Result<_, 〜Error>`）の失敗側を表す失敗バリアント型（`〜Error`）はサービスと同居させてよく、対象から除外する
 - **`@RestController` のハンドラは成功レスポンスで `ResponseEntity` を返さない**。成功は `@ResponseStatus` ＋戻り値で resource を返す（[error-handling.md](error-handling.md) / [api-design.md](api-design.md)）。エラー描画 funnel の `GlobalExceptionHandler` は `@RestController` ではない（`ResponseEntityExceptionHandler` 継承）ため誤検出されない
 - **HTTP 契約（request / response DTO）はフィールド型にドメイン enum を持たない**。`controller` 層に契約専用の `〜Dto` enum を置き、`toDomain()` / `toApi()` でマッピングする（[api-design.md](api-design.md) / [ADR-0007](../../docs/adr/0007-wire-enum-dto-decoupling.md)）。`controller` 配下のフィールドがドメイン（`domain..`）の enum を raw type に持たないことを ArchUnit で検証する。マッパー関数はドメイン enum を引数・戻り値で扱うが、フィールド型のみを対象とするため誤検出されない（ルールが実際に違反を検出することは `DtoDomainEnumRuleTest` で別途担保）
+- **ドメイン / アプリケーション層では `throw` しない**。業務エラーは `Result<V, E>` で返し、プログラミングエラーは `require` / `check` を使う（[error-handling.md](error-handling.md)）。`domain..` / `application..` 配下の明示的な `throw` 式を **detekt カスタムルール** `NoThrowInDomainAndApplication`（`:detekt-rules` モジュール）で検出してビルドを失敗させる。例外送出は `infrastructure`（インフラ障害）と Controller 境界の `orThrowProblem()` に限るため、両者はパッケージ判定で対象外。`require` / `check` / `error` は `throw` 式ではないため検出されない。テストコードは detekt 設定の `excludes` で対象外
+
+> 強制手段は ArchUnit（`src/test/.../architecture/`）に限らない。`throw` 文のような構文レベルの規約は ArchUnit では検出しづらいため、detekt のカスタムルールを `:detekt-rules` モジュール（`RuleSetProvider` を ServiceLoader 登録）に置き、本体 build の `detektPlugins` に組み込んで `./gradlew detekt` で強制する。ルール挙動の検証テストは同モジュール内（`detekt-test` 使用）に置く。
 
 ## ルールの変更・追加
 

--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -19,6 +19,8 @@ paths:
 | プログラミングエラー（NPE、不正な前提条件等） | 例外。`@ControllerAdvice` で 500 |
 | Repository の単純な lookup（`findById` 等） | `T?` で可。Result を強制しない |
 
+> **機械強制**: ドメイン / アプリケーション層（`domain..` / `application..`）の明示的な `throw` 式は detekt カスタムルール `NoThrowInDomainAndApplication`（`:detekt-rules` モジュール）が検出してビルドを失敗させる。プログラミングエラーの表明は `throw` 式でない `require` / `check` / `error` に寄せる（これらは検出されない）。`infrastructure`（インフラ障害）と Controller 境界の `orThrowProblem()` は対象外。詳細は [architecture.md](architecture.md)「その他の強制ルール」。
+
 ## エラー型の設計
 
 - ドメイン操作の失敗のしかたが **1 種類** なら単一の `data class` をエラー型として持つ

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ mise exec -- ./gradlew build # mise 未活性化の非対話シェルのみ
 ./gradlew check
 ```
 
-ktfmt はフォーマッタ、detekt は静的解析ツールという役割分担です。detekt の設定は `config/detekt/detekt.yml` にあり、`buildUponDefaultConfig = true` でデフォルト設定に上書きする形で運用しています。雛形を再生成したい場合は `./gradlew detektGenerateConfig` を実行してください。レポートは `build/reports/detekt/` に HTML / SARIF / Checkstyle XML / Markdown 形式で出力されます。
+ktfmt はフォーマッタ、detekt は静的解析ツールという役割分担です。detekt の設定は `config/detekt/detekt.yml` にあり、`buildUponDefaultConfig = true` でデフォルト設定に上書きする形で運用しています。雛形を再生成したい場合は `./gradlew detektGenerateConfig` を実行してください。レポートは `build/reports/detekt/` に HTML / SARIF / Checkstyle XML / Markdown 形式で出力されます。プロジェクト固有のカスタムルール（例: ドメイン / アプリケーション層で `throw` しない）は `:detekt-rules` モジュールで定義し、`detektPlugins` 経由で組み込んでいます（詳細は `.claude/rules/architecture.md`）。
 
 ### 単一テストの実行
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     testImplementation(libs.archunit.junit5)
     testImplementation(libs.jmolecules.archunit)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // プロジェクト固有の detekt カスタムルール（domain/application で throw しない 等）を detekt 実行時に組み込む
+    detektPlugins(project(":detekt-rules"))
 }
 
 kotlin { compilerOptions { freeCompilerArgs.addAll("-Xjsr305=strict") } }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -29,3 +29,12 @@ style:
           'kotlin.test は使用禁止。テストには org.junit.jupiter.api.Test と
           Power Assert (kotlin.assert) を使用すること（CLAUDE.md テスト規約参照）。'
         value: 'kotlin.test.*'
+
+# toy-box プロジェクト固有のカスタムルールセット（detekt-rules モジュールで定義）。
+toy-box:
+  # ドメイン / アプリケーション層は Result-first を保ち throw しない（.claude/rules/error-handling.md）。
+  # Controller 境界（orThrowProblem）と infrastructure はルール側のパッケージ判定で対象外。
+  # テストコード（fixture 等で throw しうる）は path で除外する。
+  NoThrowInDomainAndApplication:
+    active: true
+    excludes: ['**/src/test/**', '**/src/testFixtures/**']

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.ktfmt)
+}
+
+// このモジュールは Spring を含まないプレーンな Kotlin ライブラリ。
+// 本体（root）の detektPlugins から project 依存で取り込まれ、detekt 実行時にカスタムルールを提供する。
+repositories { mavenCentral() }
+
+java { toolchain { languageVersion = JavaLanguageVersion.of(21) } }
+
+dependencies {
+    // detekt のルール API（PSI は kotlin-compiler 経由で推移的に入る）。実行時は detekt 本体が供給するため compileOnly。
+    compileOnly(libs.detekt.api)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.detekt.test)
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+ktfmt { kotlinLangStyle() }
+
+tasks.withType<Test> { useJUnitPlatform() }

--- a/detekt-rules/src/main/kotlin/com/example/api/detekt/NoThrowInDomainAndApplication.kt
+++ b/detekt-rules/src/main/kotlin/com/example/api/detekt/NoThrowInDomainAndApplication.kt
@@ -1,0 +1,45 @@
+package com.example.api.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.Rule
+import org.jetbrains.kotlin.psi.KtThrowExpression
+
+/**
+ * ドメイン / アプリケーション層で `throw` による例外送出を禁止する detekt カスタムルール。
+ *
+ * 業務エラーは `Result<V, E>`（kotlin-result）で型として返し、例外はインフラ障害・プログラミングエラーに限定する という Result-first
+ * 方針（`.claude/rules/error-handling.md`）を機械的に強制する。例外化は Controller 境界の `orThrowProblem()`
+ * 一手に閉じ込めるため、`controller` / `infrastructure` は対象外（=パッケージで除外）。
+ *
+ * 検出対象は明示的な `throw` 式（[KtThrowExpression]）のみ。`require` / `check` / `error` は関数呼び出しであり
+ * 本ルールに掛からないため、プログラミングエラーの表明にはこれらを用いる。テストコードは detekt 設定の `excludes` で対象から外す。
+ */
+class NoThrowInDomainAndApplication(config: Config) :
+    Rule(
+        config,
+        "ドメイン / アプリケーション層では throw せず Result-first を保つこと。" +
+            "業務エラーは Result<V, E> で返し、プログラミングエラーは require / check を使う。",
+    ) {
+    override fun visitThrowExpression(expression: KtThrowExpression) {
+        super.visitThrowExpression(expression)
+
+        val packageName = expression.containingKtFile.packageFqName.asString()
+        if (TARGET_PACKAGE_PREFIXES.any { packageName == it || packageName.startsWith("$it.") }) {
+            report(
+                Finding(
+                    Entity.from(expression),
+                    "ドメイン / アプリケーション層では throw しないこと。業務エラーは Result<V, E> で返し、" +
+                        "プログラミングエラーは require / check を使う（.claude/rules/error-handling.md）。",
+                )
+            )
+        }
+    }
+
+    private companion object {
+        /** Result-first を強制する対象パッケージ（このプレフィックス配下を検査する）。 */
+        val TARGET_PACKAGE_PREFIXES =
+            listOf("com.example.api.domain", "com.example.api.application")
+    }
+}

--- a/detekt-rules/src/main/kotlin/com/example/api/detekt/ToyBoxRuleSetProvider.kt
+++ b/detekt-rules/src/main/kotlin/com/example/api/detekt/ToyBoxRuleSetProvider.kt
@@ -1,0 +1,30 @@
+package com.example.api.detekt
+
+import dev.detekt.api.Config
+import dev.detekt.api.Rule
+import dev.detekt.api.RuleName
+import dev.detekt.api.RuleSet
+import dev.detekt.api.RuleSetId
+import dev.detekt.api.RuleSetProvider
+
+/**
+ * toy-box プロジェクト固有のカスタムルールセットを detekt に提供する [RuleSetProvider]。
+ *
+ * `META-INF/services/dev.detekt.api.RuleSetProvider` に登録され、detekt 実行時に ServiceLoader 経由で読み込まれる。
+ * 設定ファイル（`config/detekt/detekt.yml`）では本ルールセットを [RULE_SET_ID]（`toy-box`）のキーで参照する。
+ */
+class ToyBoxRuleSetProvider : RuleSetProvider {
+    override val ruleSetId = RuleSetId(RULE_SET_ID)
+
+    override fun instance() =
+        RuleSet(
+            ruleSetId,
+            mapOf<RuleName, (Config) -> Rule>(
+                RuleName("NoThrowInDomainAndApplication") to ::NoThrowInDomainAndApplication
+            ),
+        )
+
+    private companion object {
+        const val RULE_SET_ID = "toy-box"
+    }
+}

--- a/detekt-rules/src/main/resources/META-INF/services/dev.detekt.api.RuleSetProvider
+++ b/detekt-rules/src/main/resources/META-INF/services/dev.detekt.api.RuleSetProvider
@@ -1,0 +1,1 @@
+com.example.api.detekt.ToyBoxRuleSetProvider

--- a/detekt-rules/src/test/kotlin/com/example/api/detekt/NoThrowInDomainAndApplicationTest.kt
+++ b/detekt-rules/src/test/kotlin/com/example/api/detekt/NoThrowInDomainAndApplicationTest.kt
@@ -1,0 +1,104 @@
+package com.example.api.detekt
+
+import dev.detekt.test.TestConfig
+import dev.detekt.test.lint
+import org.junit.jupiter.api.Test
+
+/**
+ * [NoThrowInDomainAndApplication] のルール挙動を検証する。
+ *
+ * ルールが「ドメイン / アプリケーション層の throw を検出する」「他層（controller / infrastructure）や require / check
+ * は検出しない」ことを能動的に確かめる（#298 の完了条件）。
+ */
+class NoThrowInDomainAndApplicationTest {
+    private val rule = NoThrowInDomainAndApplication(TestConfig())
+
+    @Test
+    fun `ドメイン層の throw を検出すること`() {
+        val findings =
+            rule.lint(
+                """
+                package com.example.api.domain.horseracing.model.horse
+
+                fun assignName(name: String) {
+                    if (name.isBlank()) throw IllegalArgumentException("blank")
+                }
+                """
+                    .trimIndent()
+            )
+
+        assert(findings.size == 1)
+    }
+
+    @Test
+    fun `アプリケーション層の throw を検出すること`() {
+        val findings =
+            rule.lint(
+                """
+                package com.example.api.application.horseracing
+
+                fun register() {
+                    throw RuntimeException("boom")
+                }
+                """
+                    .trimIndent()
+            )
+
+        assert(findings.size == 1)
+    }
+
+    @Test
+    fun `controller 層の throw は検出しないこと`() {
+        // Controller 境界（orThrowProblem）での例外化は許容される（描画 funnel への委譲）。
+        val findings =
+            rule.lint(
+                """
+                package com.example.api.controller.horse
+
+                fun handle() {
+                    throw IllegalStateException("rendered as problem")
+                }
+                """
+                    .trimIndent()
+            )
+
+        assert(findings.isEmpty())
+    }
+
+    @Test
+    fun `infrastructure 層の throw は検出しないこと`() {
+        // インフラ障害は例外で表現してよい。
+        val findings =
+            rule.lint(
+                """
+                package com.example.api.infrastructure.horseracing
+
+                fun query() {
+                    throw RuntimeException("db down")
+                }
+                """
+                    .trimIndent()
+            )
+
+        assert(findings.isEmpty())
+    }
+
+    @Test
+    fun `require や check は throw 式ではないため検出しないこと`() {
+        // プログラミングエラーの表明は require / check に寄せる（関数呼び出しなので本ルール対象外）。
+        val findings =
+            rule.lint(
+                """
+                package com.example.api.domain.horseracing.model.horse
+
+                fun assignName(name: String) {
+                    require(name.isNotBlank()) { "blank" }
+                    check(name.length < 100) { "too long" }
+                }
+                """
+                    .trimIndent()
+            )
+
+        assert(findings.isEmpty())
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ mockk = "1.14.11"
 springmockk = "5.0.1"
 archunit = "1.4.2"
 jmolecules-bom = "2025.0.2"
+junit = "6.0.3"
 
 [libraries]
 # SpringDoc OpenAPI
@@ -41,6 +42,15 @@ jmolecules-ddd = { module = "org.jmolecules:jmolecules-ddd" }
 # ArchUnit（アーキテクチャテスト）
 archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "archunit" }
 jmolecules-archunit = { module = "org.jmolecules.integrations:jmolecules-archunit" }
+
+# detekt カスタムルール開発（detekt-rules モジュール用）
+detekt-api = { module = "dev.detekt:detekt-api", version.ref = "detekt" }
+detekt-test = { module = "dev.detekt:detekt-test", version.ref = "detekt" }
+
+# JUnit（detekt-rules モジュールのテスト用。本体は spring-boot-starter-test 経由で取得する）
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 
 [plugins]
 # Kotlin プラグイン

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,3 +7,7 @@ pluginManagement {
 }
 
 rootProject.name = "api"
+
+// detekt のカスタムルール（プロジェクト固有のアーキテクチャ規約強制）を提供するモジュール。
+// 本体 build の detektPlugins に組み込んで使う。
+include(":detekt-rules")


### PR DESCRIPTION
## 概要

Closes #298

ドメイン / アプリケーション層は Result-first を保ち `throw` しない、という方針（[error-handling.md](.claude/rules/error-handling.md)）を **detekt カスタムルールで機械強制**する。業務エラーは `Result<V, E>` で返し、例外はインフラ障害・プログラミングエラーに限定する。

`throw` 文のような構文レベルの規約は ArchUnit では検出しづらいため、detekt のカスタムルールを新設の `:detekt-rules` モジュールに置き、本体 build の `detektPlugins` に組み込んだ。規約強制化トラッキング #291 の (6)。

## 変更点

- **`:detekt-rules`（新規 Gradle モジュール）**
  - `NoThrowInDomainAndApplication`: `domain..` / `application..` 配下の明示的な `throw` 式（`KtThrowExpression`）を検出する detekt `Rule`。`controller`（`orThrowProblem`）/ `infrastructure`（インフラ障害）はパッケージ判定で対象外
  - `ToyBoxRuleSetProvider` + `META-INF/services/dev.detekt.api.RuleSetProvider` で ServiceLoader 登録
  - `NoThrowInDomainAndApplicationTest`: ルール挙動を `detekt-test` で検証
- **`settings.gradle.kts` / `build.gradle.kts`**: モジュールを include し `detektPlugins(project(":detekt-rules"))` で組み込み
- **`config/detekt/detekt.yml`**: `toy-box` ルールセットを有効化。テストコードは `excludes` で対象外
- **`gradle/libs.versions.toml`**: `detekt-api` / `detekt-test` / `junit`（bom / jupiter / platform-launcher）を追加
- **docs**: `architecture.md` / `error-handling.md` / `CLAUDE.md` に強制ルールと detekt カスタムルール機構を明文化

## 完了条件

- [x] domain / application で throw するとビルドが失敗する（ローカルで一時的に throw を仕込み `detekt` が `[NoThrowInDomainAndApplication]` で FAILED することを確認 + 単体テストで実証）
- [x] Controller 境界（`orThrowProblem`）は対象外にできている（`controller` パッケージは検出対象外。テストで実証）

## 設計メモ

- 検出対象は明示的な `throw` 式のみ。`require` / `check` / `error` は関数呼び出しで `throw` 式ではないため検出されず、プログラミングエラーの表明にはこれらを使う（方針と整合）
- 強制手段が ArchUnit だけではないことを `architecture.md` に明記し、構文レベルの規約は `:detekt-rules` に置く方針を確立した
- 現状 `domain` / `application` に `throw` は 0 件のため実コードはグリーン。`./gradlew check`（全モジュール）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
