### PR TITLE
feat: 父母不明個体（輸入馬・基礎輸入馬）の血統登録経路を設ける (#267)

### DIFF
--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -146,8 +146,11 @@ graph LR
 | FoalingOutcome.TwinNeonatalDeath | 値オブジェクト | domain.horseracing.model.breeding |
 | FoalingOutcome.TwinStillbirth | 値オブジェクト | domain.horseracing.model.breeding |
 | HorseName | 値オブジェクト | domain.horseracing.model.horse.bloodhorse |
+| ImportedHorseEntry | 値オブジェクト | domain.horseracing.model.horse.bloodhorse |
 | JockeyId | 値オブジェクト | domain.horseracing.model.jockey |
+| LandingDate | 値オブジェクト | domain.horseracing.model.horse.bloodhorse |
 | MicrochipNumber | 値オブジェクト | domain.horseracing.model.horse.bloodhorse |
+| OriginCountry | 値オブジェクト | domain.horseracing.model.horse.bloodhorse |
 | PedigreeRegistrationNumber | 値オブジェクト | domain.horseracing.model.horse.bloodhorse |
 | RaceId | 値オブジェクト | domain.horseracing.model.race |
 | StudBookEntry | 値オブジェクト | domain.horseracing.model.horse.bloodhorse |
@@ -159,6 +162,7 @@ graph LR
 | recordCovering | ドメインサービス | domain.horseracing.service.breeding |
 | registerFoal | ドメインサービス | domain.horseracing.service.horse |
 | registerForBreeding | ドメインサービス | domain.horseracing.service.breeding |
+| registerImportedHorse | ドメインサービス | domain.horseracing.service.horse |
 | registerInStudBook | ドメインサービス | domain.horseracing.service.horse |
 
 ### sakamichi

--- a/src/main/kotlin/com/example/api/application/horseracing/horse/RegisterImportedHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/horseracing/horse/RegisterImportedHorseUseCase.kt
@@ -1,0 +1,116 @@
+package com.example.api.application.horseracing.horse
+
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorse
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BreedType
+import com.example.api.domain.horseracing.model.horse.bloodhorse.Breeder
+import com.example.api.domain.horseracing.model.horse.bloodhorse.CoatColor
+import com.example.api.domain.horseracing.model.horse.bloodhorse.DateOfBirth
+import com.example.api.domain.horseracing.model.horse.bloodhorse.ImportedHorseEntry
+import com.example.api.domain.horseracing.model.horse.bloodhorse.LandingDate
+import com.example.api.domain.horseracing.model.horse.bloodhorse.MicrochipNumber
+import com.example.api.domain.horseracing.model.horse.bloodhorse.OriginCountry
+import com.example.api.domain.horseracing.model.horse.bloodhorse.PedigreeRegistrationNumber
+import com.example.api.domain.horseracing.model.horse.bloodhorse.Sex
+import com.example.api.domain.horseracing.service.horse.registerImportedHorse
+import com.example.api.domain.shared.Command
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import com.github.michaelbull.result.mapError
+import java.time.LocalDate
+import org.springframework.stereotype.Service
+
+/**
+ * 輸入馬血統登録ユースケースの入力コマンド。
+ *
+ * 輸入馬・基礎輸入馬の登録申請書に相当する境界の生入力。内国産馬（[RegisterInStudBookCommand]）と異なり父母 ID・DNA 親子判定結果は
+ * 持たず、代わりに原産国・揚陸日を持つ。VO で表す項目（番号・マイクロチップ・生産者・原産国）は素の文字列で受け取り、ユースケース内で 各 VO の `create` を通して検証する。
+ *
+ * @property sex 性
+ * @property coatColor 毛色
+ * @property breedType 品種
+ * @property dateOfBirth 生年月日
+ * @property breeder 生産者名
+ * @property microchipNumber マイクロチップ番号
+ * @property originCountry 原産国名
+ * @property landingDate 揚陸日
+ * @property registrationNumber 交付される血統登録番号
+ */
+@Suppress("LongParameterList") // 登録申請フォーム相当の境界入力であり、項目の分割はかえって意味を損なう
+data class RegisterImportedHorseCommand(
+    val sex: Sex,
+    val coatColor: CoatColor,
+    val breedType: BreedType,
+    val dateOfBirth: LocalDate,
+    val breeder: String,
+    val microchipNumber: String,
+    val originCountry: String,
+    val landingDate: LocalDate,
+    val registrationNumber: String,
+)
+
+/** 輸入馬血統登録時に発生しうる業務ルール違反。 */
+sealed interface RegisterImportedHorseUseCaseError {
+    /** 血統登録番号がブランク。 */
+    data object InvalidRegistrationNumber : RegisterImportedHorseUseCaseError
+
+    /** マイクロチップ番号が 15 桁の数字でない。 */
+    data object InvalidMicrochipNumber : RegisterImportedHorseUseCaseError
+
+    /** 生産者名がブランク。 */
+    data object BlankBreeder : RegisterImportedHorseUseCaseError
+
+    /** 原産国名がブランク。 */
+    data object BlankOriginCountry : RegisterImportedHorseUseCaseError
+}
+
+/**
+ * 輸入馬血統登録ユースケース。
+ *
+ * 境界の生入力を VO に変換し（不正なら検証エラー）、ドメインサービス registerImportedHorse で輸入馬の [BloodHorse] を生成して
+ * 永続化する。父母が当システムに存在しないため、内国産馬の登録（[RegisterInStudBookUseCase]）のような父母の引き当て・前提条件検証は 行わない。Controller
+ * 層は本クラスのみに依存し、ポートやドメインサービスは知らない。
+ *
+ * @return 登録された [BloodHorse]、または業務ルール違反を表す [RegisterImportedHorseUseCaseError]
+ */
+@Service
+class RegisterImportedHorseUseCase(private val bloodHorseRepository: BloodHorseRepository) {
+    operator fun invoke(
+        command: Command<RegisterImportedHorseCommand>
+    ): Result<BloodHorse, RegisterImportedHorseUseCaseError> = binding {
+        val input = command.payload
+
+        val registrationNumber =
+            PedigreeRegistrationNumber.create(input.registrationNumber)
+                .mapError { RegisterImportedHorseUseCaseError.InvalidRegistrationNumber }
+                .bind()
+        val microchipNumber =
+            MicrochipNumber.create(input.microchipNumber)
+                .mapError { RegisterImportedHorseUseCaseError.InvalidMicrochipNumber }
+                .bind()
+        val breeder =
+            Breeder.create(input.breeder)
+                .mapError { RegisterImportedHorseUseCaseError.BlankBreeder }
+                .bind()
+        val originCountry =
+            OriginCountry.create(input.originCountry)
+                .mapError { RegisterImportedHorseUseCaseError.BlankOriginCountry }
+                .bind()
+
+        val entry =
+            ImportedHorseEntry(
+                sex = input.sex,
+                coatColor = input.coatColor,
+                breedType = input.breedType,
+                dateOfBirth = DateOfBirth(input.dateOfBirth),
+                breeder = breeder,
+                microchipNumber = microchipNumber,
+                originCountry = originCountry,
+                landingDate = LandingDate(input.landingDate),
+            )
+
+        val bloodHorse = registerImportedHorse(entry, registrationNumber)
+
+        bloodHorseRepository.save(bloodHorse)
+    }
+}

--- a/src/main/kotlin/com/example/api/controller/horse/BloodHorseController.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/BloodHorseController.kt
@@ -1,6 +1,7 @@
 package com.example.api.controller.horse
 
 import com.example.api.application.horseracing.horse.NameHorseUseCase
+import com.example.api.application.horseracing.horse.RegisterImportedHorseUseCase
 import com.example.api.application.horseracing.horse.RegisterInStudBookUseCase
 import com.example.api.controller.orThrowProblem
 import com.example.api.domain.shared.Command
@@ -23,13 +24,15 @@ import org.springframework.web.bind.annotation.RestController
 /**
  * 軽種馬リソースの HTTP アダプター。
  *
- * Google AIP のリソース指向設計に従い、コレクション `/api/bloodHorses` に対する Create（血統登録）と、 個体への カスタムメソッド
- * `:registerName`（馬名登録、[AIP-136](https://google.aip.dev/136)）を提供する。 エラーレスポンスは RFC 9457 (Problem
- * Details) 形式で返す。
+ * Google AIP のリソース指向設計に従い、コレクション `/api/bloodHorses` に対する Create（内国産馬の血統登録）と、 個体への カスタムメソッド
+ * `:registerName`（馬名登録、[AIP-136](https://google.aip.dev/136)）を提供する。 父母不明の輸入馬は前提条件が
+ * 大きく異なるため、コレクションへのカスタムメソッド `:registerImported`（[AIP-136](https://google.aip.dev/136)）として
+ * 登録経路を分ける。エラーレスポンスは RFC 9457 (Problem Details) 形式で返す。
  */
 @RestController
 class BloodHorseController(
     private val registerInStudBook: RegisterInStudBookUseCase,
+    private val registerImportedHorse: RegisterImportedHorseUseCase,
     private val nameHorse: NameHorseUseCase,
     private val clock: Clock,
 ) {
@@ -78,6 +81,46 @@ class BloodHorseController(
     @PostMapping("/api/bloodHorses")
     fun register(@RequestBody request: RegisterBloodHorseRequest): BloodHorseResponse =
         registerInStudBook(Command.now(request.toCommand(), clock))
+            .mapError { it.toProblemDetail() }
+            .orThrowProblem()
+            .toResponse()
+
+    @Operation(
+        summary = "父母不明の輸入馬を血統登録する",
+        description =
+            "父母が当システムに存在しない輸入馬・基礎輸入馬を、原産国・揚陸日とともに血統登録し、誕生した軽種馬を返す。" +
+                "業務ルール違反時は RFC 9457 形式の problem+json を返す。",
+        tags = ["BloodHorse"],
+        responses =
+            [
+                ApiResponse(
+                    responseCode = "201",
+                    description = "血統登録成功（登録された軽種馬リソースを返す）",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = BloodHorseResponse::class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "400",
+                    description = "入力値が不正（登録番号・マイクロチップ・生産者・原産国など）",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+            ],
+    )
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/api/bloodHorses:registerImported")
+    fun registerImported(@RequestBody request: RegisterImportedHorseRequest): BloodHorseResponse =
+        registerImportedHorse(Command.now(request.toCommand(), clock))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()
             .toResponse()

--- a/src/main/kotlin/com/example/api/controller/horse/BloodHorseResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/BloodHorseResponse.kt
@@ -1,5 +1,6 @@
 package com.example.api.controller.horse
 
+import com.example.api.application.horseracing.horse.RegisterImportedHorseUseCaseError
 import com.example.api.application.horseracing.horse.RegisterInStudBookUseCaseError
 import com.example.api.controller.problem
 import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorse
@@ -16,6 +17,9 @@ import org.springframework.http.ProblemDetail
  * [AIP-133](https://google.aip.dev/133) / [AIP-136](https://google.aip.dev/136) に倣い
  * 一律でこのリソース表現全体を返す。父・母は登録済みの軽種馬IDで参照する。
  *
+ * 父母不明の輸入馬では [sireId] / [damId] が null となり、代わりに原産国（[originCountry]）と揚陸日（[landingDate]）を持つ。
+ * 内国産馬ではその逆で、[originCountry] / [landingDate] が null となる。
+ *
  * @property id 軽種馬の生 UUID
  * @property registrationNumber 血統登録番号
  * @property sex 性
@@ -24,8 +28,10 @@ import org.springframework.http.ProblemDetail
  * @property dateOfBirth 生年月日
  * @property breeder 生産者名
  * @property microchipNumber マイクロチップ番号
- * @property sireId 父（雄）の生 UUID
- * @property damId 母（雌）の生 UUID
+ * @property sireId 父（雄）の生 UUID。父母不明の輸入馬では null
+ * @property damId 母（雌）の生 UUID。父母不明の輸入馬では null
+ * @property originCountry 原産国名。輸入馬のみ。内国産馬では null
+ * @property landingDate 揚陸日。輸入馬のみ。内国産馬では null
  * @property name 馬名。未命名なら null
  */
 @Suppress("LongParameterList") // resource 全体を返すため項目数が多いのは必然
@@ -38,8 +44,10 @@ data class BloodHorseResponse(
     val dateOfBirth: LocalDate,
     val breeder: String,
     val microchipNumber: String,
-    val sireId: UUID,
-    val damId: UUID,
+    val sireId: UUID?,
+    val damId: UUID?,
+    val originCountry: String?,
+    val landingDate: LocalDate?,
     val name: String?,
 )
 
@@ -54,8 +62,10 @@ fun BloodHorse.toResponse(): BloodHorseResponse =
         dateOfBirth = dateOfBirth.value,
         breeder = breeder.name,
         microchipNumber = microchipNumber.value,
-        sireId = sireId.value,
-        damId = damId.value,
+        sireId = sireId?.value,
+        damId = damId?.value,
+        originCountry = originCountry?.name,
+        landingDate = landingDate?.value,
         name = name?.value,
     )
 
@@ -136,5 +146,43 @@ private fun RegisterInStudBookError.toProblemDetail(): ProblemDetail =
                 code = "breed-mismatch",
                 title = "Breed mismatch",
                 detail = "仔の品種が父母の品種と整合しません。",
+            )
+    }
+
+/**
+ * [RegisterImportedHorseUseCaseError] を RFC 9457 (`application/problem+json`) の [ProblemDetail] に
+ * 変換する。
+ *
+ * 輸入馬登録は父母の引き当てを行わないため、失敗は VO 検証エラー（入力不正）のみで、すべて 400 Bad Request とする。
+ */
+fun RegisterImportedHorseUseCaseError.toProblemDetail(): ProblemDetail =
+    when (this) {
+        RegisterImportedHorseUseCaseError.InvalidRegistrationNumber ->
+            problem(
+                status = HttpStatus.BAD_REQUEST,
+                code = "invalid-registration-number",
+                title = "Invalid registration number",
+                detail = "registration_number は空であってはいけません。",
+            )
+        RegisterImportedHorseUseCaseError.InvalidMicrochipNumber ->
+            problem(
+                status = HttpStatus.BAD_REQUEST,
+                code = "invalid-microchip-number",
+                title = "Invalid microchip number",
+                detail = "microchip_number は 15 桁の数字でなければなりません。",
+            )
+        RegisterImportedHorseUseCaseError.BlankBreeder ->
+            problem(
+                status = HttpStatus.BAD_REQUEST,
+                code = "blank-breeder",
+                title = "Breeder is blank",
+                detail = "breeder は空であってはいけません。",
+            )
+        RegisterImportedHorseUseCaseError.BlankOriginCountry ->
+            problem(
+                status = HttpStatus.BAD_REQUEST,
+                code = "blank-origin-country",
+                title = "Origin country is blank",
+                detail = "origin_country は空であってはいけません。",
             )
     }

--- a/src/main/kotlin/com/example/api/controller/horse/RegisterImportedHorseRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/RegisterImportedHorseRequest.kt
@@ -1,0 +1,48 @@
+package com.example.api.controller.horse
+
+import com.example.api.application.horseracing.horse.RegisterImportedHorseCommand
+import java.time.LocalDate
+
+/**
+ * `POST /api/blood_horses:registerImported` のリクエストボディ。
+ *
+ * 輸入馬・基礎輸入馬の登録申請フォームに相当する。内国産馬（[RegisterBloodHorseRequest]）と異なり父母 ID・DNA 判定は受け取らず、
+ * 代わりに原産国・揚陸日を受け取る。enum 項目（性・毛色・品種）は HTTP 契約専用の `〜Dto` enum で受け取り、ドメイン enum への変換は [toCommand] が
+ * [toDomain] マッピングで行う。VO で表す項目（番号・マイクロチップ・生産者・原産国）は素の文字列で受け取り、 ユースケースで検証する。
+ *
+ * @property sex 性
+ * @property coatColor 毛色
+ * @property breedType 品種
+ * @property dateOfBirth 生年月日
+ * @property breeder 生産者名
+ * @property microchipNumber マイクロチップ番号
+ * @property originCountry 原産国名
+ * @property landingDate 揚陸日
+ * @property registrationNumber 交付される血統登録番号
+ */
+@Suppress("LongParameterList") // 登録申請フォーム相当の境界入力であり、項目の分割はかえって意味を損なう
+data class RegisterImportedHorseRequest(
+    val sex: SexDto,
+    val coatColor: CoatColorDto,
+    val breedType: BreedTypeDto,
+    val dateOfBirth: LocalDate,
+    val breeder: String,
+    val microchipNumber: String,
+    val originCountry: String,
+    val landingDate: LocalDate,
+    val registrationNumber: String,
+)
+
+/** リクエストボディを輸入馬血統登録ユースケースの入力コマンドへ変換する。境界 DTO ↔ コマンドのフィールド対応はここに集約する。 */
+fun RegisterImportedHorseRequest.toCommand(): RegisterImportedHorseCommand =
+    RegisterImportedHorseCommand(
+        sex = sex.toDomain(),
+        coatColor = coatColor.toDomain(),
+        breedType = breedType.toDomain(),
+        dateOfBirth = dateOfBirth,
+        breeder = breeder,
+        microchipNumber = microchipNumber,
+        originCountry = originCountry,
+        landingDate = landingDate,
+        registrationNumber = registrationNumber,
+    )

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/BloodHorse.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/BloodHorse.kt
@@ -41,6 +41,10 @@ enum class Sex {
  * registerInStudBook の責務とする。検証を経た生成のみを許すため、コンストラクタは private とし、生成口 [of] は同モジュールの ドメインサービスからのみ呼べるよう
  * internal とする。
  *
+ * 父母が当システムに存在しない個体（輸入馬・基礎輸入馬）もある。この場合 [sireId] / [damId] は null となり、 代わりに原産国
+ * （[originCountry]）と揚陸日（[landingDate]）を持つ。輸入馬の生成は registerImportedHorse（生成口
+ * [ofImported]）が担い、内国産馬とは経路を分ける。逆に内国産馬は [originCountry] / [landingDate] を持たない（null）。
+ *
  * 状態はイミュータブルに扱う。出生時は血統登録のみで馬名を持たず（[name] は null）、後日の「馬名登録」で一度だけ命名される。 命名は [assignName] が 馬名を持つ新しい
  * [BloodHorse] を返すことで表し、同一性（[id]）は引き継ぐ。元のインスタンスは変更しない。
  *
@@ -52,8 +56,10 @@ enum class Sex {
  * @property dateOfBirth 生年月日
  * @property breeder 生産者
  * @property microchipNumber マイクロチップ番号
- * @property sireId 父（雄）の軽種馬ID
- * @property damId 母（雌）の軽種馬ID
+ * @property sireId 父（雄）の軽種馬ID。父母不明の輸入馬では null
+ * @property damId 母（雌）の軽種馬ID。父母不明の輸入馬では null
+ * @property originCountry 原産国。輸入馬のみ持ち、内国産馬では null
+ * @property landingDate 揚陸日。輸入馬のみ持ち、内国産馬では null
  * @property name 馬名。未命名なら null。命名は [assignName] でのみ行う
  */
 @AggregateRoot
@@ -67,8 +73,10 @@ private constructor(
     val dateOfBirth: DateOfBirth,
     val breeder: Breeder,
     val microchipNumber: MicrochipNumber,
-    val sireId: BloodHorseId,
-    val damId: BloodHorseId,
+    val sireId: BloodHorseId?,
+    val damId: BloodHorseId?,
+    val originCountry: OriginCountry?,
+    val landingDate: LandingDate?,
     val name: HorseName?,
 ) : Entity<BloodHorseId>() {
     /**
@@ -102,6 +110,8 @@ private constructor(
             microchipNumber = microchipNumber,
             sireId = sireId,
             damId = damId,
+            originCountry = originCountry,
+            landingDate = landingDate,
             name = name,
         )
 
@@ -129,6 +139,38 @@ private constructor(
                 microchipNumber = entry.microchipNumber,
                 sireId = sireId,
                 damId = damId,
+                originCountry = null,
+                landingDate = null,
+                name = null,
+            )
+
+        /**
+         * 父母不明の輸入馬・基礎輸入馬として [BloodHorse] を生成する。
+         *
+         * 父母が当システムに存在しないため父母 ID は持たず（[sireId] / [damId] は null）、代わりに原産国・揚陸日を持つ。
+         * 内国産馬の前提条件（父=雄・母=雌・DNA 親子整合・親仔の品種整合）は適用されない。輸入馬固有の審査（承認海外機関の血統書
+         * による品種確定、親子判定の血液型・海外機関フォールバック）は別途のモデリングに委ねる。
+         *
+         * 内国産馬の [of] と同様、検証を経た生成のみを許すため同モジュールのドメインサービス registerImportedHorse からのみ 呼べるよう internal
+         * とする。生成直後は未命名（[name] は null）。
+         */
+        internal fun ofImported(
+            entry: ImportedHorseEntry,
+            registrationNumber: PedigreeRegistrationNumber,
+        ): BloodHorse =
+            BloodHorse(
+                id = BloodHorseId(generateId()),
+                registrationNumber = registrationNumber,
+                sex = entry.sex,
+                coatColor = entry.coatColor,
+                breedType = entry.breedType,
+                dateOfBirth = entry.dateOfBirth,
+                breeder = entry.breeder,
+                microchipNumber = entry.microchipNumber,
+                sireId = null,
+                damId = null,
+                originCountry = entry.originCountry,
+                landingDate = entry.landingDate,
                 name = null,
             )
     }

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/ImportedHorseEntry.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/ImportedHorseEntry.kt
@@ -1,0 +1,33 @@
+package com.example.api.domain.horseracing.model.horse.bloodhorse
+
+import org.jmolecules.ddd.annotation.ValueObject
+
+/**
+ * 輸入馬・基礎輸入馬の血統登録申請に際して申請者が持ち込む、馬自身の個体識別情報の束。
+ *
+ * 通常の内国産馬（[StudBookEntry]）と異なり、**父・母が当システムに存在しない**ことを前提とする。このため父母 ID や 申告された親子関係の DNA
+ * 判定結果（[DnaParentageResult]）は含めない。品種は承認海外機関の血統書・輸出証明書に依拠するため、
+ * 父母の品種との整合検証も行わない（これらの輸入特有の審査は別途のモデリングに委ねる）。
+ *
+ * 代わりに輸入馬固有の属性として、原産国（[originCountry]）と揚陸日（[landingDate]）を保持する。
+ *
+ * @property sex 性
+ * @property coatColor 毛色
+ * @property breedType 品種（承認海外機関の血統書・輸出証明書に基づく）
+ * @property dateOfBirth 生年月日（海外血統書に基づく）
+ * @property breeder 生産者
+ * @property microchipNumber マイクロチップ番号
+ * @property originCountry 原産国
+ * @property landingDate 揚陸日（陸揚げされた日。登録の起算点）
+ */
+@ValueObject
+data class ImportedHorseEntry(
+    val sex: Sex,
+    val coatColor: CoatColor,
+    val breedType: BreedType,
+    val dateOfBirth: DateOfBirth,
+    val breeder: Breeder,
+    val microchipNumber: MicrochipNumber,
+    val originCountry: OriginCountry,
+    val landingDate: LandingDate,
+)

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/LandingDate.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/LandingDate.kt
@@ -1,0 +1,17 @@
+package com.example.api.domain.horseracing.model.horse.bloodhorse
+
+import java.time.LocalDate
+import org.jmolecules.ddd.annotation.ValueObject
+
+/**
+ * 揚陸日。
+ *
+ * 輸入馬・基礎輸入馬が本邦に陸揚げされた日。輸入馬の血統登録は出生・繁殖登録のチェーンではなく、この揚陸日を起算点とする
+ * （登録の提出期限・登録料区分が揚陸日からの経過日数で定まる）。内国産馬は揚陸日を持たない（[BloodHorse.landingDate] は null）。
+ *
+ * 時刻・タイムゾーンを持たない暦日として [LocalDate] で保持する。揚陸日からの提出期限（90 日）の判定は基準時刻を要するため
+ * ドメインモデル単体では行わず、必要に応じて上位で検証する。
+ *
+ * @property value 陸揚げされた暦日
+ */
+@ValueObject @JvmInline value class LandingDate(val value: LocalDate)

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/OriginCountry.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/OriginCountry.kt
@@ -1,0 +1,28 @@
+package com.example.api.domain.horseracing.model.horse.bloodhorse
+
+import com.example.api.domain.shared.createNonBlank
+import com.github.michaelbull.result.Result
+import org.jmolecules.ddd.annotation.ValueObject
+
+/** 原産国名がブランク。 */
+data object BlankOriginCountry
+
+/**
+ * 原産国。
+ *
+ * 輸入馬・基礎輸入馬の血統登録で記録される、その馬の生まれた国。内国産馬は原産国を持たない（[BloodHorse.originCountry] は null）。
+ *
+ * 品種・血統の確定は承認海外機関の血統書及び輸出証明書に依拠するが、本モデルでは原産国名のみを値オブジェクトとして保持する （承認海外機関による品種確定や原産国の ISO
+ * コード正規化は別途のモデリングに委ねる）。
+ *
+ * @property name 原産国名
+ */
+@ValueObject
+@JvmInline
+value class OriginCountry private constructor(val name: String) {
+    companion object {
+        /** ブランクでないことを検証して [OriginCountry] を生成する。 */
+        fun create(name: String): Result<OriginCountry, BlankOriginCountry> =
+            createNonBlank(name, BlankOriginCountry, ::OriginCountry)
+    }
+}

--- a/src/main/kotlin/com/example/api/domain/horseracing/service/horse/RegisterImportedHorse.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/service/horse/RegisterImportedHorse.kt
@@ -1,0 +1,24 @@
+package com.example.api.domain.horseracing.service.horse
+
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorse
+import com.example.api.domain.horseracing.model.horse.bloodhorse.ImportedHorseEntry
+import com.example.api.domain.horseracing.model.horse.bloodhorse.PedigreeRegistrationNumber
+
+/**
+ * 父母不明の輸入馬・基礎輸入馬の血統登録を行い、軽種馬（[BloodHorse]）を誕生させる。
+ *
+ * 内国産馬の registerInStudBook と異なり、父・母が当システムに存在しないため父母の引き当て・親子判定・親仔の品種整合は行わない。
+ * 品種・血統は承認海外機関の血統書及び輸出証明書に依拠する前提とし（その審査自体は別途のモデリングに委ねる）、本サービスは輸入馬固有の 個体識別情報（原産国・揚陸日を含む
+ * [ImportedHorseEntry]）から [BloodHorse] を生成する。
+ *
+ * 現状は内国産馬のような前提条件違反を持たないため [BloodHorse] をそのまま返す。生成口 [BloodHorse.ofImported] は internal で
+ * あり、この生成を本サービスに封じ込めることで「血統登録を経た個体」であることを型で担保する（内国産馬の registerInStudBook と同じ方針）。
+ *
+ * @param entry 輸入馬自身の個体識別情報（原産国・揚陸日を含む）
+ * @param registrationNumber 交付される血統登録番号
+ * @return 生成された [BloodHorse]
+ */
+fun registerImportedHorse(
+    entry: ImportedHorseEntry,
+    registrationNumber: PedigreeRegistrationNumber,
+): BloodHorse = BloodHorse.ofImported(entry, registrationNumber)

--- a/src/test/kotlin/com/example/api/application/horseracing/horse/RegisterImportedHorseUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/horseracing/horse/RegisterImportedHorseUseCaseTest.kt
@@ -1,0 +1,92 @@
+package com.example.api.application.horseracing.horse
+
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BreedType
+import com.example.api.domain.horseracing.model.horse.bloodhorse.CoatColor
+import com.example.api.domain.horseracing.model.horse.bloodhorse.Sex
+import com.example.api.domain.shared.Command
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Instant
+import java.time.LocalDate
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class RegisterImportedHorseUseCaseTest {
+
+    /** すべて正しい既定のペイロード。変種は `copy` で 1 項目だけ差し替える。 */
+    private fun validPayload() =
+        RegisterImportedHorseCommand(
+            sex = Sex.MALE,
+            coatColor = CoatColor.BAY,
+            breedType = BreedType.THOROUGHBRED,
+            dateOfBirth = LocalDate.of(2020, 4, 10),
+            breeder = "Coolmore",
+            microchipNumber = "392140000000002",
+            originCountry = "アイルランド",
+            landingDate = LocalDate.of(2024, 9, 1),
+            registrationNumber = "2020900001",
+        )
+
+    private fun command(
+        payload: RegisterImportedHorseCommand
+    ): Command<RegisterImportedHorseCommand> = Command(payload, Instant.now())
+
+    @Nested
+    inner class SuccessCase {
+        @Test
+        fun `正しい入力のとき父母不明の輸入馬が登録され永続化される`() {
+            val repository =
+                mockk<BloodHorseRepository> { every { save(any()) } answers { firstArg() } }
+            val useCase = RegisterImportedHorseUseCase(repository)
+
+            val bloodHorse = useCase(command(validPayload())).unwrap()
+
+            assert(bloodHorse.sireId == null)
+            assert(bloodHorse.damId == null)
+            assert(bloodHorse.originCountry?.name == "アイルランド")
+            assert(bloodHorse.landingDate?.value == LocalDate.of(2024, 9, 1))
+            assert(bloodHorse.registrationNumber.value == "2020900001")
+            verify(exactly = 1) { repository.save(any()) }
+        }
+    }
+
+    @Nested
+    inner class FailureCase {
+        @Test
+        fun `血統登録番号がブランクのとき InvalidRegistrationNumber を返し永続化されない`() {
+            val repository = mockk<BloodHorseRepository>()
+            val useCase = RegisterImportedHorseUseCase(repository)
+
+            val result = useCase(command(validPayload().copy(registrationNumber = "")))
+
+            assert(result.getError() == RegisterImportedHorseUseCaseError.InvalidRegistrationNumber)
+            verify(exactly = 0) { repository.save(any()) }
+        }
+
+        @Test
+        fun `マイクロチップ番号が不正なとき InvalidMicrochipNumber を返し永続化されない`() {
+            val repository = mockk<BloodHorseRepository>()
+            val useCase = RegisterImportedHorseUseCase(repository)
+
+            val result = useCase(command(validPayload().copy(microchipNumber = "123")))
+
+            assert(result.getError() == RegisterImportedHorseUseCaseError.InvalidMicrochipNumber)
+            verify(exactly = 0) { repository.save(any()) }
+        }
+
+        @Test
+        fun `原産国がブランクのとき BlankOriginCountry を返し永続化されない`() {
+            val repository = mockk<BloodHorseRepository>()
+            val useCase = RegisterImportedHorseUseCase(repository)
+
+            val result = useCase(command(validPayload().copy(originCountry = "")))
+
+            assert(result.getError() == RegisterImportedHorseUseCaseError.BlankOriginCountry)
+            verify(exactly = 0) { repository.save(any()) }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -3,6 +3,9 @@ package com.example.api.controller.horse
 import com.example.api.application.horseracing.horse.NameHorseCommand
 import com.example.api.application.horseracing.horse.NameHorseUseCase
 import com.example.api.application.horseracing.horse.NameHorseUseCaseError
+import com.example.api.application.horseracing.horse.RegisterImportedHorseCommand
+import com.example.api.application.horseracing.horse.RegisterImportedHorseUseCase
+import com.example.api.application.horseracing.horse.RegisterImportedHorseUseCaseError
 import com.example.api.application.horseracing.horse.RegisterInStudBookCommand
 import com.example.api.application.horseracing.horse.RegisterInStudBookUseCase
 import com.example.api.application.horseracing.horse.RegisterInStudBookUseCaseError
@@ -34,6 +37,7 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class BloodHorseControllerTest(val mockMvc: MockMvc) {
     @MockkBean private lateinit var registerInStudBook: RegisterInStudBookUseCase
+    @MockkBean private lateinit var registerImportedHorse: RegisterImportedHorseUseCase
     @MockkBean private lateinit var nameHorse: NameHorseUseCase
 
     private val tester = MockMvcTester.create(mockMvc)
@@ -218,6 +222,64 @@ class BloodHorseControllerTest(val mockMvc: MockMvc) {
                 .bodyJson()
                 .extractingPath("$.error_code")
                 .isEqualTo("horse-already-named")
+        }
+    }
+
+    @Nested
+    inner class RegisterImportedCase {
+        private val uri = "/api/bloodHorses:registerImported"
+
+        /** 父母 ID・DNA を持たず、原産国・揚陸日を持つ輸入馬のリクエストボディ。 */
+        private val validBody =
+            """
+            {
+                "sex": "MALE",
+                "coat_color": "BAY",
+                "breed_type": "THOROUGHBRED",
+                "date_of_birth": "2020-04-10",
+                "breeder": "Coolmore",
+                "microchip_number": "392140000000002",
+                "origin_country": "アイルランド",
+                "landing_date": "2024-09-01",
+                "registration_number": "2020900001"
+            }
+            """
+                .trimIndent()
+
+        @Test
+        fun `正常な入力で 201 Created と父母不明の登録結果が返ること`() {
+            val saved = BloodHorseFixture.importedBloodHorse()
+            every { registerImportedHorse(any<Command<RegisterImportedHorseCommand>>()) } returns
+                Ok(saved)
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.CREATED)
+                .bodyJson()
+                .extractingPath("$.origin_country")
+                .isEqualTo("アイルランド")
+        }
+
+        @Test
+        fun `BlankOriginCountry で 400 と problem+json が返ること`() {
+            every { registerImportedHorse(any<Command<RegisterImportedHorseCommand>>()) } returns
+                Err(RegisterImportedHorseUseCaseError.BlankOriginCountry)
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.error_code")
+                .isEqualTo("blank-origin-country")
         }
     }
 }

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/BloodHorseFixture.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/BloodHorseFixture.kt
@@ -53,4 +53,32 @@ object BloodHorseFixture {
             damId = BloodHorseId(generateId()),
             registrationNumber = PedigreeRegistrationNumber.create("2023104567").unwrap(),
         )
+
+    /** 既定値を持つ [ImportedHorseEntry]（輸入馬）を生成する。必要な属性のみ上書きする。 */
+    fun importedHorseEntry(
+        sex: Sex = Sex.MALE,
+        coatColor: CoatColor = CoatColor.BAY,
+        breedType: BreedType = BreedType.THOROUGHBRED,
+        originCountry: String = "アイルランド",
+    ): ImportedHorseEntry =
+        ImportedHorseEntry(
+            sex = sex,
+            coatColor = coatColor,
+            breedType = breedType,
+            dateOfBirth = DateOfBirth(LocalDate.of(2020, 4, 10)),
+            breeder = Breeder.create("Coolmore").unwrap(),
+            microchipNumber = MicrochipNumber.create("392140000000002").unwrap(),
+            originCountry = OriginCountry.create(originCountry).unwrap(),
+            landingDate = LandingDate(LocalDate.of(2024, 9, 1)),
+        )
+
+    /** 既定値を持つ父母不明の輸入馬 [BloodHorse] を生成する。性・品種など必要な属性のみ上書きする。 */
+    fun importedBloodHorse(
+        sex: Sex = Sex.MALE,
+        breedType: BreedType = BreedType.THOROUGHBRED,
+    ): BloodHorse =
+        BloodHorse.ofImported(
+            entry = importedHorseEntry(sex = sex, breedType = breedType),
+            registrationNumber = PedigreeRegistrationNumber.create("2020900001").unwrap(),
+        )
 }

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/OriginCountryTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/horse/bloodhorse/OriginCountryTest.kt
@@ -1,0 +1,36 @@
+package com.example.api.domain.horseracing.model.horse.bloodhorse
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import org.junit.jupiter.api.Test
+
+/** OriginCountry VO の不変条件のテスト */
+class OriginCountryTest {
+    @Test
+    fun `ブランクでない原産国名から生成できること`() {
+        val originCountry = OriginCountry.create("アイルランド").unwrap()
+
+        assert(originCountry.name == "アイルランド")
+    }
+
+    @Test
+    fun `前後の空白は trim されること`() {
+        val originCountry = OriginCountry.create("  アメリカ  ").unwrap()
+
+        assert(originCountry.name == "アメリカ")
+    }
+
+    @Test
+    fun `空文字のとき BlankOriginCountry を返すこと`() {
+        val result = OriginCountry.create("")
+
+        assert(result.getError() == BlankOriginCountry)
+    }
+
+    @Test
+    fun `空白のみのとき BlankOriginCountry を返すこと`() {
+        val result = OriginCountry.create("   ")
+
+        assert(result.getError() == BlankOriginCountry)
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/horseracing/service/horse/RegisterImportedHorseTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/service/horse/RegisterImportedHorseTest.kt
@@ -1,0 +1,42 @@
+package com.example.api.domain.horseracing.service.horse
+
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseFixture
+import com.example.api.domain.horseracing.model.horse.bloodhorse.BreedType
+import com.example.api.domain.horseracing.model.horse.bloodhorse.PedigreeRegistrationNumber
+import com.example.api.domain.horseracing.model.horse.bloodhorse.Sex
+import com.github.michaelbull.result.unwrap
+import org.junit.jupiter.api.Test
+
+/** registerImportedHorse ドメインサービスのユニットテスト */
+class RegisterImportedHorseTest {
+    private val registrationNumber = PedigreeRegistrationNumber.create("2020900001").unwrap()
+
+    @Test
+    fun `父母不明の輸入馬が血統登録され父母 ID を持たず原産国と揚陸日を持つこと`() {
+        val entry = BloodHorseFixture.importedHorseEntry(originCountry = "アイルランド")
+
+        val bloodHorse = registerImportedHorse(entry, registrationNumber)
+
+        assert(bloodHorse.sireId == null)
+        assert(bloodHorse.damId == null)
+        assert(bloodHorse.originCountry == entry.originCountry)
+        assert(bloodHorse.landingDate == entry.landingDate)
+        assert(bloodHorse.registrationNumber == registrationNumber)
+    }
+
+    @Test
+    fun `親の品種を問わず申告された品種がそのまま登録されること`() {
+        // 内国産馬と異なり父母の品種整合は検証しないため、サラブレッド種でも親なしで登録できる。
+        val entry =
+            BloodHorseFixture.importedHorseEntry(
+                sex = Sex.FEMALE,
+                breedType = BreedType.THOROUGHBRED,
+            )
+
+        val bloodHorse = registerImportedHorse(entry, registrationNumber)
+
+        assert(bloodHorse.sex == Sex.FEMALE)
+        assert(bloodHorse.breedType == BreedType.THOROUGHBRED)
+        assert(bloodHorse.name == null)
+    }
+}


### PR DESCRIPTION
## 概要

#267 父母不明個体（輸入馬・基礎輸入馬）の血統登録経路を設ける。JRA/JAIRS の一次資料（#267 のコメントに条番号・典拠つきで整理）に基づき、**父母が当システムに存在しない輸入馬を、内国産馬とは別経路で血統登録できる**ようにする。

設計判断は #355 のスコープ確認に従い、輸入馬固有属性（原産国・揚陸日）を含めて実装し、より広い/別サブドメインに食い込む部分はフォローアップに切り出した。

## 一次資料の要点（#267 既出）

- 内国産馬の血統登録は「母馬の繁殖登録証明書＋種付証明書」を前提とする＝**父母が JSI 登録済**が前提（現状 `registerInStudBook` が `SireNotFound` に倒れるのはこれを写したもの）。
- **輸入馬は別区分・別起算**（「揚陸の日」から 90 日 / 91 日以上で料金区分）。母馬繁殖登録証明書・種付証明書の前提が国内に存在しない。
- 品種・血統は**承認海外機関の血統書＋輸出証明書**に依拠。親子判定は DNA 型が使えるとは限らず血液型・海外機関判定にフォールバックする。

## 変更内容

ドメイン:
- `BloodHorse`: `sireId`/`damId` を **nullable 化**。輸入馬用に `originCountry`（原産国）/ `landingDate`（揚陸日）を追加。父母不明の生成口 `ofImported`（internal）を追加し、ドメインサービス `registerImportedHorse` に封じ込め（ADR-0010 準拠）
- VO 追加: `OriginCountry` / `LandingDate` / `ImportedHorseEntry`
- ドメインサービス `registerImportedHorse`: 父母引き当て・親子 DNA 判定・親仔の品種整合を**行わない**輸入馬の血統登録

アプリ/アダプタ:
- `RegisterImportedHorseUseCase`（+ Command + 失敗バリアント）
- `POST /api/bloodHorses:registerImported`（AIP-136 カスタムメソッド）。リクエスト DTO `RegisterImportedHorseRequest`
- `BloodHorseResponse`: `sire_id`/`dam_id` を nullable 化し `origin_country`/`landing_date` を追加（#337 の snake_case 規約準拠）

テスト/ドキュメント:
- 各リングにテスト追加（ドメインサービス / ユースケース / VO / コントローラ slice）。カバレッジ成熟ゲート 93.9%（≥85%）
- ユビキタス言語カタログ（#346）を再生成

## フォローアップに切り出す範囲

本 PR では扱わず、後続 issue で対応する（いずれも一次資料の典拠あり）:
- 父母・原産国を sealed `Origin` VO に統合して相互排他を型で強制（nullable 四つ組の硬化）
- 親子判定の血液型/海外機関フォールバック（#312 寄り）
- 承認海外機関の血統書＋輸出証明書による品種確定（#277 寄り）
- 揚陸日起算の 90 日締切・登録料区分（#315 寄り）

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)
