### PR TITLE
feat: 集約に data class を使わない規約(ADR-0009)を ArchUnit で強制する (#307)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -93,12 +93,17 @@ domain/
 - フィールドインジェクション禁止（コンストラクタインジェクションを使う）
 - `UUID.randomUUID()` の直接呼び出し禁止。ID は `domain.shared.generateId()`（UUIDv7 相当のタイムベース生成）経由で生成する（永続化時のインデックス局所性のため。[ADR-0005](../../docs/adr/0005-time-based-uuid-generation.md)）。main コードのみ対象（テストの fixture は対象外）
 - **集約（`@AggregateRoot` / `@Entity`）はイミュータブル**（`val` のみ・`var` 禁止）。状態遷移は対象を書き換えず、同一性（ID）を引き継いだ新インスタンスを返すメソッドで表す（[ADR-0009](../../docs/adr/0009-immutable-aggregates.md)）。`val` は final フィールド・`var` は非 final フィールドへコンパイルされるため、集約クラスが直接宣言するフィールドが全て final であることを ArchUnit で検証して `var` を排除する
+- **集約（`@AggregateRoot` / `@Entity`）は `data class` を使わない**（[ADR-0009](../../docs/adr/0009-immutable-aggregates.md)）。`data class` は全プロパティから `equals` / `hashCode` を生成し、ID ベースの `final equals` / `hashCode` と衝突するため、`private constructor` ＋手書き `copy` で写像する。`data class` は各プロパティに `componentN()` を生成するため、集約クラスが `componentN()` を持たないことを ArchUnit で検証して `data class` を排除する（手書き `copy` は `componentN()` を生成しないため誤検出されない。ルールが実際に違反を検出することは `AggregateNotDataClassRuleTest` で別途担保）
 - **ドメインサービス（`domain.*.service`）はトップレベル関数で書く**（`object` / `class` でラップしない）。トップレベル関数はファイルごとのファサードクラス（`〜Kt`）へコンパイルされるため、service パッケージ内のクラスが `Kt` で終わることを ArchUnit で検証して `object` / `class` 宣言を排除する。ただしサービスの戻り値（`Result<_, 〜Error>`）の失敗側を表す失敗バリアント型（`〜Error`）はサービスと同居させてよく、対象から除外する
 - **`@RestController` のハンドラは成功レスポンスで `ResponseEntity` を返さない**。成功は `@ResponseStatus` ＋戻り値で resource を返す（[error-handling.md](error-handling.md) / [api-design.md](api-design.md)）。エラー描画 funnel の `GlobalExceptionHandler` は `@RestController` ではない（`ResponseEntityExceptionHandler` 継承）ため誤検出されない
 - **HTTP 契約（request / response DTO）はフィールド型にドメイン enum を持たない**。`controller` 層に契約専用の `〜Dto` enum を置き、`toDomain()` / `toApi()` でマッピングする（[api-design.md](api-design.md) / [ADR-0007](../../docs/adr/0007-wire-enum-dto-decoupling.md)）。`controller` 配下のフィールドがドメイン（`domain..`）の enum を raw type に持たないことを ArchUnit で検証する。マッパー関数はドメイン enum を引数・戻り値で扱うが、フィールド型のみを対象とするため誤検出されない（ルールが実際に違反を検出することは `DtoDomainEnumRuleTest` で別途担保）
 - **ドメイン / アプリケーション層では `throw` しない**。業務エラーは `Result<V, E>` で返し、プログラミングエラーは `require` / `check` を使う（[error-handling.md](error-handling.md)）。`domain..` / `application..` 配下の明示的な `throw` 式を **detekt カスタムルール** `NoThrowInDomainAndApplication`（`:detekt-rules` モジュール）で検出してビルドを失敗させる。例外送出は `infrastructure`（インフラ障害）と Controller 境界の `orThrowProblem()` に限るため、両者はパッケージ判定で対象外。`require` / `check` / `error` は `throw` 式ではないため検出されない。テストコードは detekt 設定の `excludes` で対象外
 
 > 強制手段は ArchUnit（`src/test/.../architecture/`）に限らない。`throw` 文のような構文レベルの規約は ArchUnit では検出しづらいため、detekt のカスタムルールを `:detekt-rules` モジュール（`RuleSetProvider` を ServiceLoader 登録）に置き、本体 build の `detektPlugins` に組み込んで `./gradlew detekt` で強制する。ルール挙動の検証テストは同モジュール内（`detekt-test` 使用）に置く。
+
+### 機械強制しない規約（レビューで担保）
+
+- **REST リソース操作の成功レスポンスは一律でリソース表現を返す**（[ADR-0008](../../docs/adr/0008-uniform-resource-representation-response.md) / [api-design.md](api-design.md)）は**機械強制しない**。この規約の本質は「同一リソースの全操作が同一の単一表現 DTO（`〜Response`）を返す」という**リソース単位の意味的一貫性**であり、ハンドラを「どのリソースを操作するか」で束ねる必要がある。ArchUnit / detekt はパッケージ・型・アノテーション・構文は検査できるが、この「リソース帰属によるグルーピング」を表現できない。名前ベースの近似（`Register〜Response` の禁止等）は、AIP-136 がリソース外の付加情報返却に専用 `Response` を認める余地（ADR-0008 でも追補余地として明記）と衝突して誤検出を生むうえ、現に移行途上の `RegisterJockeyResponse`（ADR-0008 が単一 DTO へ寄せる対象とする既知の不整合）を機械的に「違反」と断ずるだけで規約の意味は捉えられない。したがって api-design.md のルール文＋レビューで担保する（#307 の調査結論）。
 
 ## ルールの変更・追加
 

--- a/src/test/kotlin/com/example/api/architecture/AggregateNotDataClassRuleTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/AggregateNotDataClassRuleTest.kt
@@ -1,0 +1,36 @@
+package com.example.api.architecture
+
+import com.example.api.architecture.fixture.DataClassAggregateFixture
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.ImportOption
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * `ArchitectureTest.aggregatesAreNotDataClasses`（集約に data class を使わない規約）のメタテスト。
+ *
+ * ルールが「data class の集約を検出する」「private ctor ＋手書き copy を持つ実集約は誤検出しない」の双方を能動的に 検証する（#307 の完了条件）。本番の
+ * `@ArchTest` は現状違反ゼロを保証するが、ルールが実際に噛むことは別途確かめないと 「常に成功するだけの無力なルール」と区別できない。
+ */
+class AggregateNotDataClassRuleTest {
+    private val rule = ArchitectureTest().aggregatesAreNotDataClasses
+
+    @Test
+    fun `data class の集約は違反として検出されること`() {
+        // @AggregateRoot data class（componentN を生成する）を与えると違反になる。
+        val classes = ClassFileImporter().importClasses(DataClassAggregateFixture::class.java)
+
+        assertThrows<AssertionError> { rule.check(classes) }
+    }
+
+    @Test
+    fun `private ctor と手書き copy を持つ実集約は違反しないこと`() {
+        // 実ドメインの集約（BloodHorse 等）は private ctor ＋手書き copy で書かれ componentN を持たない。
+        val classes =
+            ClassFileImporter()
+                .withImportOption(ImportOption.DoNotIncludeTests())
+                .importPackages("com.example.api.domain")
+
+        rule.check(classes)
+    }
+}

--- a/src/test/kotlin/com/example/api/architecture/ArchitectureTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/ArchitectureTest.kt
@@ -199,6 +199,31 @@ class ArchitectureTest {
             .beFinal()
             .because("集約はイミュータブルに保ち、状態遷移は新インスタンスで表す（ADR-0009）。var は禁止")
 
+    /**
+     * 集約（@AggregateRoot / @Entity）は `data class` を使わないこと。
+     *
+     * `data class` は全プロパティから `equals` / `hashCode` を生成するため、ID ベースの `final equals` / `hashCode`
+     * （[EntityTest] 参照）と衝突する。状態遷移は `private constructor` ＋手書き `copy` で同一性（ID）を引き継いだ新インスタンスとして
+     * 写像する（ADR-0009）。Kotlin の `data class` は各プロパティに `componentN()` を生成するため、集約クラスが
+     * `componentN()`（`component1` / `component2` …）を持たないことを検証して `data class` を排除する。手書き `copy` は
+     * `componentN()` を生成しないため誤検出されない。
+     */
+    @ArchTest
+    val aggregatesAreNotDataClasses =
+        noMethods()
+            .that()
+            .areDeclaredInClassesThat()
+            .areAnnotatedWith(AggregateRoot::class.java)
+            .or()
+            .areDeclaredInClassesThat()
+            .areAnnotatedWith(DddEntity::class.java)
+            .should()
+            .haveNameMatching("component\\d+")
+            .because(
+                "集約は data class を使わない。ID ベースの final equals / hashCode と衝突するため、" +
+                    "private constructor ＋手書き copy で同一性を引き継いだ新インスタンスへ写像する（ADR-0009）"
+            )
+
     /** HTTP アダプター（@RestController）は controller 層に置くこと。 */
     @ArchTest
     val restControllersResideInControllerLayer =

--- a/src/test/kotlin/com/example/api/architecture/fixture/DataClassAggregateFixture.kt
+++ b/src/test/kotlin/com/example/api/architecture/fixture/DataClassAggregateFixture.kt
@@ -1,0 +1,11 @@
+package com.example.api.architecture.fixture
+
+import org.jmolecules.ddd.annotation.AggregateRoot
+
+/**
+ * `aggregatesAreNotDataClasses` ルールが違反を検出することを確認するためのフィクスチャ。
+ *
+ * `@AggregateRoot` を付与しつつ `data class` で宣言した「違反集約」を意図的に表す（data class は `componentN()` を
+ * 生成する）。`ArchitectureTest` 本体は `DoNotIncludeTests` でテストソースを除外するため、本番ルールを汚染しない。
+ */
+@AggregateRoot data class DataClassAggregateFixture(val name: String)


### PR DESCRIPTION
## 概要

Closes #307

ADR-0008 / ADR-0009 の機械強制可否を検討し、機械化できるものを実装した。規約強制化トラッキング #291 の (7)。

- **ADR-0009（集約イミュータブル）**: 「`val` のみ」は既存の `aggregatesAreImmutable` で強制済み。今回は残る **「集約に `data class` を使わない」** を ArchUnit で強制する。
- **ADR-0008（リソース一律返却）**: 構造では表現しにくいため**機械強制せず**、ルール文＋レビューで担保する判断を明文化した（理由は下記）。

## 変更点

- **`ArchitectureTest.kt`**: `aggregatesAreNotDataClasses` を追加。`@AggregateRoot` / `@Entity` 付与クラスが `componentN()`（Kotlin の data class が各プロパティに生成）を持たないことを検証して `data class` を排除する。手書き `copy` は `componentN()` を生成しないため誤検出されない
- **`AggregateNotDataClassRuleTest.kt`（新規・メタテスト）**: ルールが data class の集約を検出すること、private ctor ＋手書き copy の実集約を誤検出しないことを能動的に検証
- **`DataClassAggregateFixture.kt`（新規・フィクスチャ）**: `@AggregateRoot data class` の違反フィクスチャ
- **`architecture.md`**: data class 禁止を強制ルール一覧に追記。「機械強制しない規約」節を新設し ADR-0008 の判断と理由を明記

## 完了条件

- [x] ADR-0009: `@AggregateRoot`/`@Entity` は `val` のみ（既存 `aggregatesAreImmutable`）
- [x] ADR-0009: 集約に `data class` を使わない（本 PR で ArchUnit 強制 + メタテストで実証）
- [x] ADR-0008: 機械強制できない理由を明記し、ルール文＋レビュー運用に留める
- [x] `ArchitectureTest` 等にテストを追加し `./gradlew check` で検証（全モジュール green）

## ADR-0008 を機械強制しない理由

規約の本質は「同一リソースの全操作が同一の単一表現 DTO を返す」という**リソース単位の意味的一貫性**で、ハンドラを「どのリソースを操作するか」で束ねる必要がある。ArchUnit / detekt はパッケージ・型・アノテーション・構文は検査できるが、この「リソース帰属によるグルーピング」を表現できない。名前ベースの近似（`Register〜Response` 禁止等）は、AIP-136 がリソース外の付加情報返却に専用 `Response` を認める余地（ADR-0008 でも追補余地として明記）と衝突して誤検出を生み、現に移行途上の `RegisterJockeyResponse`（ADR-0008 が単一 DTO へ寄せる対象とする既知の不整合）を機械的に「違反」と断ずるだけで規約の意味は捉えられない。

> 補足: `RegisterJockeyResponse` の単一 DTO への移行（ADR-0008 適用）は本 PR のスコープ外。必要なら別 issue 化します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
