### PR TITLE
perf: Gradle ビルド性能を実測で改善する (#349)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -19,6 +19,15 @@
 - 統合テスト（`@SpringBootTest`）は配線確認の最小限に留める。ロジックの網羅は内側のリングで済ませる（ピラミッドの底を厚く）。
 - テスト規約（JUnit 5 / Power Assert / `@WebMvcTest` / 日本語ケース名）の詳細は CLAUDE.md「テスト規約」を参照。
 
+## テスト実行性能（コンテキストキャッシュ優先・並列化しない）
+
+Spring テストの主コストは `ApplicationContext` の構築。速度の本筋は**並列化ではなくコンテキストキャッシュの再利用最大化**にある（実測の根拠は [ADR-0015](../../docs/adr/0015-gradle-build-performance-tuning.md)）。
+
+- **distinct なコンテキスト構成を増やさない**。キャッシュは「同一の unique 構成」のときだけ再利用される（キーは classes / context customizers / active profiles / property sources 等の組合せ）。`@MockkBean` は context customizer を足してキーを分けるので**乱発しない**、`@Import` 構成は揃える、`@SpringBootTest(webEnvironment=...)` を不必要に散らさない。
+- **`@DirtiesContext` は原則使わない**（キャッシュを退避させ再構築を強いる）。状態リークは設計で断つ。
+- **テスト並列化（`maxParallelForks` / JUnit 5 の `junit.jupiter.execution.parallel`）は採らない**。フォークはキャッシュが JVM 単位のため逆効果、JVM 内並列は `@MockBean`/`@MockkBean` や共有状態を使うテストを Spring 公式が非推奨とする。再評価は #338（永続化層）でテスト隔離を整えてから。
+- 速度を縮めたいときの効く順: ビルドキャッシュ/デーモン（[ADR-0015](../../docs/adr/0015-gradle-build-performance-tuning.md)）→ コンテキスト構成の共通化 → （将来）隔離を整えた上での並列化。
+
 ## カバレッジハーネス（Kover）
 
 カバレッジは [Kover](https://github.com/Kotlin/kotlinx-kover) で計測する（JaCoCo ではない。理由は [ADR-0006](../../docs/adr/0006-kover-over-jacoco.md)）。設定は `build.gradle.kts` の `kover {}` ブロック。

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -30,6 +30,10 @@ jobs:
           distribution: 'temurin'
 
       - name: Set up Gradle
+        # cache-provider: basic は Gradle User Home（依存・wrapper・ローカル build cache の
+        # ~/.gradle/caches/build-cache-1 を含む）を actions/cache で runner 間に持ち越す。
+        # gradle.properties の org.gradle.caching=true と組み合わせ、PR では読み取り・main では
+        # 書き込み（setup-gradle 既定）で compile/test 出力を再利用する（#349）。
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,9 +50,12 @@ tasks.withType<Test> {
     useJUnitPlatform()
     // maxParallelForks（テスト JVM の並列フォーク）は意図的に既定（1）のまま据え置く。
     // 計測上、単一モジュール・小規模スイートの本プロジェクトでは forks を増やすと逆に遅くなる
-    // （42s→97s @ forks=4）。Spring の ApplicationContext キャッシュは JVM 単位のため、
-    // フォークすると重い @SpringBootTest のコンテキスト初期化が各 JVM で重複し、JVM 起動コストも嵩む。
-    // 採否の根拠は ADR-0015 / #349。テスト規模が増えフォーク間でコンテキスト起動を償却できるようになったら再評価する。
+    // （42s→97s @ forks=4）。コンテキストキャッシュ統計の実測では distinct な ApplicationContext は
+    // 6 個のみ・ヒット率 ~99%（hit 525 / miss 6）で、:test の時間は「一度きりの 6 コンテキスト構築 +
+    // JVM ウォームアップ(~7.8s)」が支配的。Spring のキャッシュは JVM 単位のためフォークすると 6 構築が
+    // 各 JVM で重複し JVM 起動も N 倍になる。JVM 内スレッド並列も @MockkBean(springmockk＝@MockBean 機構)が
+    // Spring 公式「Parallel Test Execution」の非推奨条件に該当するため不可。詳細・根拠は ADR-0015 / #349。
+    // #338 で DB 導入後にテスト隔離を整えるか統合テストが多数になったら再評価する。
     // ユビキタス言語カタログの再生成フラグ（-DubiquitousLanguage.update=true）をフォークした JVM へ引き渡す。
     // UbiquitousLanguageCatalogTest が docs/ubiquitous-language.md の自動生成ブロックを書き戻すために参照する。
     System.getProperty("ubiquitousLanguage.update")?.let {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,11 @@ kotlin { compilerOptions { freeCompilerArgs.addAll("-Xjsr305=strict") } }
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    // maxParallelForks（テスト JVM の並列フォーク）は意図的に既定（1）のまま据え置く。
+    // 計測上、単一モジュール・小規模スイートの本プロジェクトでは forks を増やすと逆に遅くなる
+    // （42s→97s @ forks=4）。Spring の ApplicationContext キャッシュは JVM 単位のため、
+    // フォークすると重い @SpringBootTest のコンテキスト初期化が各 JVM で重複し、JVM 起動コストも嵩む。
+    // 採否の根拠は ADR-0015 / #349。テスト規模が増えフォーク間でコンテキスト起動を償却できるようになったら再評価する。
     // ユビキタス言語カタログの再生成フラグ（-DubiquitousLanguage.update=true）をフォークした JVM へ引き渡す。
     // UbiquitousLanguageCatalogTest が docs/ubiquitous-language.md の自動生成ブロックを書き戻すために参照する。
     System.getProperty("ubiquitousLanguage.update")?.let {

--- a/docs/adr/0015-gradle-build-performance-tuning.md
+++ b/docs/adr/0015-gradle-build-performance-tuning.md
@@ -1,0 +1,47 @@
+# 0015. Gradle ビルド性能チューニングの採否を実測で決める
+
+- Status: Accepted
+- Date: 2026-06-22
+- Deciders: ptiringo
+
+## Context（背景・課題）
+
+ビルド・テストの待ち時間を縮めたい（#349）。Gradle 公式パフォーマンスガイドの各レバーのうち、本プロジェクト（単一本体モジュール + 極小の `:detekt-rules`、Kotlin + Spring Boot、JDK 21、Gradle 9.5.1）で実際に効くものを実測で見極めて採用する。
+
+計測は 8 論理コア環境で、`--build-cache` / `--configuration-cache` / `--daemon` のフラグでレバーを個別に切り替えて before/after を取得した（後述「計測環境の制約」のとおり、ローカルのグローバル設定がキャッシュ機構を無効化しているため、フラグで実環境を模した）。
+
+検討したレバーと実測:
+
+| レバー | 計測 | 判断 |
+|---|---|---|
+| build cache | clean test 87s→2s / clean check 32.7s→4s（フルヒット） | 採用 |
+| configuration cache（既存有効） | no-op test 14s→1.5s（daemon 併用） | 維持 + 健全性ゲート追加 |
+| JVM ヒープ（`-Xmx2g`） | 現規模では実測差ノイズ範囲 | 採用（将来備え） |
+| `org.gradle.parallel` | assemble 6.0s vs 6.1s（差なし） | 見送り |
+| `maxParallelForks`（テスト並列フォーク） | forks=1/2/4 で 42s→61s→97s（逆効果） | 見送り |
+
+`maxParallelForks` が逆効果になるのは、Spring の `ApplicationContext` キャッシュが JVM 単位であるため。テスト JVM をフォークすると重い `@SpringBootTest` のコンテキスト初期化が各フォークで重複し、JVM 起動コストも加わって、単一モジュール・小規模スイートでは並列化の利得を上回る。公式ガイドが一般論として勧める「テストフォークの並列化」が、本プロジェクトの規模・構成では成立しないことを実証した。
+
+`org.gradle.parallel` が無効果なのは、プロジェクトが root + 極小の `:detekt-rules` の2つしかなく、並列プロジェクト実行で重ねられる仕事が無いため。
+
+## Decision（決定）
+
+`gradle.properties` に以下を設定する:
+
+- `org.gradle.caching=true` — build cache を有効化（最大の効果）。
+- `org.gradle.configuration-cache.problems=fail` — configuration cache 非互換の混入を警告で素通りさせず失敗させる健全性ゲート（CC 自体は従来どおり有効）。
+- `org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8` — デーモンヒープを明示（既定 512MB の GC 圧予防。現規模では効果小だが将来備え）。
+
+採用しないものは、理由（実測値）を `gradle.properties` / `build.gradle.kts` のコメントに残す:
+
+- `org.gradle.parallel` は設定しない（効果なし）。マルチモジュール化時に再評価。
+- `maxParallelForks` は既定（1）のまま据え置く（逆効果）。テスト規模がフォーク間でコンテキスト起動を償却できる水準になったら再評価。
+
+CI（`api-tests.yml`）は `gradle/actions/setup-gradle`（`cache-provider: basic`）が Gradle User Home（ローカル build cache の `~/.gradle/caches/build-cache-1` を含む）を runner 間で持ち越すため、`org.gradle.caching=true` の有効化だけで build cache が CI でも効く。ワークフロー自体の変更は根拠コメントの追記に留める。
+
+## Consequences（結果・影響）
+
+- ローカル（非サンドボックス）・CI のクリーン／インクリメンタルビルドが、キャッシュヒット時に大幅に短縮される。`koverVerifyMature` のカバレッジゲートは test が FROM-CACHE でも正常に通過することを確認済み。
+- `problems=fail` により、今後 configuration cache 非互換な記述（設定フェーズでの非決定的な値参照など）を加えるとビルドが失敗する。CC 互換性を保つ規律を強制できる一方、CC 非互換な記述を入れたいときは明示的な対処が要る。
+- **計測環境の制約**: ローカル開発環境の `~/.gradle/gradle.properties` がサンドボックス安定化のため VFS watch / configuration cache / daemon / build cache をすべて無効化している（グローバルがプロジェクト設定を上書きする）。このため本決定の施策は **CI および非サンドボックスのローカル開発でのみ効く**（サンドボックス内ビルドでは無効化されたまま）。このグローバル無効化が過剰でないか（VFS watch のみで stale を防げないか等）の評価は本 ADR のスコープ外とし、別途検討する。
+- スコープ外: dependency locking / repository 整理（現状の単一 `mavenCentral()` で問題なし）、Develocity（リモート build cache / Build Scan）は別途検討。

--- a/docs/adr/0015-gradle-build-performance-tuning.md
+++ b/docs/adr/0015-gradle-build-performance-tuning.md
@@ -20,7 +20,11 @@
 | `org.gradle.parallel` | assemble 6.0s vs 6.1s（差なし） | 見送り |
 | `maxParallelForks`（テスト並列フォーク） | forks=1/2/4 で 42s→61s→97s（逆効果） | 見送り |
 
-`maxParallelForks` が逆効果になるのは、Spring の `ApplicationContext` キャッシュが JVM 単位であるため。テスト JVM をフォークすると重い `@SpringBootTest` のコンテキスト初期化が各フォークで重複し、JVM 起動コストも加わって、単一モジュール・小規模スイートでは並列化の利得を上回る。公式ガイドが一般論として勧める「テストフォークの並列化」が、本プロジェクトの規模・構成では成立しないことを実証した。
+`maxParallelForks` が逆効果になる理由は、コンテキストキャッシュ統計の実測で裏づけた。本スイートは 38 テストクラス中コンテキストを要するのは 8 のみ（@SpringBootTest 3 + @WebMvcTest 5）で、実際に構築される distinct な `ApplicationContext` は **6 個**（`missCount=6` / `hitCount=525` / `failureCount=0`、`@DirtiesContext` ゼロ）。**コンテキスト再利用は単一 JVM 内で既にヒット率 ~99%** と最適に近い。構築コストの内訳は MOCK 環境のフル `@SpringBootTest` が 6.6s、RANDOM_PORT が 2.0s（Tomcat 起動は全体で 1 回のみ）、各 @WebMvcTest スライスが 0.4〜0.9s、加えて JVM+クラスロードのウォームアップが約 7.8s。つまり `:test` の時間は「**一度きりの 6 コンテキスト構築 + JVM ウォームアップ + テスト実行**」であって、フォークで削れる "繰り返しのコンテキスト起動" は存在しない。テスト JVM をフォークすると、Spring のコンテキストキャッシュは **JVM 単位**のため 6 コンテキストが複数 JVM に分散・重複構築され、約 7.8s の JVM ウォームアップも N 倍になる。これが forks=1/2/4 の 42s→61s→97s（単調悪化）の正体である。
+
+JVM 内スレッド並列（JUnit 5 `junit.jupiter.execution.parallel`、単一キャッシュ共有）も本プロジェクトでは採れない。Spring Framework リファレンス「Parallel Test Execution」は、`@DirtiesContext` / `@MockitoBean`・`@MockitoSpyBean` / Spring Boot の `@MockBean`・`@SpyBean` / `@TestMethodOrder` を使うテスト、および DB・メッセージブローカ・ファイルシステム等の共有状態を変更するテストを並列実行しないよう求めている。本スイートは 5 つの @WebMvcTest 中 4 つで `@MockkBean`（springmockk）を使用しており、これは Spring Boot の `@MockBean` と同じ仕組み（context customizer 登録 + メソッドごとの mock リセットで singleton mock を共有）であるため、機構として上記制約に該当する（`MockMvc`/`MockMvcTester` も並行共有想定でない）。並列化が現実的に効くのは、#338 の永続化層導入後にテスト隔離（トランザクションロールバックやフォークごとの独立 DB/Testcontainers）を整えるか、互いに独立した重い統合テストが多数になりクラスレベル並列を共有キャッシュで回せる段になってから。
+
+`org.gradle.parallel` が無効果なのは、プロジェクトが root + 極小の `:detekt-rules` の2つしかなく、並列プロジェクト実行で重ねられる仕事が無いため。
 
 `org.gradle.parallel` が無効果なのは、プロジェクトが root + 極小の `:detekt-rules` の2つしかなく、並列プロジェクト実行で重ねられる仕事が無いため。
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,3 +24,4 @@
 | [0012](0012-rest-naming-convention.md) | REST 命名規約を URL=camelCase / ボディ=snake_case に確定する | Accepted |
 | [0013](0013-racehorse-registration-as-separate-context.md) | 競走馬登録(JRA)を JAIRS 中心ドメインから別の境界づけられたコンテキストとして分離する | Accepted |
 | [0014](0014-self-validating-factory-over-confinement.md) | 集約をまたぐ前提条件は自己検証ファクトリで検証し、生成口の封じ込めを行わない | Accepted |
+| [0015](0015-gradle-build-performance-tuning.md) | Gradle ビルド性能チューニング（build cache 採用・並列フォーク見送り）を実測で決める | Accepted |

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,26 @@
 # Gradle ビルド設定
+# 各施策の採否根拠・before/after 計測は ADR-0015（docs/adr/0015-gradle-build-performance-tuning.md）/ #349 を参照。
 
 # configuration cache: 設定フェーズ（ビルドスクリプト評価・タスクグラフ構築）の結果をキャッシュし、
 # ビルドスクリプトに変更がない場合は設定フェーズをスキップして起動を高速化する
+# （計測: no-op test 14s→1.5s（デーモン併用時）。本リポジトリのビルドは CC 互換）
 org.gradle.configuration-cache=true
+
+# configuration cache の健全性ゲート: CC 非互換な記述が混入したら警告で済まさず失敗させ、
+# 設定フェーズのキャッシュ可能性を後戻りさせない
+org.gradle.configuration-cache.problems=fail
+
+# build cache: コンパイル・テスト等のタスク出力をキー（入力ハッシュ）単位でキャッシュし再利用する。
+# clean ビルドでもキャッシュヒットすれば compile/test を丸ごとスキップできる
+# （計測: clean test 87s→2s（フルヒット時））。CI でも setup-gradle が ~/.gradle を復元するため runner 間で効く。
+org.gradle.caching=true
+
+# Gradle デーモンの JVM 設定。既定ヒープ(512m)は Kotlin + Spring + detekt のビルドには小さく
+# GC 圧の原因になりうるため引き上げる（現規模では実測差は小さいが将来の肥大化に備える）。
+org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+# org.gradle.parallel は見送り（計測上 effect なし: assemble 6.0s vs 6.5s）。
+# root + :detekt-rules の 2 プロジェクト構成かつ :detekt-rules が極小のため並列実行の利得が無い。
+# マルチモジュール化したら再評価する。
+# maxParallelForks（テスト JVM の並列フォーク）も見送り（計測上 逆効果: forks=1 42s → forks=4 97s）。
+# 根拠は build.gradle.kts の tasks.withType<Test> のコメントを参照。

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -63,7 +63,7 @@ commit-msg:
     # コミットメッセージのフォーマットチェック（オプション）
     commitizen-check:
       run: |
-        if ! echo "$(head -n1 {1})" | grep -E "^(feat|fix|docs|style|refactor|test|chore)(\(.+\))?: .{1,50}" > /dev/null; then
+        if ! echo "$(head -n1 {1})" | grep -E "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .{1,50}" > /dev/null; then
           echo "コミットメッセージは conventional commit 形式で記述してください"
           echo "例: feat: 新機能を追加"
           echo "例: fix: バグを修正"


### PR DESCRIPTION
## 概要

Gradle 公式パフォーマンスガイドの各レバーを実測で評価し、効くものだけを採用した（#349）。変更は `gradle.properties` / `build.gradle.kts` / CI ワークフロー / ADR / lefthook の計6ファイル（コメント・ドキュメント中心）。

## 計測（8 論理コア / JDK 21 / Gradle 9.5.1、実環境を模してフラグでグローバル無効化をバイパス）

| シナリオ | before | after | 効いたレバー |
|---|---|---|---|
| no-op test（dev ループ） | 14s | **1.5s** | configuration cache + daemon |
| clean test（フルヒット） | 87s | **2s** | build cache |
| clean check（フルヒット） | 32.7s | **4s** | build cache（`koverVerifyMature` も FROM-CACHE で通過確認） |

## 採用

- ✅ **build cache 有効化**（`org.gradle.caching=true`）。最大の効果。CI は `setup-gradle`（`cache-provider: basic`）が Gradle User Home を runner 間で持ち越すため有効化だけで効く。
- ✅ **configuration cache 健全性ゲート**（`org.gradle.configuration-cache.problems=fail`）。CC 非互換の混入を失敗させる（CC 自体は従来どおり有効）。
- ✅ **JVM ヒープ明示**（`org.gradle.jvmargs=-Xmx2g ...`）。現規模では効果小だが将来備え。

## 見送り（計測根拠付き）

- ❌ **`org.gradle.parallel`**: 効果なし（assemble 6.0s vs 6.1s）。root + 極小 `:detekt-rules` の2プロジェクトのため。
- ❌ **`maxParallelForks`**: **逆効果**（forks=1→4 で 42s→97s）。Spring の `ApplicationContext` キャッシュが JVM 単位で、フォークすると重い `@SpringBootTest` のコンテキスト初期化が各 JVM で重複するため。

## その他

- `lefthook.yml`: commit-msg の許可タイプに欠けていた標準 Conventional Commits 型（`perf`/`build`/`ci`/`revert`）を追加（`perf:` でコミットできるように）。
- `docs/adr/0015`: 上記の採否判断を ADR 化。

## 環境前提（重要）

ローカルの `~/.gradle/gradle.properties` がサンドボックス安定化のため caching/daemon/config-cache を無効化しており、本施策は **CI と非サンドボックスのローカルでのみ効く**。このグローバル無効化が過剰でないかの評価は別途実施する（本 PR スコープ外）。

## 受け入れ条件

- [x] 採用施策を `gradle.properties` / `build.gradle.kts` / CI に反映
- [x] 見送り施策の理由を計測値付きで記録
- [x] before/after を計測値で提示
- [x] `./gradlew check` グリーン（`koverVerifyMature` ラチェット含む）

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)
