### PR TITLE
feat: 繁殖成績の「種付せず」区分（種付なし年次成績）をモデル化する (#322)

### DIFF
--- a/docs/adr/0016-not-covered-as-foaling-outcome-variant.md
+++ b/docs/adr/0016-not-covered-as-foaling-outcome-variant.md
@@ -1,0 +1,43 @@
+# 0016. 「種付せず」を FoalingOutcome の区分として表し、covering を nullable 化する
+
+- Status: Accepted
+- Date: 2026-06-22
+- Deciders: ptiringo
+
+## Context（背景・課題）
+
+繁殖成績報告（様式第14号）は、繁殖牝馬ごとの年次成績として8区分（生産／不受胎／流産／双子流産／死産／双子死産／生後直死／双子生後直死／**種付せず**）を報告する。#265（PR #321）で繁殖成績のドメイン層を実装した際、スコープを絞るため「種付せず」を除外した。
+
+当時の `BreedingResult` 集約は種付（`Covering`）を必須としてモデル化しており、
+
+- `covering: Covering`（非 null）を `create` の必須引数で受け取る
+- 種付年は `covering.coveringDate` から導出する（`coveringYear` getter）
+- `FoalingOutcome` は「**種付後に生じる**帰結」の sealed 語彙
+
+という前提に立っていた。このため「その年に種付しなかった」年次成績を表現できない。種付せずは種付が存在しない帰結であり、上記前提（covering 必須・年は種付日から導出・分娩結果は種付後の帰結）をすべて崩す。#322 でこれをモデル化するにあたり、設計の分岐を整理する必要があった。
+
+検討した代替案:
+
+- **案B: 種付せずを別概念（別レコード／別集約）として表す**。`BreedingResult` は種付必須のまま不変とし、種付せずを `UncoveredBreedingYear(broodmareRegistrationId, year)` 等の別型で持つ。集約は清潔に保てるが、年次の繁殖成績という**単一の報告単位**が2つの型に割れ、年次集計（#325 の受胎率・生産率・登録率や提出期限制約）でレポート時に2型を union する必要が生じる。様式第14号が8区分を**単一の「繁殖成績」列の値**として扱う現実とも乖離する。
+
+## Decision（決定）
+
+**「種付せず」を `FoalingOutcome` の区分 `NotCovered` として追加し（案A）、`BreedingResult.covering` を nullable 化する。**
+
+- `FoalingOutcome` を「分娩結果」から「**年次の繁殖成績区分**」へと意味を広げ、8区分目 `NotCovered`（`data object`）を加える。`NotCovered` だけは種付を伴わない区分である。
+- `BreedingResult` に繁殖年 `breedingYear: Year` を**明示フィールド**として持たせる（種付せずは種付日から年を導出できないため）。種付した年は `breedingYear == covering の年` を不変条件で保証する。`coveringYear` getter は廃し `breedingYear` に統一する。
+- `covering: Covering?` を nullable 化し、covering と区分の整合を**集約の不変条件**（private constructor の `require`）で強制する:
+  - `covering == null` ⇔ `outcome == NotCovered`（種付せずは生成時に終端）
+  - `covering != null` ⇒ `outcome != NotCovered` かつ `breedingYear == 種付日の年`
+- 種付せずの生成は専用の自己検証ファクトリ `BreedingResult.createUncovered(broodmareRegistration, breedingYear)` に限る（[ADR-0014](0014-self-validating-factory-over-confinement.md) の方針に沿い、繁殖牝馬ロールを自己検証して `Result` を返す）。失敗は1種類のため単一型 `NotBroodmareForUncovered` とする。
+- 種付せずは終端レコードのため `recordFoaling` の対象にならない（outcome が既に確定済みのため二重報告として弾かれ、加えて `NotCovered` を分娩結果として報告する経路は `require` で塞ぐ）。
+- HTTP 契約では `FoalingOutcomeDto.NOT_COVERED` を追加し、`BreedingResultResponse` の種付関連項目（`stallionId` / `coveringDate` / `certificateNumber`）と `outcome` を nullable 化する。`:reportFoaling` カスタムメソッドは種付済み成績への分娩結果報告であり、`NOT_COVERED` は受け付けず 400 を返す（種付せずの記録経路は分娩結果報告とは別）。
+
+## Consequences（結果・影響）
+
+- 年次の繁殖成績が**単一の集約・単一の区分語彙**で表現でき、#325 の年次集計が1つの `BreedingResult` 列を走査するだけで済む。様式第14号の8区分という現実にも一致する。
+- `FoalingOutcome` の意味が「分娩結果」から「年次成績区分」へ広がった。`NotCovered` は名目上 `FoalingOutcome` に属すが分娩を伴わない唯一の区分であり、この非対称は covering との整合を集約の不変条件で吸収する。
+- `covering` の nullable 化により、covering を参照する側（`RegisterFoalUseCase` の父解決、レスポンスの種付項目）は null を扱う必要がある。`RegisterFoalUseCase` は種付せず成績から産駒登録が呼ばれた場合、父解決の前に既存の `RegisterFoalError.NotLiveFoal` 前提条件違反へ寄せて短絡する（種付せずから生まれる産駒は存在しない）。
+- レスポンス DTO のフィールド名が `coveringYear`→`breedingYear`（wire は `covering_year`→`breeding_year`）に変わり、種付関連3項目が nullable になる。HTTP 契約の変更を伴う。
+- 種付せずを**記録する** application / controller の入口（`createUncovered` ユースケースとエンドポイント）は本決定のスコープ外。本 ADR はドメインモデルの表現可能性を確立するもので、駆動経路は別途整備する（#322 のフォロー）。
+- 集約の不変条件・ファクトリ方針は [ADR-0009](0009-immutable-aggregates.md)（イミュータブル集約）・[ADR-0014](0014-self-validating-factory-over-confinement.md)（自己検証ファクトリ）に整合する。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,3 +25,4 @@
 | [0013](0013-racehorse-registration-as-separate-context.md) | 競走馬登録(JRA)を JAIRS 中心ドメインから別の境界づけられたコンテキストとして分離する | Accepted |
 | [0014](0014-self-validating-factory-over-confinement.md) | 集約をまたぐ前提条件は自己検証ファクトリで検証し、生成口の封じ込めを行わない | Accepted |
 | [0015](0015-gradle-build-performance-tuning.md) | Gradle ビルド性能チューニング（build cache 採用・並列フォーク見送り）を実測で決める | Accepted |
+| [0016](0016-not-covered-as-foaling-outcome-variant.md) | 「種付せず」を FoalingOutcome の区分として表し covering を nullable 化する | Accepted |

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -154,6 +154,7 @@ graph LR
 | FoalingOutcome.LiveFoal | 値オブジェクト | domain.horseracing.model.breeding |
 | FoalingOutcome.NeonatalDeath | 値オブジェクト | domain.horseracing.model.breeding |
 | FoalingOutcome.NotConceived | 値オブジェクト | domain.horseracing.model.breeding |
+| FoalingOutcome.NotCovered | 値オブジェクト | domain.horseracing.model.breeding |
 | FoalingOutcome.Stillbirth | 値オブジェクト | domain.horseracing.model.breeding |
 | FoalingOutcome.TwinAbortion | 値オブジェクト | domain.horseracing.model.breeding |
 | FoalingOutcome.TwinNeonatalDeath | 値オブジェクト | domain.horseracing.model.breeding |

--- a/src/main/kotlin/com/example/api/application/horseracing/horse/RegisterFoalUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/horseracing/horse/RegisterFoalUseCase.kt
@@ -1,6 +1,7 @@
 package com.example.api.application.horseracing.horse
 
 import com.example.api.domain.horseracing.model.breeding.BreedingRegistrationRepository
+import com.example.api.domain.horseracing.model.breeding.BreedingResult
 import com.example.api.domain.horseracing.model.breeding.BreedingResultId
 import com.example.api.domain.horseracing.model.breeding.BreedingResultRepository
 import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorse
@@ -135,12 +136,7 @@ class RegisterFoalUseCase(
                 }
                 .bind()
 
-        val sireId = breedingResult.covering.stallionId
-        val sire =
-            bloodHorseRepository
-                .findById(sireId)
-                .toResultOr { RegisterFoalUseCaseError.SireNotFound(sireId.value) }
-                .bind()
+        val sire = resolveSire(breedingResult).bind()
 
         val damId = breedingRegistration.registeredHorseId
         val dam =
@@ -165,5 +161,30 @@ class RegisterFoalUseCase(
                 .bind()
 
         bloodHorseRepository.save(bloodHorse)
+    }
+
+    /**
+     * 繁殖成績から父（種付の種牡馬）を解決する。
+     *
+     * 種付せず（covering が無い）の年次成績からは産駒が生じず父も定まらないため、父の解決前に、ドメインサービスと
+     * 同じ「生産でない」前提条件違反（[RegisterFoalError.NotLiveFoal]）へ寄せて短絡する。種付がある場合のみ種牡馬を [BloodHorseRepository]
+     * で引き当てる。
+     */
+    private fun resolveSire(
+        breedingResult: BreedingResult
+    ): Result<BloodHorse, RegisterFoalUseCaseError> = binding {
+        val covering =
+            breedingResult.covering
+                .toResultOr {
+                    RegisterFoalUseCaseError.PreconditionViolated(
+                        RegisterFoalError.NotLiveFoal(breedingResult.outcome)
+                    )
+                }
+                .bind()
+        val sireId = covering.stallionId
+        bloodHorseRepository
+            .findById(sireId)
+            .toResultOr { RegisterFoalUseCaseError.SireNotFound(sireId.value) }
+            .bind()
     }
 }

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
@@ -15,23 +15,25 @@ import org.springframework.http.ProblemDetail
  *
  * 繁殖成績に対する操作（種付記録の Create、分娩結果報告の `:reportFoaling` カスタムメソッド）は、
  * [AIP-133](https://google.aip.dev/133) / [AIP-136](https://google.aip.dev/136) に倣い一律で
- * このリソース表現全体を返す。種付年は種付日から導出した値を持つ。分娩結果は未報告なら null。
+ * このリソース表現全体を返す。繁殖年は集計・報告の単位で、種付した年は種付日の年と一致する。種付せず（その年に 種付しなかった）の年次成績では種付関連の項目（[stallionId] /
+ * [coveringDate] / [certificateNumber]）が null に なり、[outcome] は種付せず区分を持つ。種付した年の分娩結果は未報告なら [outcome]
+ * が null。
  *
  * @property id 繁殖成績の生 UUID
  * @property breedingRegistrationId 紐づく繁殖登録（繁殖牝馬のロール）の生 UUID
- * @property coveringYear 種付年
- * @property stallionId 種牡馬の生 UUID
- * @property coveringDate 種付日
- * @property certificateNumber 種付証明書番号
- * @property outcome 分娩結果。未報告なら null
+ * @property breedingYear 繁殖年
+ * @property stallionId 種牡馬の生 UUID。種付せずの年は null
+ * @property coveringDate 種付日。種付せずの年は null
+ * @property certificateNumber 種付証明書番号。種付せずの年は null
+ * @property outcome 分娩結果。種付した年で未報告なら null
  */
 data class BreedingResultResponse(
     val id: UUID,
     val breedingRegistrationId: UUID,
-    val coveringYear: Int,
-    val stallionId: UUID,
-    val coveringDate: LocalDate,
-    val certificateNumber: String,
+    val breedingYear: Int,
+    val stallionId: UUID?,
+    val coveringDate: LocalDate?,
+    val certificateNumber: String?,
     val outcome: FoalingOutcomeResponse?,
 )
 
@@ -40,10 +42,10 @@ fun BreedingResult.toResponse(): BreedingResultResponse =
     BreedingResultResponse(
         id = id.value,
         breedingRegistrationId = breedingRegistrationId.value,
-        coveringYear = coveringYear.value,
-        stallionId = covering.stallionId.value,
-        coveringDate = covering.coveringDate,
-        certificateNumber = covering.certificateNumber.value,
+        breedingYear = breedingYear.value,
+        stallionId = covering?.stallionId?.value,
+        coveringDate = covering?.coveringDate,
+        certificateNumber = covering?.certificateNumber?.value,
         outcome = outcome?.toResponse(),
     )
 

--- a/src/main/kotlin/com/example/api/controller/breeding/FoalingOutcomeWire.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/FoalingOutcomeWire.kt
@@ -38,6 +38,9 @@ enum class FoalingOutcomeDto {
 
     /** 双子生後直死。 */
     TWIN_NEONATAL_DEATH,
+
+    /** 種付せず（その年に種付しなかった）。種付を伴わない年次成績の区分。 */
+    NOT_COVERED,
 }
 
 /**
@@ -63,4 +66,5 @@ fun FoalingOutcome.toResponse(): FoalingOutcomeResponse =
             FoalingOutcomeResponse(FoalingOutcomeDto.NEONATAL_DEATH, null)
         FoalingOutcome.TwinNeonatalDeath ->
             FoalingOutcomeResponse(FoalingOutcomeDto.TWIN_NEONATAL_DEATH, null)
+        FoalingOutcome.NotCovered -> FoalingOutcomeResponse(FoalingOutcomeDto.NOT_COVERED, null)
     }

--- a/src/main/kotlin/com/example/api/controller/breeding/ReportFoalingRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/ReportFoalingRequest.kt
@@ -25,10 +25,20 @@ data class ReportFoalingRequest(val outcome: FoalingOutcomeDto, val foalingDate:
  * リクエストボディをドメインの分娩結果へ変換する。
  *
  * 生産（[FoalingOutcomeDto.LIVE_FOAL]）は分娩日が必須であり、欠けている場合は入力不正として 400 を表す [ProblemDetail]
- * を返す。産駒なしの各区分は分娩日を持たない（指定されても無視する）。
+ * を返す。産駒なしの各区分は分娩日を持たない（指定されても無視する）。種付せず （[FoalingOutcomeDto.NOT_COVERED]）は種付を伴わない年次成績の区分であり分娩結果報告
+ * （`:reportFoaling`）では 受け付けない（別経路で記録する）。入力不正として 400 を返す。
  */
 fun ReportFoalingRequest.toOutcome(): Result<FoalingOutcome, ProblemDetail> =
     when (outcome) {
+        FoalingOutcomeDto.NOT_COVERED ->
+            Err(
+                problem(
+                    status = HttpStatus.BAD_REQUEST,
+                    code = "foaling-outcome-not-reportable",
+                    title = "Foaling outcome not reportable",
+                    detail = "種付せず（NOT_COVERED）は分娩結果として報告できません。",
+                )
+            )
         FoalingOutcomeDto.LIVE_FOAL ->
             if (foalingDate == null) {
                 Err(

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResult.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResult.kt
@@ -39,45 +39,78 @@ sealed interface RecordCoveringError {
 }
 
 /**
- * 繁殖成績を表す集約ルート。種付年ごとの「種付〜分娩」の年次レコード。
+ * 種付せず（年次成績）の記録（[BreedingResult.createUncovered]）の前提条件違反。
  *
- * 繁殖登録済みの牝馬（[BreedingRegistration]）について、その年の種付（[Covering]）と分娩結果
- * （[FoalingOutcome]）を記録する。「繁殖成績報告書」（様式第14号）が報告する 1 行ぶんの年次成績に対応する。 繁殖登録は別集約であり、参照は
- * [BreedingRegistrationId] 経由で表す。種付年は種付日から導出する。
+ * 種付せずも繁殖牝馬の年次成績であり、対象の繁殖登録のロールが繁殖牝馬であることを前提とする。失敗のしかたは この1種類のみのため単一型とする（種付記録と異なり配合相手の検証はない）。
  *
- * 状態はイミュータブルに扱う。種付の記録で生成され（[outcome] は null＝分娩結果は未報告）、後日の分娩結果報告 で一度だけ [outcome] が確定する。報告は
- * [recordFoaling] が分娩結果を持つ新しい [BreedingResult] を返す ことで表し、同一性（[id]）は引き継ぐ。元のインスタンスは変更しない。
+ * @property registration 種付せずの記録対象として渡された繁殖登録
+ */
+data class NotBroodmareForUncovered(val registration: BreedingRegistration)
+
+/**
+ * 繁殖成績を表す集約ルート。繁殖年ごとの年次レコード。
  *
- * 両者の登録ロール（繁殖牝馬・種牡馬）の検証など集約をまたぐ前提条件は、繁殖登録を引数で受け取る生成ファクトリ [create] がその場で自己検証する。コンストラクタは private
- * とし、生成は [create] のみに限る。
+ * 繁殖登録済みの牝馬（[BreedingRegistration]）について、その年の繁殖成績を記録する。「繁殖成績報告書」 （様式第14号）が報告する 1
+ * 行ぶんの年次成績に対応する。繁殖登録は別集約であり、参照は [BreedingRegistrationId] 経由で表す。
+ *
+ * 年次成績は2種類ある。**種付した年**は種付（[Covering]）を持ち、後日その年の分娩結果（[FoalingOutcome]
+ * の種付後7区分のいずれか）が確定する。**種付しなかった年**（種付せず）は [Covering] を持たず、[outcome] は 生成時に
+ * [FoalingOutcome.NotCovered] で確定する終端レコードとなる。繁殖年（[breedingYear]）は両者を通じて
+ * 成績の集計・報告の単位であり、種付した年は種付日の年と一致する。
+ *
+ * 状態はイミュータブルに扱う。種付の記録（[create]）で生成された成績は [outcome] が null（分娩結果は未報告）で 始まり、後日の分娩結果報告で一度だけ [outcome]
+ * が確定する。報告は [recordFoaling] が分娩結果を持つ新しい [BreedingResult]
+ * を返すことで表し、同一性（[id]）は引き継ぐ。元のインスタンスは変更しない。種付せずの記録 （[createUncovered]）は最初から終端のため [recordFoaling]
+ * の対象にならない。
+ *
+ * 登録ロール（繁殖牝馬・種牡馬）の検証など集約をまたぐ前提条件は、繁殖登録を引数で受け取る生成ファクトリ （[create] /
+ * [createUncovered]）がその場で自己検証する。コンストラクタは private とし、生成はこれらの ファクトリのみに限る。「種付した年は covering を持ち outcome
+ * は NotCovered でない」「種付せずの年は covering を 持たず outcome は NotCovered」という covering
+ * と区分の整合は本クラスの不変条件として強制する。
  *
  * @property id 繁殖成績ID（生成時に自動採番し、以後の写像でも引き継ぐ）
  * @property breedingRegistrationId この成績が紐づく繁殖登録（繁殖牝馬のロール）のID
- * @property covering その年の種付
- * @property outcome その年の分娩結果。未報告なら null。報告は [recordFoaling] でのみ行う
+ * @property breedingYear 繁殖年（この成績を集計・報告する年単位）。種付した年は種付日の年と一致する
+ * @property covering その年の種付。種付せずの年は null
+ * @property outcome その年の分娩結果。種付した年は未報告なら null・報告は [recordFoaling] で行う。種付せずの年は
+ *   [FoalingOutcome.NotCovered]
  */
 @AggregateRoot
 class BreedingResult
 private constructor(
     @field:Identity override val id: BreedingResultId,
     val breedingRegistrationId: BreedingRegistrationId,
-    val covering: Covering,
+    val breedingYear: Year,
+    val covering: Covering?,
     val outcome: FoalingOutcome?,
 ) : Entity<BreedingResultId>() {
-    /** 種付年。種付日から導出する（繁殖成績はこの年単位で集計・報告される）。 */
-    val coveringYear: Year
-        get() = Year.of(covering.coveringDate.year)
+    init {
+        if (covering == null) {
+            require(outcome == FoalingOutcome.NotCovered) {
+                "種付せずの繁殖成績（covering が無い）の区分は NotCovered でなければならない。"
+            }
+        } else {
+            require(breedingYear.value == covering.coveringDate.year) {
+                "種付した年の繁殖年は種付日の年と一致しなければならない。"
+            }
+            require(outcome != FoalingOutcome.NotCovered) { "種付した繁殖成績の区分は NotCovered であってはならない。" }
+        }
+    }
 
     /**
      * 分娩結果を報告した新しい [BreedingResult] を返す。
      *
-     * 分娩結果の報告は種付年ごとに一度だけ行えるドメインイベント。既に報告済みの成績への再報告は 不変条件違反として [FoalingAlreadyRecorded]
+     * 分娩結果の報告は繁殖年ごとに一度だけ行えるドメインイベント。既に報告済みの成績（種付せずを含む）への 再報告は不変条件違反として [FoalingAlreadyRecorded]
      * を返し、写像を行わない（元の [BreedingResult] も不変）。 成功時は [outcome] のみ差し替え、[id] を含む他の属性は引き継ぐ。
+     *
+     * 種付せず（[FoalingOutcome.NotCovered]）は種付を伴わない年次成績の区分であり分娩結果ではないため、報告区分 として渡してはならない（生成は
+     * [createUncovered] に限る）。
      *
      * @param outcome 報告する分娩結果
      * @return 報告済みの新しい [BreedingResult]、既に報告済みなら [FoalingAlreadyRecorded]
      */
     fun recordFoaling(outcome: FoalingOutcome): Result<BreedingResult, FoalingAlreadyRecorded> {
+        require(outcome != FoalingOutcome.NotCovered) { "種付せず（NotCovered）は分娩結果として報告できない。" }
         val current = this.outcome
         return if (current != null) {
             Err(FoalingAlreadyRecorded(current))
@@ -91,6 +124,7 @@ private constructor(
         BreedingResult(
             id = id,
             breedingRegistrationId = breedingRegistrationId,
+            breedingYear = breedingYear,
             covering = covering,
             outcome = outcome,
         )
@@ -126,6 +160,7 @@ private constructor(
                         BreedingResult(
                             id = BreedingResultId(generateId()),
                             breedingRegistrationId = broodmareRegistration.id,
+                            breedingYear = Year.of(coveringDate.year),
                             covering =
                                 Covering(
                                     stallionRegistration.registeredHorseId,
@@ -135,6 +170,35 @@ private constructor(
                             outcome = null,
                         )
                     )
+            }
+
+        /**
+         * 繁殖牝馬のその年の「種付せず」（種付しなかった年次成績）を記録し、終端の [BreedingResult] を生成する。
+         *
+         * 種付せずも繁殖牝馬の年次成績であり、対象の繁殖登録のロールが繁殖牝馬であることを前提とする。本ファクトリは その前提を自己検証してから生成する。満たさなければ生成せず
+         * [NotBroodmareForUncovered] を返す。生成物は種付 （[covering]）を持たず、[outcome] は
+         * [FoalingOutcome.NotCovered] で確定する終端レコードであり、分娩結果報告 （[recordFoaling]）の対象にはならない。
+         *
+         * @param broodmareRegistration 種付せずの記録対象の繁殖牝馬の繁殖登録（ロールが繁殖牝馬であること）
+         * @param breedingYear 種付しなかった繁殖年
+         * @return 種付せずを記録した [BreedingResult]、または前提条件違反を表す [NotBroodmareForUncovered]
+         */
+        fun createUncovered(
+            broodmareRegistration: BreedingRegistration,
+            breedingYear: Year,
+        ): Result<BreedingResult, NotBroodmareForUncovered> =
+            if (broodmareRegistration.role != BreedingRole.BROODMARE) {
+                Err(NotBroodmareForUncovered(broodmareRegistration))
+            } else {
+                Ok(
+                    BreedingResult(
+                        id = BreedingResultId(generateId()),
+                        breedingRegistrationId = broodmareRegistration.id,
+                        breedingYear = breedingYear,
+                        covering = null,
+                        outcome = FoalingOutcome.NotCovered,
+                    )
+                )
             }
     }
 }

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/FoalingOutcome.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/FoalingOutcome.kt
@@ -4,15 +4,17 @@ import java.time.LocalDate
 import org.jmolecules.ddd.annotation.ValueObject
 
 /**
- * 分娩結果。種付を行った繁殖牝馬がその年に迎えた帰結を表す。
+ * 年次の繁殖成績区分。繁殖牝馬がその年に迎えた帰結を表す。
  *
- * 「繁殖成績報告書」（様式第14号）が報告する分娩の帰結を sealed なドメイン語彙として表す。生産（産駒あり） の [LiveFoal]
- * と、産駒なしに終わった各区分（様式第14号裏「子馬のない母の繁殖成績」のうち**種付後に生じる もの**）に分かれる。帰結は相互排他であり、`when` の網羅性で漏れを防ぐため sealed
- * interface とする。
+ * 「繁殖成績報告書」（様式第14号）が報告する年次の繁殖成績を sealed なドメイン語彙として表す。生産（産駒あり） の [LiveFoal]
+ * と、産駒なしに終わった各区分（様式第14号裏「子馬のない母の繁殖成績」の8区分）に分かれる。区分は相互排他であり、`when` の網羅性で漏れを防ぐため sealed interface
+ * とする。
  *
- * 「種付せず」（その年に種付しなかった区分）は種付（[Covering]）が存在しない帰結であり、種付を起点とする本モデル
- * の対象外として今回は表現しない（別途モデル化を検討）。妊娠期間・生後日数の閾値（例: 流産と死産の境、生後直死 の判定日数）は様式の OCR
- * が不鮮明なため数値としては保持せず、報告者の区分判断をそのまま受け取る分類として扱う。
+ * 8区分のうち7区分（[NotConceived] / [Abortion] / [TwinAbortion] / [Stillbirth] / [TwinStillbirth] /
+ * [NeonatalDeath] / [TwinNeonatalDeath]）は**種付後に生じる**帰結だが、8区分目の [NotCovered]（種付せず）だけは
+ * 種付（[Covering]）が存在しない年次成績を表す。このため [NotCovered] は [BreedingResult] において covering を 伴わない唯一の区分であり、整合は
+ * [BreedingResult] のファクトリと不変条件が強制する（経緯は ADR-0016）。妊娠期間・ 生後日数の閾値（例: 流産と死産の境、生後直死の判定日数）は様式の OCR
+ * が不鮮明なため数値としては保持せず、報告者の 区分判断をそのまま受け取る分類として扱う。
  */
 sealed interface FoalingOutcome {
     /**
@@ -46,4 +48,12 @@ sealed interface FoalingOutcome {
 
     /** 双子生後直死。双子の生後直死。 */
     @ValueObject data object TwinNeonatalDeath : FoalingOutcome
+
+    /**
+     * 種付せず。その年に種付しなかった（種付が存在しない）年次成績。
+     *
+     * 様式第14号裏「子馬のない母の繁殖成績」の8区分目。他の7区分が種付を起点とするのに対し、本区分は種付 （[Covering]）を伴わない。[BreedingResult]
+     * ではこの区分のみ covering を持たず、生成は専用ファクトリ [BreedingResult.createUncovered] に限る。
+     */
+    @ValueObject data object NotCovered : FoalingOutcome
 }

--- a/src/test/kotlin/com/example/api/application/horseracing/breeding/RecordCoveringUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/horseracing/breeding/RecordCoveringUseCaseTest.kt
@@ -57,10 +57,12 @@ class RecordCoveringUseCaseTest {
                     )
                     .unwrap()
 
+            val covering = result.covering
+            assert(covering != null)
             assert(result.breedingRegistrationId == broodmareRegistration.id)
-            assert(result.covering.stallionId == stallionRegistration.registeredHorseId)
-            assert(result.covering.coveringDate == LocalDate.of(2024, 4, 1))
-            assert(result.covering.certificateNumber.value == "C-2024-0001")
+            assert(covering?.stallionId == stallionRegistration.registeredHorseId)
+            assert(covering?.coveringDate == LocalDate.of(2024, 4, 1))
+            assert(covering?.certificateNumber?.value == "C-2024-0001")
             assert(result.outcome == null)
             verify(exactly = 1) { breedingResultRepository.save(any()) }
         }

--- a/src/test/kotlin/com/example/api/application/horseracing/horse/RegisterFoalUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/horseracing/horse/RegisterFoalUseCaseTest.kt
@@ -222,6 +222,26 @@ class RegisterFoalUseCaseTest {
         }
 
         @Test
+        fun `種付せずの繁殖成績だと PreconditionViolated(NotLiveFoal) を返し永続化されない`() {
+            val w = Wiring()
+            val uncovered =
+                BreedingFixture.uncoveredBreedingResult(
+                    broodmareRegistration = w.breedingRegistration
+                )
+            every { w.breedingResultRepository.findById(uncovered.id) } returns uncovered
+
+            val result = w.useCase()(command(uncovered.id.value))
+
+            assert(
+                result.getError() ==
+                    RegisterFoalUseCaseError.PreconditionViolated(
+                        RegisterFoalError.NotLiveFoal(FoalingOutcome.NotCovered)
+                    )
+            )
+            verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
+        }
+
+        @Test
         fun `委譲先の前提条件違反は PreconditionViolated(RegistrationFailed) に wrap される`() {
             // 父が雌のため registerInStudBook が SireNotMale を返す
             val w = Wiring()

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
@@ -67,7 +67,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 .assertThat()
                 .hasStatus(HttpStatus.CREATED)
                 .bodyJson()
-                .extractingPath("$.covering_year")
+                .extractingPath("$.breeding_year")
                 .isEqualTo(2024)
         }
 

--- a/src/test/kotlin/com/example/api/controller/breeding/FoalingOutcomeWireTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/FoalingOutcomeWireTest.kt
@@ -29,6 +29,8 @@ class FoalingOutcomeWireTest {
                     FoalingOutcomeResponse(FoalingOutcomeDto.NEONATAL_DEATH, null),
                 FoalingOutcome.TwinNeonatalDeath to
                     FoalingOutcomeResponse(FoalingOutcomeDto.TWIN_NEONATAL_DEATH, null),
+                FoalingOutcome.NotCovered to
+                    FoalingOutcomeResponse(FoalingOutcomeDto.NOT_COVERED, null),
             )
 
         cases.forEach { (domain, expected) -> assert(domain.toResponse() == expected) }
@@ -61,5 +63,14 @@ class FoalingOutcomeWireTest {
 
         assert(problem != null)
         assert(problem?.properties?.get("error_code") == "missing-foaling-date")
+    }
+
+    @Test
+    fun `種付せずは分娩結果報告では受け付けず入力不正の ProblemDetail を返すこと`() {
+        val problem =
+            ReportFoalingRequest(FoalingOutcomeDto.NOT_COVERED, null).toOutcome().getError()
+
+        assert(problem != null)
+        assert(problem?.properties?.get("error_code") == "foaling-outcome-not-reportable")
     }
 }

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingFixture.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingFixture.kt
@@ -5,6 +5,7 @@ import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseFixtu
 import com.example.api.domain.horseracing.model.horse.bloodhorse.Sex
 import com.github.michaelbull.result.unwrap
 import java.time.LocalDate
+import java.time.Year
 
 /**
  * テスト用に繁殖コンテキストの集約・値オブジェクトを組み立てる Object Mother。
@@ -46,4 +47,10 @@ object BreedingFixture {
                 certificateNumber,
             )
             .unwrap()
+
+    /** 既定値を持つ、種付せず（種付しなかった年次成績）の [BreedingResult] を生成する。 */
+    fun uncoveredBreedingResult(
+        broodmareRegistration: BreedingRegistration = breedingRegistration(),
+        breedingYear: Year = Year.of(2024),
+    ): BreedingResult = BreedingResult.createUncovered(broodmareRegistration, breedingYear).unwrap()
 }

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultCreateTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultCreateTest.kt
@@ -24,10 +24,12 @@ class BreedingResultCreateTest {
                 )
                 .unwrap()
 
+        val covering = result.covering
+        assert(covering != null)
         assert(result.breedingRegistrationId == broodmareRegistration.id)
-        assert(result.covering.stallionId == stallionRegistration.registeredHorseId)
-        assert(result.covering.coveringDate == coveringDate)
-        assert(result.covering.certificateNumber == certificateNumber)
+        assert(covering?.stallionId == stallionRegistration.registeredHorseId)
+        assert(covering?.coveringDate == coveringDate)
+        assert(covering?.certificateNumber == certificateNumber)
         assert(result.outcome == null)
     }
 

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultCreateUncoveredTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultCreateUncoveredTest.kt
@@ -1,0 +1,30 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import java.time.Year
+import org.junit.jupiter.api.Test
+
+/** [BreedingResult.createUncovered]（種付せず＝種付しなかった年次成績の記録）のユニットテスト */
+class BreedingResultCreateUncoveredTest {
+    @Test
+    fun `繁殖牝馬の登録なら種付を伴わない NotCovered の年次成績が生成されること`() {
+        val broodmareRegistration = BreedingFixture.breedingRegistration()
+
+        val result = BreedingResult.createUncovered(broodmareRegistration, Year.of(2024)).unwrap()
+
+        assert(result.breedingRegistrationId == broodmareRegistration.id)
+        assert(result.breedingYear == Year.of(2024))
+        assert(result.covering == null)
+        assert(result.outcome == FoalingOutcome.NotCovered)
+    }
+
+    @Test
+    fun `登録ロールが繁殖牝馬でないと NotBroodmareForUncovered を返すこと`() {
+        val stallionRegistration = BreedingFixture.stallionRegistration()
+
+        val result = BreedingResult.createUncovered(stallionRegistration, Year.of(2024))
+
+        assert(result.getError() == NotBroodmareForUncovered(stallionRegistration))
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultTest.kt
@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Test
 /** BreedingResult 集約のユニットテスト */
 class BreedingResultTest {
     @Test
-    fun `種付日からその年が種付年として導出されること`() {
+    fun `種付した年の繁殖年は種付日の年と一致すること`() {
         val result = BreedingFixture.breedingResult(coveringDate = LocalDate.of(2024, 4, 1))
 
-        assert(result.coveringYear == Year.of(2024))
+        assert(result.breedingYear == Year.of(2024))
     }
 
     @Test
@@ -52,5 +52,33 @@ class BreedingResultTest {
         val error = reported.recordFoaling(FoalingOutcome.NotConceived).getError()
 
         assert(error == FoalingAlreadyRecorded(first))
+    }
+
+    @Test
+    fun `種付せずの成績は covering を持たず NotCovered で終端すること`() {
+        val result = BreedingFixture.uncoveredBreedingResult(breedingYear = Year.of(2024))
+
+        assert(result.covering == null)
+        assert(result.breedingYear == Year.of(2024))
+        assert(result.outcome == FoalingOutcome.NotCovered)
+    }
+
+    @Test
+    fun `種付せずの成績へ分娩結果を報告すると FoalingAlreadyRecorded を返すこと`() {
+        val result = BreedingFixture.uncoveredBreedingResult()
+
+        val error = result.recordFoaling(FoalingOutcome.NotConceived).getError()
+
+        assert(error == FoalingAlreadyRecorded(FoalingOutcome.NotCovered))
+    }
+
+    @Test
+    fun `NotCovered を分娩結果として報告しようとすると拒否されること`() {
+        val result = BreedingFixture.breedingResult()
+
+        val error =
+            runCatching { result.recordFoaling(FoalingOutcome.NotCovered) }.exceptionOrNull()
+
+        assert(error is IllegalArgumentException)
     }
 }


### PR DESCRIPTION
## 概要

#322 の対応。様式第14号裏「子馬のない母の繁殖成績」8区分のうち未実装だった8区分目「**種付せず**」（その年に種付しなかった年次成績）をモデル化する。

設計は2案を検討し、**案A**（`FoalingOutcome` に `NotCovered` を追加し `covering` を nullable 化）を採用した。経緯・却下案（案B: 別概念として別レコード化）は [ADR-0016](../blob/feat/322-not-covered-breeding-result/docs/adr/0016-not-covered-as-foaling-outcome-variant.md) に記録。

## 変更内容

### ドメイン
- `FoalingOutcome` に区分 `NotCovered` を追加し、語彙の意味を「分娩結果」から「**年次の繁殖成績区分**」へ拡張
- `BreedingResult`:
  - `covering` を nullable 化、繁殖年 `breedingYear: Year` を明示フィールド化（種付せずは種付日から年を導出できないため）
  - covering と区分の整合を**集約の不変条件**で強制（`covering == null` ⇔ `outcome == NotCovered`）
  - 種付せず専用の自己検証ファクトリ `createUncovered`（失敗は単一型 `NotBroodmareForUncovered`）を追加
  - `recordFoaling` は `NotCovered` を分娩結果として受け付けない。`coveringYear` getter は `breedingYear` に統一

### アプリケーション
- `RegisterFoalUseCase`: 種付せず（covering なし）成績からは産駒が生じないため、父解決前にドメインサービスと同じ `NotLiveFoal` 前提条件違反へ短絡。父解決を `resolveSire` に抽出

### アダプター（HTTP 契約）
- `BreedingResultResponse`: 種付関連3項目（`stallionId`/`coveringDate`/`certificateNumber`）を nullable 化、`coveringYear`→`breedingYear`（wire は `covering_year`→`breeding_year`）に rename
- `FoalingOutcomeWire`: `NOT_COVERED` の wire 区分と `toResponse` を追加
- `ReportFoalingRequest`: `:reportFoaling` は分娩結果報告であり `NOT_COVERED` を 400 で拒否

### テスト・ドキュメント
- `createUncovered` / 不変条件 / 種付せず成績からの産駒登録短絡 / wire 往復のテストを追加・更新
- `docs/ubiquitous-language.md`（自動生成カタログ）に `FoalingOutcome.NotCovered` を反映

## スコープ外（フォロー）
- 種付せずを**記録する** application/controller の入口（`createUncovered` ユースケース＋エンドポイント）。本 PR はドメインモデルの表現可能性の確立に絞り、駆動経路は別途整備する。

## 確認
- `./gradlew check`（ktfmt / detekt / test / koverVerifyMature）グリーン

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)
