### PR TITLE
refactor: 父母不在のレスポンスを 422 Unprocessable Entity で確定する (#275)

### DIFF
--- a/.claude/rules/api-design.md
+++ b/.claude/rules/api-design.md
@@ -66,6 +66,7 @@ VO で表す項目（番号・名前など）は素の文字列で DTO に受け
 | リクエストボディ内で参照する別リソースが不在 | **422 Unprocessable Entity** | リクエストは構文的に正しく処理されたが、ボディ内参照先が無く意味的に処理できない | `SireNotFound` / `DamNotFound`（`sire_id` / `dam_id`）、`BreedingRegistrationNotFound` |
 
 - VO 検証エラー（形式不正）は入力不正として **400 Bad Request**、状態の競合（二重登録等）は **409 Conflict** とする。
-- 経緯は [ADR-0018](../../docs/adr/0018-record-uncovered-status-and-422.md)（基準の確立）と [ADR-0021](../../docs/adr/0021-parent-not-found-unprocessable-entity.md)（父母不在への適用）を参照。
+- なお [AIP-193](https://google.aip.dev/193) は参照先/親の不在に `NOT_FOUND`（404）を must とし、その error code 体系に 422 は存在しない。本プロジェクトはエラーのステータス選択を AIP の管轄外とし、RFC 9457 側で 422 を採る（リソース設計は AIP / エラー描画は RFC 9457 の二系統使い分け）。詳細は ADR-0021。
+- 経緯は [ADR-0018](../../docs/adr/0018-record-uncovered-status-and-422.md)（基準の確立）と [ADR-0021](../../docs/adr/0021-parent-not-found-unprocessable-entity.md)（父母不在への適用・AIP との対比）を参照。
 
 > AIP-193 (Errors) はレスポンスボディの形（`google.rpc.Status`）を規定するが、本プロジェクトでは REST 寄りの RFC 9457 を採用する。リソース設計など構造系のみ AIP を適用する。

--- a/.claude/rules/api-design.md
+++ b/.claude/rules/api-design.md
@@ -56,4 +56,16 @@ VO で表す項目（番号・名前など）は素の文字列で DTO に受け
 - 業務エラー固有の追加情報は拡張プロパティで保持する（例: `error_code` / `existing_id` 等。拡張キーは snake_case。前述「命名規約」を参照）
 - `type` は当面 `urn:problem-type:{kebab-case-code}` 形式を用い、HTTP で公開する Resolvable URI ができたら差し替える
 
+### リソース不在のステータス（404 vs 422）
+
+参照先リソースが存在しない場合のステータスは、その参照が **URL パスにあるかリクエストボディにあるか** で一貫して切り分ける。
+
+| 参照の位置 | ステータス | 根拠 | 例 |
+|---|---|---|---|
+| URL パス上の操作対象が不在 | **404 Not Found** | パスで識別される対象そのものが無い | `/api/bloodHorses/{id}:registerName` の対象馬不在（`HorseNotFound`）、`BreedingResultNotFound` |
+| リクエストボディ内で参照する別リソースが不在 | **422 Unprocessable Entity** | リクエストは構文的に正しく処理されたが、ボディ内参照先が無く意味的に処理できない | `SireNotFound` / `DamNotFound`（`sire_id` / `dam_id`）、`BreedingRegistrationNotFound` |
+
+- VO 検証エラー（形式不正）は入力不正として **400 Bad Request**、状態の競合（二重登録等）は **409 Conflict** とする。
+- 経緯は [ADR-0018](../../docs/adr/0018-record-uncovered-status-and-422.md)（基準の確立）と [ADR-0021](../../docs/adr/0021-parent-not-found-unprocessable-entity.md)（父母不在への適用）を参照。
+
 > AIP-193 (Errors) はレスポンスボディの形（`google.rpc.Status`）を規定するが、本プロジェクトでは REST 寄りの RFC 9457 を採用する。リソース設計など構造系のみ AIP を適用する。

--- a/docs/adr/0021-parent-not-found-unprocessable-entity.md
+++ b/docs/adr/0021-parent-not-found-unprocessable-entity.md
@@ -34,6 +34,15 @@ ADR-0018 で確立した判断軸をそのまま踏襲する。
 
 「父というリソースが存在しない」という見方から 404 を採る余地はあるが、それを採ると ADR-0018 で確立した「ボディ内参照の不在＝422」と矛盾し、`BreedingRegistrationNotFound`（422）との一貫性も崩れる。リソース参照の不在に対するステータスは、参照が URL パスにあるかボディにあるかで一貫して切り分ける方が、横断的に判断がぶれない。
 
+### AIP との対比（AIP は 404 を MUST とするが採らない）
+
+本プロジェクトのリソース設計は [Google AIP](https://google.aip.dev/) 準拠（[api-design.md](../../.claude/rules/api-design.md)）だが、エラーステータスの選択については AIP に**従わない**。
+
+- [AIP-193 (Errors)](https://google.aip.dev/193) は「権限はあるが要求された resource または parent が存在しない場合は `NOT_FOUND`（HTTP 404）を返さなければならない（must）」と規定する。AIP のエラーモデルは gRPC の canonical error codes（`google.rpc.Code`）であり、**HTTP 422 にマップされるコードがそもそも存在しない**（参照先不在は一律 `NOT_FOUND` → 404、前提条件違反は `FAILED_PRECONDITION` → 400）。
+- したがって AIP に厳密に従えば、本ケースは 404（ないし 400）であって 422 ではない。
+
+それでも 422 を採るのは、本プロジェクトが**エラーのレスポンス形・ステータス選択を AIP の管轄外と切り分けている**ためである。`api-design.md` の注記どおり「AIP-193 はレスポンスボディの形（`google.rpc.Status`）を規定するが、本プロジェクトでは REST 寄りの RFC 9457 を採用し、リソース設計など構造系のみ AIP を適用する」。422（RFC 9457 / RFC 4918 由来の「構文は正しいが意味的に処理できない」）は AIP のコード体系には無いが、REST API では広く使われる。リソース設計（URL・命名・単一表現）は AIP に、エラー描画は RFC 9457 に従う、という**二系統の使い分けを明示的に選択している**。
+
 ## 影響
 
 - `RegisterInStudBookUseCaseError.SireNotFound` / `DamNotFound`、`RegisterFoalUseCase` の同等バリアントは 422 にマッピングする（既存実装どおり。挙動の変更はない）。

--- a/docs/adr/0021-parent-not-found-unprocessable-entity.md
+++ b/docs/adr/0021-parent-not-found-unprocessable-entity.md
@@ -1,0 +1,42 @@
+# ADR-0021: 父母不在（sire/dam 参照先不在）を 422 Unprocessable Entity で確定する
+
+- ステータス: Accepted
+- 日付: 2026-06-23
+- 関連: Issue #275, ADR-0018, ADR-0017, ADR-0016
+
+## コンテキスト
+
+軽種馬（`BloodHorse`）を血統登録（内国産馬登録 `RegisterInStudBookUseCase` / 生産産駒登録 `RegisterFoalUseCase`）する際、リクエストボディで指定された父（`sire_id`）・母（`dam_id`）が `BloodHorseRepository` に存在しない場合がある。このとき返す HTTP ステータスを 422 とするか 404 とするかが未確定のまま、実装は暫定的に 422 を返していた（`SireNotFound` / `DamNotFound` → `422 Unprocessable Entity`）。
+
+この「未確定」を解消し、判断の所在を明示するのが本 ADR の目的である。
+
+なお、この論点は ADR-0018（「種付せず」記録における繁殖登録の参照先不在を 422 とする）で確立した一般原則の、別ユースケースへの適用にあたる。父母 ID もまた「URL パスのリソース識別子」ではなく「リクエストボディ内の他リソースへの参照」であり、同じ判断軸が適用できる。
+
+## 決定
+
+父母の参照先不在は **422 Unprocessable Entity** で確定する。
+
+- リクエストボディの `sire_id` が指す軽種馬が存在しない場合は `422`（`sire-not-found`、拡張プロパティ `sire_id`）
+- リクエストボディの `dam_id` が指す軽種馬が存在しない場合は `422`（`dam-not-found`、拡張プロパティ `dam_id`）
+
+これに伴い、404 と 422 の判断基準を `.claude/rules/api-design.md`（エラーレスポンス節）に昇格して明文化する。
+
+## 理由
+
+ADR-0018 で確立した判断軸をそのまま踏襲する。
+
+- **URL パス上のリソース不在は 404 Not Found**: `/api/bloodHorses/{id}:registerName` のように URL パスで識別される操作対象が存在しない場合は 404 が自然（例: `HorseNotFound`、`BreedingResultNotFound`）。
+- **リクエストボディ内の参照先不在は 422 Unprocessable Entity**: リクエストは構文的に正しくサーバーに到達して処理されたが、ボディ内で参照する別リソースが見つからず意味的に処理できない場合は 422 が適切（例: `BreedingRegistrationNotFound`、本 ADR の `SireNotFound` / `DamNotFound`）。
+
+父母 ID は登録対象の `BloodHorse` を識別するパス要素ではなく、ボディ内で参照する協力リソースである。したがって 422 が判断軸に合致する。
+
+### 404 を採らなかった理由
+
+「父というリソースが存在しない」という見方から 404 を採る余地はあるが、それを採ると ADR-0018 で確立した「ボディ内参照の不在＝422」と矛盾し、`BreedingRegistrationNotFound`（422）との一貫性も崩れる。リソース参照の不在に対するステータスは、参照が URL パスにあるかボディにあるかで一貫して切り分ける方が、横断的に判断がぶれない。
+
+## 影響
+
+- `RegisterInStudBookUseCaseError.SireNotFound` / `DamNotFound`、`RegisterFoalUseCase` の同等バリアントは 422 にマッピングする（既存実装どおり。挙動の変更はない）。
+- `.claude/rules/api-design.md` のエラーレスポンス節に「404 vs 422 の判断基準」表を追記し、常時参照のルールとして昇格する。
+- `BloodHorseResponse.kt` の `toProblemDetail()` の doc コメントに本 ADR を参照させる。
+- 今後リクエストボディ内で他リソースを参照するユースケースは、ADR-0018 / 本 ADR の方針（ボディ内参照の不在＝422）に従う。

--- a/src/main/kotlin/com/example/api/controller/horse/BloodHorseResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/BloodHorseResponse.kt
@@ -64,7 +64,8 @@ fun BloodHorse.toResponse(): BloodHorseResponse =
  * [RegisterInStudBookUseCaseError] を RFC 9457 (`application/problem+json`) の [ProblemDetail] に変換する。
  *
  * - VO 検証エラーは入力不正として 400 Bad Request
- * - 父母の不在・ドメイン前提条件違反は、整った入力だが意味的に処理できないため 422 Unprocessable Entity
+ * - 父母の不在（ボディ内 sire_id / dam_id の参照先不在）・ドメイン前提条件違反は、整った入力だが意味的に 処理できないため 422 Unprocessable
+ *   Entity（判断基準は ADR-0018 / ADR-0021、api-design.md「404 vs 422」）
  */
 fun RegisterInStudBookUseCaseError.toProblemDetail(): ProblemDetail =
     when (this) {


### PR DESCRIPTION
## 概要

軽種馬の血統登録で、指定された父(`sire_id`)・母(`dam_id`)の参照先が存在しない場合のレスポンスステータスを **422 Unprocessable Entity** で確定します。Closes #275。

実装は従来から `SireNotFound` / `DamNotFound` を 422 にマッピングしており、**挙動の変更はありません**。issue の論点は「422 か 404 か未確定・未文書化」だったため、これを**決定して文書化**するのが本 PR の主旨です。

## 決定と判断軸

判断軸は ADR-0018 で既に確立済みの基準をそのまま踏襲します。

| 参照の位置 | ステータス | 例 |
|---|---|---|
| URL パス上の操作対象が不在 | 404 Not Found | `HorseNotFound`, `BreedingResultNotFound` |
| リクエストボディ内で参照する別リソースが不在 | **422 Unprocessable Entity** | `SireNotFound`/`DamNotFound`, `BreedingRegistrationNotFound` |

`sire_id`/`dam_id` は登録対象を識別するパス要素ではなく、ボディ内で参照する協力リソースなので 422 が適合します。404 を採ると ADR-0018 / `BreedingRegistrationNotFound`(422) と矛盾するため採りません。

## 変更点

- **docs/adr/0021-parent-not-found-unprocessable-entity.md**: 父母不在を 422 で確定する ADR を追加（ADR-0018 を踏襲）
- **.claude/rules/api-design.md**: エラーレスポンス節に「404 vs 422」の判断基準表を追記し、常時参照ルールへ昇格
- **BloodHorseResponse.kt**: `toProblemDetail` の doc コメントに判断根拠と ADR 参照を補強（コメントのみ）

## 確認

- `./gradlew check` 通過（既存の「SireNotFound で 422」テストはそのまま green）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
