### PR TITLE
refactor: RegisterJockeyResponse を単一リソース DTO JockeyResponse へ寄せる (#361)

### DIFF
--- a/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
@@ -41,7 +41,7 @@ class JockeyController(
                     content =
                         [
                             Content(
-                                schema = Schema(implementation = RegisterJockeyResponse::class),
+                                schema = Schema(implementation = JockeyResponse::class),
                                 mediaType = MediaType.APPLICATION_JSON_VALUE,
                             )
                         ],
@@ -72,13 +72,9 @@ class JockeyController(
     )
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/jockeys")
-    fun register(@RequestBody request: RegisterJockeyRequest): RegisterJockeyResponse {
+    fun register(@RequestBody request: RegisterJockeyRequest): JockeyResponse {
         val command = Command.now(RegisterJockeyCommand(request.firstName, request.lastName), clock)
         val jockey = registerJockey(command).mapError { it.toProblemDetail() }.orThrowProblem()
-        return RegisterJockeyResponse(
-            id = jockey.id.value,
-            firstName = jockey.firstName,
-            lastName = jockey.lastName,
-        )
+        return jockey.toResponse()
     }
 }

--- a/src/main/kotlin/com/example/api/controller/jockey/JockeyProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/JockeyProblem.kt
@@ -3,18 +3,8 @@ package com.example.api.controller.jockey
 import com.example.api.application.horseracing.jockey.JockeyRegistrationError
 import com.example.api.controller.problem
 import com.example.api.domain.horseracing.model.jockey.JockeyValidationError
-import java.util.UUID
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
-
-/**
- * `POST /api/jockeys` の成功レスポンスボディ。
- *
- * @property id 登録された [com.example.api.domain.horseracing.model.jockey.JockeyId] の生 UUID
- * @property firstName 名
- * @property lastName 姓
- */
-data class RegisterJockeyResponse(val id: UUID, val firstName: String, val lastName: String)
 
 /**
  * [JockeyRegistrationError] を RFC 9457 (`application/problem+json`) 形式の [ProblemDetail] に 変換する。

--- a/src/main/kotlin/com/example/api/controller/jockey/JockeyResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/JockeyResponse.kt
@@ -1,0 +1,20 @@
+package com.example.api.controller.jockey
+
+import com.example.api.domain.horseracing.model.jockey.Jockey
+import java.util.UUID
+
+/**
+ * ジョッキーリソースの表現（HTTP 契約）。
+ *
+ * ジョッキーリソースに対する操作（登録の Create など）は、[AIP-133](https://google.aip.dev/133) /
+ * [AIP-136](https://google.aip.dev/136) に倣い一律でこのリソース表現全体を返す（ADR-0008）。
+ *
+ * @property id ジョッキーの生 UUID
+ * @property firstName 名
+ * @property lastName 姓
+ */
+data class JockeyResponse(val id: UUID, val firstName: String, val lastName: String)
+
+/** [Jockey] をジョッキーリソースの表現へ変換する。各操作の成功レスポンスはこのリソース表現を一律で返す。 */
+fun Jockey.toResponse(): JockeyResponse =
+    JockeyResponse(id = id.value, firstName = firstName, lastName = lastName)

--- a/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
@@ -38,16 +38,20 @@ class JockeyControllerTest(val mockMvc: MockMvc) {
             val savedJockey = Jockey.create("武", "豊").unwrap()
             every { registerJockey(any<Command<RegisterJockeyCommand>>()) } returns Ok(savedJockey)
 
-            tester
-                .post()
-                .uri("/api/jockeys")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"first_name":"武","last_name":"豊"}""")
-                .assertThat()
-                .hasStatus(HttpStatus.CREATED)
-                .bodyJson()
-                .extractingPath("$.first_name")
-                .isEqualTo("武")
+            val response =
+                tester
+                    .post()
+                    .uri("/api/jockeys")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"first_name":"武","last_name":"豊"}""")
+                    .assertThat()
+                    .hasStatus(HttpStatus.CREATED)
+                    .bodyJson()
+
+            // リソース表現（JockeyResponse）の全項目が返ること（ADR-0008）
+            response.extractingPath("$.id").isEqualTo(savedJockey.id.value.toString())
+            response.extractingPath("$.first_name").isEqualTo("武")
+            response.extractingPath("$.last_name").isEqualTo("豊")
         }
     }
 


### PR DESCRIPTION
## 概要

ADR-0008（REST リソース操作の成功レスポンスは一律でリソース表現を返す）を jockey リソースへ適用する。`JockeyController.register` が操作別の部分レスポンス `RegisterJockeyResponse` を返していた未追従箇所を、リソース名ベースの単一 DTO `JockeyResponse` へ寄せる（軽種馬リソースの `BloodHorseResponse` と同じ形）。

closes #361

## 変更内容

- **`controller/jockey/JockeyResponse.kt`（新規）**: リソース表現 DTO（`id` / `firstName` / `lastName`）と `Jockey.toResponse()` マッパーを新設
- **`controller/jockey/JockeyController.kt`**: `register` の戻り値・OpenAPI `@Schema(implementation = ...)` を `JockeyResponse` に変更し、`jockey.toResponse()` で返す
- **`RegisterJockeyResponse.kt` → `JockeyProblem.kt`（リネーム）**: 部分レスポンス DTO を削除し、同居していた problem マッパー（`JockeyRegistrationError` / `JockeyValidationError` の `toProblemDetail()`）を別ファイルへ退避
- **`JockeyControllerTest`**: 成功ケースでリソース表現の全項目（`id` / `first_name` / `last_name`）を検証するよう強化

## 補足

- jockey に未設定属性は現状ないため、全項目 non-null のまま（ADR-0008 の nullable 化は将来カスタムメソッドが増えたとき）。
- 本 PR は ADR-0008 の適用であり新規の設計判断は伴わないため ADR は追加しない。
- `GlobalExceptionHandlerTest`（jockey 経路を踏み台）は package-level の `toProblemDetail()` 参照で影響なし。
- `./gradlew check` 緑を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
