### PR TITLE
test: BloodHorseControllerTest の validBody を DTO シリアライズ由来にする (#274)

### DIFF
--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -19,6 +19,7 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.unwrap
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
+import java.time.LocalDate
 import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -30,34 +31,39 @@ import org.springframework.test.context.TestConstructor
 import org.springframework.test.context.TestConstructor.AutowireMode
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
+import tools.jackson.databind.json.JsonMapper
 
 @WebMvcTest(BloodHorseController::class)
 @Import(ClockConfiguration::class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
-class BloodHorseControllerTest(val mockMvc: MockMvc) {
+class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper) {
     @MockkBean private lateinit var registerInStudBook: RegisterInStudBookUseCase
     @MockkBean private lateinit var registerImportedHorse: RegisterImportedHorseUseCase
     @MockkBean private lateinit var nameHorse: NameHorseUseCase
 
     private val tester = MockMvcTester.create(mockMvc)
 
-    /** デシリアライズに通る正しいリクエストボディ。ユースケースはモックのため中身の整合は問われない。 */
+    /**
+     * デシリアライズに通る正しいリクエストボディ。ユースケースはモックのため中身の整合は問われない。
+     *
+     * 手書き JSON リテラルではなく [RegisterBloodHorseRequest] を実アプリと同じ [jsonMapper] でシリアライズして組み立てる。 DTO
+     * のフィールドが変わればボディも追従し、契約とテストの二重管理を避ける。`sireId` は SireNotFound ケースの アサーションと揃えてある。
+     */
     private val validBody =
-        """
-        {
-            "sire_id": "11111111-1111-1111-1111-111111111111",
-            "dam_id": "22222222-2222-2222-2222-222222222222",
-            "sex": "MALE",
-            "coat_color": "BAY",
-            "breed_type": "THOROUGHBRED",
-            "date_of_birth": "2023-03-15",
-            "breeder": "ノーザンファーム",
-            "microchip_number": "392140000000001",
-            "dna_parentage": "CONSISTENT",
-            "registration_number": "2023104567"
-        }
-        """
-            .trimIndent()
+        jsonMapper.writeValueAsString(
+            RegisterBloodHorseRequest(
+                sireId = UUID.fromString("11111111-1111-1111-1111-111111111111"),
+                damId = UUID.fromString("22222222-2222-2222-2222-222222222222"),
+                sex = SexDto.MALE,
+                coatColor = CoatColorDto.BAY,
+                breedType = BreedTypeDto.THOROUGHBRED,
+                dateOfBirth = LocalDate.of(2023, 3, 15),
+                breeder = "ノーザンファーム",
+                microchipNumber = "392140000000001",
+                dnaParentage = DnaParentageResultDto.CONSISTENT,
+                registrationNumber = "2023104567",
+            )
+        )
 
     @Nested
     inner class SuccessCase {
@@ -228,22 +234,21 @@ class BloodHorseControllerTest(val mockMvc: MockMvc) {
     inner class RegisterImportedCase {
         private val uri = "/api/bloodHorses:registerImported"
 
-        /** 父母 ID・DNA を持たず、原産国・揚陸日を持つ輸入馬のリクエストボディ。 */
+        /** 父母 ID・DNA を持たず、原産国・揚陸日を持つ輸入馬のリクエストボディ。実アプリと同じ [jsonMapper] で DTO をシリアライズして組み立てる。 */
         private val validBody =
-            """
-            {
-                "sex": "MALE",
-                "coat_color": "BAY",
-                "breed_type": "THOROUGHBRED",
-                "date_of_birth": "2020-04-10",
-                "breeder": "Coolmore",
-                "microchip_number": "392140000000002",
-                "origin_country": "アイルランド",
-                "landing_date": "2024-09-01",
-                "registration_number": "2020900001"
-            }
-            """
-                .trimIndent()
+            jsonMapper.writeValueAsString(
+                RegisterImportedHorseRequest(
+                    sex = SexDto.MALE,
+                    coatColor = CoatColorDto.BAY,
+                    breedType = BreedTypeDto.THOROUGHBRED,
+                    dateOfBirth = LocalDate.of(2020, 4, 10),
+                    breeder = "Coolmore",
+                    microchipNumber = "392140000000002",
+                    originCountry = "アイルランド",
+                    landingDate = LocalDate.of(2024, 9, 1),
+                    registrationNumber = "2020900001",
+                )
+            )
 
         @Test
         fun `正常な入力で 201 Created と父母不明の登録結果が返ること`() {


### PR DESCRIPTION
## 概要

`BloodHorseControllerTest` の `validBody`（手書き JSON リテラル）を DTO シリアライズ由来にして、契約とテストの二重管理を解消する。Closes #274。

## 背景

`RegisterBloodHorseRequest` のフィールドを変更すると、テスト側の手書き JSON リテラルが静かにずれる（/code-review 指摘 #10）。リクエストボディを DTO インスタンスのシリアライズで組み立てれば、DTO 変更にボディが追従する。

## 変更内容

- 内国産（`RegisterBloodHorseRequest`）と輸入馬（`RegisterImportedHorseRequest`）の 2 箇所の `validBody` を、実アプリと同じ JSON マッパーでのシリアライズに置き換え。
  - 同一マッパーを使うことで `application.yml` の `SNAKE_CASE` 戦略も含めて実契約と一致する。
- Boot 4.1 / Jackson 3 に合わせ、注入する bean は `tools.jackson.databind.json.JsonMapper`。
- `sireId` の値は `SireNotFound` ケースのアサーションと揃えて維持。

## 確認

- `./gradlew test --tests "BloodHorseControllerTest"` → 10 件すべて成功
- `./gradlew check` → BUILD SUCCESSFUL（ktfmt / detekt / Kover ゲート含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)