### PR TITLE
feat: 種付せず記録にも種付年の一意性ガードを対称適用する (#399)

### DIFF
--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -177,6 +177,7 @@ graph LR
 | JockeyRepository | リポジトリポート | domain.horseracing.model.jockey |
 | confirmRaceResult | ドメインサービス | domain.horseracing.service.race |
 | recordCovering | ドメインサービス | domain.horseracing.service.breeding |
+| recordUncovered | ドメインサービス | domain.horseracing.service.breeding |
 | registerFoal | ドメインサービス | domain.horseracing.service.horse |
 
 ### sakamichi

--- a/src/main/kotlin/com/example/api/application/horseracing/breeding/RecordUncoveredUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/horseracing/breeding/RecordUncoveredUseCase.kt
@@ -4,7 +4,8 @@ import com.example.api.domain.horseracing.model.breeding.BreedingRegistrationId
 import com.example.api.domain.horseracing.model.breeding.BreedingRegistrationRepository
 import com.example.api.domain.horseracing.model.breeding.BreedingResult
 import com.example.api.domain.horseracing.model.breeding.BreedingResultRepository
-import com.example.api.domain.horseracing.model.breeding.NotBroodmareForUncovered
+import com.example.api.domain.horseracing.model.breeding.RecordUncoveredError
+import com.example.api.domain.horseracing.service.breeding.recordUncovered
 import com.example.api.domain.shared.Command
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
@@ -32,20 +33,20 @@ sealed interface RecordUncoveredUseCaseError {
         RecordUncoveredUseCaseError
 
     /**
-     * 生成ファクトリ [BreedingResult.createUncovered] の前提条件違反を application 層エラーに wrap したもの。
+     * ドメインサービス recordUncovered の前提条件違反を application 層エラーに wrap したもの。
      *
-     * 種付せずの記録は対象の登録ロールが繁殖牝馬であることを前提とする（[NotBroodmareForUncovered]）。
+     * 個別バリアント（登録ロールが繁殖牝馬でない・同一繁殖年の重複）は [RecordUncoveredError] を参照する。
      */
-    data class PreconditionViolated(val cause: NotBroodmareForUncovered) :
-        RecordUncoveredUseCaseError
+    data class PreconditionViolated(val cause: RecordUncoveredError) : RecordUncoveredUseCaseError
 }
 
 /**
  * 種付せず（種付しなかった年次成績）記録ユースケース。
  *
- * 対象の繁殖牝馬の繁殖登録を Repository で引き当て、生成ファクトリ [BreedingResult.createUncovered] で前提条件
- * （登録ロールが繁殖牝馬であること）を検証してから、その年の終端の繁殖成績（[BreedingResult]）を永続化する。
- * 種付記録（[RecordCoveringUseCase]）と対称だが、配合相手の種牡馬は伴わない。Controller 層は本クラスのみに依存し、 ドメインの生成経路の詳細は知らない。
+ * 対象の繁殖牝馬の繁殖登録を Repository で引き当て、ドメインサービス recordUncovered を呼ぶ。サービスは前提条件 （登録ロールが繁殖牝馬であること・「繁殖牝馬 ×
+ * 繁殖年」で一意であること）を検証してから、その年の終端の繁殖成績 （[BreedingResult]）を起こす。一意性の判定に要する同年の既存成績の引き当てはサービスが繁殖成績ポートを介して
+ * 行うため、本ユースケースは生成された成績を永続化するだけでよい。種付記録（[RecordCoveringUseCase]）と対称だが、 配合相手の種牡馬は伴わない。Controller
+ * 層は本クラスのみに依存し、ドメインの生成経路の詳細は知らない。
  *
  * @return 起こされた種付せずの [BreedingResult]、または業務ルール違反を表す [RecordUncoveredUseCaseError]
  */
@@ -70,7 +71,7 @@ class RecordUncoveredUseCase(
                 .bind()
 
         val breedingResult =
-            BreedingResult.createUncovered(broodmareRegistration, input.breedingYear)
+            recordUncovered(broodmareRegistration, input.breedingYear, breedingResultRepository)
                 .mapError { RecordUncoveredUseCaseError.PreconditionViolated(it) }
                 .bind()
 

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
@@ -6,6 +6,7 @@ import com.example.api.application.horseracing.breeding.ReportFoalingUseCaseErro
 import com.example.api.controller.problem
 import com.example.api.domain.horseracing.model.breeding.BreedingResult
 import com.example.api.domain.horseracing.model.breeding.RecordCoveringError
+import com.example.api.domain.horseracing.model.breeding.RecordUncoveredError
 import java.time.LocalDate
 import java.util.UUID
 import org.springframework.http.HttpStatus
@@ -116,8 +117,9 @@ private fun RecordCoveringError.toProblemDetail(): ProblemDetail =
 /**
  * [RecordUncoveredUseCaseError] を RFC 9457 (`application/problem+json`) の [ProblemDetail] に変換する。
  *
- * 種付記録（[RecordCoveringUseCaseError]）と対称に、繁殖登録の不在・前提条件違反はいずれも整った入力だが意味的に 処理できないため 422 Unprocessable
- * Entity とする。種付せずは配合相手を伴わないため、前提条件違反は登録ロールが 繁殖牝馬でない（not-broodmare）の1種類のみ。
+ * 種付記録（[RecordCoveringUseCaseError]）と対称に、繁殖登録の不在・前提条件違反（登録ロール）はいずれも整った 入力だが意味的に処理できないため 422
+ * Unprocessable Entity、同一繁殖年の重複記録は状態の競合として 409 Conflict
+ * とする。種付せずは配合相手を伴わないため、登録ロールの前提条件違反は繁殖牝馬でない（not-broodmare）の1種類のみ。
  */
 fun RecordUncoveredUseCaseError.toProblemDetail(): ProblemDetail =
     when (this) {
@@ -129,13 +131,29 @@ fun RecordUncoveredUseCaseError.toProblemDetail(): ProblemDetail =
                     detail = "種付せずの記録対象として指定された繁殖登録が存在しません。",
                 )
                 .apply { setProperty("breeding_registration_id", breedingRegistrationId) }
-        is RecordUncoveredUseCaseError.PreconditionViolated ->
+        is RecordUncoveredUseCaseError.PreconditionViolated -> cause.toProblemDetail()
+    }
+
+private fun RecordUncoveredError.toProblemDetail(): ProblemDetail =
+    when (this) {
+        RecordUncoveredError.NotBroodmare ->
             problem(
                 status = HttpStatus.UNPROCESSABLE_ENTITY,
                 code = "not-broodmare",
                 title = "Registration is not a broodmare",
                 detail = "種付せずの記録対象として指定された繁殖登録のロールが繁殖牝馬ではありません。",
             )
+        is RecordUncoveredError.AlreadyRecordedForYear ->
+            problem(
+                    status = HttpStatus.CONFLICT,
+                    code = "breeding-result-already-recorded-for-year",
+                    title = "Breeding result already recorded for the year",
+                    detail = "この繁殖牝馬には指定された繁殖年の繁殖成績が既に記録されています。",
+                )
+                .apply {
+                    setProperty("breeding_year", year.value)
+                    setProperty("existing_breeding_result_id", existingBreedingResultId.value)
+                }
     }
 
 /**

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResult.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResult.kt
@@ -55,13 +55,32 @@ sealed interface RecordCoveringError {
 }
 
 /**
- * 種付せず（年次成績）の記録（[BreedingResult.createUncovered]）の前提条件違反。
+ * 種付せず（年次成績）記録（ドメインサービス recordUncovered）の前提条件違反。
  *
- * 種付せずも繁殖牝馬の年次成績であり、対象の繁殖登録のロールが繁殖牝馬であることを前提とする。失敗のしかたは この1種類のみのため単一型とする（種付記録と異なり配合相手の検証はない）。
- *
- * @property registration 種付せずの記録対象として渡された繁殖登録
+ * 種付せずも繁殖牝馬の年次成績であり、前提は2系統ある。(1) 対象の繁殖登録のロールが繁殖牝馬であること ＝単一インスタンスの構築時不変条件で、ファクトリ
+ * [BreedingResult.createUncovered] が検証する（[NotBroodmare]）。 (2)「繁殖牝馬 × 繁殖年」で 一意
+ * （同一年への重複記録の禁止。種付した年・種付せずの年を問わない）という集合制約で、既存成績群をまたぐため ドメインサービス recordUncovered が検証する
+ * （[AlreadyRecordedForYear]）。種付記録の [RecordCoveringError] と対称に、 共通の語彙として 1 つの sealed にまとめ、Controller
+ * 境界で一括して problem へ写す。
  */
-data class NotBroodmareForUncovered(val registration: BreedingRegistration)
+sealed interface RecordUncoveredError {
+    /** 種付せずの記録対象の繁殖登録のロールが繁殖牝馬（BROODMARE）でない。ファクトリ [BreedingResult.createUncovered] が検証する。 */
+    data object NotBroodmare : RecordUncoveredError
+
+    /**
+     * 同一繁殖牝馬・同一繁殖年に既に年次の繁殖成績が存在する（種付した年・種付せずの年を問わない）。
+     *
+     * 繁殖成績は「繁殖牝馬 × 繁殖年」で一意であり、同一年への重複記録は不変条件違反。これは単一インスタンスの構築では 完結しない集合制約のため、ドメインサービス
+     * recordUncovered が検証する。既存レコードの引き当て（coordination）は アプリケーション層が行い、その結果をサービスへ渡す。
+     *
+     * @property year 重複した繁殖年
+     * @property existingBreedingResultId 既に存在する同年の繁殖成績のID
+     */
+    data class AlreadyRecordedForYear(
+        val year: Year,
+        val existingBreedingResultId: BreedingResultId,
+    ) : RecordUncoveredError
+}
 
 /**
  * 繁殖成績を表す集約ルート。繁殖年ごとの年次レコード。
@@ -196,19 +215,23 @@ private constructor(
          * 繁殖牝馬のその年の「種付せず」（種付しなかった年次成績）を記録し、終端の [BreedingResult] を生成する。
          *
          * 種付せずも繁殖牝馬の年次成績であり、対象の繁殖登録のロールが繁殖牝馬であることを前提とする。本ファクトリは その前提を自己検証してから生成する。満たさなければ生成せず
-         * [NotBroodmareForUncovered] を返す。生成物は種付 （[covering]）を持たず、[outcome] は
+         * [RecordUncoveredError.NotBroodmare] を返す。生成物は種付 （[covering]）を持たず、[outcome] は
          * [FoalingOutcome.NotCovered] で確定する終端レコードであり、分娩結果報告 （[recordFoaling]）の対象にはならない。
+         *
+         * 本ファクトリが守るのは「単一の繁殖成績インスタンスの構築時不変条件」（登録ロール）に限る。「繁殖牝馬 × 繁殖年」で
+         * 一意という集合制約（同一年の重複記録の禁止）は単一インスタンスの構築では完結しないため、既存成績群をまたぐ ドメインサービス recordUncovered
+         * が担い、本ファクトリはその検証を経た上で呼び出される（種付記録の [create] と対称）。
          *
          * @param broodmareRegistration 種付せずの記録対象の繁殖牝馬の繁殖登録（ロールが繁殖牝馬であること）
          * @param breedingYear 種付しなかった繁殖年
-         * @return 種付せずを記録した [BreedingResult]、または前提条件違反を表す [NotBroodmareForUncovered]
+         * @return 種付せずを記録した [BreedingResult]、または登録ロールの前提条件違反を表す [RecordUncoveredError.NotBroodmare]
          */
         fun createUncovered(
             broodmareRegistration: BreedingRegistration,
             breedingYear: Year,
-        ): Result<BreedingResult, NotBroodmareForUncovered> =
+        ): Result<BreedingResult, RecordUncoveredError> =
             if (broodmareRegistration.role != BreedingRole.BROODMARE) {
-                Err(NotBroodmareForUncovered(broodmareRegistration))
+                Err(RecordUncoveredError.NotBroodmare)
             } else {
                 Ok(
                     BreedingResult(

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultRepository.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultRepository.kt
@@ -16,7 +16,7 @@ interface BreedingResultRepository {
     /**
      * 同一繁殖牝馬（繁殖登録）・同一繁殖年の既存の年次成績を検索する。存在しなければ null。
      *
-     * 繁殖成績は「繁殖牝馬 × 繁殖年」で一意であり、種付記録の重複（同一年の二重記録）検出に用いる。
+     * 繁殖成績は「繁殖牝馬 × 繁殖年」で一意であり、種付記録・種付せず記録の重複（同一年の二重記録）検出に用いる。
      */
     fun findByBreedingRegistrationIdAndBreedingYear(
         breedingRegistrationId: BreedingRegistrationId,

--- a/src/main/kotlin/com/example/api/domain/horseracing/service/breeding/RecordUncovered.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/service/breeding/RecordUncovered.kt
@@ -1,0 +1,46 @@
+package com.example.api.domain.horseracing.service.breeding
+
+import com.example.api.domain.horseracing.model.breeding.BreedingRegistration
+import com.example.api.domain.horseracing.model.breeding.BreedingResult
+import com.example.api.domain.horseracing.model.breeding.BreedingResultRepository
+import com.example.api.domain.horseracing.model.breeding.RecordUncoveredError
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Result
+import java.time.Year
+
+/**
+ * 種付せず（種付しなかった年次成績）を記録し、繁殖成績の終端レコード（[BreedingResult]）を起こすドメインサービス。
+ *
+ * 種付記録（[recordCovering]）と対称で、前提条件は2系統あり性質が異なるため担い手を分ける:
+ * - **登録ロール（繁殖牝馬）** … 単一の繁殖成績インスタンスの構築時不変条件。委譲先のファクトリ [BreedingResult.createUncovered]
+ *   が自己検証する（[RecordUncoveredError.NotBroodmare]）。
+ * - **「繁殖牝馬 × 繁殖年」で一意（同一年への重複記録の禁止）** … 既存成績群（集合）をまたぐ集合制約で、単一インスタンスの 構築では完結しない。本サービスが
+ *   [breedingResultRepository] から同年の既存成績を引き当てて検証する （[RecordUncoveredError.AlreadyRecordedForYear]）。
+ *
+ * 繁殖成績の一意性は「種付した年・種付せずの年を問わず繁殖牝馬 × 繁殖年で年次レコード1件」であるため、種付せず側も 種付記録と同じ
+ * [BreedingResultRepository.findByBreedingRegistrationIdAndBreedingYear] を引き当てる。これにより
+ * 「種付せずの二重起票」も「既に種付記録がある年への種付せず併存」も同じ AlreadyRecordedForYear で弾く。一意性は
+ * 永続化された成績集合に対する問い合わせが本質であるため、本サービスがリポジトリポート [breedingResultRepository] を 直接受け取って引き当てる（リポジトリポートは
+ * domainModel に属するため、ドメインサービスからの依存はオニオンの 依存方向 service → model
+ * に反しない。[ADR-0022]）。重複が無ければファクトリへ委譲して終端レコードを生成する。
+ *
+ * @param broodmareRegistration 種付せずの記録対象の繁殖牝馬の繁殖登録（ロールが繁殖牝馬であること）
+ * @param breedingYear 種付しなかった繁殖年
+ * @param breedingResultRepository 同一繁殖牝馬・同一繁殖年の既存成績を引き当てる繁殖成績ポート
+ * @return 起こされた種付せずの [BreedingResult]、または前提条件違反を表す [RecordUncoveredError]
+ */
+fun recordUncovered(
+    broodmareRegistration: BreedingRegistration,
+    breedingYear: Year,
+    breedingResultRepository: BreedingResultRepository,
+): Result<BreedingResult, RecordUncoveredError> {
+    val existingForYear =
+        breedingResultRepository.findByBreedingRegistrationIdAndBreedingYear(
+            broodmareRegistration.id,
+            breedingYear,
+        )
+    if (existingForYear != null) {
+        return Err(RecordUncoveredError.AlreadyRecordedForYear(breedingYear, existingForYear.id))
+    }
+    return BreedingResult.createUncovered(broodmareRegistration, breedingYear)
+}

--- a/src/test/kotlin/com/example/api/application/horseracing/breeding/RecordUncoveredUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/horseracing/breeding/RecordUncoveredUseCaseTest.kt
@@ -5,7 +5,7 @@ import com.example.api.domain.horseracing.model.breeding.BreedingRegistrationId
 import com.example.api.domain.horseracing.model.breeding.BreedingRegistrationRepository
 import com.example.api.domain.horseracing.model.breeding.BreedingResultRepository
 import com.example.api.domain.horseracing.model.breeding.FoalingOutcome
-import com.example.api.domain.horseracing.model.breeding.NotBroodmareForUncovered
+import com.example.api.domain.horseracing.model.breeding.RecordUncoveredError
 import com.example.api.domain.shared.Command
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap
@@ -33,7 +33,10 @@ class RecordUncoveredUseCaseTest {
                     every { findById(broodmareRegistration.id) } returns broodmareRegistration
                 }
             val breedingResultRepository =
-                mockk<BreedingResultRepository> { every { save(any()) } answers { firstArg() } }
+                mockk<BreedingResultRepository> {
+                    every { findByBreedingRegistrationIdAndBreedingYear(any(), any()) } returns null
+                    every { save(any()) } answers { firstArg() }
+                }
             val useCase = RecordUncoveredUseCase(registrationRepository, breedingResultRepository)
 
             val result =
@@ -81,7 +84,10 @@ class RecordUncoveredUseCaseTest {
                 mockk<BreedingRegistrationRepository> {
                     every { findById(stallionRegistration.id) } returns stallionRegistration
                 }
-            val breedingResultRepository = mockk<BreedingResultRepository>()
+            val breedingResultRepository =
+                mockk<BreedingResultRepository> {
+                    every { findByBreedingRegistrationIdAndBreedingYear(any(), any()) } returns null
+                }
             val useCase = RecordUncoveredUseCase(registrationRepository, breedingResultRepository)
 
             val result =
@@ -92,7 +98,44 @@ class RecordUncoveredUseCaseTest {
             assert(
                 result.getError() ==
                     RecordUncoveredUseCaseError.PreconditionViolated(
-                        NotBroodmareForUncovered(stallionRegistration)
+                        RecordUncoveredError.NotBroodmare
+                    )
+            )
+            verify(exactly = 0) { breedingResultRepository.save(any()) }
+        }
+
+        @Test
+        fun `同一繁殖牝馬の同一繁殖年に既存成績があると AlreadyRecordedForYear を PreconditionViolated に wrap して返す`() {
+            val broodmareRegistration = BreedingFixture.breedingRegistration()
+            val existing =
+                BreedingFixture.uncoveredBreedingResult(
+                    broodmareRegistration = broodmareRegistration,
+                    breedingYear = Year.of(2024),
+                )
+            val registrationRepository =
+                mockk<BreedingRegistrationRepository> {
+                    every { findById(broodmareRegistration.id) } returns broodmareRegistration
+                }
+            val breedingResultRepository =
+                mockk<BreedingResultRepository> {
+                    every {
+                        findByBreedingRegistrationIdAndBreedingYear(
+                            broodmareRegistration.id,
+                            Year.of(2024),
+                        )
+                    } returns existing
+                }
+            val useCase = RecordUncoveredUseCase(registrationRepository, breedingResultRepository)
+
+            val result =
+                useCase(
+                    command(RecordUncoveredCommand(broodmareRegistration.id.value, Year.of(2024)))
+                )
+
+            assert(
+                result.getError() ==
+                    RecordUncoveredUseCaseError.PreconditionViolated(
+                        RecordUncoveredError.AlreadyRecordedForYear(Year.of(2024), existing.id)
                     )
             )
             verify(exactly = 0) { breedingResultRepository.save(any()) }

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
@@ -12,8 +12,8 @@ import com.example.api.application.horseracing.breeding.ReportFoalingUseCaseErro
 import com.example.api.config.ClockConfiguration
 import com.example.api.domain.horseracing.model.breeding.BreedingFixture
 import com.example.api.domain.horseracing.model.breeding.FoalingOutcome
-import com.example.api.domain.horseracing.model.breeding.NotBroodmareForUncovered
 import com.example.api.domain.horseracing.model.breeding.RecordCoveringError
+import com.example.api.domain.horseracing.model.breeding.RecordUncoveredError
 import com.example.api.domain.shared.Command
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
@@ -273,7 +273,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
             every { recordUncovered(any<Command<RecordUncoveredCommand>>()) } returns
                 Err(
                     RecordUncoveredUseCaseError.PreconditionViolated(
-                        NotBroodmareForUncovered(BreedingFixture.stallionRegistration())
+                        RecordUncoveredError.NotBroodmare
                     )
                 )
 
@@ -288,6 +288,29 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 .bodyJson()
                 .extractingPath("$.error_code")
                 .isEqualTo("not-broodmare")
+        }
+
+        @Test
+        fun `重複記録（AlreadyRecordedForYear）が 409 と繁殖年つきの problem+json に変換されること`() {
+            val existing = BreedingFixture.uncoveredBreedingResult()
+            every { recordUncovered(any<Command<RecordUncoveredCommand>>()) } returns
+                Err(
+                    RecordUncoveredUseCaseError.PreconditionViolated(
+                        RecordUncoveredError.AlreadyRecordedForYear(Year.of(2024), existing.id)
+                    )
+                )
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.CONFLICT)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.breeding_year")
+                .isEqualTo(2024)
         }
     }
 

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultCreateUncoveredTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultCreateUncoveredTest.kt
@@ -20,11 +20,11 @@ class BreedingResultCreateUncoveredTest {
     }
 
     @Test
-    fun `登録ロールが繁殖牝馬でないと NotBroodmareForUncovered を返すこと`() {
+    fun `登録ロールが繁殖牝馬でないと NotBroodmare を返すこと`() {
         val stallionRegistration = BreedingFixture.stallionRegistration()
 
         val result = BreedingResult.createUncovered(stallionRegistration, Year.of(2024))
 
-        assert(result.getError() == NotBroodmareForUncovered(stallionRegistration))
+        assert(result.getError() == RecordUncoveredError.NotBroodmare)
     }
 }

--- a/src/test/kotlin/com/example/api/domain/horseracing/service/breeding/RecordUncoveredTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/service/breeding/RecordUncoveredTest.kt
@@ -1,0 +1,87 @@
+package com.example.api.domain.horseracing.service.breeding
+
+import com.example.api.domain.horseracing.model.breeding.BreedingFixture
+import com.example.api.domain.horseracing.model.breeding.BreedingResultRepository
+import com.example.api.domain.horseracing.model.breeding.FoalingOutcome
+import com.example.api.domain.horseracing.model.breeding.RecordUncoveredError
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Year
+import org.junit.jupiter.api.Test
+
+/** [recordUncovered] ドメインサービスのユニットテスト */
+class RecordUncoveredTest {
+    private val breedingYear = Year.of(2024)
+
+    @Test
+    fun `同年の既存成績が無ければ種付せずの終端な繁殖成績が生成されること`() {
+        val broodmareRegistration = BreedingFixture.breedingRegistration()
+        val repository =
+            mockk<BreedingResultRepository> {
+                every { findByBreedingRegistrationIdAndBreedingYear(any(), any()) } returns null
+            }
+
+        val result = recordUncovered(broodmareRegistration, breedingYear, repository).unwrap()
+
+        assert(result.breedingRegistrationId == broodmareRegistration.id)
+        assert(result.breedingYear == breedingYear)
+        assert(result.covering == null)
+        assert(result.outcome == FoalingOutcome.NotCovered)
+    }
+
+    @Test
+    fun `同一繁殖牝馬の同一繁殖年に既存成績があると AlreadyRecordedForYear を返し既存IDを伴うこと`() {
+        val broodmareRegistration = BreedingFixture.breedingRegistration()
+        val existing = BreedingFixture.breedingResult(broodmareRegistration = broodmareRegistration)
+        val repository =
+            mockk<BreedingResultRepository> {
+                every {
+                    findByBreedingRegistrationIdAndBreedingYear(
+                        broodmareRegistration.id,
+                        breedingYear,
+                    )
+                } returns existing
+            }
+
+        val result = recordUncovered(broodmareRegistration, breedingYear, repository)
+
+        assert(
+            result.getError() ==
+                RecordUncoveredError.AlreadyRecordedForYear(breedingYear, existing.id)
+        )
+    }
+
+    @Test
+    fun `既に種付記録がある年への種付せずも AlreadyRecordedForYear で弾かれること`() {
+        val broodmareRegistration = BreedingFixture.breedingRegistration()
+        val existingCovered =
+            BreedingFixture.breedingResult(broodmareRegistration = broodmareRegistration)
+        val repository =
+            mockk<BreedingResultRepository> {
+                every { findByBreedingRegistrationIdAndBreedingYear(any(), any()) } returns
+                    existingCovered
+            }
+
+        val result = recordUncovered(broodmareRegistration, breedingYear, repository)
+
+        assert(
+            result.getError() ==
+                RecordUncoveredError.AlreadyRecordedForYear(breedingYear, existingCovered.id)
+        )
+    }
+
+    @Test
+    fun `記録対象の登録ロールが繁殖牝馬でないとファクトリの NotBroodmare が伝播すること`() {
+        val notBroodmareRegistration = BreedingFixture.stallionRegistration()
+        val repository =
+            mockk<BreedingResultRepository> {
+                every { findByBreedingRegistrationIdAndBreedingYear(any(), any()) } returns null
+            }
+
+        val result = recordUncovered(notBroodmareRegistration, breedingYear, repository)
+
+        assert(result.getError() == RecordUncoveredError.NotBroodmare)
+    }
+}


### PR DESCRIPTION
## 概要

種付記録（`recordCovering`）に追加した「繁殖牝馬 × 繁殖年で一意」の不変条件（#370 / PR #398）を、**種付せず記録（`recordUncovered`）へ対称に適用**する（#399）。

これまで `recordUncovered` には一意性ガードが無く、次の穴が残っていた:

- 同一繁殖牝馬の同一年に「種付せず」を**二重に**起票できる
- 既に種付記録がある年へ「種付せず」を起票でき、**covered と uncovered が同年に併存**しうる

本 PR でいずれも `AlreadyRecordedForYear`（**409 Conflict**）で弾く。

## 設計

種付記録と対称に、集合制約（一意性）の検証は**ドメインサービスへ寄せる**（構築時不変条件ではない、という #370 / [ADR-0022](docs/adr/0022-domain-service-repository-for-set-invariants.md) の整理に合わせる）。

- `recordUncovered` ドメインサービスを `service/breeding/` に新設し、`BreedingResult.createUncovered`（ファクトリ＝ロール検証のみ）へ委譲
- 既存成績の引き当て（coordination）は `RecordUncoveredUseCase` が繁殖成績ポートを渡し、サービスが `findByBreedingRegistrationIdAndBreedingYear`（#398 で追加済み）を流用
- エラー型を単一 `data class NotBroodmareForUncovered` から `sealed interface RecordUncoveredError { NotBroodmare, AlreadyRecordedForYear }` へ昇格
- Controller: 重複は #398 と同様 **409 Conflict**（`breeding_year` / `existing_breeding_result_id` 付き problem+json）

種付記録側（`RecordCovering` / `RecordCoveringError`）と並びが揃う形になっている。

## テスト

- ドメインサービス `RecordUncoveredTest` を新設（既存なし／重複／種付済み年への種付せず／NotBroodmare 伝播）
- `BreedingResultCreateUncoveredTest`・`RecordUncoveredUseCaseTest`・`BreedingResultControllerTest` を新エラー型と 409 ケースに合わせて更新
- `docs/ubiquitous-language.md` の自動生成カタログに `recordUncovered` を追加
- `./gradlew check` 緑（ktfmt / detekt / test / koverVerifyMature）

## 関連

- #370 / PR #398（種付記録側の一意性。設計の整理＝集合制約はドメインサービス）
- ADR-0022（ドメインサービスは集合制約検証に限りリポジトリポートを受け取ってよい）

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)
