### PR TITLE
chore: Issue 操作を issue-ops スキルに集約する

### DIFF
--- a/.claude/skills/issue-ops/SKILL.md
+++ b/.claude/skills/issue-ops/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: issue-ops
+description: toy-box で GitHub Issue を扱うときの操作手順集。次にやる Issue を選ぶ・候補を一覧する／Issue を新規作成して Project #4 に追加し優先度を設定する／優先度を変更する、のいずれか。「イシュー何かやろう」「次やるのは？」「優先度高いの教えて」「Issue 立てて」「優先度を P2 に」等が合図。クローズ済み・実装済みを候補に出さないための手順と、Project #4（Priority/Status カスタムフィールド）の操作 ID をここに集約する。
+---
+
+# issue-ops（toy-box の Issue 操作手順）
+
+toy-box の Issue は **GitHub Projects #4（owner: ptiringo）** の `Priority` / `Status` single-select カスタムフィールドで
+管理する（ラベルではない。ADR-0011 / CLAUDE.md「優先度管理」）。常時ロードの CLAUDE.md には *守るべきルール*
+だけを置き、*操作のやり方*（ID・jq・確認手順）はこのスキルに集約する。
+
+- 優先度語彙: `P1: 今すぐ` / `P2: 近いうち` / `P3: いずれ` / `P4: 探索・保留`。
+- 進行状況 `Status`: `Todo` / `In Progress` / `Done`（`Done` は「Issue close → Status=Done」の Project Workflow で自動設定される派生値）。
+- Project スコープが要るので、権限エラーが出たら `gh auth refresh -s project`。
+- **操作 ID 実値**（2026-06-21 確認。ズレたら `gh project field-list 4 --owner ptiringo --format json` で取り直す）:
+  - project-id = `PVT_kwHOAGtZ7c4BbL04`
+  - Priority field-id = `PVTSSF_lAHOAGtZ7c4BbL04zhV-LEM`
+  - option-id = P1:`e9ce2b26` / P2:`61f24689` / P3:`1d0a06c9` / P4:`12ac3381`
+  - item-id は `gh project item-list 4 --owner ptiringo --format json` で issue number から引く。
+
+---
+
+## A. 次にやる Issue を選ぶ／候補を一覧する
+
+「次に何をやるか」をユーザーに提案する前に、**必ずこの手順で候補集合を作る**。過去に Project ボードを
+priority だけ見て拾い、**クローズ済み・実装済みの Issue（例: Done 済みの #346）を「未対応」として提案する失敗を繰り返した**。
+原因は `gh project item-list` がクローズ済みも含み、出力に open/closed が無いこと。下記で構造的に防ぐ。
+
+### 1. 候補集合を作る（未 Done に絞る）
+
+`.status != "Done"`（着手前だけ見たいなら `== "Todo"`）で絞る。1 回の呼び出しで priority + status が揃い join 不要。
+
+```bash
+gh project item-list 4 --owner ptiringo --format json --limit 200 \
+  | jq -r '.items[] | select(.content.type=="Issue" and .status != "Done")
+      | "\(.priority // "未設定")\t\(.status)\t#\(.content.number)\t\(.content.title)"' | sort
+```
+
+優先度順に整列したいときは `.priority` を `P1..P4 → 0..3` に写してソートする。
+
+### 2. 動的な絞り込み（ラベル / キーワード / 担当）
+
+「security の」「breeding 周りの」等の条件付き依頼は、一次情報の `gh issue list` で絞ってから priority を付ける:
+
+```bash
+gh issue list --state open --label security --search "breeding" --json number,title
+```
+
+`gh issue list` に優先度列は無いので、得た番号を 1 の出力と突き合わせて priority を引く。
+
+### 3. 整合性チェック（保険・任意）
+
+`.status` は派生値なので、たまに一次情報と件数照合する:
+
+```bash
+gh issue list --state open --limit 300 --json number -q '.[].number' | wc -l   # ↑ 1 の not-Done 件数と一致するはず
+```
+
+### 4. 特定 Issue を「やりましょう」と推す前に実装済みでないか確認【必須】
+
+- `gh issue view <n> --json state,closed` が `OPEN` か
+- linked merged PR / `closingIssuesReferences` が無いか（`gh issue view <n> --json ...` や `gh pr list --search "<n>"`）
+- feature 系なら成果物がリポジトリに既にないか軽く grep（期待する型・ファイル名・docs）
+
+### 5. 提案する
+
+上位候補（通常は最優先の段から数件）を `AskUserQuestion` 等で提示し、ユーザーに選んでもらう。
+すでに `In Progress` のものは、ユーザーが明示しない限り候補から外す。
+
+---
+
+## B. Issue を新規作成する（→ Project 追加 → 優先度設定まで 1 セット）
+
+**CLAUDE.md のルール: 作成した Issue は必ず Project #4 に追加し、Priority を設定する**（未定でも Project には入れる）。
+作成だけで止めない。手順:
+
+```bash
+# 1) 作成
+gh issue create --title "<title>" --body "<body>"   # 返ってくる issue URL を控える
+
+# 2) Project #4 に追加
+gh project item-add 4 --owner ptiringo --url <issue-url>
+
+# 3) 優先度を設定（item-id は number から引く。ID 実値は冒頭参照）
+item=$(gh project item-list 4 --owner ptiringo --format json --limit 300 \
+  | jq -r --argjson n <number> '.items[] | select(.content.number==$n) | .id')
+gh project item-edit --id "$item" --project-id PVT_kwHOAGtZ7c4BbL04 \
+  --field-id PVTSSF_lAHOAGtZ7c4BbL04zhV-LEM --single-select-option-id <option-id>
+```
+
+---
+
+## C. 既存 Issue の優先度を変更する
+
+```bash
+item=$(gh project item-list 4 --owner ptiringo --format json --limit 300 \
+  | jq -r --argjson n <number> '.items[] | select(.content.number==$n) | .id')
+gh project item-edit --id "$item" --project-id PVT_kwHOAGtZ7c4BbL04 \
+  --field-id PVTSSF_lAHOAGtZ7c4BbL04zhV-LEM --single-select-option-id <option-id>
+```
+
+---
+
+## やってはいけないこと
+
+- `gh project item-list` を priority だけ見て、open/closed・`.status` を無視して候補に出す（A）。
+- メモリや記憶だけに頼って「たぶん未対応」と推測で提案する（必ず A-4 を実行）。
+- Issue を作って Project 追加・優先度設定をせずに終える（B のルール違反）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,17 +226,7 @@ Issue の優先度は **GitHub Projects（`toy-box` = Project #4）の `Priority
 - オプションは `P1: 今すぐ` / `P2: 近いうち` / `P3: いずれ` / `P4: 探索・保留` の 4 段階。
 - **作成した Issue は必ず Project（#4）に追加する**。Project に入れた Issue だけが `Priority` フィールドを持てるため、issue を立てたら「Project へ追加 → `Priority` 設定」までを 1 セットで行う（優先度が即決でなくても Project には必ず入れ、未定なら後から設定する）。
 - 優先度順に眺める・束ねる・絞るときは Project のビューを使う（`gh issue list` のラベル列には優先度は出ない）。
-- CLI からの確認・設定:
-
-```bash
-# 優先度付きで一覧（Web ビューが基本だが CLI でも確認可）
-gh project item-list 4 --owner ptiringo
-
-# Issue を Project に追加して優先度を設定（field-id / option-id は field-list で確認）
-gh project item-add 4 --owner ptiringo --url <issue-url>
-gh project field-list 4 --owner ptiringo --format json   # フィールド/オプション ID の確認
-```
-
+- **Issue の操作は `/issue-ops` スキルに集約**。次にやる Issue を選ぶ・候補を一覧する／新規作成して Project 追加＋優先度設定／優先度変更の手順（jq・操作 ID・実装済み確認）はそこを使う。とくに候補選びは、`gh project item-list` がクローズ済みも含み出力に open/closed が無いため priority だけで拾うとクローズ済み・実装済みを「未対応」として提案してしまう（再発実績あり）。`.status != "Done"` で絞る手順がスキルにある。
 - フィールド定義と既存ラベルからの移行はスクリプト化してある（`scripts/migrate-priority-to-project.sh`、`gh project` CLI で再現可能）。Project スコープが要るので事前に `gh auth refresh -s project`。
 
 ## ツール管理


### PR DESCRIPTION
## 背景 / 問題

「実装済み・クローズ済みの Issue を未対応として提案してしまう」失敗が再発した（直近では Done 済みの #346 を「未対応」として提案）。原因は **`gh project item-list` がクローズ済みも含み、出力に open/closed が無い**こと。priority だけ見て候補を拾うと CLOSED が混ざる。

この再発対策に加え、Issue 操作一般（選定・作成＋優先度設定・優先度変更）の手順が CLAUDE.md に散っていたので、**1 つのオンデマンドスキルへ集約**する。「守るべきルールは常時ロード（CLAUDE.md）、意図して呼ぶ手続きはスキル」という分割。

## 変更

- **`.claude/skills/issue-ops/SKILL.md`（新設）**:
  - **A. 次にやる Issue を選ぶ/候補一覧** — Project #4 の `.status != "Done"` で絞る（1 呼び出しで priority + status）、ラベル/キーワードでの動的フィルタ、open 件数との整合性チェック、提案前の**実装済み確認（必須）**
  - **B. 新規作成 → Project 追加 → 優先度設定**を 1 セット（CLAUDE.md のルールの機械手順）
  - **C. 優先度変更**
  - 操作 ID（project-id / Priority field-id / option-id）も集約
- **`CLAUDE.md`「優先度管理」**: 候補一覧・優先度設定の手順（jq / CLI ブロック）を撤去し「Issue 操作は `/issue-ops` を使う」のポインタへスリム化。守るべきルール（出所は Project 1 つ・必ず Project 追加＋優先度設定・優先度語彙・ADR-0011）は常時ロードに残す

## 確認

- pre-commit（editorconfig / gitleaks）・commit-msg 通過。変更はドキュメント＋スキルのみで main コードは不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
