### PR TITLE
feat: 種付の有効性（種畜証明書の有効区域・有効期間）を検証する (#316)

### DIFF
--- a/docs/adr/0023-covering-validity-via-stud-certificate.md
+++ b/docs/adr/0023-covering-validity-via-stud-certificate.md
@@ -1,0 +1,61 @@
+# 0023. 種付の有効性（種畜証明書の有効区域・有効期間）をファクトリの段階導入前提条件として検証する
+
+- Status: Accepted
+- Date: 2026-06-24
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+登録規程実施基準・第9条第1項(1) は、種畜証明書を有する種雄馬の種付による産駒として血統登録できるのは、その種付が
+**証明書に記載された有効区域内かつ有効期間内**に行われた場合に限る、と定める（issue #316）。これを軽種馬登録ドメインに
+取り込むにあたり、いくつか決めるべき点があった。
+
+- **種畜証明書（種畜証明書）と種付証明書（`CoveringCertificateNumber`）の区別**。後者は既存で「種付の事実」を証する書面。
+  前者は種雄馬が繁殖に供されることを証し、有効区域・有効期間を記載する**別書面**。両者を混同しないモデルが要る。
+- **有効区域の表現**。一次資料には区域の具体的な分類体系（都道府県・全国など）が明示されていない。enum で固定区分を切るのは
+  時期尚早で誤りを招く。
+- **検証の置き場所**。本プロジェクトは「構築時に協力与件を引数で受け取れる前提条件はファクトリが自己検証する」方針
+  （[ADR-0014](0014-self-validating-factory-over-confinement.md)）と、「集合制約（一意性等）はリポジトリポートを取る
+  ドメインサービスが検証する」方針（[ADR-0022](0022-domain-service-repository-for-set-invariants.md)）を持つ。種付の
+  有効性はどちらかを判断する必要がある。
+- **既存の記録経路を壊さない**。`recordCovering` ドメインサービスは application 層（`RecordCoveringUseCase`）と Controller から
+  呼ばれており、API 入口はまだ種畜証明書・種付場所を供給しない。今回のスコープはドメイン＋サービスに限り、app/controller の
+  本格配線は別 PR とする。
+
+検討した代替案:
+
+- **有効区域を enum で固定**。一次資料の区分が不明なため却下（誤った語彙を固定するリスク）。
+- **検証をドメインサービス `recordCovering` に置く**。種付の有効性は既存成績集合への問い合わせを要さず、協力与件（種畜証明書）
+  を引数で受け取れば構築時に完結する。集合制約ではないため ADR-0022 の対象ではなく、ADR-0014 のファクトリ自己検証が適切。
+- **新引数を必須にする**。`BreedingResult.create` / `recordCovering` の署名を破壊し app/controller が即コンパイル不能になる。
+  スコープ（ドメイン＋サービス）を超えるため却下。
+
+## Decision（決定）
+
+1. **種畜証明書を値オブジェクト `StudCertificate`（番号 `StudCertificateNumber` / 有効区域 `validRegions` / 有効期間
+   `ValidityPeriod`）としてモデル化する**。種付の事実を証する `CoveringCertificateNumber`（種付証明書）とは別型とする。
+2. **有効区域は `BreedingRegion`（名前付きの値）の集合で表し、有効性は集合メンバーシップで判定する**（種付場所が
+   `validRegions` に含まれるか）。「全国」が個別区域を包含するといった**区域の包含関係はモデル対象外**とし、区分体系が
+   判明したら具体化する。
+3. **有効性検証はファクトリ `BreedingResult.create` の構築時前提条件として自己検証する**（ADR-0014）。検証本体は
+   `StudCertificate.authorizes(coveringDate, coveringPlace)` が担い、有効期間外＝`OutsideValidPeriod` / 有効区域外＝
+   `OutsideValidRegion`（`CoveringValidityError`）を返す。ファクトリはこれを `RecordCoveringError.InvalidCovering` に
+   包んで返す。`recordCovering` ドメインサービスは種畜証明書・種付場所を**素通し**するだけで、集合制約（種付年の一意性）は
+   従来どおり自身が検証する。
+4. **段階導入とする**。`BreedingResult.create` / `recordCovering` の種畜証明書・種付場所引数は省略可能（デフォルト null）とし、
+   渡されたときだけ有効性を検証する。これにより API 入口が証明書を供給しない現状でも既存の記録経路は無改修でコンパイル・動作する。
+   `Covering.coveringPlace` も nullable とし、供給された記録でのみ場所を保持する。API が種畜証明書・種付場所を供給する配線が
+   整い次第、必須化する（エラー描画の段階的導入方針 `error-handling.md` と整合）。
+
+## Consequences（結果・影響）
+
+- 種畜証明書と種付証明書が型で分離され、用語集（`docs/ubiquitous-language.md`）にも両者の区別を明記した。`StudCertificate` /
+  `StudCertificateNumber` / `ValidityPeriod` / `BreedingRegion` が型レベル用語カタログに追加される。
+- 有効性検証はロール検証と同じファクトリに同居し、`RecordCoveringError` の語彙が 3 系統（ロール・有効性・一意性）に揃った。
+  Controller の problem 変換は有効性違反を 422 Unprocessable Entity として描画する（整った入力だが意味的に処理できない。
+  登録ロール違反と同じ扱い。`api-design.md`）。
+- 段階導入の代償として、種畜証明書・種付場所が**省略可能**であり `Covering.coveringPlace` が nullable である。これは「API が
+  まだ供給しない」ことに対する過渡的措置であり、供給配線（別 PR）で必須化する前提。それまで有効性検証は呼び出し側が証明書を
+  渡したときのみ働く。
+- 有効区域の包含関係（全国 ⊇ 個別区域）と、種畜証明書番号・種付証明書番号の桁数/形式検証は本 ADR のスコープ外。区分体系・形式が
+  判明した時点で具体化する。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,3 +32,4 @@
 | [0020](0020-sealed-origin-and-discriminated-origin-subobject.md) | 出自を sealed Origin に統合し、リソース表現に discriminated 部分オブジェクトを許す | Accepted |
 | [0021](0021-parent-not-found-unprocessable-entity.md) | 父母不在（sire/dam 参照先不在）を 422 Unprocessable Entity で確定する | Accepted |
 | [0022](0022-domain-service-repository-for-set-invariants.md) | ドメインサービスは集合制約の検証に限りリポジトリポートを受け取ってよい | Accepted |
+| [0023](0023-covering-validity-via-stud-certificate.md) | 種付の有効性（種畜証明書の有効区域・有効期間）をファクトリの段階導入前提条件として検証する | Accepted |

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -55,8 +55,13 @@ JRA 管掌で別コンテキスト（[ADR-0013](adr/0013-racehorse-registration-
 | BreedingRegistration | 繁殖登録 | 集約ルート | 馬を繁殖に供するための登録（JAIRS）。**雄雌共通の単一の登録**で、繁殖登録証明書の `性` によって担うロール（種牡馬／繁殖牝馬）が決まる。 | 雄雌で別集約にしない（種牡馬も繁殖登録の対象） |
 | BreedingRole | 繁殖ロール | （enum） | 繁殖登録で付与されるロール。雄=種牡馬（`STALLION`）／雌=繁殖牝馬（`BROODMARE`）。性から定まる。 | jMolecules 非付与のためカタログには出ない。Stallion/Broodmare は別個体でなくこのロール |
 | BreedingResult | 繁殖成績 | 集約ルート | 種付年ごとの「種付〜分娩」の年次レコード。「繁殖成績報告書」（様式第14号）1 行に対応。 | — |
-| Covering | 種付 | 値オブジェクト | 種牡馬を繁殖牝馬に交配したという事実。種牡馬は `BloodHorseId` 参照。 | — |
-| CoveringCertificateNumber | 種付証明書番号 | 値オブジェクト | 種付の事実を証明する種付証明書の番号。 | — |
+| Covering | 種付 | 値オブジェクト | 種牡馬を繁殖牝馬に交配したという事実。種牡馬は `BloodHorseId` 参照。種付日・種付場所（`coveringPlace`）を持つ。 | — |
+| CoveringCertificateNumber | 種付証明書番号 | 値オブジェクト | 種付の**事実**を証明する種付証明書の番号。 | 禁止: 種畜証明書（`StudCertificate`）と混同しない。別書面 |
+| StudCertificate | 種畜証明書 | 値オブジェクト | 種雄馬が繁殖に供されることを証する書面。有効区域（`validRegions`）と有効期間（`validPeriod`）を持ち、種付がその内側で行われたかを `authorizes` で検証する（第9条第1項(1)）。 | 禁止: 種付証明書（`CoveringCertificateNumber`）と混同しない |
+| StudCertificateNumber | 種畜証明書番号 | 値オブジェクト | 種畜証明書の番号。 | — |
+| ValidityPeriod | 有効期間 | 値オブジェクト | 種畜証明書の有効期間（起点・終点を含む暦日の閉区間）。`contains` で種付日が内側かを判定。 | — |
+| BreedingRegion | 区域（有効区域／種付場所） | 値オブジェクト | 種畜証明書の有効区域、および種付が行われた場所を表す名前付きの値。有効性は集合メンバーシップで判定（区域の包含関係はモデル対象外）。 | — |
+| CoveringValidityError | 種付有効性違反 | 値オブジェクト（sealed） | 種付が種畜証明書の有効区域外（`OutsideValidRegion`）／有効期間外（`OutsideValidPeriod`）であることを表す。 | sealed 親型は jMolecules 非付与のためカタログには出ない |
 | FoalingOutcome | 分娩結果 | 値オブジェクト（sealed） | 種付した繁殖牝馬がその年に迎えた帰結。生産（`LiveFoal`）と産駒なし各区分の sealed 語彙。 | sealed 親型自体は jMolecules 非付与（カタログには variant のみ出る） |
 | FoalingOutcome.LiveFoal | 生産（産駒あり） | 値オブジェクト | 分娩により生存産駒を得た帰結。血統登録（`BloodHorse.create`）の入力に接続する。 | — |
 | BreedingRegistrationNumber | 繁殖登録番号 | 値オブジェクト | 繁殖登録に交付される番号。 | — |
@@ -141,6 +146,7 @@ graph LR
 | BloodHorseId | 値オブジェクト | domain.horseracing.model.horse.bloodhorse |
 | BreedType | 値オブジェクト | domain.horseracing.model.horse.bloodhorse |
 | Breeder | 値オブジェクト | domain.horseracing.model.horse.bloodhorse |
+| BreedingRegion | 値オブジェクト | domain.horseracing.model.breeding |
 | BreedingRegistrationId | 値オブジェクト | domain.horseracing.model.breeding |
 | BreedingRegistrationNumber | 値オブジェクト | domain.horseracing.model.breeding |
 | BreedingResultId | 値オブジェクト | domain.horseracing.model.breeding |
@@ -171,6 +177,9 @@ graph LR
 | PedigreeRegistrationNumber | 値オブジェクト | domain.horseracing.model.horse.bloodhorse |
 | RaceId | 値オブジェクト | domain.horseracing.model.race |
 | StudBookEntry | 値オブジェクト | domain.horseracing.model.horse.bloodhorse |
+| StudCertificate | 値オブジェクト | domain.horseracing.model.breeding |
+| StudCertificateNumber | 値オブジェクト | domain.horseracing.model.breeding |
+| ValidityPeriod | 値オブジェクト | domain.horseracing.model.breeding |
 | BloodHorseRepository | リポジトリポート | domain.horseracing.model.horse.bloodhorse |
 | BreedingRegistrationRepository | リポジトリポート | domain.horseracing.model.breeding |
 | BreedingResultRepository | リポジトリポート | domain.horseracing.model.breeding |

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
@@ -5,6 +5,7 @@ import com.example.api.application.horseracing.breeding.RecordUncoveredUseCaseEr
 import com.example.api.application.horseracing.breeding.ReportFoalingUseCaseError
 import com.example.api.controller.problem
 import com.example.api.domain.horseracing.model.breeding.BreedingResult
+import com.example.api.domain.horseracing.model.breeding.CoveringValidityError
 import com.example.api.domain.horseracing.model.breeding.RecordCoveringError
 import com.example.api.domain.horseracing.model.breeding.RecordUncoveredError
 import java.time.LocalDate
@@ -111,6 +112,40 @@ private fun RecordCoveringError.toProblemDetail(): ProblemDetail =
                 .apply {
                     setProperty("breeding_year", year.value)
                     setProperty("existing_breeding_result_id", existingBreedingResultId.value)
+                }
+        is RecordCoveringError.InvalidCovering -> cause.toProblemDetail()
+    }
+
+/**
+ * 種付の有効性検証の失敗（[CoveringValidityError]）を [ProblemDetail] に変換する。
+ *
+ * いずれも入力は整っているが種畜証明書の有効区域・有効期間を外れて意味的に処理できないため 422 Unprocessable Entity とする
+ * （登録ロール違反と同じ扱い。api-design.md）。
+ */
+private fun CoveringValidityError.toProblemDetail(): ProblemDetail =
+    when (this) {
+        is CoveringValidityError.OutsideValidPeriod ->
+            problem(
+                    status = HttpStatus.UNPROCESSABLE_ENTITY,
+                    code = "covering-outside-valid-period",
+                    title = "Covering outside the stud certificate's valid period",
+                    detail = "種付日が種畜証明書の有効期間外です。",
+                )
+                .apply {
+                    setProperty("covering_date", coveringDate)
+                    setProperty("valid_period_start", validPeriod.start)
+                    setProperty("valid_period_end", validPeriod.end)
+                }
+        is CoveringValidityError.OutsideValidRegion ->
+            problem(
+                    status = HttpStatus.UNPROCESSABLE_ENTITY,
+                    code = "covering-outside-valid-region",
+                    title = "Covering outside the stud certificate's valid region",
+                    detail = "種付場所が種畜証明書の有効区域外です。",
+                )
+                .apply {
+                    setProperty("covering_place", coveringPlace.value)
+                    setProperty("valid_regions", validRegions.map { it.value })
                 }
     }
 

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingRegion.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingRegion.kt
@@ -1,0 +1,29 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.example.api.domain.shared.createNonBlank
+import com.github.michaelbull.result.Result
+import org.jmolecules.ddd.annotation.ValueObject
+
+/** 繁殖の区域名がブランク。 */
+data object BlankBreedingRegion
+
+/**
+ * 繁殖に関わる区域（地域）。
+ *
+ * 種畜証明書（[StudCertificate]）の有効区域、および種付が行われた場所を表すのに用いる。種付が産駒の血統登録要件を満たすには、
+ * その種付が種畜証明書に記載された有効区域内で行われている必要がある（登録規程実施基準・第9条第1項(1)）。
+ *
+ * 一次資料には区域の具体的な分類（都道府県・全国などの体系）が明示されていないため、本モデルでは区域を**名前付きの値**として
+ * 抽象化し、有効性は集合メンバーシップ（種付場所が有効区域の集合に含まれるか）で判定する。「全国」が個別区域を包含するといった 包含関係は本モデルの対象外とする。形式が判明したら具体化する。
+ *
+ * @property value 区域名
+ */
+@ValueObject
+@JvmInline
+value class BreedingRegion private constructor(val value: String) {
+    companion object {
+        /** ブランクでないことを検証して [BreedingRegion] を生成する。 */
+        fun create(value: String): Result<BreedingRegion, BlankBreedingRegion> =
+            createNonBlank(value, BlankBreedingRegion, ::BreedingRegion)
+    }
+}

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResult.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResult.kt
@@ -5,6 +5,8 @@ import com.example.api.domain.shared.generateId
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
+import com.github.michaelbull.result.mapError
 import java.time.LocalDate
 import java.time.Year
 import java.util.UUID
@@ -27,8 +29,10 @@ data class FoalingAlreadyRecorded(val current: FoalingOutcome)
 /**
  * 種付記録（ドメインサービス recordCovering）の前提条件違反。
  *
- * 種付記録の前提は2系統ある。(1) 配合の登録ロール（繁殖牝馬 × 種牡馬）＝単一インスタンスの構築時不変条件で、 ファクトリ [BreedingResult.create]
- * が検証する（[NotBroodmare] / [NotStallion]）。(2) 「繁殖牝馬 × 繁殖年」で 一意 （繁殖成績報告書
+ * 種付記録の前提は3系統ある。(1) 配合の登録ロール（繁殖牝馬 × 種牡馬）＝単一インスタンスの構築時不変条件で、 ファクトリ [BreedingResult.create]
+ * が検証する（[NotBroodmare] / [NotStallion]）。(2) 種付の有効性（種畜証明書の有効区域・有効期間内であること）＝協力与件
+ * （種畜証明書）を引数で受け取れば構築時に検証できる前提条件で、これもファクトリ [BreedingResult.create] が自己検証する （[InvalidCovering]。検証本体は
+ * [StudCertificate.authorizes]）。(3) 「繁殖牝馬 × 繁殖年」で 一意 （繁殖成績報告書
  * 様式第14号が報告する年次成績は種付年ごとに1行）という集合制約で、既存成績群をまたぐため ドメインサービス recordCovering が検証する
  * （[AlreadyRecordedForYear]）。共通の語彙として 1 つの sealed にまとめ、Controller 境界で一括して problem へ写す。
  */
@@ -38,6 +42,16 @@ sealed interface RecordCoveringError {
 
     /** 配合相手の繁殖登録のロールが種牡馬（STALLION）でない。ファクトリ [BreedingResult.create] が検証する。 */
     data object NotStallion : RecordCoveringError
+
+    /**
+     * 種付が種畜証明書の有効区域・有効期間の内側にない（産駒の血統登録要件を満たさない）。
+     *
+     * 種畜証明書を引数で受け取れる場合にファクトリ [BreedingResult.create] が自己検証する構築時前提条件。詳細な失敗内容 （有効期間外／有効区域外）は [cause]
+     * が表す。
+     *
+     * @property cause 有効性検証の失敗内容
+     */
+    data class InvalidCovering(val cause: CoveringValidityError) : RecordCoveringError
 
     /**
      * 同一繁殖牝馬・同一繁殖年に既に年次の繁殖成績が存在する（種付した年・種付せずの年を問わない）。
@@ -173,21 +187,27 @@ private constructor(
          * として、牝側の登録ロールが繁殖牝馬・雄側の登録ロールが種牡馬であることを自己検証してから生成する。検証を満たさなければ 生成せず [RecordCoveringError]
          * を返す。生成物は種牡馬を `BloodHorseId` 経由で参照する。生成直後は分娩結果が 未報告（[outcome] は null）。
          *
-         * 本ファクトリが守るのは「単一の繁殖成績インスタンスの構築時不変条件」（登録ロール）に限る。「繁殖牝馬 × 繁殖年」で
-         * 一意という集合制約（同一年の重複記録の禁止）は単一インスタンスの構築では完結しないため、既存成績群をまたぐ ドメインサービス recordCovering
+         * 本ファクトリが守るのは「単一の繁殖成績インスタンスの構築時不変条件」（登録ロール）と、協力与件を引数で受け取れる 構築時前提条件（種畜証明書による種付の有効性）に限る。後者は
+         * [studCertificate] が渡されたときだけ検証する段階導入で、 渡されなければ従来どおりロール検証のみで生成する（API
+         * 入口が種畜証明書・種付場所を供給するようになり次第、必須化する）。 「繁殖牝馬 ×
+         * 繁殖年」で一意という集合制約（同一年の重複記録の禁止）は単一インスタンスの構築では完結しないため、 既存成績群をまたぐ ドメインサービス recordCovering
          * が担い、本ファクトリはその検証を経た上で呼び出される。
          *
          * @param broodmareRegistration 種付対象の繁殖牝馬の繁殖登録（ロールが繁殖牝馬であること）
          * @param stallionRegistration 配合相手の種牡馬の繁殖登録（ロールが種牡馬であること）
          * @param coveringDate 種付日
          * @param certificateNumber 種付の事実を証明する種付証明書の番号
-         * @return 種付を記録した [BreedingResult]、または登録ロールの前提条件違反を表す [RecordCoveringError]
+         * @param studCertificate 種牡馬の種畜証明書。渡された場合のみ種付の有効性（有効区域・有効期間）を検証する
+         * @param coveringPlace 種付場所。[studCertificate] を渡す場合は必須（有効区域の整合検証に用いる）
+         * @return 種付を記録した [BreedingResult]、または前提条件違反を表す [RecordCoveringError]
          */
         fun create(
             broodmareRegistration: BreedingRegistration,
             stallionRegistration: BreedingRegistration,
             coveringDate: LocalDate,
             certificateNumber: CoveringCertificateNumber,
+            studCertificate: StudCertificate? = null,
+            coveringPlace: BreedingRegion? = null,
         ): Result<BreedingResult, RecordCoveringError> =
             when {
                 broodmareRegistration.role != BreedingRole.BROODMARE ->
@@ -195,20 +215,40 @@ private constructor(
                 stallionRegistration.role != BreedingRole.STALLION ->
                     Err(RecordCoveringError.NotStallion)
                 else ->
-                    Ok(
-                        BreedingResult(
-                            id = BreedingResultId(generateId()),
-                            breedingRegistrationId = broodmareRegistration.id,
-                            breedingYear = Year.of(coveringDate.year),
-                            covering =
-                                Covering(
-                                    stallionRegistration.registeredHorseId,
-                                    coveringDate,
-                                    certificateNumber,
-                                ),
-                            outcome = null,
-                        )
-                    )
+                    validateCovering(studCertificate, coveringDate, coveringPlace)
+                        .map {
+                            BreedingResult(
+                                id = BreedingResultId(generateId()),
+                                breedingRegistrationId = broodmareRegistration.id,
+                                breedingYear = Year.of(coveringDate.year),
+                                covering =
+                                    Covering(
+                                        stallionRegistration.registeredHorseId,
+                                        coveringDate,
+                                        coveringPlace,
+                                        certificateNumber,
+                                    ),
+                                outcome = null,
+                            )
+                        }
+                        .mapError { RecordCoveringError.InvalidCovering(it) }
+            }
+
+        /**
+         * 種畜証明書が渡された場合に種付の有効性（有効区域・有効期間）を検証する。渡されなければ検証なし（段階導入）。
+         *
+         * [studCertificate] を渡す場合、有効区域の整合検証のため [coveringPlace] は必須（プログラミングエラーとして表明）。
+         */
+        private fun validateCovering(
+            studCertificate: StudCertificate?,
+            coveringDate: LocalDate,
+            coveringPlace: BreedingRegion?,
+        ): Result<Unit, CoveringValidityError> =
+            if (studCertificate == null) {
+                Ok(Unit)
+            } else {
+                require(coveringPlace != null) { "種畜証明書を渡す場合は種付場所も必須。" }
+                studCertificate.authorizes(coveringDate, coveringPlace)
             }
 
         /**

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/Covering.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/Covering.kt
@@ -7,16 +7,22 @@ import org.jmolecules.ddd.annotation.ValueObject
 /**
  * 種付（種牡馬を繁殖牝馬に交配したという事実）を表す値オブジェクト。
  *
- * 繁殖成績の年次レコード（[BreedingResult]）における最初の節目で、どの種牡馬と・いつ交配し・その事実を どの種付証明書で証明するかを束ねる。種牡馬は別個体（別集約）であり、参照は
- * [BloodHorseId] 経由で表す。 種牡馬が雄であることなど集約をまたぐ前提条件の検証はドメインサービス recordCovering の責務とし、 検証を経た記録のみを許す。
+ * 繁殖成績の年次レコード（[BreedingResult]）における最初の節目で、どの種牡馬と・いつ・どこで交配し・その事実を
+ * どの種付証明書で証明するかを束ねる。種牡馬は別個体（別集約）であり、参照は [BloodHorseId] 経由で表す。 種牡馬が雄であることなど 集約をまたぐ前提条件の検証はドメインサービス
+ * recordCovering の責務とし、 検証を経た記録のみを許す。
+ *
+ * 種付場所（[coveringPlace]）は、種畜証明書（[StudCertificate]）の有効区域に対する種付の有効性検証に用いる。現状は API 入口が場所・種畜証明書を供給しないため
+ * nullable とし、供給された記録でのみ場所を保持する（段階導入。供給経路が 整い次第、必須化する）。
  *
  * @property stallionId 種牡馬（雄の軽種馬）の軽種馬ID
  * @property coveringDate 種付日
+ * @property coveringPlace 種付が行われた場所（有効性検証に用いる）。未供給の記録では null
  * @property certificateNumber 種付の事実を証明する種付証明書の番号
  */
 @ValueObject
 data class Covering(
     val stallionId: BloodHorseId,
     val coveringDate: LocalDate,
+    val coveringPlace: BreedingRegion?,
     val certificateNumber: CoveringCertificateNumber,
 )

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/StudCertificate.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/StudCertificate.kt
@@ -1,0 +1,95 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import java.time.LocalDate
+import org.jmolecules.ddd.annotation.ValueObject
+
+/** 種畜証明書の不変条件違反。 */
+sealed interface InvalidStudCertificate {
+    /** 有効区域が 1 つも指定されていない。 */
+    data object NoValidRegion : InvalidStudCertificate
+}
+
+/**
+ * 種付が種畜証明書の有効性に反する（産駒の血統登録要件を満たさない）。
+ *
+ * 登録規程実施基準・第9条第1項(1)：種畜証明書を有する種雄馬の種付による産駒として血統登録できるのは、その種付が証明書に
+ * 記載された**有効区域内かつ有効期間内**に行われた場合に限る。本エラーは種付がその条件を外れたことを表す。
+ */
+sealed interface CoveringValidityError {
+    /**
+     * 種付日が種畜証明書の有効期間外。
+     *
+     * @property coveringDate 検証対象の種付日
+     * @property validPeriod 種畜証明書の有効期間
+     */
+    data class OutsideValidPeriod(val coveringDate: LocalDate, val validPeriod: ValidityPeriod) :
+        CoveringValidityError
+
+    /**
+     * 種付場所が種畜証明書の有効区域外。
+     *
+     * @property coveringPlace 検証対象の種付場所
+     * @property validRegions 種畜証明書の有効区域
+     */
+    data class OutsideValidRegion(
+        val coveringPlace: BreedingRegion,
+        val validRegions: Set<BreedingRegion>,
+    ) : CoveringValidityError
+}
+
+/**
+ * 種畜証明書。種雄馬が繁殖に供されることを証する書面で、有効区域と有効期間を記載する値オブジェクト。
+ *
+ * 種付が産駒の血統登録要件を満たすかは、その種付（日付・場所）がこの証明書の有効区域・有効期間の内側にあるかで定まる （登録規程実施基準・第9条第1項(1)）。判定は [authorizes]
+ * が担う。有効区域は[BreedingRegion] の集合で表し、種付場所が その集合に含まれるかで区域整合を判定する（区域の包含関係はモデル対象外。[BreedingRegion] 参照）。
+ *
+ * 種畜証明書は種雄馬が持つ与件であり、種付記録の有効性検証に外から渡される。種付の事実を証する「種付証明書」 （[CoveringCertificateNumber]）とは別物である。
+ *
+ * @property number 種畜証明書番号
+ * @property validRegions 有効区域（1 つ以上）
+ * @property validPeriod 有効期間
+ */
+@ValueObject
+@ConsistentCopyVisibility
+data class StudCertificate
+private constructor(
+    val number: StudCertificateNumber,
+    val validRegions: Set<BreedingRegion>,
+    val validPeriod: ValidityPeriod,
+) {
+    /**
+     * [coveringDate] に [coveringPlace] で行われた種付が、本証明書の有効区域・有効期間の内側にあるかを検証する。
+     *
+     * 有効期間外なら [CoveringValidityError.OutsideValidPeriod]、有効区域外なら
+     * [CoveringValidityError.OutsideValidRegion] を返す。両方を満たすとき [Ok] を返す。
+     *
+     * @param coveringDate 種付日
+     * @param coveringPlace 種付場所
+     * @return 有効なら [Ok]、外れていれば該当する [CoveringValidityError]
+     */
+    fun authorizes(
+        coveringDate: LocalDate,
+        coveringPlace: BreedingRegion,
+    ): Result<Unit, CoveringValidityError> =
+        when {
+            !validPeriod.contains(coveringDate) ->
+                Err(CoveringValidityError.OutsideValidPeriod(coveringDate, validPeriod))
+            coveringPlace !in validRegions ->
+                Err(CoveringValidityError.OutsideValidRegion(coveringPlace, validRegions))
+            else -> Ok(Unit)
+        }
+
+    companion object {
+        /** 有効区域が 1 つ以上あることを検証して [StudCertificate] を生成する。 */
+        fun create(
+            number: StudCertificateNumber,
+            validRegions: Set<BreedingRegion>,
+            validPeriod: ValidityPeriod,
+        ): Result<StudCertificate, InvalidStudCertificate> =
+            if (validRegions.isEmpty()) Err(InvalidStudCertificate.NoValidRegion)
+            else Ok(StudCertificate(number, validRegions, validPeriod))
+    }
+}

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/StudCertificateNumber.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/StudCertificateNumber.kt
@@ -1,0 +1,27 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.example.api.domain.shared.createNonBlank
+import com.github.michaelbull.result.Result
+import org.jmolecules.ddd.annotation.ValueObject
+
+/** 種畜証明書番号がブランク。 */
+data object BlankStudCertificateNumber
+
+/**
+ * 種畜証明書番号。
+ *
+ * 種畜証明書は種雄馬が繁殖に供されることを公的に証する書面で、有効区域・有効期間が記載される（登録規程第15条・実施基準第9条）。
+ * 種付の事実を証する「種付証明書」（[CoveringCertificateNumber]）とは別物である点に注意。具体的な桁数・形式は未確認のため、
+ * 現時点ではブランクでないことのみを不変条件とする（形式が判明したら桁数検証を加える）。
+ *
+ * @property value 種畜証明書番号
+ */
+@ValueObject
+@JvmInline
+value class StudCertificateNumber private constructor(val value: String) {
+    companion object {
+        /** ブランクでないことを検証して [StudCertificateNumber] を生成する。 */
+        fun create(value: String): Result<StudCertificateNumber, BlankStudCertificateNumber> =
+            createNonBlank(value, BlankStudCertificateNumber, ::StudCertificateNumber)
+    }
+}

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/ValidityPeriod.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/ValidityPeriod.kt
@@ -1,0 +1,41 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import java.time.LocalDate
+import org.jmolecules.ddd.annotation.ValueObject
+
+/**
+ * 有効期間の不変条件違反（終点が起点より前）。
+ *
+ * @property start 指定された起点
+ * @property end 指定された終点
+ */
+data class InvalidValidityPeriod(val start: LocalDate, val end: LocalDate)
+
+/**
+ * 有効期間（起点・終点とも含む閉区間）。
+ *
+ * 種畜証明書（[StudCertificate]）の有効期間を表す。種付が産駒の血統登録要件を満たすには、その種付日が証明書の有効期間内で
+ * ある必要がある（登録規程実施基準・第9条第1項(1)）。期間は暦日で扱えば足りるため [LocalDate] の閉区間とし、起点・終点の 当日を含む。
+ *
+ * @property start 有効期間の起点（当日を含む）
+ * @property end 有効期間の終点（当日を含む）
+ */
+@ValueObject
+@ConsistentCopyVisibility
+data class ValidityPeriod private constructor(val start: LocalDate, val end: LocalDate) {
+    /** [date] が有効期間内（起点・終点の当日を含む）かを返す。 */
+    fun contains(date: LocalDate): Boolean = !date.isBefore(start) && !date.isAfter(end)
+
+    companion object {
+        /** 終点が起点以降であることを検証して [ValidityPeriod] を生成する。 */
+        fun create(
+            start: LocalDate,
+            end: LocalDate,
+        ): Result<ValidityPeriod, InvalidValidityPeriod> =
+            if (end.isBefore(start)) Err(InvalidValidityPeriod(start, end))
+            else Ok(ValidityPeriod(start, end))
+    }
+}

--- a/src/main/kotlin/com/example/api/domain/horseracing/service/breeding/RecordCovering.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/service/breeding/RecordCovering.kt
@@ -1,10 +1,12 @@
 package com.example.api.domain.horseracing.service.breeding
 
+import com.example.api.domain.horseracing.model.breeding.BreedingRegion
 import com.example.api.domain.horseracing.model.breeding.BreedingRegistration
 import com.example.api.domain.horseracing.model.breeding.BreedingResult
 import com.example.api.domain.horseracing.model.breeding.BreedingResultRepository
 import com.example.api.domain.horseracing.model.breeding.CoveringCertificateNumber
 import com.example.api.domain.horseracing.model.breeding.RecordCoveringError
+import com.example.api.domain.horseracing.model.breeding.StudCertificate
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import java.time.LocalDate
@@ -14,8 +16,10 @@ import java.time.Year
  * 種付（配合）を記録し、繁殖成績の年次レコード（[BreedingResult]）を起こすドメインサービス。
  *
  * 種付記録の前提条件は2系統あり、性質が異なるため担い手を分ける:
- * - **配合の登録ロール（繁殖牝馬 × 種牡馬）** … 単一の繁殖成績インスタンスの構築時不変条件。委譲先のファクトリ [BreedingResult.create]
- *   が自己検証する（NotBroodmare / NotStallion の [RecordCoveringError]）。
+ * - **配合の登録ロール（繁殖牝馬 × 種牡馬）／種付の有効性（種畜証明書の有効区域・有効期間）** … いずれも単一の繁殖成績
+ *   インスタンスの構築時前提条件で、協力与件（繁殖登録・種畜証明書）を引数で受け取れる。委譲先のファクトリ [BreedingResult.create]
+ *   が自己検証する（NotBroodmare / NotStallion / InvalidCovering の [RecordCoveringError]）。有効性検証は
+ *   [studCertificate] が渡された場合のみ行う段階導入。
  * - **「繁殖牝馬 × 繁殖年」で一意（同一年の重複記録の禁止）** … 既存成績群（集合）をまたぐ集合制約で、単一インスタンスの 構築では完結しない。本サービスが
  *   [breedingResultRepository] から同年の既存成績を引き当てて検証する （[RecordCoveringError.AlreadyRecordedForYear]）。
  *
@@ -28,6 +32,8 @@ import java.time.Year
  * @param coveringDate 種付日
  * @param certificateNumber 種付の事実を証明する種付証明書の番号
  * @param breedingResultRepository 同一繁殖牝馬・同一繁殖年の既存成績を引き当てる繁殖成績ポート
+ * @param studCertificate 種牡馬の種畜証明書。渡された場合のみ種付の有効性（有効区域・有効期間）をファクトリが検証する
+ * @param coveringPlace 種付場所。[studCertificate] を渡す場合は必須（有効区域の整合検証に用いる）
  * @return 起こされた [BreedingResult]、または前提条件違反を表す [RecordCoveringError]
  */
 fun recordCovering(
@@ -36,6 +42,8 @@ fun recordCovering(
     coveringDate: LocalDate,
     certificateNumber: CoveringCertificateNumber,
     breedingResultRepository: BreedingResultRepository,
+    studCertificate: StudCertificate? = null,
+    coveringPlace: BreedingRegion? = null,
 ): Result<BreedingResult, RecordCoveringError> {
     val breedingYear = Year.of(coveringDate.year)
     val existingForYear =
@@ -51,5 +59,7 @@ fun recordCovering(
         stallionRegistration,
         coveringDate,
         certificateNumber,
+        studCertificate,
+        coveringPlace,
     )
 }

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
@@ -11,9 +11,12 @@ import com.example.api.application.horseracing.breeding.ReportFoalingUseCase
 import com.example.api.application.horseracing.breeding.ReportFoalingUseCaseError
 import com.example.api.config.ClockConfiguration
 import com.example.api.domain.horseracing.model.breeding.BreedingFixture
+import com.example.api.domain.horseracing.model.breeding.BreedingRegion
+import com.example.api.domain.horseracing.model.breeding.CoveringValidityError
 import com.example.api.domain.horseracing.model.breeding.FoalingOutcome
 import com.example.api.domain.horseracing.model.breeding.RecordCoveringError
 import com.example.api.domain.horseracing.model.breeding.RecordUncoveredError
+import com.example.api.domain.horseracing.model.breeding.ValidityPeriod
 import com.example.api.domain.shared.Command
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
@@ -175,6 +178,61 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 .bodyJson()
                 .extractingPath("$.error_code")
                 .isEqualTo("not-broodmare")
+        }
+
+        @Test
+        fun `有効期間外（InvalidCovering OutsideValidPeriod）が 422 と problem+json に変換されること`() {
+            val period =
+                ValidityPeriod.create(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 3, 31)).unwrap()
+            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+                Err(
+                    RecordCoveringUseCaseError.PreconditionViolated(
+                        RecordCoveringError.InvalidCovering(
+                            CoveringValidityError.OutsideValidPeriod(
+                                LocalDate.of(2024, 4, 1),
+                                period,
+                            )
+                        )
+                    )
+                )
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.error_code")
+                .isEqualTo("covering-outside-valid-period")
+        }
+
+        @Test
+        fun `有効区域外（InvalidCovering OutsideValidRegion）が 422 と problem+json に変換されること`() {
+            val hokkaido = BreedingRegion.create("北海道").unwrap()
+            val aomori = BreedingRegion.create("青森").unwrap()
+            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+                Err(
+                    RecordCoveringUseCaseError.PreconditionViolated(
+                        RecordCoveringError.InvalidCovering(
+                            CoveringValidityError.OutsideValidRegion(aomori, setOf(hokkaido))
+                        )
+                    )
+                )
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.error_code")
+                .isEqualTo("covering-outside-valid-region")
         }
 
         @Test

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingFixture.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingFixture.kt
@@ -7,6 +7,9 @@ import com.github.michaelbull.result.unwrap
 import java.time.LocalDate
 import java.time.Year
 
+/** テスト用の有効区域（種付場所）。 */
+private val DEFAULT_REGION = BreedingRegion.create("北海道").unwrap()
+
 /**
  * テスト用に繁殖コンテキストの集約・値オブジェクトを組み立てる Object Mother。
  *
@@ -32,6 +35,18 @@ object BreedingFixture {
             horse = stallion,
         )
 
+    /**
+     * 既定で [coveringDate]（2024-04-01）・[validRegions]（北海道）を覆う種畜証明書を生成する。
+     *
+     * 有効性検証（有効区域・有効期間）のテストで、種付日・場所を覆う／外れる証明書を組むのに使う。
+     */
+    fun studCertificate(
+        number: StudCertificateNumber = StudCertificateNumber.create("S-2024-0001").unwrap(),
+        validRegions: Set<BreedingRegion> = setOf(DEFAULT_REGION),
+        validPeriod: ValidityPeriod =
+            ValidityPeriod.create(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31)).unwrap(),
+    ): StudCertificate = StudCertificate.create(number, validRegions, validPeriod).unwrap()
+
     /** 既定値を持つ、分娩結果未報告の [BreedingResult] を生成する。必要な属性のみ上書きする。 */
     fun breedingResult(
         broodmareRegistration: BreedingRegistration = breedingRegistration(),
@@ -39,12 +54,16 @@ object BreedingFixture {
         coveringDate: LocalDate = LocalDate.of(2024, 4, 1),
         certificateNumber: CoveringCertificateNumber =
             CoveringCertificateNumber.create("C-2024-0001").unwrap(),
+        studCertificate: StudCertificate? = null,
+        coveringPlace: BreedingRegion? = null,
     ): BreedingResult =
         BreedingResult.create(
                 broodmareRegistration,
                 stallionRegistration,
                 coveringDate,
                 certificateNumber,
+                studCertificate,
+                coveringPlace,
             )
             .unwrap()
 

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingRegionTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingRegionTest.kt
@@ -1,0 +1,29 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import org.junit.jupiter.api.Test
+
+/** [BreedingRegion] のユニットテスト */
+class BreedingRegionTest {
+    @Test
+    fun `ブランクでない区域名なら生成できること`() {
+        val region = BreedingRegion.create("北海道").unwrap()
+
+        assert(region.value == "北海道")
+    }
+
+    @Test
+    fun `前後の空白は trim されること`() {
+        val region = BreedingRegion.create("  北海道  ").unwrap()
+
+        assert(region.value == "北海道")
+    }
+
+    @Test
+    fun `ブランクだと BlankBreedingRegion を返すこと`() {
+        val result = BreedingRegion.create("   ")
+
+        assert(result.getError() == BlankBreedingRegion)
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultCreateTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultCreateTest.kt
@@ -64,4 +64,73 @@ class BreedingResultCreateTest {
 
         assert(result.getError() == RecordCoveringError.NotStallion)
     }
+
+    @Test
+    fun `種畜証明書を渡すと有効区域内かつ有効期間内の種付が記録され場所を保持すること`() {
+        val place = BreedingRegion.create("北海道").unwrap()
+        val studCertificate = BreedingFixture.studCertificate(validRegions = setOf(place))
+
+        val result =
+            BreedingResult.create(
+                    BreedingFixture.breedingRegistration(),
+                    BreedingFixture.stallionRegistration(),
+                    coveringDate,
+                    certificateNumber,
+                    studCertificate,
+                    place,
+                )
+                .unwrap()
+
+        assert(result.covering?.coveringPlace == place)
+    }
+
+    @Test
+    fun `種付日が種畜証明書の有効期間外だと InvalidCovering(OutsideValidPeriod) を返すこと`() {
+        val place = BreedingRegion.create("北海道").unwrap()
+        val period =
+            ValidityPeriod.create(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 3, 31)).unwrap()
+        val studCertificate =
+            BreedingFixture.studCertificate(validRegions = setOf(place), validPeriod = period)
+
+        val result =
+            BreedingResult.create(
+                BreedingFixture.breedingRegistration(),
+                BreedingFixture.stallionRegistration(),
+                coveringDate, // 2024-04-01 は 3/31 までの有効期間外
+                certificateNumber,
+                studCertificate,
+                place,
+            )
+
+        val error = result.getError()
+        assert(error is RecordCoveringError.InvalidCovering)
+        assert(
+            (error as RecordCoveringError.InvalidCovering).cause
+                is CoveringValidityError.OutsideValidPeriod
+        )
+    }
+
+    @Test
+    fun `種付場所が種畜証明書の有効区域外だと InvalidCovering(OutsideValidRegion) を返すこと`() {
+        val validRegion = BreedingRegion.create("北海道").unwrap()
+        val otherPlace = BreedingRegion.create("青森").unwrap()
+        val studCertificate = BreedingFixture.studCertificate(validRegions = setOf(validRegion))
+
+        val result =
+            BreedingResult.create(
+                BreedingFixture.breedingRegistration(),
+                BreedingFixture.stallionRegistration(),
+                coveringDate,
+                certificateNumber,
+                studCertificate,
+                otherPlace,
+            )
+
+        val error = result.getError()
+        assert(error is RecordCoveringError.InvalidCovering)
+        assert(
+            (error as RecordCoveringError.InvalidCovering).cause
+                is CoveringValidityError.OutsideValidRegion
+        )
+    }
 }

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/StudCertificateNumberTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/StudCertificateNumberTest.kt
@@ -1,0 +1,29 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import org.junit.jupiter.api.Test
+
+/** [StudCertificateNumber] のユニットテスト */
+class StudCertificateNumberTest {
+    @Test
+    fun `ブランクでない番号なら生成できること`() {
+        val number = StudCertificateNumber.create("S-2024-0001").unwrap()
+
+        assert(number.value == "S-2024-0001")
+    }
+
+    @Test
+    fun `前後の空白は trim されること`() {
+        val number = StudCertificateNumber.create("  S-2024-0001  ").unwrap()
+
+        assert(number.value == "S-2024-0001")
+    }
+
+    @Test
+    fun `ブランクだと BlankStudCertificateNumber を返すこと`() {
+        val result = StudCertificateNumber.create("   ")
+
+        assert(result.getError() == BlankStudCertificateNumber)
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/StudCertificateTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/StudCertificateTest.kt
@@ -1,0 +1,70 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import java.time.LocalDate
+import org.junit.jupiter.api.Test
+
+/** [StudCertificate] のユニットテスト（生成不変条件と [StudCertificate.authorizes] による有効性検証） */
+class StudCertificateTest {
+    private val number = StudCertificateNumber.create("S-2024-0001").unwrap()
+    private val hokkaido = BreedingRegion.create("北海道").unwrap()
+    private val aomori = BreedingRegion.create("青森").unwrap()
+    private val period =
+        ValidityPeriod.create(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31)).unwrap()
+
+    @Test
+    fun `有効区域が1つ以上あれば生成できること`() {
+        val certificate = StudCertificate.create(number, setOf(hokkaido), period).unwrap()
+
+        assert(certificate.validRegions == setOf(hokkaido))
+        assert(certificate.validPeriod == period)
+    }
+
+    @Test
+    fun `有効区域が空だと NoValidRegion を返すこと`() {
+        val result = StudCertificate.create(number, emptySet(), period)
+
+        assert(result.getError() == InvalidStudCertificate.NoValidRegion)
+    }
+
+    @Test
+    fun `有効区域内かつ有効期間内の種付は authorizes が成功すること`() {
+        val certificate = StudCertificate.create(number, setOf(hokkaido), period).unwrap()
+
+        val result = certificate.authorizes(LocalDate.of(2024, 4, 1), hokkaido)
+
+        assert(result.getError() == null)
+    }
+
+    @Test
+    fun `有効期間外の種付日は OutsideValidPeriod を返すこと`() {
+        val certificate = StudCertificate.create(number, setOf(hokkaido), period).unwrap()
+        val outOfPeriod = LocalDate.of(2025, 1, 1)
+
+        val result = certificate.authorizes(outOfPeriod, hokkaido)
+
+        assert(result.getError() == CoveringValidityError.OutsideValidPeriod(outOfPeriod, period))
+    }
+
+    @Test
+    fun `有効区域外の種付場所は OutsideValidRegion を返すこと`() {
+        val certificate = StudCertificate.create(number, setOf(hokkaido), period).unwrap()
+
+        val result = certificate.authorizes(LocalDate.of(2024, 4, 1), aomori)
+
+        assert(
+            result.getError() == CoveringValidityError.OutsideValidRegion(aomori, setOf(hokkaido))
+        )
+    }
+
+    @Test
+    fun `有効期間外かつ有効区域外なら有効期間を優先して OutsideValidPeriod を返すこと`() {
+        val certificate = StudCertificate.create(number, setOf(hokkaido), period).unwrap()
+        val outOfPeriod = LocalDate.of(2025, 1, 1)
+
+        val result = certificate.authorizes(outOfPeriod, aomori)
+
+        assert(result.getError() == CoveringValidityError.OutsideValidPeriod(outOfPeriod, period))
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/ValidityPeriodTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/ValidityPeriodTest.kt
@@ -1,0 +1,56 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import java.time.LocalDate
+import org.junit.jupiter.api.Test
+
+/** [ValidityPeriod] のユニットテスト */
+class ValidityPeriodTest {
+    @Test
+    fun `終点が起点以降なら生成できること`() {
+        val period =
+            ValidityPeriod.create(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31)).unwrap()
+
+        assert(period.start == LocalDate.of(2024, 1, 1))
+        assert(period.end == LocalDate.of(2024, 12, 31))
+    }
+
+    @Test
+    fun `起点と終点が同日でも生成できること`() {
+        val day = LocalDate.of(2024, 4, 1)
+
+        val period = ValidityPeriod.create(day, day).unwrap()
+
+        assert(period.start == day && period.end == day)
+    }
+
+    @Test
+    fun `終点が起点より前だと InvalidValidityPeriod を返すこと`() {
+        val start = LocalDate.of(2024, 12, 31)
+        val end = LocalDate.of(2024, 1, 1)
+
+        val result = ValidityPeriod.create(start, end)
+
+        assert(result.getError() == InvalidValidityPeriod(start, end))
+    }
+
+    @Test
+    fun `contains は起点・終点の当日を含むこと`() {
+        val period =
+            ValidityPeriod.create(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31)).unwrap()
+
+        assert(period.contains(LocalDate.of(2024, 1, 1)))
+        assert(period.contains(LocalDate.of(2024, 12, 31)))
+        assert(period.contains(LocalDate.of(2024, 6, 1)))
+    }
+
+    @Test
+    fun `contains は期間外の日を含まないこと`() {
+        val period =
+            ValidityPeriod.create(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31)).unwrap()
+
+        assert(!period.contains(LocalDate.of(2023, 12, 31)))
+        assert(!period.contains(LocalDate.of(2025, 1, 1)))
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/horseracing/service/breeding/RecordCoveringTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/service/breeding/RecordCoveringTest.kt
@@ -1,8 +1,10 @@
 package com.example.api.domain.horseracing.service.breeding
 
 import com.example.api.domain.horseracing.model.breeding.BreedingFixture
+import com.example.api.domain.horseracing.model.breeding.BreedingRegion
 import com.example.api.domain.horseracing.model.breeding.BreedingResultRepository
 import com.example.api.domain.horseracing.model.breeding.CoveringCertificateNumber
+import com.example.api.domain.horseracing.model.breeding.CoveringValidityError
 import com.example.api.domain.horseracing.model.breeding.RecordCoveringError
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap
@@ -113,5 +115,58 @@ class RecordCoveringTest {
             )
 
         assert(result.getError() == RecordCoveringError.NotStallion)
+    }
+
+    @Test
+    fun `種畜証明書と種付場所を渡すと有効性検証がファクトリへ素通しされ有効なら記録されること`() {
+        val place = BreedingRegion.create("北海道").unwrap()
+        val studCertificate = BreedingFixture.studCertificate(validRegions = setOf(place))
+        val repository =
+            mockk<BreedingResultRepository> {
+                every { findByBreedingRegistrationIdAndBreedingYear(any(), any()) } returns null
+            }
+
+        val result =
+            recordCovering(
+                    BreedingFixture.breedingRegistration(),
+                    BreedingFixture.stallionRegistration(),
+                    coveringDate,
+                    certificateNumber,
+                    repository,
+                    studCertificate,
+                    place,
+                )
+                .unwrap()
+
+        assert(result.covering?.coveringPlace == place)
+    }
+
+    @Test
+    fun `有効区域外の種付場所だとファクトリの InvalidCovering が素通しで伝播すること`() {
+        val validRegion = BreedingRegion.create("北海道").unwrap()
+        val otherPlace = BreedingRegion.create("青森").unwrap()
+        val studCertificate = BreedingFixture.studCertificate(validRegions = setOf(validRegion))
+        val repository =
+            mockk<BreedingResultRepository> {
+                every { findByBreedingRegistrationIdAndBreedingYear(any(), any()) } returns null
+            }
+
+        val result =
+            recordCovering(
+                BreedingFixture.breedingRegistration(),
+                BreedingFixture.stallionRegistration(),
+                coveringDate,
+                certificateNumber,
+                repository,
+                studCertificate,
+                otherPlace,
+            )
+
+        val error = result.getError()
+        assert(error is RecordCoveringError.InvalidCovering)
+        assert(
+            (error as RecordCoveringError.InvalidCovering).cause
+                is CoveringValidityError.OutsideValidRegion
+        )
     }
 }


### PR DESCRIPTION
Closes #316

## 概要

登録規程実施基準・**第9条第1項(1)**（種畜証明書を有する種雄馬の種付による産駒として血統登録できるのは、その種付が証明書の**有効区域内かつ有効期間内**に行われた場合に限る）を軽種馬登録ドメインに取り込む。

スコープは **ドメイン＋サービス** に限定。API 入口（request/response・command）の本格配線は別 PR とするため、種畜証明書・種付場所の引数は**省略可能の段階導入**とした（詳細は [ADR-0023](docs/adr/0023-covering-validity-via-stud-certificate.md)）。

## 設計判断（ADR-0023）

- **種畜証明書 `StudCertificate`（新 VO）** をモデル化。番号・有効区域 `validRegions`・有効期間 `validPeriod` を持ち、`authorizes(coveringDate, coveringPlace)` で有効性を検証。種付の**事実**を証する種付証明書 `CoveringCertificateNumber` とは**別書面**として型で分離。
- **有効区域は `BreedingRegion` の集合メンバーシップで判定**（一次資料に区分体系が無いため名前付き値に抽象化。「全国」の包含関係はスコープ外）。
- **検証はファクトリ `BreedingResult.create` の構築時前提条件として自己検証**（[ADR-0014](docs/adr/0014-self-validating-factory-over-confinement.md)）。集合制約ではないため `recordCovering` ではなくファクトリ。サービスは素通し。
- 有効性違反は `RecordCoveringError.InvalidCovering(cause)` で表し、Controller で **422 Unprocessable Entity**（有効期間外／有効区域外）に描画（整った入力だが意味的に処理できない。`api-design.md`）。

## 変更

| 種別 | 内容 |
|---|---|
| 新 VO | `StudCertificate` / `StudCertificateNumber` / `ValidityPeriod` / `BreedingRegion` |
| 変更 | `Covering`（`coveringPlace` nullable 追加）／ `BreedingResult.create`（有効性自己検証・`InvalidCovering`）／ `recordCovering`（素通し）／ `BreedingResultResponse`（422 変換・網羅 when 対応） |
| テスト | 新 VO 単体・`create`／`recordCovering` の有効性・Controller の 422 変換。`BreedingFixture` に `studCertificate` 追加 |
| docs | 用語集に新語追記＋型カタログ再生成（種畜証明書/種付証明書の区別）、ADR-0023 |

## 段階導入の割り切り

種畜証明書・種付場所引数は省略可能（デフォルト null）で、渡されたときだけ有効性を検証する。`Covering.coveringPlace` も nullable。これは API がまだ証明書を供給しないことへの過渡措置で、供給配線（別 PR）で必須化する前提。

## 確認

- `./gradlew check`（ktfmt / detekt / 全テスト / koverVerifyMature）が BUILD SUCCESSFUL。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
