### PR TITLE
feat: 繁殖供用停止（retirement）をロール終了状態として表す

### DIFF
--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -150,6 +150,7 @@ graph LR
 | BreedingRegistrationId | 値オブジェクト | domain.horseracing.model.breeding |
 | BreedingRegistrationNumber | 値オブジェクト | domain.horseracing.model.breeding |
 | BreedingResultId | 値オブジェクト | domain.horseracing.model.breeding |
+| BreedingRetirement | 値オブジェクト | domain.horseracing.model.breeding |
 | CoatColor | 値オブジェクト | domain.horseracing.model.horse.bloodhorse |
 | Covering | 値オブジェクト | domain.horseracing.model.breeding |
 | CoveringCertificateNumber | 値オブジェクト | domain.horseracing.model.breeding |

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingRegistration.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingRegistration.kt
@@ -4,6 +4,10 @@ import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorse
 import com.example.api.domain.horseracing.model.horse.bloodhorse.BloodHorseId
 import com.example.api.domain.shared.Entity
 import com.example.api.domain.shared.generateId
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import java.time.LocalDate
 import java.util.UUID
 import org.jmolecules.ddd.annotation.AggregateRoot
 import org.jmolecules.ddd.annotation.Identity
@@ -11,6 +15,15 @@ import org.jmolecules.ddd.annotation.ValueObject
 
 /** 繁殖登録ID */
 @ValueObject @JvmInline value class BreedingRegistrationId(val value: UUID)
+
+/**
+ * 既に供用停止済みの繁殖登録に対して、重ねて供用停止しようとした。
+ *
+ * 供用停止は繁殖登録ライフサイクルの終端であり一度きり。二重の供用停止は不変条件違反。
+ *
+ * @property current 既に記録されている供用停止
+ */
+data class AlreadyRetired(val current: BreedingRetirement)
 
 /**
  * 繁殖登録を表す集約ルート。
@@ -22,20 +35,52 @@ import org.jmolecules.ddd.annotation.ValueObject
  * 繁殖供用する個体は別集約であり、参照は [BloodHorseId] 経由で表す。生成は登録対象の [BloodHorse] を引数で受け取る 生成ファクトリ [create]
  * に限り、ロールはその個体の性から定める。
  *
+ * 状態はイミュータブルに扱う。繁殖登録は当初「供用中」（[retirement] は null）で、後日の「供用停止」で一度だけ終端する。 供用停止は [retire] が供用停止を記録した新しい
+ * [BreedingRegistration] を返すことで表し、同一性（[id]）は引き継ぐ。元のインスタンスは変更しない （登録規程実施基準・第15条第1項(3)
+ * は供用停止した繁殖登録馬に事由と発生日の記載を求める）。
+ *
  * @property registrationNumber 繁殖登録番号
  * @property registeredHorseId 繁殖登録した個体（血統登録済み）の軽種馬ID
  * @property role 繁殖登録によって付与されたロール（性から定まる）
- * @property id 繁殖登録ID（自動生成）
+ * @property retirement 供用停止。供用中なら null、供用停止済みなら事由と発生日を持つ
+ * @property id 繁殖登録ID（生成時に自動採番し、以後の写像でも引き継ぐ）
  */
 @AggregateRoot
 class BreedingRegistration
 private constructor(
+    @field:Identity override val id: BreedingRegistrationId,
     val registrationNumber: BreedingRegistrationNumber,
     val registeredHorseId: BloodHorseId,
     val role: BreedingRole,
+    val retirement: BreedingRetirement?,
 ) : Entity<BreedingRegistrationId>() {
-    /** 繁殖登録ID */
-    @field:Identity override val id = BreedingRegistrationId(generateId())
+    /** 繁殖供用を停止済みか（供用停止が記録されているか）を返す。 */
+    val isRetired: Boolean
+        get() = retirement != null
+
+    /**
+     * 繁殖供用を停止した新しい [BreedingRegistration] を返す。
+     *
+     * 供用停止は繁殖登録ライフサイクルの終端であり一度だけ行える（登録規程実施基準・第15条第1項(3)）。 既に供用停止済みの登録への再停止は不変条件違反として
+     * [AlreadyRetired] を返し、写像を行わない（元の [BreedingRegistration] も不変）。成功時は [retirement] のみ差し替え、[id]
+     * を含む他の属性は引き継ぐ。
+     *
+     * @param reason 供用停止の事由
+     * @param occurredOn 事由が発生した日
+     * @return 供用停止済みの新しい [BreedingRegistration]、既に供用停止済みなら [AlreadyRetired]
+     */
+    fun retire(
+        reason: RetirementReason,
+        occurredOn: LocalDate,
+    ): Result<BreedingRegistration, AlreadyRetired> {
+        val current = retirement
+        return if (current != null) Err(AlreadyRetired(current))
+        else Ok(copy(retirement = BreedingRetirement(reason, occurredOn)))
+    }
+
+    /** [id] と未指定の属性を引き継ぎ、指定された属性だけを差し替えた新しい [BreedingRegistration] を返す。 */
+    private fun copy(retirement: BreedingRetirement? = this.retirement): BreedingRegistration =
+        BreedingRegistration(id, registrationNumber, registeredHorseId, role, retirement)
 
     companion object {
         /**
@@ -43,6 +88,8 @@ private constructor(
          *
          * 繁殖登録は雄雌どちらも対象で、付与される [BreedingRole]（雄=種牡馬／雌=繁殖牝馬）は対象個体の性から定まる。 制度上の前提条件（②馬名登録済み
          * ③競走馬登録があれば抹消済み 等）は対応する集約が未モデル化のため現時点では 検証しない。検証すべき前提条件が増えたら戻り値を `Result` に変える。
+         *
+         * 生成直後は供用中（[retirement] は null）。
          *
          * @param registrationNumber 交付される繁殖登録番号
          * @param horse 繁殖登録する馬（血統登録済みの [BloodHorse]）
@@ -52,6 +99,12 @@ private constructor(
             registrationNumber: BreedingRegistrationNumber,
             horse: BloodHorse,
         ): BreedingRegistration =
-            BreedingRegistration(registrationNumber, horse.id, BreedingRole.from(horse.sex))
+            BreedingRegistration(
+                id = BreedingRegistrationId(generateId()),
+                registrationNumber = registrationNumber,
+                registeredHorseId = horse.id,
+                role = BreedingRole.from(horse.sex),
+                retirement = null,
+            )
     }
 }

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingRetirement.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingRetirement.kt
@@ -1,0 +1,35 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import java.time.LocalDate
+import org.jmolecules.ddd.annotation.ValueObject
+
+/**
+ * 繁殖供用を停止した事由。
+ *
+ * 登録規程実施基準・第15条第1項(3)は、血統書に「供用停止した繁殖登録馬にあっては供用停止の事由とその事由が発生した日」を 記載すると定めるが、事由のカテゴリ自体は列挙していない（開放的）。
+ * 繁殖成績報告書（様式第14号）は繁殖馬本体の異動として「死亡（死産・生後直死を除く）／用途変更」を名指しするため、 この2つを区分として持ち、第15条の開放性を受ける逃がしとして [OTHER]
+ * を置く。
+ *
+ * なお「輸出」は第15条で供用停止とは別号（輸出先国・輸出年月日）として扱われるため、供用停止事由には含めない。
+ */
+enum class RetirementReason {
+    /** 死亡（死産・生後直死を除く）。 */
+    DEATH,
+
+    /** 用途変更（乗用馬等への転用など、繁殖以外の用途への変更）。 */
+    USE_CHANGE,
+
+    /** その他の事由（第15条は事由を限定しないため、上記以外を受ける）。 */
+    OTHER,
+}
+
+/**
+ * 繁殖供用の停止（供用停止）を表す値オブジェクト。
+ *
+ * 繁殖登録（[BreedingRegistration]）のライフサイクル終端であり、供用停止の[事由][reason]と
+ * その事由が[発生した日][occurredOn]を対で持つ（登録規程実施基準・第15条第1項(3)）。
+ *
+ * @property reason 供用停止の事由
+ * @property occurredOn 事由が発生した日
+ */
+@ValueObject data class BreedingRetirement(val reason: RetirementReason, val occurredOn: LocalDate)

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingRegistrationTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingRegistrationTest.kt
@@ -1,0 +1,61 @@
+package com.example.api.domain.horseracing.model.breeding
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import java.time.LocalDate
+import org.junit.jupiter.api.Test
+
+/** BreedingRegistration 集約の繁殖供用停止（retire）に関するユニットテスト。 */
+class BreedingRegistrationTest {
+    private val occurredOn = LocalDate.of(2024, 6, 1)
+
+    @Test
+    fun `生成直後は供用中で供用停止を持たない`() {
+        val registration = BreedingFixture.breedingRegistration()
+
+        assert(!registration.isRetired)
+        assert(registration.retirement == null)
+    }
+
+    @Test
+    fun `供用停止すると事由と発生日を持つ新しい登録が返り 同一性は引き継がれる`() {
+        val active = BreedingFixture.breedingRegistration()
+
+        val retired = active.retire(RetirementReason.DEATH, occurredOn).unwrap()
+
+        assert(retired.isRetired)
+        assert(retired.retirement == BreedingRetirement(RetirementReason.DEATH, occurredOn))
+        assert(retired.id == active.id)
+        // 他の属性も引き継がれる
+        assert(retired.registrationNumber == active.registrationNumber)
+        assert(retired.role == active.role)
+        assert(retired.registeredHorseId == active.registeredHorseId)
+    }
+
+    @Test
+    fun `retire は元の登録を変更しない（イミュータブル）`() {
+        val active = BreedingFixture.breedingRegistration()
+
+        active.retire(RetirementReason.USE_CHANGE, occurredOn).unwrap()
+
+        assert(!active.isRetired)
+        assert(active.retirement == null)
+    }
+
+    @Test
+    fun `供用停止済みの登録への再停止は AlreadyRetired を返し 供用停止は変わらない`() {
+        val retired =
+            BreedingFixture.breedingRegistration()
+                .retire(RetirementReason.DEATH, occurredOn)
+                .unwrap()
+        val again = LocalDate.of(2025, 1, 1)
+
+        val result = retired.retire(RetirementReason.OTHER, again)
+
+        assert(
+            result.getError() ==
+                AlreadyRetired(BreedingRetirement(RetirementReason.DEATH, occurredOn))
+        )
+        assert(retired.retirement == BreedingRetirement(RetirementReason.DEATH, occurredOn))
+    }
+}


### PR DESCRIPTION
## 概要

繁殖供用停止（retirement）を `BreedingRegistration` 集約のロール終了状態として表す（#318）。供用停止した繁殖登録馬に事由と発生日の記載を求める**登録規程実施基準・第15条第1項(3)** を満たすモデルを追加する。

## 設計判断

- **配置: BreedingRegistration に内包**（独立集約にしない）。供用停止は繁殖登録ライフサイクルの終端状態であり、第15条も「供用停止した繁殖登録馬」に事由・発生日を紐付けるため。
- **事由区分（典拠ベースで決定）**: `RetirementReason { DEATH, USE_CHANGE, OTHER }`
  - 第15条は供用停止事由を**列挙していない**（開放的に事由＋発生日を要求）
  - 繁殖成績報告書（**様式第14号**）が繁殖馬本体の異動として「**死亡（死産・生後直死を除く）／用途変更**」を名指し → DEATH / USE_CHANGE
  - 「輸出」は第15条で供用停止とは**別号**（輸出先国・輸出年月日）→ 供用停止事由に含めない
  - `OTHER` は第15条の開放性を受ける逃がし弁

## 変更内容

- **`BreedingRetirement.kt`（新規）**: 事由 enum `RetirementReason` と、事由＋発生日を対で持つ `@ValueObject BreedingRetirement`
- **`BreedingRegistration.kt`**: `retirement: BreedingRetirement?`（null=供用中）を内包。`id` をコンストラクタへ移し同一性を引き継ぐ `copy` を追加し、`retire(reason, occurredOn): Result<_, AlreadyRetired>`（二重供用停止は不変条件違反）と `isRetired` を実装（イミュータブル集約 ADR-0009 の `assignName` パターンに準拠）
- **`BreedingRegistrationTest.kt`（新規）**: 供用中の初期状態／供用停止の写像と同一性引き継ぎ／イミュータブル／再停止の `AlreadyRetired` を検証
- **`docs/ubiquitous-language.md`**: 自動生成カタログに `BreedingRetirement` を追記

## スコープ外（フォローアップ issue 化済み）

- **API 配線**（供用停止報告ユースケース＋controller）→ #408。繁殖登録の登録 API 自体が未実装（`create` はテスト fixture からのみ）という前提ブロッカーがあるため分離
- **#314（異動・死亡）との連携**（死亡＝`RetirementReason.DEATH` として `retire()` へ橋渡し）→ #314 にコメントで記録

## テスト

`./gradlew check` 緑（ktfmt / detekt / 全テスト / koverVerifyMature）。

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)
