### PR TITLE
feat: 種付の有効性検証を API 入口へ配線し種畜証明書・種付場所を必須化する (#404)

### DIFF
--- a/docs/adr/0023-covering-validity-via-stud-certificate.md
+++ b/docs/adr/0023-covering-validity-via-stud-certificate.md
@@ -59,3 +59,19 @@
   渡したときのみ働く。
 - 有効区域の包含関係（全国 ⊇ 個別区域）と、種畜証明書番号・種付証明書番号の桁数/形式検証は本 ADR のスコープ外。区分体系・形式が
   判明した時点で具体化する。
+
+## 追補（2026-06-24）: 段階導入の解消
+
+決定 4 の段階導入（種畜証明書・種付場所を省略可能とし `Covering.coveringPlace` を nullable とする過渡措置）は、API 入口の供給配線
+（issue #404）の完了により解消した。`POST /api/breedingResults` のリクエストが種付場所（`covering_place`）と種畜証明書
+（`stud_certificate`：番号・有効区域・有効期間）を受け取り、`RecordCoveringUseCase` が各 VO を `create` 検証して
+（VO 形式不正は 400）`recordCovering` へ渡すようになった。これに伴い:
+
+- `BreedingResult.create` / `recordCovering` の `studCertificate` / `coveringPlace` 引数を**必須（非 null）化**し、デフォルト
+  `null` を撤去した。有効性検証は常に `StudCertificate.authorizes` を通る（「渡されたときだけ検証」を廃止）。
+- `Covering.coveringPlace` を非 null 化した。種付は必ずどこかで行われた事実であり、有効性検証の与件でもあるため。
+- `BreedingResultResponse` に `covering_place` を加え、リソース表現に種付場所を反映した（種畜証明書は永続化しない与件のため
+  レスポンスには載せない）。
+
+決定そのもの（検証の置き場所＝ファクトリ自己検証、有効区域＝集合メンバーシップ、種畜証明書と種付証明書の型分離）は不変で、
+本追補は決定 4 が予告した過渡措置の終了を記録するもの。

--- a/src/main/kotlin/com/example/api/application/horseracing/breeding/RecordCoveringUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/horseracing/breeding/RecordCoveringUseCase.kt
@@ -1,11 +1,15 @@
 package com.example.api.application.horseracing.breeding
 
+import com.example.api.domain.horseracing.model.breeding.BreedingRegion
 import com.example.api.domain.horseracing.model.breeding.BreedingRegistrationId
 import com.example.api.domain.horseracing.model.breeding.BreedingRegistrationRepository
 import com.example.api.domain.horseracing.model.breeding.BreedingResult
 import com.example.api.domain.horseracing.model.breeding.BreedingResultRepository
 import com.example.api.domain.horseracing.model.breeding.CoveringCertificateNumber
 import com.example.api.domain.horseracing.model.breeding.RecordCoveringError
+import com.example.api.domain.horseracing.model.breeding.StudCertificate
+import com.example.api.domain.horseracing.model.breeding.StudCertificateNumber
+import com.example.api.domain.horseracing.model.breeding.ValidityPeriod
 import com.example.api.domain.horseracing.service.breeding.recordCovering
 import com.example.api.domain.shared.Command
 import com.github.michaelbull.result.Result
@@ -19,25 +23,59 @@ import org.springframework.stereotype.Service
 /**
  * 種付記録ユースケースの入力コマンド。
  *
- * 繁殖成績報告書の「種付」欄に相当する境界の生入力。種付証明書番号は素の文字列で受け取り、ユースケース内で VO の `create`
+ * 繁殖成績報告書の「種付」欄に相当する境界の生入力。VO で表す項目（種付証明書番号・種付場所・種畜証明書）は素の値で 受け取り、ユースケース内で各 VO の `create`
  * を通して検証する。繁殖牝馬・種牡馬はいずれも既存の繁殖登録IDで参照する（種牡馬も繁殖登録の対象）。
  *
  * @property breedingRegistrationId 種付対象の繁殖牝馬の繁殖登録ID
  * @property stallionRegistrationId 配合相手の種牡馬の繁殖登録ID
  * @property coveringDate 種付日
+ * @property coveringPlace 種付が行われた場所（有効区域の整合検証に用いる）
  * @property certificateNumber 種付の事実を証明する種付証明書の番号
+ * @property studCertificate 種牡馬の種畜証明書（種付の有効性検証の与件）
  */
 data class RecordCoveringCommand(
     val breedingRegistrationId: UUID,
     val stallionRegistrationId: UUID,
     val coveringDate: LocalDate,
+    val coveringPlace: String,
     val certificateNumber: String,
+    val studCertificate: StudCertificateInput,
+)
+
+/**
+ * 種畜証明書の入力（[RecordCoveringCommand.studCertificate]）。各項目は素の値で受け取り、ユースケースが VO 検証する。
+ *
+ * @property number 種畜証明書番号
+ * @property validRegions 有効区域名（1 つ以上）
+ * @property validPeriodStart 有効期間の起点（当日を含む）
+ * @property validPeriodEnd 有効期間の終点（当日を含む）
+ */
+data class StudCertificateInput(
+    val number: String,
+    val validRegions: List<String>,
+    val validPeriodStart: LocalDate,
+    val validPeriodEnd: LocalDate,
 )
 
 /** 種付記録時に発生しうる業務ルール違反。 */
 sealed interface RecordCoveringUseCaseError {
     /** 種付証明書番号がブランク。 */
     data object InvalidCertificateNumber : RecordCoveringUseCaseError
+
+    /** 種付場所がブランク。 */
+    data object InvalidCoveringPlace : RecordCoveringUseCaseError
+
+    /** 種畜証明書番号がブランク。 */
+    data object InvalidStudCertificateNumber : RecordCoveringUseCaseError
+
+    /** 種畜証明書の有効区域名のいずれかがブランク。 */
+    data object InvalidValidRegion : RecordCoveringUseCaseError
+
+    /** 種畜証明書の有効期間が不正（終点が起点より前）。 */
+    data object InvalidValidityPeriod : RecordCoveringUseCaseError
+
+    /** 種畜証明書の有効区域が 1 つも指定されていない。 */
+    data object EmptyValidRegions : RecordCoveringUseCaseError
 
     /** 種付対象として指定された繁殖牝馬の繁殖登録が存在しない。 */
     data class BreedingRegistrationNotFound(val breedingRegistrationId: UUID) :
@@ -80,6 +118,13 @@ class RecordCoveringUseCase(
                 .mapError { RecordCoveringUseCaseError.InvalidCertificateNumber }
                 .bind()
 
+        val coveringPlace =
+            BreedingRegion.create(input.coveringPlace)
+                .mapError { RecordCoveringUseCaseError.InvalidCoveringPlace }
+                .bind()
+
+        val studCertificate = buildStudCertificate(input.studCertificate).bind()
+
         val broodmareRegistration =
             breedingRegistrationRepository
                 .findById(BreedingRegistrationId(input.breedingRegistrationId))
@@ -107,10 +152,40 @@ class RecordCoveringUseCase(
                     input.coveringDate,
                     certificateNumber,
                     breedingResultRepository,
+                    studCertificate,
+                    coveringPlace,
                 )
                 .mapError { RecordCoveringUseCaseError.PreconditionViolated(it) }
                 .bind()
 
         breedingResultRepository.save(breedingResult)
+    }
+
+    /** 種畜証明書の生入力を各 VO 検証して [StudCertificate] を組み立てる。形式不正は 400 系の入力エラーにマップする。 */
+    private fun buildStudCertificate(
+        input: StudCertificateInput
+    ): Result<StudCertificate, RecordCoveringUseCaseError> = binding {
+        val number =
+            StudCertificateNumber.create(input.number)
+                .mapError { RecordCoveringUseCaseError.InvalidStudCertificateNumber }
+                .bind()
+
+        val validRegions = mutableSetOf<BreedingRegion>()
+        for (region in input.validRegions) {
+            validRegions.add(
+                BreedingRegion.create(region)
+                    .mapError { RecordCoveringUseCaseError.InvalidValidRegion }
+                    .bind()
+            )
+        }
+
+        val validityPeriod =
+            ValidityPeriod.create(input.validPeriodStart, input.validPeriodEnd)
+                .mapError { RecordCoveringUseCaseError.InvalidValidityPeriod }
+                .bind()
+
+        StudCertificate.create(number, validRegions, validityPeriod)
+            .mapError { RecordCoveringUseCaseError.EmptyValidRegions }
+            .bind()
     }
 }

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
@@ -27,6 +27,7 @@ import org.springframework.http.ProblemDetail
  * @property breedingYear 繁殖年
  * @property stallionId 種牡馬の生 UUID。種付せずの年は null
  * @property coveringDate 種付日。種付せずの年は null
+ * @property coveringPlace 種付が行われた場所。種付せずの年は null
  * @property certificateNumber 種付証明書番号。種付せずの年は null
  * @property outcome 分娩結果。種付した年で未報告なら null
  */
@@ -36,6 +37,7 @@ data class BreedingResultResponse(
     val breedingYear: Int,
     val stallionId: UUID?,
     val coveringDate: LocalDate?,
+    val coveringPlace: String?,
     val certificateNumber: String?,
     val outcome: FoalingOutcomeResponse?,
 )
@@ -48,9 +50,14 @@ fun BreedingResult.toResponse(): BreedingResultResponse =
         breedingYear = breedingYear.value,
         stallionId = covering?.stallionId?.value,
         coveringDate = covering?.coveringDate,
+        coveringPlace = covering?.coveringPlace?.value,
         certificateNumber = covering?.certificateNumber?.value,
         outcome = outcome?.toResponse(),
     )
+
+/** 入力不正（VO 形式違反）を 400 Bad Request の [ProblemDetail] に描画する小さなビルダ。 */
+private fun badRequest(code: String, title: String, detail: String): ProblemDetail =
+    problem(status = HttpStatus.BAD_REQUEST, code = code, title = title, detail = detail)
 
 /**
  * [RecordCoveringUseCaseError] を RFC 9457 (`application/problem+json`) の [ProblemDetail] に変換する。
@@ -61,11 +68,40 @@ fun BreedingResult.toResponse(): BreedingResultResponse =
 fun RecordCoveringUseCaseError.toProblemDetail(): ProblemDetail =
     when (this) {
         RecordCoveringUseCaseError.InvalidCertificateNumber ->
-            problem(
-                status = HttpStatus.BAD_REQUEST,
-                code = "invalid-covering-certificate-number",
-                title = "Invalid covering certificate number",
-                detail = "certificate_number は空であってはいけません。",
+            badRequest(
+                "invalid-covering-certificate-number",
+                "Invalid covering certificate number",
+                "certificate_number は空であってはいけません。",
+            )
+        RecordCoveringUseCaseError.InvalidCoveringPlace ->
+            badRequest(
+                "invalid-covering-place",
+                "Invalid covering place",
+                "covering_place は空であってはいけません。",
+            )
+        RecordCoveringUseCaseError.InvalidStudCertificateNumber ->
+            badRequest(
+                "invalid-stud-certificate-number",
+                "Invalid stud certificate number",
+                "stud_certificate.number は空であってはいけません。",
+            )
+        RecordCoveringUseCaseError.InvalidValidRegion ->
+            badRequest(
+                "invalid-valid-region",
+                "Invalid valid region",
+                "stud_certificate.valid_regions の各区域名は空であってはいけません。",
+            )
+        RecordCoveringUseCaseError.InvalidValidityPeriod ->
+            badRequest(
+                "invalid-validity-period",
+                "Invalid validity period",
+                "stud_certificate の有効期間の終点は起点以降でなければなりません。",
+            )
+        RecordCoveringUseCaseError.EmptyValidRegions ->
+            badRequest(
+                "empty-valid-regions",
+                "Empty valid regions",
+                "stud_certificate.valid_regions は 1 つ以上指定してください。",
             )
         is RecordCoveringUseCaseError.BreedingRegistrationNotFound ->
             problem(

--- a/src/main/kotlin/com/example/api/controller/breeding/RecordBreedingResultRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/RecordBreedingResultRequest.kt
@@ -2,6 +2,7 @@ package com.example.api.controller.breeding
 
 import com.example.api.application.horseracing.breeding.RecordCoveringCommand
 import com.example.api.application.horseracing.breeding.RecordUncoveredCommand
+import com.example.api.application.horseracing.breeding.StudCertificateInput
 import com.example.api.controller.problem
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
@@ -34,16 +35,35 @@ data class RecordBreedingResultRequest(
 /**
  * 種付の入力（[RecordBreedingResultRequest.covering]）。
  *
- * 繁殖牝馬・種牡馬はいずれも登録済みの繁殖登録IDで参照する。VO で表す種付証明書番号は素の文字列で受け取り、 ユースケースで検証する。
+ * 繁殖牝馬・種牡馬はいずれも登録済みの繁殖登録IDで参照する。VO で表す項目（種付場所・種付証明書番号・種畜証明書）は 素の値で受け取り、ユースケースで検証する。
  *
  * @property stallionRegistrationId 配合相手の種牡馬の繁殖登録ID
  * @property coveringDate 種付日
+ * @property coveringPlace 種付が行われた場所（有効区域の整合検証に用いる）
  * @property certificateNumber 種付証明書番号
+ * @property studCertificate 種牡馬の種畜証明書（種付の有効性検証の与件）
  */
 data class CoveringRequest(
     val stallionRegistrationId: UUID,
     val coveringDate: LocalDate,
+    val coveringPlace: String,
     val certificateNumber: String,
+    val studCertificate: StudCertificateRequest,
+)
+
+/**
+ * 種畜証明書の入力（[CoveringRequest.studCertificate]）。各項目は素の値で受け取り、ユースケースで VO 検証する。
+ *
+ * @property number 種畜証明書番号
+ * @property validRegions 有効区域名（1 つ以上）
+ * @property validPeriodStart 有効期間の起点（当日を含む）
+ * @property validPeriodEnd 有効期間の終点（当日を含む）
+ */
+data class StudCertificateRequest(
+    val number: String,
+    val validRegions: List<String>,
+    val validPeriodStart: LocalDate,
+    val validPeriodEnd: LocalDate,
 )
 
 /** 種付ありの入力を種付記録ユースケースの入力コマンドへ変換する。 */
@@ -54,7 +74,15 @@ fun RecordBreedingResultRequest.toCoveringCommand(
         breedingRegistrationId = breedingRegistrationId,
         stallionRegistrationId = covering.stallionRegistrationId,
         coveringDate = covering.coveringDate,
+        coveringPlace = covering.coveringPlace,
         certificateNumber = covering.certificateNumber,
+        studCertificate =
+            StudCertificateInput(
+                number = covering.studCertificate.number,
+                validRegions = covering.studCertificate.validRegions,
+                validPeriodStart = covering.studCertificate.validPeriodStart,
+                validPeriodEnd = covering.studCertificate.validPeriodEnd,
+            ),
     )
 
 /**

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResult.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResult.kt
@@ -188,8 +188,8 @@ private constructor(
          * を返す。生成物は種牡馬を `BloodHorseId` 経由で参照する。生成直後は分娩結果が 未報告（[outcome] は null）。
          *
          * 本ファクトリが守るのは「単一の繁殖成績インスタンスの構築時不変条件」（登録ロール）と、協力与件を引数で受け取れる 構築時前提条件（種畜証明書による種付の有効性）に限る。後者は
-         * [studCertificate] が渡されたときだけ検証する段階導入で、 渡されなければ従来どおりロール検証のみで生成する（API
-         * 入口が種畜証明書・種付場所を供給するようになり次第、必須化する）。 「繁殖牝馬 ×
+         * [studCertificate] の有効区域・有効期間に対し種付（[coveringDate] / [coveringPlace]）が内側にあるかを
+         * [StudCertificate.authorizes] で検証する。 「繁殖牝馬 ×
          * 繁殖年」で一意という集合制約（同一年の重複記録の禁止）は単一インスタンスの構築では完結しないため、 既存成績群をまたぐ ドメインサービス recordCovering
          * が担い、本ファクトリはその検証を経た上で呼び出される。
          *
@@ -197,8 +197,8 @@ private constructor(
          * @param stallionRegistration 配合相手の種牡馬の繁殖登録（ロールが種牡馬であること）
          * @param coveringDate 種付日
          * @param certificateNumber 種付の事実を証明する種付証明書の番号
-         * @param studCertificate 種牡馬の種畜証明書。渡された場合のみ種付の有効性（有効区域・有効期間）を検証する
-         * @param coveringPlace 種付場所。[studCertificate] を渡す場合は必須（有効区域の整合検証に用いる）
+         * @param studCertificate 種牡馬の種畜証明書。種付の有効性（有効区域・有効期間）を検証する与件
+         * @param coveringPlace 種付場所（有効区域の整合検証に用いる）
          * @return 種付を記録した [BreedingResult]、または前提条件違反を表す [RecordCoveringError]
          */
         fun create(
@@ -206,8 +206,8 @@ private constructor(
             stallionRegistration: BreedingRegistration,
             coveringDate: LocalDate,
             certificateNumber: CoveringCertificateNumber,
-            studCertificate: StudCertificate? = null,
-            coveringPlace: BreedingRegion? = null,
+            studCertificate: StudCertificate,
+            coveringPlace: BreedingRegion,
         ): Result<BreedingResult, RecordCoveringError> =
             when {
                 broodmareRegistration.role != BreedingRole.BROODMARE ->
@@ -215,7 +215,8 @@ private constructor(
                 stallionRegistration.role != BreedingRole.STALLION ->
                     Err(RecordCoveringError.NotStallion)
                 else ->
-                    validateCovering(studCertificate, coveringDate, coveringPlace)
+                    studCertificate
+                        .authorizes(coveringDate, coveringPlace)
                         .map {
                             BreedingResult(
                                 id = BreedingResultId(generateId()),
@@ -232,23 +233,6 @@ private constructor(
                             )
                         }
                         .mapError { RecordCoveringError.InvalidCovering(it) }
-            }
-
-        /**
-         * 種畜証明書が渡された場合に種付の有効性（有効区域・有効期間）を検証する。渡されなければ検証なし（段階導入）。
-         *
-         * [studCertificate] を渡す場合、有効区域の整合検証のため [coveringPlace] は必須（プログラミングエラーとして表明）。
-         */
-        private fun validateCovering(
-            studCertificate: StudCertificate?,
-            coveringDate: LocalDate,
-            coveringPlace: BreedingRegion?,
-        ): Result<Unit, CoveringValidityError> =
-            if (studCertificate == null) {
-                Ok(Unit)
-            } else {
-                require(coveringPlace != null) { "種畜証明書を渡す場合は種付場所も必須。" }
-                studCertificate.authorizes(coveringDate, coveringPlace)
             }
 
         /**

--- a/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/Covering.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/model/breeding/Covering.kt
@@ -11,12 +11,12 @@ import org.jmolecules.ddd.annotation.ValueObject
  * どの種付証明書で証明するかを束ねる。種牡馬は別個体（別集約）であり、参照は [BloodHorseId] 経由で表す。 種牡馬が雄であることなど 集約をまたぐ前提条件の検証はドメインサービス
  * recordCovering の責務とし、 検証を経た記録のみを許す。
  *
- * 種付場所（[coveringPlace]）は、種畜証明書（[StudCertificate]）の有効区域に対する種付の有効性検証に用いる。現状は API 入口が場所・種畜証明書を供給しないため
- * nullable とし、供給された記録でのみ場所を保持する（段階導入。供給経路が 整い次第、必須化する）。
+ * 種付場所（[coveringPlace]）は、種畜証明書（[StudCertificate]）の有効区域に対する種付の有効性検証に用いる。種付は必ずどこかで
+ * 行われた事実であり、有効性検証の与件でもあるため必須とする。
  *
  * @property stallionId 種牡馬（雄の軽種馬）の軽種馬ID
  * @property coveringDate 種付日
- * @property coveringPlace 種付が行われた場所（有効性検証に用いる）。未供給の記録では null
+ * @property coveringPlace 種付が行われた場所（有効性検証に用いる）
  * @property certificateNumber 種付の事実を証明する種付証明書の番号
  */
 @ValueObject

--- a/src/main/kotlin/com/example/api/domain/horseracing/service/breeding/RecordCovering.kt
+++ b/src/main/kotlin/com/example/api/domain/horseracing/service/breeding/RecordCovering.kt
@@ -18,8 +18,7 @@ import java.time.Year
  * 種付記録の前提条件は2系統あり、性質が異なるため担い手を分ける:
  * - **配合の登録ロール（繁殖牝馬 × 種牡馬）／種付の有効性（種畜証明書の有効区域・有効期間）** … いずれも単一の繁殖成績
  *   インスタンスの構築時前提条件で、協力与件（繁殖登録・種畜証明書）を引数で受け取れる。委譲先のファクトリ [BreedingResult.create]
- *   が自己検証する（NotBroodmare / NotStallion / InvalidCovering の [RecordCoveringError]）。有効性検証は
- *   [studCertificate] が渡された場合のみ行う段階導入。
+ *   が自己検証する（NotBroodmare / NotStallion / InvalidCovering の [RecordCoveringError]）。
  * - **「繁殖牝馬 × 繁殖年」で一意（同一年の重複記録の禁止）** … 既存成績群（集合）をまたぐ集合制約で、単一インスタンスの 構築では完結しない。本サービスが
  *   [breedingResultRepository] から同年の既存成績を引き当てて検証する （[RecordCoveringError.AlreadyRecordedForYear]）。
  *
@@ -32,8 +31,8 @@ import java.time.Year
  * @param coveringDate 種付日
  * @param certificateNumber 種付の事実を証明する種付証明書の番号
  * @param breedingResultRepository 同一繁殖牝馬・同一繁殖年の既存成績を引き当てる繁殖成績ポート
- * @param studCertificate 種牡馬の種畜証明書。渡された場合のみ種付の有効性（有効区域・有効期間）をファクトリが検証する
- * @param coveringPlace 種付場所。[studCertificate] を渡す場合は必須（有効区域の整合検証に用いる）
+ * @param studCertificate 種牡馬の種畜証明書。種付の有効性（有効区域・有効期間）をファクトリが検証する与件
+ * @param coveringPlace 種付場所（有効区域の整合検証に用いる）
  * @return 起こされた [BreedingResult]、または前提条件違反を表す [RecordCoveringError]
  */
 fun recordCovering(
@@ -42,8 +41,8 @@ fun recordCovering(
     coveringDate: LocalDate,
     certificateNumber: CoveringCertificateNumber,
     breedingResultRepository: BreedingResultRepository,
-    studCertificate: StudCertificate? = null,
-    coveringPlace: BreedingRegion? = null,
+    studCertificate: StudCertificate,
+    coveringPlace: BreedingRegion,
 ): Result<BreedingResult, RecordCoveringError> {
     val breedingYear = Year.of(coveringDate.year)
     val existingForYear =

--- a/src/test/kotlin/com/example/api/application/horseracing/breeding/RecordCoveringUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/horseracing/breeding/RecordCoveringUseCaseTest.kt
@@ -26,7 +26,15 @@ class RecordCoveringUseCaseTest {
             breedingRegistrationId = breedingRegistrationId,
             stallionRegistrationId = stallionRegistrationId,
             coveringDate = LocalDate.of(2024, 4, 1),
+            coveringPlace = "北海道",
             certificateNumber = "C-2024-0001",
+            studCertificate =
+                StudCertificateInput(
+                    number = "S-2024-0001",
+                    validRegions = listOf("北海道"),
+                    validPeriodStart = LocalDate.of(2024, 1, 1),
+                    validPeriodEnd = LocalDate.of(2024, 12, 31),
+                ),
         )
 
     private fun command(payload: RecordCoveringCommand): Command<RecordCoveringCommand> =
@@ -66,6 +74,7 @@ class RecordCoveringUseCaseTest {
             assert(result.breedingRegistrationId == broodmareRegistration.id)
             assert(covering?.stallionId == stallionRegistration.registeredHorseId)
             assert(covering?.coveringDate == LocalDate.of(2024, 4, 1))
+            assert(covering?.coveringPlace?.value == "北海道")
             assert(covering?.certificateNumber?.value == "C-2024-0001")
             assert(result.outcome == null)
             verify(exactly = 1) { breedingResultRepository.save(any()) }
@@ -89,6 +98,122 @@ class RecordCoveringUseCaseTest {
                 )
 
             assert(result.getError() == RecordCoveringUseCaseError.InvalidCertificateNumber)
+            verify(exactly = 0) { breedingResultRepository.save(any()) }
+        }
+
+        @Test
+        fun `種付場所がブランクのとき InvalidCoveringPlace を返し永続化されない`() {
+            val breedingResultRepository = mockk<BreedingResultRepository>()
+            val useCase =
+                RecordCoveringUseCase(
+                    mockk<BreedingRegistrationRepository>(),
+                    breedingResultRepository,
+                )
+
+            val result =
+                useCase(
+                    command(
+                        validPayload(UUID.randomUUID(), UUID.randomUUID()).copy(coveringPlace = "")
+                    )
+                )
+
+            assert(result.getError() == RecordCoveringUseCaseError.InvalidCoveringPlace)
+            verify(exactly = 0) { breedingResultRepository.save(any()) }
+        }
+
+        @Test
+        fun `種畜証明書番号がブランクのとき InvalidStudCertificateNumber を返し永続化されない`() {
+            val breedingResultRepository = mockk<BreedingResultRepository>()
+            val useCase =
+                RecordCoveringUseCase(
+                    mockk<BreedingRegistrationRepository>(),
+                    breedingResultRepository,
+                )
+
+            val payload = validPayload(UUID.randomUUID(), UUID.randomUUID())
+            val result =
+                useCase(
+                    command(
+                        payload.copy(studCertificate = payload.studCertificate.copy(number = ""))
+                    )
+                )
+
+            assert(result.getError() == RecordCoveringUseCaseError.InvalidStudCertificateNumber)
+            verify(exactly = 0) { breedingResultRepository.save(any()) }
+        }
+
+        @Test
+        fun `有効区域名にブランクが混じるとき InvalidValidRegion を返し永続化されない`() {
+            val breedingResultRepository = mockk<BreedingResultRepository>()
+            val useCase =
+                RecordCoveringUseCase(
+                    mockk<BreedingRegistrationRepository>(),
+                    breedingResultRepository,
+                )
+
+            val payload = validPayload(UUID.randomUUID(), UUID.randomUUID())
+            val result =
+                useCase(
+                    command(
+                        payload.copy(
+                            studCertificate =
+                                payload.studCertificate.copy(validRegions = listOf("北海道", ""))
+                        )
+                    )
+                )
+
+            assert(result.getError() == RecordCoveringUseCaseError.InvalidValidRegion)
+            verify(exactly = 0) { breedingResultRepository.save(any()) }
+        }
+
+        @Test
+        fun `有効区域が空のとき EmptyValidRegions を返し永続化されない`() {
+            val breedingResultRepository = mockk<BreedingResultRepository>()
+            val useCase =
+                RecordCoveringUseCase(
+                    mockk<BreedingRegistrationRepository>(),
+                    breedingResultRepository,
+                )
+
+            val payload = validPayload(UUID.randomUUID(), UUID.randomUUID())
+            val result =
+                useCase(
+                    command(
+                        payload.copy(
+                            studCertificate =
+                                payload.studCertificate.copy(validRegions = emptyList())
+                        )
+                    )
+                )
+
+            assert(result.getError() == RecordCoveringUseCaseError.EmptyValidRegions)
+            verify(exactly = 0) { breedingResultRepository.save(any()) }
+        }
+
+        @Test
+        fun `有効期間の終点が起点より前のとき InvalidValidityPeriod を返し永続化されない`() {
+            val breedingResultRepository = mockk<BreedingResultRepository>()
+            val useCase =
+                RecordCoveringUseCase(
+                    mockk<BreedingRegistrationRepository>(),
+                    breedingResultRepository,
+                )
+
+            val payload = validPayload(UUID.randomUUID(), UUID.randomUUID())
+            val result =
+                useCase(
+                    command(
+                        payload.copy(
+                            studCertificate =
+                                payload.studCertificate.copy(
+                                    validPeriodStart = LocalDate.of(2024, 12, 31),
+                                    validPeriodEnd = LocalDate.of(2024, 1, 1),
+                                )
+                        )
+                    )
+                )
+
+            assert(result.getError() == RecordCoveringUseCaseError.InvalidValidityPeriod)
             verify(exactly = 0) { breedingResultRepository.save(any()) }
         }
 

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
@@ -59,7 +59,14 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 "covering": {
                     "stallion_registration_id": "22222222-2222-2222-2222-222222222222",
                     "covering_date": "2024-04-01",
-                    "certificate_number": "C-2024-0001"
+                    "covering_place": "北海道",
+                    "certificate_number": "C-2024-0001",
+                    "stud_certificate": {
+                        "number": "S-2024-0001",
+                        "valid_regions": ["北海道"],
+                        "valid_period_start": "2024-01-01",
+                        "valid_period_end": "2024-12-31"
+                    }
                 }
             }
             """
@@ -78,8 +85,8 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 .assertThat()
                 .hasStatus(HttpStatus.CREATED)
                 .bodyJson()
-                .extractingPath("$.breeding_year")
-                .isEqualTo(2024)
+                .extractingPath("$.covering_place")
+                .isEqualTo("北海道")
         }
 
         @Test
@@ -98,6 +105,24 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 .bodyJson()
                 .extractingPath("$.error_code")
                 .isEqualTo("invalid-covering-certificate-number")
+        }
+
+        @Test
+        fun `InvalidStudCertificateNumber で 400 と problem+json が返ること`() {
+            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+                Err(RecordCoveringUseCaseError.InvalidStudCertificateNumber)
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.error_code")
+                .isEqualTo("invalid-stud-certificate-number")
         }
 
         @Test

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingFixture.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingFixture.kt
@@ -54,8 +54,8 @@ object BreedingFixture {
         coveringDate: LocalDate = LocalDate.of(2024, 4, 1),
         certificateNumber: CoveringCertificateNumber =
             CoveringCertificateNumber.create("C-2024-0001").unwrap(),
-        studCertificate: StudCertificate? = null,
-        coveringPlace: BreedingRegion? = null,
+        studCertificate: StudCertificate = studCertificate(),
+        coveringPlace: BreedingRegion = DEFAULT_REGION,
     ): BreedingResult =
         BreedingResult.create(
                 broodmareRegistration,

--- a/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultCreateTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/model/breeding/BreedingResultCreateTest.kt
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.Test
 class BreedingResultCreateTest {
     private val coveringDate = LocalDate.of(2024, 4, 1)
     private val certificateNumber = CoveringCertificateNumber.create("C-2024-0001").unwrap()
+    private val coveringPlace = BreedingRegion.create("北海道").unwrap()
+    private val studCertificate =
+        BreedingFixture.studCertificate(validRegions = setOf(coveringPlace))
 
     @Test
     fun `繁殖牝馬と種牡馬の登録なら種付が記録され種牡馬を ID で参照する繁殖成績が生成されること`() {
@@ -21,6 +24,8 @@ class BreedingResultCreateTest {
                     stallionRegistration,
                     coveringDate,
                     certificateNumber,
+                    studCertificate,
+                    coveringPlace,
                 )
                 .unwrap()
 
@@ -29,6 +34,7 @@ class BreedingResultCreateTest {
         assert(result.breedingRegistrationId == broodmareRegistration.id)
         assert(covering?.stallionId == stallionRegistration.registeredHorseId)
         assert(covering?.coveringDate == coveringDate)
+        assert(covering?.coveringPlace == coveringPlace)
         assert(covering?.certificateNumber == certificateNumber)
         assert(result.outcome == null)
     }
@@ -44,6 +50,8 @@ class BreedingResultCreateTest {
                 stallionRegistration,
                 coveringDate,
                 certificateNumber,
+                studCertificate,
+                coveringPlace,
             )
 
         assert(result.getError() == RecordCoveringError.NotBroodmare)
@@ -60,6 +68,8 @@ class BreedingResultCreateTest {
                 stallionRegistration,
                 coveringDate,
                 certificateNumber,
+                studCertificate,
+                coveringPlace,
             )
 
         assert(result.getError() == RecordCoveringError.NotStallion)

--- a/src/test/kotlin/com/example/api/domain/horseracing/service/breeding/RecordCoveringTest.kt
+++ b/src/test/kotlin/com/example/api/domain/horseracing/service/breeding/RecordCoveringTest.kt
@@ -18,6 +18,9 @@ import org.junit.jupiter.api.Test
 class RecordCoveringTest {
     private val coveringDate = LocalDate.of(2024, 4, 1)
     private val certificateNumber = CoveringCertificateNumber.create("C-2024-0001").unwrap()
+    private val coveringPlace = BreedingRegion.create("北海道").unwrap()
+    private val studCertificate =
+        BreedingFixture.studCertificate(validRegions = setOf(coveringPlace))
 
     @Test
     fun `同年の既存成績が無ければ種付が記録され分娩結果未報告の繁殖成績が生成されること`() {
@@ -35,6 +38,8 @@ class RecordCoveringTest {
                     coveringDate,
                     certificateNumber,
                     repository,
+                    studCertificate,
+                    coveringPlace,
                 )
                 .unwrap()
 
@@ -67,6 +72,8 @@ class RecordCoveringTest {
                 coveringDate,
                 certificateNumber,
                 repository,
+                studCertificate,
+                coveringPlace,
             )
 
         assert(
@@ -91,6 +98,8 @@ class RecordCoveringTest {
                 coveringDate,
                 certificateNumber,
                 repository,
+                studCertificate,
+                coveringPlace,
             )
 
         assert(result.getError() == RecordCoveringError.NotBroodmare)
@@ -112,6 +121,8 @@ class RecordCoveringTest {
                 coveringDate,
                 certificateNumber,
                 repository,
+                studCertificate,
+                coveringPlace,
             )
 
         assert(result.getError() == RecordCoveringError.NotStallion)


### PR DESCRIPTION
## 概要

#316 (ADR-0023) でドメイン＋サービスに実装した種付の有効性検証を **API 入口へ配線**し、段階導入（種畜証明書・種付場所の省略可能・`Covering.coveringPlace` の nullable）を解消する。

Closes #404

## 変更点

### 配線（request → command → usecase → domain）
- `CoveringRequest` に `covering_place` と `stud_certificate`（番号・有効区域・有効期間）を追加（`StudCertificateRequest` を新設）。`RecordCoveringCommand` / `StudCertificateInput` を経て `RecordCoveringUseCase` が各 VO を `create` 検証（`buildStudCertificate` に抽出）し `recordCovering` へ渡す。
- VO 形式不正（種付場所ブランク・種畜証明書番号ブランク・有効区域名ブランク・有効区域空・有効期間逆転）は **400 Bad Request**（固有 `error_code`）。有効性違反は既存の **422**（`covering-outside-valid-period` / `covering-outside-valid-region`）。

### 必須化（ADR-0023 段階導入の解消）
- `BreedingResult.create` / `recordCovering` の `studCertificate` / `coveringPlace` のデフォルト null を撤去し**非 null 必須**化。有効性検証は常に `StudCertificate.authorizes` を通る。
- `Covering.coveringPlace` を**非 null** 化。

### レスポンス
- `BreedingResultResponse` に `covering_place` を追加（種畜証明書は永続化しない与件のためレスポンスには載せない）。

### テスト
- Fixture / 既存テストを必須引数に追従。`RecordCoveringUseCase` に VO 検証 400 ケース 5 種、controller slice に request 新フィールド・response `covering_place`・新 400 描画を追加。

## 確認
- `./gradlew check`（ktfmt / detekt / test / koverVerifyMature）green。
- 規約: VO 検証=400 / 意味的不可=422 の切り分けは api-design.md・error-handling.md に整合。ADR-0023 に「段階導入の解消」を追補。

## 関連
- 前段: #316 (PR #403) / ADR-0023
- バリデーション方針の継続検討: #409（Bean Validation 採否と VO 検証の境界）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
