### PR TITLE
feat: 繁殖登録（BreedingRegistration）の登録ユースケースと API 入口を整備する (#414)

### DIFF
--- a/src/main/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCase.kt
@@ -1,0 +1,76 @@
+package com.example.api.application.studbook.breeding
+
+import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.breeding.BreedingRegistration
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationNumber
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import com.github.michaelbull.result.mapError
+import com.github.michaelbull.result.toResultOr
+import java.util.UUID
+import org.springframework.stereotype.Service
+
+/**
+ * 繁殖登録ユースケースの入力コマンド。
+ *
+ * 繁殖登録（JAIRS）は血統登録済みの個体を繁殖の用に供するための追加登録で、雄雌共通の単一の登録。担うロール （雄=種牡馬／雌=繁殖牝馬）は対象個体の性から定まるため、境界の生入力としては
+ * 対象個体の軽種馬IDと交付される 繁殖登録番号だけを受け取る。
+ *
+ * @property bloodHorseId 繁殖登録する個体（血統登録済み）の軽種馬ID
+ * @property registrationNumber 交付される繁殖登録番号
+ */
+data class RegisterBreedingRegistrationCommand(
+    val bloodHorseId: UUID,
+    val registrationNumber: String,
+)
+
+/** 繁殖登録時に発生しうる業務ルール違反。 */
+sealed interface RegisterBreedingRegistrationUseCaseError {
+    /** 繁殖登録番号がブランク（VO 検証違反）。 */
+    data object BlankRegistrationNumber : RegisterBreedingRegistrationUseCaseError
+
+    /** 繁殖登録の対象として指定された軽種馬（血統登録済みの個体）が存在しない。 */
+    data class BloodHorseNotFound(val bloodHorseId: UUID) : RegisterBreedingRegistrationUseCaseError
+}
+
+/**
+ * 繁殖登録ユースケース。
+ *
+ * 繁殖登録番号を VO 検証し、対象の軽種馬（血統登録済みの個体）を Repository で引き当てたうえで、繁殖登録集約
+ * （[BreedingRegistration]）を生成して永続化する。付与されるロールはその個体の性から [BreedingRegistration.create]
+ * が定めるため、本ユースケースは前提となる参照の解決と永続化のみを担う。種付記録・種付せず・分娩報告・供用停止といった
+ * 繁殖の書き込み経路は、いずれもここで起こした繁殖登録を起点にする。Controller 層は本クラスのみに依存し、ドメインの 生成経路の詳細は知らない。
+ *
+ * @return 生成された [BreedingRegistration]、または業務ルール違反を表す [RegisterBreedingRegistrationUseCaseError]
+ */
+@Service
+class RegisterBreedingRegistrationUseCase(
+    private val bloodHorseRepository: BloodHorseRepository,
+    private val breedingRegistrationRepository: BreedingRegistrationRepository,
+) {
+    operator fun invoke(
+        command: Command<RegisterBreedingRegistrationCommand>
+    ): Result<BreedingRegistration, RegisterBreedingRegistrationUseCaseError> = binding {
+        val input = command.payload
+
+        val registrationNumber =
+            BreedingRegistrationNumber.create(input.registrationNumber)
+                .mapError { RegisterBreedingRegistrationUseCaseError.BlankRegistrationNumber }
+                .bind()
+
+        val horse =
+            bloodHorseRepository
+                .findById(BloodHorseId(input.bloodHorseId))
+                .toResultOr {
+                    RegisterBreedingRegistrationUseCaseError.BloodHorseNotFound(input.bloodHorseId)
+                }
+                .bind()
+
+        val registration = BreedingRegistration.create(registrationNumber, horse)
+
+        breedingRegistrationRepository.save(registration)
+    }
+}

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationController.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationController.kt
@@ -1,0 +1,85 @@
+package com.example.api.controller.breeding
+
+import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationUseCase
+import com.example.api.controller.orThrowProblem
+import com.example.api.domain.shared.Command
+import com.github.michaelbull.result.mapError
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import java.time.Clock
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ProblemDetail
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 繁殖登録リソースの HTTP アダプター。
+ *
+ * Google AIP のリソース指向設計に従い、コレクション `/api/breedingRegistrations` に対する Create（血統登録済みの個体を
+ * 繁殖の用に供するための繁殖登録）を提供する。繁殖の書き込み経路（種付記録・種付せず・分娩報告・供用停止）はいずれも ここで起こした繁殖登録を起点にする。エラーレスポンスは RFC 9457
+ * (Problem Details) 形式で返す。
+ */
+@RestController
+class BreedingRegistrationController(
+    private val registerBreedingRegistration: RegisterBreedingRegistrationUseCase,
+    private val clock: Clock,
+) {
+    @Operation(
+        summary = "軽種馬を繁殖登録する",
+        description =
+            "血統登録済みの軽種馬を繁殖の用に供するため繁殖登録し、繁殖登録リソースを返す。担うロール（種牡馬／繁殖牝馬）は" +
+                "個体の性から定まる。業務ルール違反時は RFC 9457 形式の problem+json を返す。",
+        tags = ["BreedingRegistration"],
+        responses =
+            [
+                ApiResponse(
+                    responseCode = "201",
+                    description = "繁殖登録成功（登録された繁殖登録リソースを返す）",
+                    content =
+                        [
+                            Content(
+                                schema =
+                                    Schema(implementation = BreedingRegistrationResponse::class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "400",
+                    description = "入力値が不正（繁殖登録番号がブランク）",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "422",
+                    description = "繁殖登録の対象として指定された軽種馬が存在しない",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+            ],
+    )
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/api/breedingRegistrations")
+    fun register(
+        @RequestBody request: RegisterBreedingRegistrationRequest
+    ): BreedingRegistrationResponse =
+        registerBreedingRegistration(Command.now(request.toCommand(), clock))
+            .mapError { it.toProblemDetail() }
+            .orThrowProblem()
+            .toResponse()
+}

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationResponse.kt
@@ -1,0 +1,79 @@
+package com.example.api.controller.breeding
+
+import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationUseCaseError
+import com.example.api.controller.problem
+import com.example.api.domain.studbook.model.breeding.BreedingRegistration
+import com.example.api.domain.studbook.model.breeding.BreedingRetirement
+import java.time.LocalDate
+import java.util.UUID
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+
+/**
+ * 繁殖登録リソースの表現（HTTP 契約）。
+ *
+ * 繁殖登録に対する操作（登録の Create、今後加わる供用停止の `:retire` カスタムメソッド）は、 [AIP-133](https://google.aip.dev/133) /
+ * [AIP-136](https://google.aip.dev/136) に倣い一律でこのリソース表現全体を 返す（[ADR-0008]
+ * の単一リソース表現に整合）。供用中（[retirement] が null）と供用停止済み（事由と発生日を持つ）の 両状態を表せるよう、供用停止は任意の [retirement] として持つ。
+ *
+ * @property id 繁殖登録の生 UUID
+ * @property registrationNumber 繁殖登録番号
+ * @property registeredHorseId 繁殖登録した個体（血統登録済み）の生 UUID
+ * @property role 繁殖登録によって付与されたロール（性から定まる）
+ * @property retirement 供用停止。供用中なら null、供用停止済みなら事由と発生日を持つ
+ */
+data class BreedingRegistrationResponse(
+    val id: UUID,
+    val registrationNumber: String,
+    val registeredHorseId: UUID,
+    val role: BreedingRoleDto,
+    val retirement: BreedingRetirementResponse?,
+)
+
+/**
+ * 供用停止のリソース表現（HTTP 契約）。
+ *
+ * @property reason 供用停止の事由の区分
+ * @property occurredOn 事由が発生した日
+ */
+data class BreedingRetirementResponse(val reason: RetirementReasonDto, val occurredOn: LocalDate)
+
+/** [BreedingRegistration] を繁殖登録リソースの表現へ変換する。各操作の成功レスポンスはこのリソース表現を一律で返す。 */
+fun BreedingRegistration.toResponse(): BreedingRegistrationResponse =
+    BreedingRegistrationResponse(
+        id = id.value,
+        registrationNumber = registrationNumber.value,
+        registeredHorseId = registeredHorseId.value,
+        role = role.toDto(),
+        retirement = retirement?.toResponse(),
+    )
+
+/** 供用停止 VO を HTTP 契約のリソース表現へ変換する。 */
+fun BreedingRetirement.toResponse(): BreedingRetirementResponse =
+    BreedingRetirementResponse(reason = reason.toDto(), occurredOn = occurredOn)
+
+/**
+ * [RegisterBreedingRegistrationUseCaseError] を RFC 9457 (`application/problem+json`) の
+ * [ProblemDetail] に変換する。
+ *
+ * - 繁殖登録番号のブランクは入力不正として 400 Bad Request
+ * - 対象個体の不在は、整った入力だが意味的に処理できないため 422 Unprocessable Entity（種付記録の繁殖登録不在と同じ扱い）
+ */
+fun RegisterBreedingRegistrationUseCaseError.toProblemDetail(): ProblemDetail =
+    when (this) {
+        RegisterBreedingRegistrationUseCaseError.BlankRegistrationNumber ->
+            problem(
+                status = HttpStatus.BAD_REQUEST,
+                code = "invalid-breeding-registration-number",
+                title = "Invalid breeding registration number",
+                detail = "registration_number は空であってはいけません。",
+            )
+        is RegisterBreedingRegistrationUseCaseError.BloodHorseNotFound ->
+            problem(
+                    status = HttpStatus.UNPROCESSABLE_ENTITY,
+                    code = "blood-horse-not-found",
+                    title = "Blood horse not found",
+                    detail = "繁殖登録の対象として指定された軽種馬が存在しません。",
+                )
+                .apply { setProperty("blood_horse_id", bloodHorseId) }
+    }

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationWire.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationWire.kt
@@ -1,0 +1,49 @@
+package com.example.api.controller.breeding
+
+import com.example.api.domain.studbook.model.breeding.BreedingRole
+import com.example.api.domain.studbook.model.breeding.RetirementReason
+
+/*
+ * 繁殖登録（[com.example.api.domain.studbook.model.breeding.BreedingRegistration]）の HTTP 契約で用いる区分 enum
+ * と、ドメインとの相互変換。
+ *
+ * ドメインの enum（[BreedingRole] / [RetirementReason]）をそのまま wire に晒すと、ドメイン側の区分変更が HTTP 契約
+ * （および生成クライアント）を無言で破壊する。これを避けるため adapter 層に契約専用の区分 enum を置き、網羅 when で
+ * domain と往復させる（区分の増減を compile エラーで検知できる）。ADR-0007。
+ */
+
+/** 繁殖登録によって付与されるロールの区分（HTTP 契約）。 */
+enum class BreedingRoleDto {
+    /** 種牡馬（繁殖の用に供する雄馬）。 */
+    STALLION,
+
+    /** 繁殖牝馬（繁殖の用に供する雌馬）。 */
+    BROODMARE,
+}
+
+/** ドメインの繁殖ロールを HTTP 契約の区分へ変換する。 */
+fun BreedingRole.toDto(): BreedingRoleDto =
+    when (this) {
+        BreedingRole.STALLION -> BreedingRoleDto.STALLION
+        BreedingRole.BROODMARE -> BreedingRoleDto.BROODMARE
+    }
+
+/** 供用停止の事由の区分（HTTP 契約）。 */
+enum class RetirementReasonDto {
+    /** 死亡（死産・生後直死を除く）。 */
+    DEATH,
+
+    /** 用途変更（繁殖以外の用途への変更）。 */
+    USE_CHANGE,
+
+    /** その他の事由。 */
+    OTHER,
+}
+
+/** ドメインの供用停止事由を HTTP 契約の区分へ変換する。 */
+fun RetirementReason.toDto(): RetirementReasonDto =
+    when (this) {
+        RetirementReason.DEATH -> RetirementReasonDto.DEATH
+        RetirementReason.USE_CHANGE -> RetirementReasonDto.USE_CHANGE
+        RetirementReason.OTHER -> RetirementReasonDto.OTHER
+    }

--- a/src/main/kotlin/com/example/api/controller/breeding/RegisterBreedingRegistrationRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/RegisterBreedingRegistrationRequest.kt
@@ -1,0 +1,25 @@
+package com.example.api.controller.breeding
+
+import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationCommand
+import java.util.UUID
+
+/**
+ * `POST /api/breedingRegistrations` のリクエストボディ。繁殖登録の Create。
+ *
+ * 繁殖登録は雄雌共通の単一の登録で、担うロール（種牡馬／繁殖牝馬）は対象個体の性から定まる。そのため境界では 対象個体の軽種馬IDと交付される繁殖登録番号だけを受け取り、ロールはユースケースが
+ * 個体の性から導出する。
+ *
+ * @property bloodHorseId 繁殖登録する個体（血統登録済み）の軽種馬ID
+ * @property registrationNumber 交付される繁殖登録番号
+ */
+data class RegisterBreedingRegistrationRequest(
+    val bloodHorseId: UUID,
+    val registrationNumber: String,
+)
+
+/** 繁殖登録の入力を繁殖登録ユースケースの入力コマンドへ変換する。 */
+fun RegisterBreedingRegistrationRequest.toCommand(): RegisterBreedingRegistrationCommand =
+    RegisterBreedingRegistrationCommand(
+        bloodHorseId = bloodHorseId,
+        registrationNumber = registrationNumber,
+    )

--- a/src/test/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCaseTest.kt
@@ -1,0 +1,141 @@
+package com.example.api.application.studbook.breeding
+
+import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.breeding.BreedingRegistration
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
+import com.example.api.domain.studbook.model.breeding.BreedingRole
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Instant
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class RegisterBreedingRegistrationUseCaseTest {
+
+    private fun command(
+        payload: RegisterBreedingRegistrationCommand
+    ): Command<RegisterBreedingRegistrationCommand> = Command(payload, Instant.now())
+
+    @Nested
+    inner class SuccessCase {
+        @Test
+        fun `雌馬を繁殖登録すると繁殖牝馬ロールの繁殖登録が永続化される`() {
+            val mare = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+            val bloodHorseRepository =
+                mockk<BloodHorseRepository> { every { findById(mare.id) } returns mare }
+            val registrationRepository =
+                mockk<BreedingRegistrationRepository> {
+                    every { save(any()) } answers { firstArg() }
+                }
+            val useCase =
+                RegisterBreedingRegistrationUseCase(bloodHorseRepository, registrationRepository)
+
+            val result =
+                useCase(
+                        command(
+                            RegisterBreedingRegistrationCommand(
+                                bloodHorseId = mare.id.value,
+                                registrationNumber = "B-2024-0001",
+                            )
+                        )
+                    )
+                    .unwrap()
+
+            assert(result.registeredHorseId == mare.id)
+            assert(result.role == BreedingRole.BROODMARE)
+            assert(result.registrationNumber.value == "B-2024-0001")
+            assert(!result.isRetired)
+            verify(exactly = 1) { registrationRepository.save(any()) }
+        }
+
+        @Test
+        fun `雄馬を繁殖登録すると種牡馬ロールになる`() {
+            val stallion = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
+            val bloodHorseRepository =
+                mockk<BloodHorseRepository> { every { findById(stallion.id) } returns stallion }
+            val registrationRepository =
+                mockk<BreedingRegistrationRepository> {
+                    every { save(any()) } answers { firstArg() }
+                }
+            val useCase =
+                RegisterBreedingRegistrationUseCase(bloodHorseRepository, registrationRepository)
+
+            val result =
+                useCase(
+                        command(
+                            RegisterBreedingRegistrationCommand(
+                                bloodHorseId = stallion.id.value,
+                                registrationNumber = "B-2024-0002",
+                            )
+                        )
+                    )
+                    .unwrap()
+
+            assert(result.role == BreedingRole.STALLION)
+        }
+    }
+
+    @Nested
+    inner class FailureCase {
+        @Test
+        fun `繁殖登録番号がブランクのとき BlankRegistrationNumber を返し永続化されない`() {
+            val mare = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+            val bloodHorseRepository = mockk<BloodHorseRepository>()
+            val registrationRepository = mockk<BreedingRegistrationRepository>()
+            val useCase =
+                RegisterBreedingRegistrationUseCase(bloodHorseRepository, registrationRepository)
+
+            val result =
+                useCase(
+                    command(
+                        RegisterBreedingRegistrationCommand(
+                            bloodHorseId = mare.id.value,
+                            registrationNumber = "  ",
+                        )
+                    )
+                )
+
+            assert(
+                result.getError() ==
+                    RegisterBreedingRegistrationUseCaseError.BlankRegistrationNumber
+            )
+            verify(exactly = 0) { registrationRepository.save(any<BreedingRegistration>()) }
+        }
+
+        @Test
+        fun `対象の軽種馬が見つからないとき BloodHorseNotFound を返し永続化されない`() {
+            val bloodHorseId = UUID.randomUUID()
+            val bloodHorseRepository =
+                mockk<BloodHorseRepository> {
+                    every { findById(BloodHorseId(bloodHorseId)) } returns null
+                }
+            val registrationRepository = mockk<BreedingRegistrationRepository>()
+            val useCase =
+                RegisterBreedingRegistrationUseCase(bloodHorseRepository, registrationRepository)
+
+            val result =
+                useCase(
+                    command(
+                        RegisterBreedingRegistrationCommand(
+                            bloodHorseId = bloodHorseId,
+                            registrationNumber = "B-2024-0001",
+                        )
+                    )
+                )
+
+            assert(
+                result.getError() ==
+                    RegisterBreedingRegistrationUseCaseError.BloodHorseNotFound(bloodHorseId)
+            )
+            verify(exactly = 0) { registrationRepository.save(any<BreedingRegistration>()) }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
@@ -1,0 +1,99 @@
+package com.example.api.controller.breeding
+
+import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationCommand
+import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationUseCase
+import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationUseCaseError
+import com.example.api.config.ClockConfiguration
+import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.breeding.BreedingFixture
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import java.util.UUID
+import org.junit.jupiter.api.Test
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.context.TestConstructor.AutowireMode
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.assertj.MockMvcTester
+
+@WebMvcTest(BreedingRegistrationController::class)
+@Import(ClockConfiguration::class)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class BreedingRegistrationControllerTest(val mockMvc: MockMvc) {
+    @MockkBean
+    private lateinit var registerBreedingRegistration: RegisterBreedingRegistrationUseCase
+
+    private val tester = MockMvcTester.create(mockMvc)
+
+    private val uri = "/api/breedingRegistrations"
+
+    /** デシリアライズに通る正しい繁殖登録リクエストボディ。ユースケースはモックのため中身の整合は問われない。 */
+    private val validBody =
+        """
+        {
+            "blood_horse_id": "11111111-1111-1111-1111-111111111111",
+            "registration_number": "B-2024-0001"
+        }
+        """
+            .trimIndent()
+
+    @Test
+    fun `正常な入力で 201 Created と登録された繁殖登録が返ること`() {
+        val saved = BreedingFixture.breedingRegistration()
+        every {
+            registerBreedingRegistration(any<Command<RegisterBreedingRegistrationCommand>>())
+        } returns Ok(saved)
+
+        tester
+            .post()
+            .uri(uri)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validBody)
+            .assertThat()
+            .hasStatus(HttpStatus.CREATED)
+            .bodyJson()
+            .extractingPath("$.role")
+            .isEqualTo("BROODMARE")
+    }
+
+    @Test
+    fun `登録番号がブランクのとき 400 と problem+json が返ること`() {
+        every {
+            registerBreedingRegistration(any<Command<RegisterBreedingRegistrationCommand>>())
+        } returns Err(RegisterBreedingRegistrationUseCaseError.BlankRegistrationNumber)
+
+        tester
+            .post()
+            .uri(uri)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validBody)
+            .assertThat()
+            .hasStatus(HttpStatus.BAD_REQUEST)
+            .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+    }
+
+    @Test
+    fun `対象の軽種馬が存在しないとき 422 と problem+json が返ること`() {
+        val bloodHorseId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+        every {
+            registerBreedingRegistration(any<Command<RegisterBreedingRegistrationCommand>>())
+        } returns Err(RegisterBreedingRegistrationUseCaseError.BloodHorseNotFound(bloodHorseId))
+
+        tester
+            .post()
+            .uri(uri)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validBody)
+            .assertThat()
+            .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+            .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+            .bodyJson()
+            .extractingPath("$.blood_horse_id")
+            .isEqualTo("11111111-1111-1111-1111-111111111111")
+    }
+}


### PR DESCRIPTION
## 概要

繁殖登録（`BreedingRegistration`）そのものを成立させる**書き込み経路**（登録ユースケース + controller 入口）を新設する。closes #414

これまで `BreedingRegistration.create` は test fixture からのみ呼ばれ、`BreedingRegistrationRepository.save()` を呼ぶ本番コードが存在しなかった。繁殖の書き込み経路（種付記録・種付せず・分娩報告・供用停止）はこの繁殖登録を起点にするため、登録経路を整備する。#408（retire の API 配線）の「対象の `BreedingRegistration` をロードする前提が無い」というブロッカー解消も兼ねる。

## やったこと

- **application**: `RegisterBreedingRegistrationUseCase` を新設。繁殖登録番号を VO 検証し、対象の軽種馬を `BloodHorseRepository` で引き当てて `BreedingRegistration.create` → `save`。失敗バリアントは `BlankRegistrationNumber` / `BloodHorseNotFound`。ロールは個体の性から `create` が導出するため、本ユースケースは参照解決と永続化のみを担う。
- **controller**: `POST /api/breedingRegistrations`（`@ResponseStatus(CREATED)`）を追加。`Result` → リソース表現／`ProblemDetail` 変換を実装。
- **DTO/マッピング**:
  - `RegisterBreedingRegistrationRequest`（+ `toCommand()`）
  - `BreedingRegistrationResponse`（リソース単一表現。供用停止 `retirement` まで含め ADR-0008 に沿わせ、#408 で再利用可能にした）+ `error.toProblemDetail()`（ブランク→400、対象不在→422）
  - `BreedingRegistrationWire`: `BreedingRoleDto` / `RetirementReasonDto` の wire enum と網羅 when マッピング（ADR-0007、ドメイン enum を DTO フィールドに晒さない）

## テスト

- application ユースケーステスト: 成功時のロール導出（雌→繁殖牝馬／雄→種牡馬）と `save` 回数、`BlankRegistrationNumber`、`BloodHorseNotFound`。
- controller slice テスト: 201 / 400 / 422 の HTTP 契約。
- `./gradlew check`（ArchUnit / detekt / Kover mature 85% ゲート含む）green。

## 関連

- #408（retire の API 配線。本 PR がその前提・ブロッカーを解消）
- #404（種付の有効性検証・配線）/ #338（永続化層。現状は InMemory リポジトリ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
