### PR TITLE
refactor: BloodHorseRepository に一括 lookup を入れ sire/dam の逐次取得を解消する (#273)

### DIFF
--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
@@ -108,14 +108,16 @@ class RegisterInStudBookUseCase(private val bloodHorseRepository: BloodHorseRepo
                 .mapError { RegisterInStudBookUseCaseError.BlankBreeder }
                 .bind()
 
+        // 父・母を 1 回の一括 lookup で引き当てる（逐次往復と sireId==damId の二重取得を避ける）。
+        val sireId = BloodHorseId(input.sireId)
+        val damId = BloodHorseId(input.damId)
+        val found = bloodHorseRepository.findAllById(setOf(sireId, damId))
         val sire =
-            bloodHorseRepository
-                .findById(BloodHorseId(input.sireId))
+            found[sireId]
                 .toResultOr { RegisterInStudBookUseCaseError.SireNotFound(input.sireId) }
                 .bind()
         val dam =
-            bloodHorseRepository
-                .findById(BloodHorseId(input.damId))
+            found[damId]
                 .toResultOr { RegisterInStudBookUseCaseError.DamNotFound(input.damId) }
                 .bind()
 

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseRepository.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseRepository.kt
@@ -12,6 +12,14 @@ interface BloodHorseRepository {
     /** 軽種馬IDで検索する。存在しなければ null。 */
     fun findById(id: BloodHorseId): BloodHorse?
 
+    /**
+     * 複数の軽種馬IDをまとめて検索する。
+     *
+     * 父・母の存在確認のように複数IDを引き当てる場面で、1件ずつの逐次 lookup（永続化層では直列往復になる）を 1 回にまとめるためのポート。見つかった分だけを ID をキーにした
+     * [Map] で返す（存在しないIDはキーに現れない）。
+     */
+    fun findAllById(ids: Set<BloodHorseId>): Map<BloodHorseId, BloodHorse>
+
     /** 軽種馬を永続化する。 */
     fun save(bloodHorse: BloodHorse): BloodHorse
 }

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/horse/InMemoryBloodHorseRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/horse/InMemoryBloodHorseRepository.kt
@@ -17,6 +17,9 @@ class InMemoryBloodHorseRepository : BloodHorseRepository {
 
     override fun findById(id: BloodHorseId): BloodHorse? = store[id]
 
+    override fun findAllById(ids: Set<BloodHorseId>): Map<BloodHorseId, BloodHorse> =
+        ids.mapNotNull { id -> store[id]?.let { id to it } }.toMap()
+
     override fun save(bloodHorse: BloodHorse): BloodHorse {
         store[bloodHorse.id] = bloodHorse
         return bloodHorse

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCaseTest.kt
@@ -49,8 +49,8 @@ class RegisterInStudBookUseCaseTest {
             val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
             val repository =
                 mockk<BloodHorseRepository> {
-                    every { findById(sire.id) } returns sire
-                    every { findById(dam.id) } returns dam
+                    every { findAllById(setOf(sire.id, dam.id)) } returns
+                        mapOf(sire.id to sire, dam.id to dam)
                     every { save(any()) } answers { firstArg() }
                 }
             val useCase = RegisterInStudBookUseCase(repository)
@@ -60,6 +60,8 @@ class RegisterInStudBookUseCaseTest {
             assert(bloodHorse.origin == Origin.Domestic(sireId = sire.id, damId = dam.id))
             assert(bloodHorse.breedType == BreedType.THOROUGHBRED)
             assert(bloodHorse.registrationNumber.value == "2023104567")
+            // 父・母の引き当ては逐次 findById ではなく 1 回の一括 lookup で行う。
+            verify(exactly = 1) { repository.findAllById(setOf(sire.id, dam.id)) }
             verify(exactly = 1) { repository.save(any()) }
         }
     }
@@ -104,9 +106,11 @@ class RegisterInStudBookUseCaseTest {
         fun `父が見つからないとき SireNotFound を返し永続化されない`() {
             val sireId = UUID.randomUUID()
             val damId = UUID.randomUUID()
+            val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
             val repository =
                 mockk<BloodHorseRepository> {
-                    every { findById(BloodHorseId(sireId)) } returns null
+                    every { findAllById(setOf(BloodHorseId(sireId), BloodHorseId(damId))) } returns
+                        mapOf(BloodHorseId(damId) to dam)
                 }
             val useCase = RegisterInStudBookUseCase(repository)
 
@@ -117,13 +121,31 @@ class RegisterInStudBookUseCaseTest {
         }
 
         @Test
+        fun `母が見つからないとき DamNotFound を返し永続化されない`() {
+            val sireId = UUID.randomUUID()
+            val damId = UUID.randomUUID()
+            val sire = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { findAllById(setOf(BloodHorseId(sireId), BloodHorseId(damId))) } returns
+                        mapOf(BloodHorseId(sireId) to sire)
+                }
+            val useCase = RegisterInStudBookUseCase(repository)
+
+            val result = useCase(command(validPayload(sireId, damId)))
+
+            assert(result.getError() == RegisterInStudBookUseCaseError.DamNotFound(damId))
+            verify(exactly = 0) { repository.save(any()) }
+        }
+
+        @Test
         fun `父が雄でないときドメイン検証違反を PreconditionViolated に wrap して返す`() {
             val sire = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
             val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
             val repository =
                 mockk<BloodHorseRepository> {
-                    every { findById(sire.id) } returns sire
-                    every { findById(dam.id) } returns dam
+                    every { findAllById(setOf(sire.id, dam.id)) } returns
+                        mapOf(sire.id to sire, dam.id to dam)
                 }
             val useCase = RegisterInStudBookUseCase(repository)
 


### PR DESCRIPTION
## 概要

Issue #273 の対応。父・母の存在確認を 2 回の逐次 `findById` ではなく 1 回の一括 lookup にまとめる。

### 背景
`RegisterInStudBookUseCase` が `findById(sire)` の後に `findById(dam)` を直列で呼んでいた。InMemory では些末だが、永続化（JDBC）化したとき直列往復が残り、`sireId == damId` でも二重取得になる（/code-review 指摘 #9）。

## 変更内容

- **`BloodHorseRepository`**: 複数IDをまとめて引き当てる `findAllById(ids: Set<BloodHorseId>): Map<BloodHorseId, BloodHorse>` ポートを追加（見つかった分だけ Map で返す。存在しないIDはキーに現れない）
- **`RegisterInStudBookUseCase`**: 逐次 `findById(sire)` → `findById(dam)` を `findAllById(setOf(sireId, damId))` の 1 回に統合。`Set` で重複排除されるため `sireId == damId` の二重取得も解消。欠損時の振り分け（`SireNotFound` / `DamNotFound`）と「両方欠損なら Sire 優先」の挙動は維持
- **`InMemoryBloodHorseRepository`**: `findAllById` を実装
- **`RegisterInStudBookUseCaseTest`**: 一括 lookup に追従し `findAllById` が 1 回だけ呼ばれることを検証。未カバーだった `DamNotFound`（父あり・母なし）ケースを追加

## 確認

- `./gradlew check` グリーン（ktfmt / detekt / test / koverVerifyMature 85% ゲート通過）

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
