### PR TITLE
feat: 永続化 Flyway の自動実行を配線する (#421)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,13 @@ dependencies {
     // PostgreSQL（Testcontainers でテスト）へ寄せる想定。H2 は Docker 不要で spike を走らせるための
     // 暫定の組み込み DB（PostgreSQL 互換モードで使用）。詳細は ADR-0027。
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
-    implementation("org.flywaydb:flyway-core")
+    // Flyway は starter で引く。Spring Boot 4 は autoconfig を機能別モジュールに分割しており、
+    // FlywayAutoConfiguration は spring-boot-autoconfigure ではなく専用モジュール spring-boot-flyway
+    // に移った。素の flyway-core だけだと autoconfig が classpath に無く、エラーも出さず migrate が
+    // 走らない（#421）。starter-flyway が spring-boot-flyway(autoconfig) + spring-boot-jdbc +
+    // flyway-core を引き込む。H2 等の組み込み DB は starter だけで足り、PostgreSQL 化（#422）で
+    // flyway-database-postgresql を追加する。
+    implementation("org.springframework.boot:spring-boot-starter-flyway")
     runtimeOnly("com.h2database:h2")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation(libs.java.uuid.generator)

--- a/src/test/kotlin/com/example/api/infrastructure/racing/jockey/JdbcJockeyRepositorySpikeTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/racing/jockey/JdbcJockeyRepositorySpikeTest.kt
@@ -9,7 +9,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.TestConstructor
 import org.springframework.test.context.TestConstructor.AutowireMode
 import org.springframework.test.context.TestPropertySource
-import org.springframework.test.context.jdbc.Sql
 
 /**
  * [#338 spike] Spring Data JDBC + H2（インメモリ）による永続化の素振り（ADR-0027）。
@@ -20,23 +19,16 @@ import org.springframework.test.context.jdbc.Sql
  * 3. 既存行の update で `@Version` がインクリメントされること（楽観ロック兼用。落とし穴③）
  * 4. イミュータブル集約 [Jockey] を ID を保ったまま再構成（reconstitute）して往復できること
  *
- * スキーマは本番マイグレーション SQL（`db/migration/V1__create_jockey.sql`）を [Sql] で適用して用意し、 DB は本テスト専用の H2
- * インメモリに隔離する。Flyway の自動実行は本テストでは無効化している（Spring Boot 4.1 + Flyway 12 では autoconfig がマイグレーションを実行せず DB
- * が空になる事象を確認済み。配線は別途の追検証事項。 ADR-0027）。本番は PostgreSQL + Testcontainers を前提とする。H2 は Docker 不要で spike
- * を走らせるための暫定。
+ * スキーマは本番マイグレーション SQL（`db/migration/V*.sql`）を Flyway が起動時に適用して用意する（#421 で配線。 旧 spike では Boot 4.1 +
+ * Flyway 12 で autoconfig がマイグレーションを実行せず `@Sql` で回避していたが、 専用 autoconfig モジュール
+ * `spring-boot-flyway`（starter-flyway 経由）を classpath に入れて解消した）。 DB は本テスト専用の H2 インメモリに隔離する。本番は
+ * PostgreSQL + Testcontainers を前提とする（#422）。 H2 は Docker 不要で spike を走らせるための暫定。
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 @TestPropertySource(
     properties =
-        [
-            "spring.datasource.url=jdbc:h2:mem:spike;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
-            "spring.flyway.enabled=false",
-        ]
-)
-@Sql(
-    scripts = ["classpath:db/migration/V1__create_jockey.sql"],
-    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS,
+        ["spring.datasource.url=jdbc:h2:mem:spike;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1"]
 )
 class JdbcJockeyRepositorySpikeTest(private val rows: JockeySpringDataRepository) {
 


### PR DESCRIPTION
## 背景

#338 の spike（PR #420 / ADR-0027）で、`flyway-core` を入れ `spring.flyway.enabled=true` でも起動時にマイグレーションが実行されず DB が空のままになる事象を確認していた（起動ログに Flyway 出力なし）。spike では `@Sql` でスキーマを用意して回避していた。本 PR でこの配線の穴を塞ぐ。

Closes #421

## 原因

Spring Boot 4 は autoconfigure を機能別モジュールへ分割しており、`FlywayAutoConfiguration` は `spring-boot-autoconfigure` から専用モジュール **`spring-boot-flyway`**（パッケージ `org.springframework.boot.flyway.autoconfigure`）へ移り、独自の `AutoConfiguration.imports` で登録されるようになった。素の `org.flywaydb:flyway-core` 直依存だけではこの autoconfig モジュールが classpath に無く、Flyway Bean が一切生成されない。ゆえにエラーも出さず黙って migrate が走らなかった（ログ無しの症状と一致）。

公式 how-to（"add the appropriate Flyway module to your classpath. In-memory and file-based databases are supported by the `spring-boot-starter-flyway` starter."）に従う。

## 変更

- **build.gradle.kts**: `org.flywaydb:flyway-core` 直依存を **`org.springframework.boot:spring-boot-starter-flyway`** に置換。starter が `spring-boot-flyway`(autoconfig) + `spring-boot-jdbc` + `flyway-core` を引き込む。H2 等の組み込み DB は starter だけで足り、PostgreSQL 化（#422）の際に `flyway-database-postgresql` を足す旨をコメントに明記。
- **JdbcJockeyRepositorySpikeTest.kt**: `@Sql` + `spring.flyway.enabled=false` の回避を撤去し、Flyway が起動時にスキーマを適用する本来の経路へ寄せた（#421 の「@Sql 回避を Flyway 実行へ寄せる」）。KDoc を配線済みの記述へ更新。

## 検証

- spike テストの 4 ケース（jockey テーブルを使う insert/update/再構成）が `@Sql` 無しで通る＝Flyway が起動時にスキーマを作っている証明。Flyway 実行ログも確認:

```
Creating Schema History table "public"."flyway_schema_history" ...
Migrating schema "public" to version "1 - create jockey"
Successfully applied 1 migration to schema "public", now at version v1
```

- `./gradlew check` 緑（main アプリを起動する全 `@SpringBootTest` コンテキストで Flyway 適用・ktfmt・detekt・Kover mature ゲートを含む）。

## 補足

- ADR-0027 は spike 時点の point-in-time 記録のため改訂しない（決定＝Flyway 採用は不変。本 follow-up の解消は #421 クローズと本 PR で記録）。
- 後続: #422（PostgreSQL + Testcontainers）/ #423（本番 Bean 配線）の前提が整う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
