### PR TITLE
feat: ドメインイベントを最小スコープで導入する (#330)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -70,7 +70,7 @@ domain/
 
 ## DDD ビルディングブロック（jMolecules）
 
-ドメインモデルには [jMolecules](https://github.com/xmolecules/jmolecules) のアノテーション（`org.jmolecules.ddd.annotation.*`）で役割を表明する。アノテーションはメタデータのみでランタイム挙動を持たないため domain 層に置いてよい。
+ドメインモデルには [jMolecules](https://github.com/xmolecules/jmolecules) のアノテーション（`org.jmolecules.ddd.annotation.*` / `org.jmolecules.event.annotation.*`）で役割を表明する。アノテーションはメタデータのみでランタイム挙動を持たないため domain 層に置いてよい。
 
 | 対象 | アノテーション | 例 |
 |------|--------------|-----|
@@ -79,13 +79,16 @@ domain/
 | 値オブジェクト（ID 値クラス含む） | `@ValueObject` | `JockeyId` |
 | 識別子プロパティ | `@field:Identity` | `Jockey.id` |
 | Repository ポート（interface） | `@Repository`（jMolecules 版） | `JockeyRepository` |
+| ドメインイベント | `@DomainEvent`（jMolecules events 版） | `HorseNamed` |
 
 ドメインサービス（`service/` のトップレベル関数）には jMolecules アノテーションを付けない。`@Service`（jMolecules）は型向けでトップレベル関数に付けられず、ドメインサービスであることは `service/` パッケージへの配置で表現する。
+
+**ドメインイベント**（`@DomainEvent`）は「起きたこと」を表すビルディングブロック。イミュータブル集約（`var` 禁止）は内部にイベントを溜め込めないため、状態遷移メソッドが遷移後の集約とイベントを `StateTransition<A, E>`（`domain.shared`）に同梱して返し、発行は application 層が担う（集約は純粋なまま保つ）。失敗しうる遷移は `Result<StateTransition<A, E>, エラー>` を返し失敗時はイベントを生成しない（例: `BloodHorse.assignName` → `HorseNamed`）。イベントは値としての等価性が自然なため `data class` を使ってよい（ID ベース `final equals` を持つ集約と異なり衝突しない）。他集約への参照は ID 値クラス経由。収集・発行方式の決定経緯は [ADR-0029](../../docs/adr/0029-domain-events-via-state-transition-return.md)（Spring `ApplicationEventPublisher` 連携・publish-after-commit・発生時刻 enrichment は別イシュー送り）。
 
 注意点:
 
 - `@Identity` は FIELD / METHOD ターゲットのため、Kotlin プロパティには **`@field:Identity`** と use-site target を明示する
-- jMolecules アノテーション付きクラスはドメインモデルリング（`domain.*.model`）にのみ置ける（ArchUnit で強制）
+- jMolecules アノテーション付きクラス（`@DomainEvent` を含む）はドメインモデルリング（`domain.*.model`）にのみ置ける（ArchUnit `dddBuildingBlocksResideInDomainModel` で強制）。`StateTransition` 等の汎用キャリアはアノテーションを持たないため `domain.shared` に置いてよい
 - `JMoleculesDddRules.all()` により以下が強制される:
   - `@Entity` / `@AggregateRoot` は `@Identity` 付き識別子を持つ
   - **他の集約への参照は ID 値クラス（または `Association`）経由のみ**。集約オブジェクトを直接フィールドに持ってはならない（例: `Stallion` は `BloodHorse` ではなく `BloodHorseId` を持つ）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,21 @@ class Command<T>(
 fun registerInStudBook(command: Command<StudBook>)
 ```
 
+#### Domain Event パターン
+
+ドメインイベントは「**起きたこと**」を表すビルディングブロック（`Command` の「何をしたいか」と対）。`@org.jmolecules.event.annotation.DomainEvent` で役割を表明し、`domain.*.model` に置く。値としての等価性が自然なため `data class` を使ってよい（ID ベース `final equals` を持つ集約と異なり衝突しない）。他集約への参照は ID 値クラス経由。
+
+イミュータブル集約（`var` 禁止）は内部にイベントを溜め込めないため、状態遷移メソッドが**遷移後の集約とイベントを `StateTransition<A, E>`（`domain.shared`）に同梱して返し**、発行は application 層が担う（集約は純粋なまま）。失敗しうる遷移は `Result<StateTransition<A, E>, エラー>` を返し、失敗時はイベントを生成しない：
+
+```kotlin
+@DomainEvent data class HorseNamed(val bloodHorseId: BloodHorseId, val name: HorseName)
+
+// 状態遷移は遷移後の集約とイベントを同梱して返す
+fun assignName(horseName: HorseName): Result<StateTransition<BloodHorse, HorseNamed>, HorseAlreadyNamed>
+```
+
+決定経緯と現状のスコープ（Spring `ApplicationEventPublisher` 連携・publish-after-commit・発生時刻 enrichment は別イシュー送り）は [ADR-0029](docs/adr/0029-domain-events-via-state-transition-return.md) を参照。
+
 ### パッケージ構成
 
 オニオンアーキテクチャの 4 リング（domainModel / domainService / applicationService / adapter）構成。`domain` 配下は各コンテキストを `model/` と `service/` に分割する。
@@ -155,7 +170,7 @@ com.example.api/
 
 **設計原則**（ArchUnit で強制。詳細は `.claude/rules/architecture.md`）:
 
-- **domain.shared**: 共有カーネル。`Command` / `Entity` 基底など、コンテキスト横断の最小限の基盤のみ
+- **domain.shared**: 共有カーネル。`Command` / `Entity` 基底 / `StateTransition`（状態遷移＋ドメインイベントの封筒）など、コンテキスト横断の最小限の基盤のみ
 - **domain.\*.model**: Entity / Value Object / Repository ポート（interface）/ 集約内で完結するロジック。Repository ポートには jMolecules の `@Repository` を付与
 - **domain.\*.service**: 複数の集約をまたぐドメインロジック。**Kotlin のトップレベル関数で書き**、`service/` への配置でドメインサービスと表現する（jMolecules `@Service` は付けない）。モデルにのみ依存でき、その逆は禁止
 - **application**: ユースケース（コマンド DTO + ユースケースクラス + そのユースケースに紐づく失敗バリアント）。ドメインを組み合わせて業務シナリオを構築する。ユースケースを DI 経由で公開するための `@Service` / `@Component` のみ Spring 依存を許容し、ロジック本体は Plain Kotlin で書く

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(libs.java.uuid.generator)
     implementation(libs.kotlin.result)
     implementation(libs.jmolecules.ddd)
+    implementation(libs.jmolecules.events)
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation(libs.springdoc.openapi.starter.webmvc.ui)
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/docs/adr/0029-domain-events-via-state-transition-return.md
+++ b/docs/adr/0029-domain-events-via-state-transition-return.md
@@ -1,0 +1,44 @@
+# 0029. イミュータブル集約のドメインイベントは状態遷移の戻り値に同梱して収集する
+
+- Status: Accepted
+- Date: 2026-06-24
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+DDD ビルディングブロックを jMolecules のアノテーション（`@AggregateRoot` / `@ValueObject` / `@Repository` / `@field:Identity`）で表明する方針を採っているが、**ドメインイベントだけが一切使われていなかった**（issue #330）。ドメインには「起きたこと」の瞬間がすでに明確にある（血統登録・馬名命名・繁殖成績報告など）一方で、`@DomainEvent` を欠いたままなのは不自然だった。現状あるのは `Command<T>`（発生時刻を添える「何をしたいか」の入力の封筒）のみで、これは「何が起きたか」ではない。
+
+そこで**最小スコープで参考実装を 1 本作り、本プロジェクトに合うドメインイベントの収集・発行方式を確立する**こととした。設計上の最大の論点は、**イミュータブル集約（[ADR-0009](0009-immutable-aggregates.md)）との整合**である。
+
+Spring / jMolecules 定番の `AbstractAggregateRoot.registerEvent()` は、集約内部のイベントバッファを**ミュータブルに溜める**イディオムで、`val` のみ・状態遷移は新インスタンスを返す本プロジェクトの方針と噛み合わない。イミュータブル集約に合うイベント収集方式を決める必要があった。検討した案:
+
+- **(A) 戻り値にイベントを同梱**: 状態遷移メソッドが「遷移後の集約とイベントの組」を返す。集約は純粋なまま、発行は application 層が担う。
+- **(B) 集約がイベントリストを保持**: 新インスタンスに `pendingEvents: List<DomainEvent>` を持たせ、`copy` で引き継ぐ。集約が「未発行イベント」という発行機構の都合を抱え込み、`copy` の引き継ぎ漏れリスクも増える。
+
+## Decision（決定）
+
+**案 (A) を採用する。** イミュータブル集約の状態遷移メソッドは、遷移後の集約と発生したドメインイベントを **`StateTransition<A, E>`（`domain.shared`）に同梱して返す**。失敗しうる遷移は `Result<StateTransition<A, E>, エラー>` を返し、**失敗時はイベントを生成しない**。
+
+- 参考実装は馬名命名: `BloodHorse.assignName(horseName): Result<StateTransition<BloodHorse, HorseNamed>, HorseAlreadyNamed>`。成功時のみ命名済みの新 `BloodHorse` と `HorseNamed` を返す。
+- ドメインイベント型（`HorseNamed`）は **`@org.jmolecules.event.annotation.DomainEvent` で役割を表明**し、他のビルディングブロックと同じく `domain.*.model` に置く。他集約への参照は ID 値クラス経由（`BloodHorseId`）とする。集約と違い `data class` を使ってよい（値としての等価性が自然で、ID ベース `final equals` を持つ集約のような衝突がない）。
+- **イベントの発行は application 層が担う**。ユースケースが `StateTransition` を受け取り、`aggregate` を永続化し、`event` を扱う。現状の最小ハンドリングは**ログ出力のみ**に留める。
+- ドメインイベントを **DDD ビルディングブロックの一員**として扱う。ArchUnit の配置ルール（`dddBuildingBlocksResideInDomainModel`）と、ユビキタス言語の型レベルカタログ（`UbiquitousLanguageCatalogTest`）に `@DomainEvent` を加える。
+
+守るべきルールの結論は [CLAUDE.md](../../CLAUDE.md)「ドメイン駆動設計」と [.claude/rules/architecture.md](../../.claude/rules/architecture.md) に置く。
+
+### スコープ外（別イシュー送り）
+
+最小スコープを保つため、以下は本決定に含めず別途とする:
+
+- Spring `ApplicationEventPublisher` / `@EventListener` への連携。
+- 永続化と整合した **publish-after-commit** のトランザクション意味論（永続化層が InMemory の現状ではフルに示せない）。
+- イベントへの**発生時刻・イベント ID 等のメタデータ付与**（enrichment）。当面イベントは純粋なペイロードのみとし、「いつ」は application 境界の `Command.issuedAt` が持つ。将来は `Command<T>` と対称な封筒で包む余地がある。
+- 複数イベントを返す遷移（現状 1 遷移 = 1 イベント。必要になれば `StateTransition` の `event` を集合へ拡張する）。
+- 他集約・他コンテキストへの横展開（繁殖成績報告 #265 等）。
+
+## Consequences（結果・影響）
+
+- 集約は純粋（`val` のみ・副作用なし）なまま、状態遷移と同時に「起きたこと」を表現できる。発行機構（バッファ・publisher）の都合を集約に持ち込まずに済む。
+- イベントの発行タイミングを application 層が一元的に握れるため、将来 publish-after-commit やパブリッシュ先の差し替えを集約に触れず導入できる。
+- 状態遷移メソッドの戻り値が `Result<集約, エラー>` から `Result<StateTransition<集約, イベント>, エラー>` へ変わるため、呼び出し側は `.aggregate` を取り出す必要がある（既存の `assignName` 呼び出しと、その単体テストを更新した）。
+- `StateTransition` は単一イベント前提の薄い封筒であり、複数イベントや遅延発行が必要になった時点で拡張する。最小スコープで「方式を 1 つ確立する」という目的に対する割り切り。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,3 +38,4 @@
 | [0026](0026-request-validation-vo-centric-defer-bean-validation.md) | API リクエストバリデーションは VO 中心を維持し Bean Validation を当面採らない | Accepted |
 | [0027](0027-persistence-spring-data-jdbc.md) | 永続化アクセスに Spring Data JDBC を主軸採用し PostgreSQL / Flyway / Testcontainers で構成する | Accepted |
 | [0028](0028-controller-adapter-dto-packaging.md) | controller アダプターの DTO を役割別サブパッケージ（request/ + problem/）へ整理する | Accepted |
+| [0029](0029-domain-events-via-state-transition-return.md) | イミュータブル集約のドメインイベントは状態遷移の戻り値に同梱して収集する | Accepted |

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -7,9 +7,9 @@
 
 1. **用語集（手書き）** — 定義・和名・別名・禁止語など、コードには現れない知識を人が書く。
 2. **型レベル用語カタログ（自動生成）** — jMolecules のビルディングブロック（`@AggregateRoot` /
-   `@Entity` / `@ValueObject` / `@Repository`）とドメインサービス（`service/` のトップレベル関数）を
-   バイトコードから走査して生成する。**コードが唯一の出所**であり、`UbiquitousLanguageCatalogTest` が
-   コミット済みの内容と一致することを検証する。
+   `@Entity` / `@ValueObject` / `@Repository` / `@DomainEvent`）とドメインサービス（`service/` の
+   トップレベル関数）を バイトコードから走査して生成する。**コードが唯一の出所**であり、
+   `UbiquitousLanguageCatalogTest` が コミット済みの内容と一致することを検証する。
 
 > **メンテナンス方法**: ビルディングブロックを追加・改名・削除すると `UbiquitousLanguageCatalogTest` が
 > 落ちる。次でカタログを再生成し、併せて下の手書き用語集にも定義を足してからコミットする。
@@ -22,7 +22,7 @@
 
 ## 用語集（手書き）
 
-凡例 — **種別**: 集約ルート / エンティティ / 値オブジェクト / リポジトリポート / ドメインサービス。
+凡例 — **種別**: 集約ルート / エンティティ / 値オブジェクト / リポジトリポート / ドメインイベント / ドメインサービス。
 **禁止語**は「使うと誤解を生むため避ける言い回し」を表す。
 
 ### studbook コンテキスト（軽種馬登録）
@@ -38,6 +38,7 @@
 | --- | --- | --- | --- | --- |
 | BloodHorse | 軽種馬 | 集約ルート | 血統及び個体識別を明らかにする血統登録の成立によって誕生する個体。ライフサイクル全体を通じて同一の `BloodHorse` が各ロールを担う。 | 禁止: 単に「Horse」と呼ぶと文脈で曖昧。父母・ロールも別個体として扱わない |
 | HorseName | 馬名 | 値オブジェクト | 血統登録済みの個体に一度だけ付与できる名。出生時は未命名（`null`）。 | — |
+| HorseNamed | 馬名登録された | ドメインイベント | 馬名登録（`BloodHorse.assignName`）の成功時に「起きたこと」を表すイベント。遷移後の集約とともに `StateTransition` で同梱して返し、発行は application 層が担う（[ADR-0029](adr/0029-domain-events-via-state-transition-return.md)）。 | 禁止: `Command`（何をしたいか）と混同しない。本型は結果（何が起きたか） |
 | PedigreeRegistrationNumber | 血統登録番号 | 値オブジェクト | 血統登録の成立時に交付される番号。 | — |
 | MicrochipNumber | マイクロチップ番号 | 値オブジェクト | 個体識別に用いるマイクロチップの番号。 | — |
 | StudBookEntry | 血統登録申請（個体識別の束） | 値オブジェクト | 申請者が持ち込む仔馬自身の個体識別情報の束。父母は集約をまたぐためここには含めない。 | — |
@@ -209,6 +210,7 @@ graph LR
 | BloodHorseRepository | リポジトリポート | domain.studbook.model.horse.bloodhorse |
 | BreedingRegistrationRepository | リポジトリポート | domain.studbook.model.breeding |
 | BreedingResultRepository | リポジトリポート | domain.studbook.model.breeding |
+| HorseNamed | ドメインイベント | domain.studbook.model.horse.bloodhorse |
 | recordCovering | ドメインサービス | domain.studbook.service.breeding |
 | recordUncovered | ドメインサービス | domain.studbook.service.breeding |
 | registerFoal | ドメインサービス | domain.studbook.service.horse |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ springmockk = { module = "com.ninja-squad:springmockk", version.ref = "springmoc
 # jMolecules（DDD ビルディングブロックをアノテーションで表明する。バージョンは BOM で管理）
 jmolecules-bom = { module = "org.jmolecules:jmolecules-bom", version.ref = "jmolecules-bom" }
 jmolecules-ddd = { module = "org.jmolecules:jmolecules-ddd" }
+jmolecules-events = { module = "org.jmolecules:jmolecules-events" }
 
 # ArchUnit（アーキテクチャテスト）
 archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "archunit" }

--- a/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
@@ -10,6 +10,7 @@ import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.mapError
 import com.github.michaelbull.result.toResultOr
 import java.util.UUID
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 /**
@@ -45,6 +46,9 @@ sealed interface NameHorseUseCaseError {
  * 境界の生入力を [HorseName] に変換し（不正なら検証エラー）、対象の軽種馬を [BloodHorseRepository] で引き当て、 集約の `assignName`
  * で命名状態を遷移させてから永続化する。血統登録 → 馬名登録という順序関係は、対象が 既に永続化済みの [BloodHorse] であることを引当が要求することで自然に満たされる。
  *
+ * 状態遷移が同梱して返すドメインイベント（`HorseNamed`）は、ここ application 層で受け取って最小限に扱う （現状はログ）。Spring の
+ * `ApplicationEventPublisher` への接続や永続化と整合した publish-after-commit は スコープ外（別イシュー送り。ADR-0029）。
+ *
  * @return 命名された [BloodHorse]、または業務ルール違反を表す [NameHorseUseCaseError]
  */
 @Service
@@ -63,12 +67,19 @@ class NameHorseUseCase(private val bloodHorseRepository: BloodHorseRepository) {
                 .toResultOr { NameHorseUseCaseError.HorseNotFound(input.bloodHorseId) }
                 .bind()
 
-        val named =
+        val transition =
             bloodHorse
                 .assignName(horseName)
                 .mapError { NameHorseUseCaseError.AlreadyNamed(it.currentName.value) }
                 .bind()
 
-        bloodHorseRepository.save(named)
+        val named = bloodHorseRepository.save(transition.aggregate)
+        // ドメインイベントは当面 application 層内で最小ハンドリング（ログ）に留める。
+        logger.info("ドメインイベント発生: {}", transition.event)
+        named
+    }
+
+    private companion object {
+        private val logger = LoggerFactory.getLogger(NameHorseUseCase::class.java)
     }
 }

--- a/src/main/kotlin/com/example/api/domain/shared/StateTransition.kt
+++ b/src/main/kotlin/com/example/api/domain/shared/StateTransition.kt
@@ -1,0 +1,20 @@
+package com.example.api.domain.shared
+
+/**
+ * 集約の状態遷移の結果。遷移後の集約と、その遷移で「起きたこと」を表すドメインイベントを同梱する封筒。
+ *
+ * イミュータブル集約（[ADR-0009]）は自身の内部にイベントバッファをミュータブルに溜め込めない（`val` のみ・ 状態遷移は新インスタンス返却）。Spring/jMolecules
+ * 定番の `AbstractAggregateRoot.registerEvent()` 方式は 集約を mutable
+ * にする前提のため噛み合わない。そこで状態遷移メソッドは遷移後の集約とイベントをまとめて本型で返し、 イベントの発行（ログ・パブリッシュ等）は application
+ * 層に委ねる。これにより集約は純粋なまま保たれる。 収集・発行方式の決定経緯は ADR-0029 を参照。
+ *
+ * 失敗しうる遷移は `Result<StateTransition<A, E>, エラー>` を返し、失敗時はイベントを生成しない （例:
+ * `BloodHorse.assignName`）。発生時刻（[Command] の `issuedAt` に相当する横断メタデータ）や イベント ID
+ * の付与は当面持たせない（最小スコープ。enrichment と Spring `ApplicationEventPublisher` への 接続は別イシュー送り）。
+ *
+ * @param A 遷移後の集約の型
+ * @param E 生成されるドメインイベントの型（`@org.jmolecules.event.annotation.DomainEvent` を付与した型）
+ * @property aggregate 遷移後の集約
+ * @property event その遷移で起きたことを表すドメインイベント
+ */
+class StateTransition<out A, out E>(val aggregate: A, val event: E)

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorse.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorse.kt
@@ -1,6 +1,7 @@
 package com.example.api.domain.studbook.model.horse.bloodhorse
 
 import com.example.api.domain.shared.Entity
+import com.example.api.domain.shared.StateTransition
 import com.example.api.domain.shared.generateId
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
@@ -93,20 +94,26 @@ private constructor(
     val name: HorseName?,
 ) : Entity<BloodHorseId>() {
     /**
-     * 馬名を登録した新しい [BloodHorse] を返す。
+     * 馬名を登録し、命名済みの新しい [BloodHorse] と発生した [HorseNamed] イベントを同梱して返す。
      *
-     * 馬名登録は血統登録済みの個体に一度だけ行えるドメインイベント。既に命名済みの個体への再命名は 不変条件違反として [HorseAlreadyNamed] を返し、写像を行わない（元の
-     * [BloodHorse] も不変）。成功時は [name] のみ差し替え、[id] を含む他の属性は引き継ぐ。
+     * 馬名登録は血統登録済みの個体に一度だけ行える状態遷移。成功時は [name] のみ差し替えた新インスタンスを作り （[id] を含む他の属性は引き継ぐ）、その遷移で「起きたこと」を表す
+     * [HorseNamed] を併せて [StateTransition] で返す。イベントの発行は application 層に委ね、集約は純粋に保つ（収集・発行方式は
+     * ADR-0029）。既に命名済みの個体への再命名は不変条件違反として [HorseAlreadyNamed] を返し、写像も イベント生成も行わない（元の [BloodHorse]
+     * も不変）。
      *
      * @param horseName 付与する馬名
-     * @return 命名済みの新しい [BloodHorse]、既に命名済みなら [HorseAlreadyNamed]
+     * @return 命名済みの新しい [BloodHorse] と [HorseNamed] を同梱した [StateTransition]、既に命名済みなら
+     *   [HorseAlreadyNamed]
      */
-    fun assignName(horseName: HorseName): Result<BloodHorse, HorseAlreadyNamed> {
+    fun assignName(
+        horseName: HorseName
+    ): Result<StateTransition<BloodHorse, HorseNamed>, HorseAlreadyNamed> {
         val current = name
         return if (current != null) {
             Err(HorseAlreadyNamed(current))
         } else {
-            Ok(copy(name = horseName))
+            val named = copy(name = horseName)
+            Ok(StateTransition(named, HorseNamed(named.id, horseName)))
         }
     }
 

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/HorseNamed.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/HorseNamed.kt
@@ -1,0 +1,17 @@
+package com.example.api.domain.studbook.model.horse.bloodhorse
+
+import org.jmolecules.event.annotation.DomainEvent
+
+/**
+ * 軽種馬に馬名が登録された、というドメインイベント（起きたこと）。
+ *
+ * 馬名登録（[BloodHorse.assignName]）の成功時に生成される。`Command<T>`（何をしたいか）に対し、本型は 「何が起きたか」を表す。`@DomainEvent`
+ * で役割を表明し（jMolecules のビルディングブロックの一員）、 他集約への参照は他のビルディングブロックと同じく ID 値クラス（[bloodHorseId]）経由とする。
+ *
+ * イミュータブル集約に合う収集・発行方式（状態遷移が [com.example.api.domain.shared.StateTransition] で 集約とイベントを同梱して返し、発行は
+ * application 層が担う）は ADR-0029 を参照。発生時刻・イベント ID といったメタデータの付与は当面持たせない（最小スコープ）。
+ *
+ * @property bloodHorseId 命名された軽種馬の ID
+ * @property name 付与された馬名
+ */
+@DomainEvent data class HorseNamed(val bloodHorseId: BloodHorseId, val name: HorseName)

--- a/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCaseTest.kt
@@ -73,6 +73,7 @@ class NameHorseUseCaseTest {
                 BloodHorseFixture.bloodHorse()
                     .assignName(HorseName.create("オグリキャップ").unwrap())
                     .unwrap()
+                    .aggregate
             val repository =
                 mockk<BloodHorseRepository> { every { findById(named.id) } returns named }
             val useCase = NameHorseUseCase(repository)

--- a/src/test/kotlin/com/example/api/architecture/ArchitectureTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/ArchitectureTest.kt
@@ -25,6 +25,7 @@ import org.jmolecules.ddd.annotation.AggregateRoot
 import org.jmolecules.ddd.annotation.Entity as DddEntity
 import org.jmolecules.ddd.annotation.Repository as DddRepository
 import org.jmolecules.ddd.annotation.ValueObject
+import org.jmolecules.event.annotation.DomainEvent
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Repository
 import org.springframework.stereotype.Service
@@ -177,7 +178,12 @@ class ArchitectureTest {
      */
     @ArchTest val dddBuildingBlocks = JMoleculesDddRules.all()
 
-    /** DDD ビルディングブロック（jMolecules アノテーション付きクラス）はドメインモデルリングに置くこと。 */
+    /**
+     * DDD ビルディングブロック（jMolecules アノテーション付きクラス）はドメインモデルリングに置くこと。
+     *
+     * 集約ルート / エンティティ / 値オブジェクト / リポジトリポートに加え、ドメインイベント（`@DomainEvent`）も
+     * 対象に含める。イベントもドメインモデルの一員であり、フレームワーク非依存の domain.*.model に置く（ADR-0029）。
+     */
     @ArchTest
     val dddBuildingBlocksResideInDomainModel =
         classes()
@@ -189,6 +195,8 @@ class ArchitectureTest {
             .areAnnotatedWith(ValueObject::class.java)
             .or()
             .areAnnotatedWith(DddRepository::class.java)
+            .or()
+            .areAnnotatedWith(DomainEvent::class.java)
             .should()
             .resideInAPackage(DOMAIN_MODEL)
 

--- a/src/test/kotlin/com/example/api/architecture/UbiquitousLanguageCatalogTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/UbiquitousLanguageCatalogTest.kt
@@ -12,14 +12,16 @@ import org.jmolecules.ddd.annotation.AggregateRoot
 import org.jmolecules.ddd.annotation.Entity as DddEntity
 import org.jmolecules.ddd.annotation.Repository as DddRepository
 import org.jmolecules.ddd.annotation.ValueObject
+import org.jmolecules.event.annotation.DomainEvent
 import org.junit.jupiter.api.Test
 
 /**
  * ユビキタス言語の「型レベル用語カタログ」を `docs/ubiquitous-language.md` の自動生成ブロックと突き合わせるテスト。
  *
  * 用語集は手書き（定義・別名・禁止語などコードに出ない知識）と、コードからの自動抽出（型レベルの実体）を 組み合わせて陳腐化を防ぐ方針（issue #346）。本テストは後者を担う:
- * jMolecules のビルディングブロック（`@AggregateRoot` / `@Entity` / `@ValueObject` / `@Repository`）と
- * ドメインサービス（`service/` のトップレベル関数）をバイトコードから走査し、コンテキスト別の用語カタログを生成して、 ドキュメントにコミットされた生成ブロックと一致することを検証する。
+ * jMolecules のビルディングブロック（`@AggregateRoot` / `@Entity` / `@ValueObject` / `@Repository` /
+ * `@DomainEvent`）と ドメインサービス（`service/` のトップレベル関数）をバイトコードから走査し、コンテキスト別の用語カタログを生成して、
+ * ドキュメントにコミットされた生成ブロックと一致することを検証する。
  *
  * コードが唯一の出所であり、ビルディングブロックを足し引きするとカタログが乖離してこのテストが落ちる。 再生成するには次を実行してドキュメントを更新し、差分をコミットする:
  * ```
@@ -81,6 +83,7 @@ class UbiquitousLanguageCatalogTest {
                 javaClass.isAnnotatedWith(DddEntity::class.java) -> Kind.ENTITY
                 javaClass.isAnnotatedWith(ValueObject::class.java) -> Kind.VALUE_OBJECT
                 javaClass.isAnnotatedWith(DddRepository::class.java) -> Kind.REPOSITORY
+                javaClass.isAnnotatedWith(DomainEvent::class.java) -> Kind.DOMAIN_EVENT
                 else -> return@mapNotNull null
             }
         Term(context, kind, displayName(javaClass), relativePackage(javaClass.packageName))
@@ -135,7 +138,8 @@ class UbiquitousLanguageCatalogTest {
         ENTITY(1, "エンティティ"),
         VALUE_OBJECT(2, "値オブジェクト"),
         REPOSITORY(3, "リポジトリポート"),
-        DOMAIN_SERVICE(4, "ドメインサービス"),
+        DOMAIN_EVENT(4, "ドメインイベント"),
+        DOMAIN_SERVICE(5, "ドメインサービス"),
     }
 
     private companion object {

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -162,6 +162,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
                 BloodHorseFixture.bloodHorse()
                     .assignName(HorseName.create("オグリキャップ").unwrap())
                     .unwrap()
+                    .aggregate
             every { nameHorse(any<Command<NameHorseCommand>>()) } returns Ok(named)
 
             tester

--- a/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseTest.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseTest.kt
@@ -12,13 +12,23 @@ class BloodHorseTest {
     fun `未命名の馬に命名すると馬名を持つ新しい個体が返り 同一性は引き継がれる`() {
         val unnamed = BloodHorseFixture.bloodHorse()
 
-        val named = unnamed.assignName(name).unwrap()
+        val named = unnamed.assignName(name).unwrap().aggregate
 
         assert(named.name == name)
         assert(named.id == unnamed.id)
         // 他の属性も引き継がれる
         assert(named.registrationNumber == unnamed.registrationNumber)
         assert(named.origin == unnamed.origin)
+    }
+
+    @Test
+    fun `命名に成功すると 命名された個体に対応する HorseNamed イベントが同梱される`() {
+        val unnamed = BloodHorseFixture.bloodHorse()
+
+        val transition = unnamed.assignName(name).unwrap()
+
+        assert(transition.aggregate.name == name)
+        assert(transition.event == HorseNamed(unnamed.id, name))
     }
 
     @Test
@@ -31,8 +41,8 @@ class BloodHorseTest {
     }
 
     @Test
-    fun `命名済みの馬への再命名は HorseAlreadyNamed を返し 馬名は変わらない`() {
-        val named = BloodHorseFixture.bloodHorse().assignName(name).unwrap()
+    fun `命名済みの馬への再命名は HorseAlreadyNamed を返し 馬名は変わらない（イベントも生成しない）`() {
+        val named = BloodHorseFixture.bloodHorse().assignName(name).unwrap().aggregate
         val another = HorseName.create("トウカイテイオー").unwrap()
 
         val result = named.assignName(another)


### PR DESCRIPTION
## 概要

ドメインイベントを最小スコープで導入し（#330）、イミュータブル集約（ADR-0009）に合う収集・発行方式を確立する参考実装。`@DomainEvent` だけが未使用だった状態を解消する。

## 設計（案A: 戻り値にイベント同梱）

`AbstractAggregateRoot.registerEvent()` 方式は集約を mutable にする前提で本プロジェクトの方針（`val` のみ・状態遷移は新インスタンス）と噛み合わない。そこで状態遷移メソッドが **遷移後の集約とイベントを `StateTransition<A, E>` に同梱して返し**、発行は application 層が担う方式を採った。集約は純粋なまま保たれる。決定は **ADR-0029**。

```kotlin
@DomainEvent data class HorseNamed(val bloodHorseId: BloodHorseId, val name: HorseName)

fun assignName(horseName: HorseName): Result<StateTransition<BloodHorse, HorseNamed>, HorseAlreadyNamed>
```

## 変更点

- **新設**: `domain/shared/StateTransition.kt`（汎用キャリア）、`HorseNamed.kt`（`@DomainEvent`・他集約参照は ID 経由）
- **集約**: `BloodHorse.assignName` をイベント同梱方式へ（成功時のみ生成・失敗時は非生成）
- **ユースケース**: `NameHorseUseCase` が `transition.aggregate` を永続化し `event` をロガーで最小ハンドリング
- **依存**: `jmolecules-events` を追加
- **規約強制**: ArchUnit 配置ルールに `@DomainEvent` を追加（`domain.*.model` 強制）。ユビキタス言語カタログに `DOMAIN_EVENT` 種別を追加し `HorseNamed` を反映
- **ドキュメント**: ADR-0029（+ README 一覧）、CLAUDE.md / architecture.md に Domain Event パターンを追記
- **テスト**: BloodHorse / UseCase / Controller を新シグネチャへ追従＋イベント生成を検証

## スコープ外（別イシュー送り。ADR-0029 に明記）

- Spring `ApplicationEventPublisher` / `@EventListener` 連携
- 永続化と整合した publish-after-commit のトランザクション意味論
- 発生時刻・イベント ID の enrichment
- 他集約・他コンテキストへの横展開（#265 等）

## 確認

`./gradlew check` 通過（ktfmt / detekt / ArchUnit / 全テスト / Kover mature 85% ラチェット）。

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)
