### PR TITLE
feat: 永続化の契約テストを Testcontainers(PostgreSQL) で整備する (#422)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,18 +25,23 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
-    // [#338 spike] 永続化アクセスの素振り（Spring Data JDBC + Flyway）。本番化時は DB を
-    // PostgreSQL（Testcontainers でテスト）へ寄せる想定。H2 は Docker 不要で spike を走らせるための
-    // 暫定の組み込み DB（PostgreSQL 互換モードで使用）。詳細は ADR-0027。
+    // 永続化アクセス（Spring Data JDBC + Flyway）。集約 write は Spring Data JDBC（集約 = 永続化境界）。
+    // ランタイムの datasource は当面 H2（PostgreSQL 互換モード）の組み込み DB のまま据え置く。実リポジトリは
+    // まだ InMemory Bean のため datasource/Flyway は付随的に初期化されるだけで、本番 PostgreSQL 化（Cloud SQL
+    // 配線）は実永続化を使う #423 / インフラ作業に委ねる。一方、永続化の契約テストは本番ターゲットの
+    // PostgreSQL を Testcontainers で用意して検証する（ADR-0027 / #422。testing.md の宿題に対応）。
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
     // Flyway は starter で引く。Spring Boot 4 は autoconfig を機能別モジュールに分割しており、
     // FlywayAutoConfiguration は spring-boot-autoconfigure ではなく専用モジュール spring-boot-flyway
     // に移った。素の flyway-core だけだと autoconfig が classpath に無く、エラーも出さず migrate が
     // 走らない（#421）。starter-flyway が spring-boot-flyway(autoconfig) + spring-boot-jdbc +
-    // flyway-core を引き込む。H2 等の組み込み DB は starter だけで足り、PostgreSQL 化（#422）で
-    // flyway-database-postgresql を追加する。
+    // flyway-core を引き込む。
     implementation("org.springframework.boot:spring-boot-starter-flyway")
     runtimeOnly("com.h2database:h2")
+    // PostgreSQL ドライバと Flyway の PostgreSQL モジュール（Flyway 10+ は DB 別サポートをモジュール分割）は
+    // 契約テスト（Testcontainers）でのみ要るため testRuntimeOnly に置く。本番 jar・ランタイムには載らない。
+    testRuntimeOnly("org.postgresql:postgresql")
+    testRuntimeOnly("org.flywaydb:flyway-database-postgresql")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation(libs.java.uuid.generator)
     implementation(libs.kotlin.result)
@@ -50,6 +55,11 @@ dependencies {
     testImplementation(libs.springmockk)
     testImplementation(libs.archunit.junit5)
     testImplementation(libs.jmolecules.archunit)
+    // 永続化の契約テストは Testcontainers(PostgreSQL) で本番ターゲット DB に対して検証する（ADR-0027 / #422）。
+    // コンテナはシングルトン起動し接続先を @DynamicPropertySource（spring-test）で注入するため、
+    // @ServiceConnection 用の spring-boot-testcontainers や JUnit5 拡張モジュールは要らず postgresql モジュール
+    // 1 本でよい（core は推移取得）。アーティファクト ID は Testcontainers 2.0 の testcontainers-<module> 体系。
+    testImplementation("org.testcontainers:testcontainers-postgresql")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // プロジェクト固有の detekt カスタムルール（domain/application で throw しない 等）を detekt 実行時に組み込む

--- a/docs/adr/0027-persistence-spring-data-jdbc.md
+++ b/docs/adr/0027-persistence-spring-data-jdbc.md
@@ -74,8 +74,10 @@ Spring Data JDBC を採るうえで、本プロジェクト固有の制約と衝
 積み残し（follow-up）:
 
 - **Flyway の自動実行が Spring Boot 4.1 + Flyway 12 で動かない**。`flyway-core` を入れ `spring.flyway.enabled=true` でもマイグレーションが走らず DB が空のままになる事象を確認（起動ログに Flyway 出力なし）。spike では `@Sql` でスキーマを用意して回避した。Flyway 12 の DB モジュール分割（`flyway-database-postgresql` 等）や Boot 4 の autoconfig 条件を要追検証。
+  - **解消（#421 / #422）**: `spring-boot-starter-flyway`（`spring-boot-flyway` autoconfig を含む）で配線（#421）、PostgreSQL 用に `flyway-database-postgresql` を追加（#422）。`@Sql` を撤廃し、契約テストは Flyway が起動時に `db/migration/V*.sql` を PostgreSQL コンテナへ適用するのを前提に成立させた。
 - **更新系（version を進める save）はドメイン経由では未対応**。ドメインが version を持たないため、アダプタの `save` は常に insert になる。update は「version を Row 取得して引き当てる」等の方針を実装イシューで決める。
 - **H2 は spike 用の暫定**。本番は PostgreSQL + Testcontainers（Docker 必須のため spike 環境では未実行）。識別子の大文字小文字など方言差は Testcontainers で詰める。
+  - **一部解消（#422）**: 永続化の契約テストを Testcontainers(PostgreSQL) で本番ターゲット DB に対して実行するようにした（共有シングルトンコンテナ `PostgresContainerSupport` が `@DynamicPropertySource` で datasource を上書き）。識別子の小文字畳み等の方言差も実 PostgreSQL で検証できるようになった。**ランタイムの datasource は当面 H2（PostgreSQL 互換モード）のまま据え置く**: 実リポジトリはまだ InMemory Bean で datasource は付随的に初期化されるだけであり、H2 を撤去すると Container Smoke Test と Cloud Run 本番デプロイ（いずれもアプリを外部 DB なしで起動する）が壊れるため。実永続化を使う本番 PostgreSQL 化（Cloud SQL の新設と Cloud Run への配線）は #423 / インフラ作業に委ねる。
 - **本番配線**: `JdbcJockeyRepository` は既存 `InMemoryJockeyRepository` との DI 衝突を避けるため spike では Bean 化していない。プロファイル分け等の配線は別イシュー。
 
 ## Consequences（結果・影響）

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,9 +7,11 @@ spring:
   threads:
     virtual:
       enabled: true
-  # [#338 spike] 永続化アクセスの素振り用データソース（ADR-0027）。
-  # 本番化時は PostgreSQL（Testcontainers でテスト）へ差し替える。spike では Docker 不要の
-  # 組み込み H2 を PostgreSQL 互換モード（識別子は小文字へ畳む）で使い、本番 DB の挙動へ寄せる。
+  # ランタイムの永続化データソース。実リポジトリはまだ InMemory Bean のため、datasource/Flyway は
+  # 付随的に初期化されるだけで実永続化には使っていない。当面は Docker 不要の組み込み H2 を PostgreSQL
+  # 互換モード（識別子は小文字へ畳む）で使い、本番ターゲット DB（PostgreSQL）の挙動へ寄せる。実永続化を
+  # 使う本番 PostgreSQL 化（Cloud SQL 配線）は #423 / インフラ作業へ。永続化の契約テストは本番ターゲットの
+  # PostgreSQL を Testcontainers で用意して検証する（PostgresContainerSupport が datasource を上書きする）。
   datasource:
     url: jdbc:h2:mem:toybox;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1
     driver-class-name: org.h2.Driver

--- a/src/main/resources/db/migration/V1__create_jockey.sql
+++ b/src/main/resources/db/migration/V1__create_jockey.sql
@@ -1,4 +1,5 @@
--- [#338 spike] jockey テーブル（ADR-0027）。
+-- jockey テーブル（ADR-0027）。スキーマは H2(PostgreSQL 互換モード) と PostgreSQL の双方で適用される
+-- （ランタイムは H2、永続化の契約テストは Testcontainers の PostgreSQL。型は両者で互換）。
 -- 識別子は外部採番の UUIDv7（ADR-0005）をアプリ側で採番して渡す（DB 採番ではない）。
 -- version は楽観ロック兼「新規 insert 判定」用の列（version が null のとき Spring Data JDBC が新規とみなす）。
 CREATE TABLE jockey (

--- a/src/test/kotlin/com/example/api/infrastructure/racing/jockey/JdbcJockeyRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/racing/jockey/JdbcJockeyRepositoryContractTest.kt
@@ -2,35 +2,31 @@ package com.example.api.infrastructure.racing.jockey
 
 import com.example.api.domain.racing.model.jockey.Jockey
 import com.example.api.domain.shared.generateId
+import com.example.api.support.PostgresContainerSupport
 import com.github.michaelbull.result.unwrap
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.TestConstructor
 import org.springframework.test.context.TestConstructor.AutowireMode
-import org.springframework.test.context.TestPropertySource
 
 /**
- * [#338 spike] Spring Data JDBC + H2（インメモリ）による永続化の素振り（ADR-0027）。
+ * [#422] ドメインポート JockeyRepository の Spring Data JDBC 実装 [JdbcJockeyRepository] の契約テスト （ADR-0027）。
  *
- * 検証する学び:
+ * spike（H2・インメモリ）を卒業し、本番ターゲットと同じ PostgreSQL（Testcontainers、[PostgresContainerSupport]
+ * で共有）に対して検証する。スキーマはマイグレーション（`db/migration/V*.sql`）を Flyway が起動時に適用して用意する （Boot 4.1 + Flyway 12 +
+ * flyway-database-postgresql で自動実行されることもこのテストの成立で担保される。旧 spike の積み残しを解消）。
+ *
+ * 検証する契約:
  * 1. value class の `JockeyId` ↔ DB `uuid` 列を、永続化モデル分離＋手書きマッパーで橋渡しできること
  * 2. 外部採番（UUIDv7）で `@Id` が常に非 null でも、`@Version` が null のとき insert と判定されること（落とし穴②）
  * 3. 既存行の update で `@Version` がインクリメントされること（楽観ロック兼用。落とし穴③）
  * 4. イミュータブル集約 [Jockey] を ID を保ったまま再構成（reconstitute）して往復できること
- *
- * スキーマは本番マイグレーション SQL（`db/migration/V*.sql`）を Flyway が起動時に適用して用意する（#421 で配線。 旧 spike では Boot 4.1 +
- * Flyway 12 で autoconfig がマイグレーションを実行せず `@Sql` で回避していたが、 専用 autoconfig モジュール
- * `spring-boot-flyway`（starter-flyway 経由）を classpath に入れて解消した）。 DB は本テスト専用の H2 インメモリに隔離する。本番は
- * PostgreSQL + Testcontainers を前提とする（#422）。 H2 は Docker 不要で spike を走らせるための暫定。
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)
-@TestPropertySource(
-    properties =
-        ["spring.datasource.url=jdbc:h2:mem:spike;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1"]
-)
-class JdbcJockeyRepositorySpikeTest(private val rows: JockeySpringDataRepository) {
+class JdbcJockeyRepositoryContractTest(private val rows: JockeySpringDataRepository) :
+    PostgresContainerSupport() {
 
     private val repository = JdbcJockeyRepository(rows)
 
@@ -62,7 +58,7 @@ class JdbcJockeyRepositorySpikeTest(private val rows: JockeySpringDataRepository
         assert(updated.id == id)
         assert(updated.version!! > inserted.version!!)
         assert(rows.count() == 1L)
-        assert(rows.findById(id).unwrapPresent().firstName == "祐一")
+        assert(rows.findById(id).orElseThrow().firstName == "祐一")
     }
 
     @Test
@@ -84,6 +80,4 @@ class JdbcJockeyRepositorySpikeTest(private val rows: JockeySpringDataRepository
     fun `存在しない名前のfindByFullNameはnullを返す`() {
         assert(repository.findByFullName("該当", "無し") == null)
     }
-
-    private fun <T> java.util.Optional<T>.unwrapPresent(): T = orElseThrow()
 }

--- a/src/test/kotlin/com/example/api/support/PostgresContainerSupport.kt
+++ b/src/test/kotlin/com/example/api/support/PostgresContainerSupport.kt
@@ -1,0 +1,40 @@
+package com.example.api.support
+
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.postgresql.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * 永続化の契約テストが本番ターゲットの PostgreSQL に対して検証するための共有コンテナ（ADR-0027 / #422）。
+ *
+ * ランタイムの datasource は当面 H2（PostgreSQL 互換モード）だが、永続化の契約テストは本番ターゲット DB と 同じ PostgreSQL
+ * で検証したい。そこで本クラスを継承したテストには Testcontainers の実 PostgreSQL を割り当てる。 コンテナはプロセス内で 1
+ * つだけ起動して全テストで共有し（シングルトン）、明示停止はしない（Testcontainers の Ryuk が JVM 終了時に破棄する）。接続先は
+ * `@DynamicPropertySource` で各コンテキストへ注入し、app.yml の既定 （H2）を上書きする。注入する値は全テストで同一なので distinct な
+ * ApplicationContext を増やさず、コンテキスト キャッシュ方針（ADR-0015 / testing.md）を維持する。
+ *
+ * 本クラスを継承するテストでは、Flyway が起動時に `db/migration/V*.sql` をこの PostgreSQL コンテナへ適用する （Boot 4.1 + Flyway
+ * 12 + flyway-database-postgresql で自動実行されることを併せて担保する）。
+ */
+// テストが継承して共有コンテナを得るための基底クラス。object 化すると継承できないため、
+// 「companion のユーティリティだけなら object にせよ」という detekt の指摘はここでは当たらない。
+@Suppress("UtilityClassWithPublicConstructor")
+abstract class PostgresContainerSupport {
+    companion object {
+        @JvmStatic
+        private val postgres =
+            PostgreSQLContainer(DockerImageName.parse("postgres:17-alpine")).apply { start() }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            // app.yml は driver-class-name を H2 に固定しているため、URL だけ差し替えると
+            // ドライバ（H2）と URL（PostgreSQL）が食い違い datasource 初期化に失敗する。ドライバも上書きする。
+            registry.add("spring.datasource.driver-class-name", postgres::getDriverClassName)
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+}


### PR DESCRIPTION
## 概要

Towards #422

infrastructure 層の Repository 実装に対する**契約テストを、本番ターゲット DB と同じ PostgreSQL（Testcontainers）で整備**する（`.claude/rules/testing.md` の宿題「`infrastructure.*` の契約テスト未整備」に対応）。`Jockey` の Spring Data JDBC 実装を題材に、spike（H2）を契約テストへ昇格させ、**Flyway 自動実行が PostgreSQL コンテナ上で機能する**ことも併せて担保する（ADR-0027 の spike 積み残しを解消）。

## スコープの判断（ランタイムは H2 据え置き）

当初 H2 を撤去してランタイムも PostgreSQL 一本化しようとしたが、それだと **Container Smoke Test と Cloud Run 本番デプロイ（いずれもアプリを外部 DB なしで起動する）が壊れる**ことが判明した。アプリの実リポジトリはまだ InMemory Bean で、ランタイムの datasource/Flyway は付随的に初期化されるだけなので、

- **テストのみ** PostgreSQL（Testcontainers）で本番ターゲット DB に対して検証する
- **ランタイムは H2（PostgreSQL 互換モード）のまま据え置く**（smoke / 本番デプロイは無傷）

とした。実永続化を使う**本番 PostgreSQL 化（Cloud SQL 新設 + Cloud Run 配線）は #423 / インフラ作業に委ねる**。本 PR は #422 のうち「契約テストの PostgreSQL 化」部分を担う。

## 変更点

- **依存（`build.gradle.kts`）**: H2(`runtimeOnly`) は据え置き。契約テスト用に `postgresql` ドライバと `flyway-database-postgresql` を `testRuntimeOnly`、`testcontainers-postgresql` を `testImplementation` 追加（Testcontainers 2.0 の `testcontainers-<module>` 体系。`@DynamicPropertySource` 方式のため core を推移取得する 1 本でよい）。
- **共有コンテナ（`PostgresContainerSupport`）**: 契約テストが本番ターゲットの PostgreSQL に対して検証するための**シングルトン PostgreSQL コンテナ**。接続先（driver/url/username/password）を `@DynamicPropertySource` で注入し、app.yml の既定（H2）を上書きする。distinct な `ApplicationContext` を増やさずコンテキストキャッシュ方針（ADR-0015）を維持。
- **契約テスト**: spike テスト（H2）を `JdbcJockeyRepositoryContractTest` に昇格し、PostgreSQL コンテナに対して検証（insert/update 判定・楽観ロック・value class ID 往復・再構成）。
- **`db/migration/V1__create_jockey.sql` / ADR-0027**: コメント更新（型は H2(PG互換)/PostgreSQL 双方で互換）、spike 積み残しの解消状況とランタイム H2 据え置きの理由を追記。

## Testcontainers 2.0 メモ

Spring Boot 4.1 が同梱する Testcontainers は **2.0 系**で、アーティファクト ID（`testcontainers-postgresql`）とパッケージ（`org.testcontainers.postgresql.PostgreSQLContainer`）が旧版から変わっている。新体系に合わせ、旧 `org.testcontainers.containers.PostgreSQLContainer`（`@Deprecated`）は使わない（`allWarningsAsErrors` 運用のため）。

## 検証

`./gradlew check` 緑（`test` を `--rerun-tasks` で強制再実行し成功率 100%）。契約テスト 4 件が Testcontainers の PostgreSQL コンテナへ実接続して通過、coverage ゲート（`koverVerifyMature`）も通過。ランタイムは H2 のままのため Container Smoke Test / Cloud Run デプロイの挙動はベースラインから変えていない。

## 残課題（別 issue）

- 本番 PostgreSQL 化（Cloud SQL 新設 + Cloud Run 配線）・本番 Bean 配線（InMemory↔JDBC 切替）と残り集約への JDBC 展開: #423
- 更新系・楽観ロックのドメイン経由対応: #424
- spike 暫定依存の version catalog 移管: #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
