### PR TITLE
feat: 繁殖登録（BreedingRegistration）の登録ユースケースと API 入口を整備する (#414)

### DIFF
--- a/src/main/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCase.kt
@@ -1,0 +1,77 @@
+package com.example.api.application.studbook.breeding
+
+import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.breeding.BreedingRegistration
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationNumber
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import com.github.michaelbull.result.mapError
+import com.github.michaelbull.result.toResultOr
+import java.util.UUID
+import org.springframework.stereotype.Service
+
+/**
+ * 繁殖登録ユースケースの入力コマンド。
+ *
+ * 繁殖登録は血統登録済みの個体を繁殖の用に供するための追加登録で、対象は登録済み軽種馬の ID で参照する。 繁殖登録番号は VO で表すため素の文字列で受け取り、ユースケース内で
+ * [BreedingRegistrationNumber] の `create` を 通して検証する。付与されるロール（種牡馬／繁殖牝馬）は対象個体の性から定まるため、入力では受け取らない。
+ *
+ * @property bloodHorseId 繁殖登録する個体（血統登録済み）の軽種馬ID
+ * @property registrationNumber 交付される繁殖登録番号
+ */
+data class RegisterBreedingRegistrationCommand(
+    val bloodHorseId: UUID,
+    val registrationNumber: String,
+)
+
+/** 繁殖登録時に発生しうる業務ルール違反。 */
+sealed interface RegisterBreedingRegistrationUseCaseError {
+    /** 繁殖登録番号がブランク。 */
+    data object InvalidRegistrationNumber : RegisterBreedingRegistrationUseCaseError
+
+    /** 繁殖登録の対象として指定された軽種馬が存在しない。 */
+    data class HorseNotFound(val bloodHorseId: UUID) : RegisterBreedingRegistrationUseCaseError
+}
+
+/**
+ * 繁殖登録ユースケース。
+ *
+ * 境界の生入力を VO に変換し（不正なら検証エラー）、繁殖登録する個体を [BloodHorseRepository] で引き当て、 集約の自己検証ファクトリ
+ * [BreedingRegistration.create] で繁殖登録を成立させてから永続化する。血統登録 → 繁殖登録という 順序関係は、対象が既に永続化済みの軽種馬であることを引当が
+ * 要求することで自然に満たされる。
+ *
+ * 繁殖登録は種付記録・種付せず・分娩報告・供用停止といった繁殖の書き込み経路の起点であり、本ユースケースが その起点（`save` 経路）を開通させる。付与されるロールは対象個体の性から
+ * [BreedingRegistration.create] が定める。 制度上の前提条件（馬名登録済み・競走馬登録抹消済み 等）は対応する集約が未モデル化のため現時点では検証しない。
+ *
+ * @return 成立した [BreedingRegistration]、または業務ルール違反を表す [RegisterBreedingRegistrationUseCaseError]
+ */
+@Service
+class RegisterBreedingRegistrationUseCase(
+    private val bloodHorseRepository: BloodHorseRepository,
+    private val breedingRegistrationRepository: BreedingRegistrationRepository,
+) {
+    operator fun invoke(
+        command: Command<RegisterBreedingRegistrationCommand>
+    ): Result<BreedingRegistration, RegisterBreedingRegistrationUseCaseError> = binding {
+        val input = command.payload
+
+        val registrationNumber =
+            BreedingRegistrationNumber.create(input.registrationNumber)
+                .mapError { RegisterBreedingRegistrationUseCaseError.InvalidRegistrationNumber }
+                .bind()
+
+        val horse =
+            bloodHorseRepository
+                .findById(BloodHorseId(input.bloodHorseId))
+                .toResultOr {
+                    RegisterBreedingRegistrationUseCaseError.HorseNotFound(input.bloodHorseId)
+                }
+                .bind()
+
+        val registration = BreedingRegistration.create(registrationNumber, horse)
+        breedingRegistrationRepository.save(registration)
+    }
+}

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationController.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationController.kt
@@ -1,0 +1,88 @@
+package com.example.api.controller.breeding
+
+import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationUseCase
+import com.example.api.controller.breeding.problem.toProblemDetail
+import com.example.api.controller.breeding.request.RegisterBreedingRegistrationRequest
+import com.example.api.controller.breeding.request.toCommand
+import com.example.api.controller.orThrowProblem
+import com.example.api.domain.shared.Command
+import com.github.michaelbull.result.mapError
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import java.time.Clock
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ProblemDetail
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 繁殖登録リソースの HTTP アダプター。
+ *
+ * Google AIP のリソース指向設計に従い、コレクション `/api/breedingRegistrations` に対する Create（繁殖登録の成立）を 提供する。繁殖登録は
+ * 種付記録・種付せず・分娩報告・供用停止といった繁殖の書き込み経路の起点であり、この Create が その起点を開通させる。 エラーレスポンスは RFC 9457 (Problem
+ * Details) 形式で返す。
+ */
+@RestController
+class BreedingRegistrationController(
+    private val registerBreedingRegistration: RegisterBreedingRegistrationUseCase,
+    private val clock: Clock,
+) {
+    @Operation(
+        summary = "繁殖登録を成立させる",
+        description =
+            "血統登録済みの個体を繁殖の用に供するための繁殖登録を成立させ、成立した繁殖登録リソースを返す。" +
+                "付与されるロール（種牡馬／繁殖牝馬）は対象個体の性から定まる。業務ルール違反時は RFC 9457 形式の problem+json を返す。",
+        tags = ["BreedingRegistration"],
+        responses =
+            [
+                ApiResponse(
+                    responseCode = "201",
+                    description = "登録成功（成立した繁殖登録リソースを返す）",
+                    content =
+                        [
+                            Content(
+                                schema =
+                                    Schema(implementation = BreedingRegistrationResponse::class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "400",
+                    description = "入力値が不正（繁殖登録番号がブランクなど）",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "422",
+                    description = "繁殖登録の対象として指定された軽種馬が存在しない",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+            ],
+    )
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/api/breedingRegistrations")
+    fun register(
+        @RequestBody request: RegisterBreedingRegistrationRequest
+    ): BreedingRegistrationResponse =
+        registerBreedingRegistration(Command.now(request.toCommand(), clock))
+            .mapError { it.toProblemDetail() }
+            .orThrowProblem()
+            .toResponse()
+}

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationResponse.kt
@@ -1,0 +1,50 @@
+package com.example.api.controller.breeding
+
+import com.example.api.domain.studbook.model.breeding.BreedingRegistration
+import com.example.api.domain.studbook.model.breeding.BreedingRetirement
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * 繁殖登録リソースの表現（HTTP 契約）。
+ *
+ * 繁殖登録に対する操作（登録の Create、将来の供用停止 `:retire` カスタムメソッド #408）は、 [AIP-133](https://google.aip.dev/133) /
+ * [AIP-136](https://google.aip.dev/136) に倣い一律でこのリソース表現全体を返す （[ADR-0008]
+ * の単一リソース表現）。供用停止前は未設定になりうる属性（[retirement]）は null で表す。 ロール・事由はドメイン enum を晒さず wire enum
+ * （[BreedingRoleDto] / [RetirementReasonDto]）で公開する（ADR-0007）。
+ *
+ * @property id 繁殖登録の生 UUID
+ * @property registrationNumber 繁殖登録番号
+ * @property registeredHorseId 繁殖登録した個体（血統登録済み）の軽種馬の生 UUID
+ * @property role 繁殖登録によって付与されたロール（種牡馬／繁殖牝馬）
+ * @property retirement 供用停止。供用中なら null、供用停止済みなら事由と発生日を持つ
+ */
+data class BreedingRegistrationResponse(
+    val id: UUID,
+    val registrationNumber: String,
+    val registeredHorseId: UUID,
+    val role: BreedingRoleDto,
+    val retirement: BreedingRetirementResponse?,
+)
+
+/**
+ * 繁殖供用停止の表現（[BreedingRegistrationResponse.retirement]）。
+ *
+ * @property reason 供用停止の事由
+ * @property occurredOn 事由が発生した日
+ */
+data class BreedingRetirementResponse(val reason: RetirementReasonDto, val occurredOn: LocalDate)
+
+/** [BreedingRegistration] を繁殖登録リソースの表現へ変換する。各操作の成功レスポンスはこのリソース表現を一律で返す。 */
+fun BreedingRegistration.toResponse(): BreedingRegistrationResponse =
+    BreedingRegistrationResponse(
+        id = id.value,
+        registrationNumber = registrationNumber.value,
+        registeredHorseId = registeredHorseId.value,
+        role = role.toApi(),
+        retirement = retirement?.toResponse(),
+    )
+
+/** [BreedingRetirement] を供用停止の表現へ変換する。 */
+fun BreedingRetirement.toResponse(): BreedingRetirementResponse =
+    BreedingRetirementResponse(reason = reason.toApi(), occurredOn = occurredOn)

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationWireEnums.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationWireEnums.kt
@@ -1,0 +1,48 @@
+package com.example.api.controller.breeding
+
+import com.example.api.domain.studbook.model.breeding.BreedingRole
+import com.example.api.domain.studbook.model.breeding.RetirementReason
+
+/**
+ * 繁殖登録リソースの wire enum 群。
+ *
+ * ドメイン enum（[BreedingRole] / [RetirementReason]）を HTTP 契約へ直接晒さず、契約専用の `〜Dto` enum を adapter 層に置いて
+ * [toApi] の網羅 `when` でマッピングする（ドメイン側の列挙子リネームが契約を無言で壊すのを防ぐ。ADR-0007）。 現状は response の露出のみだが、wire enum
+ * は将来 request とも共有しうるためリソース root に置く。
+ */
+
+/** 繁殖登録によって付与されるロールの wire 表現（[BreedingRole] の契約専用 enum）。 */
+enum class BreedingRoleDto {
+    /** 種牡馬（繁殖の用に供する雄馬）。 */
+    STALLION,
+
+    /** 繁殖牝馬（繁殖の用に供する雌馬）。 */
+    BROODMARE,
+}
+
+/** [BreedingRole] を wire 表現 [BreedingRoleDto] へマッピングする。 */
+fun BreedingRole.toApi(): BreedingRoleDto =
+    when (this) {
+        BreedingRole.STALLION -> BreedingRoleDto.STALLION
+        BreedingRole.BROODMARE -> BreedingRoleDto.BROODMARE
+    }
+
+/** 繁殖供用停止の事由の wire 表現（[RetirementReason] の契約専用 enum）。 */
+enum class RetirementReasonDto {
+    /** 死亡（死産・生後直死を除く）。 */
+    DEATH,
+
+    /** 用途変更（繁殖以外の用途への変更）。 */
+    USE_CHANGE,
+
+    /** その他の事由。 */
+    OTHER,
+}
+
+/** [RetirementReason] を wire 表現 [RetirementReasonDto] へマッピングする。 */
+fun RetirementReason.toApi(): RetirementReasonDto =
+    when (this) {
+        RetirementReason.DEATH -> RetirementReasonDto.DEATH
+        RetirementReason.USE_CHANGE -> RetirementReasonDto.USE_CHANGE
+        RetirementReason.OTHER -> RetirementReasonDto.OTHER
+    }

--- a/src/main/kotlin/com/example/api/controller/breeding/problem/BreedingRegistrationProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/problem/BreedingRegistrationProblem.kt
@@ -1,0 +1,38 @@
+package com.example.api.controller.breeding.problem
+
+import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationUseCaseError
+import com.example.api.controller.problem
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+
+/**
+ * 繁殖登録リソースの業務エラーを RFC 9457 (`application/problem+json`) の [ProblemDetail] へ変換するマッパー群。
+ *
+ * どのエラーをどの `status` / `errorCode` に描画するかの方針をここ（adapter 層の `problem/` パッケージ）へ集約する。
+ */
+
+/**
+ * [RegisterBreedingRegistrationUseCaseError] を RFC 9457 の [ProblemDetail] に変換する。
+ *
+ * - 繁殖登録番号の VO 検証エラーは入力不正として 400 Bad Request
+ * - リクエストボディで参照する軽種馬の不在は、整った入力だが意味的に処理できないため 422 Unprocessable Entity
+ *   （api-design.md「リソース不在のステータス（404 vs 422）」: ボディ内参照先の不在は 422）
+ */
+fun RegisterBreedingRegistrationUseCaseError.toProblemDetail(): ProblemDetail =
+    when (this) {
+        RegisterBreedingRegistrationUseCaseError.InvalidRegistrationNumber ->
+            problem(
+                status = HttpStatus.BAD_REQUEST,
+                code = "invalid-breeding-registration-number",
+                title = "Invalid breeding registration number",
+                detail = "registration_number は空であってはいけません。",
+            )
+        is RegisterBreedingRegistrationUseCaseError.HorseNotFound ->
+            problem(
+                    status = HttpStatus.UNPROCESSABLE_ENTITY,
+                    code = "blood-horse-not-found",
+                    title = "Blood horse not found",
+                    detail = "繁殖登録の対象として指定された軽種馬が存在しません。",
+                )
+                .apply { setProperty("blood_horse_id", bloodHorseId) }
+    }

--- a/src/main/kotlin/com/example/api/controller/breeding/request/RegisterBreedingRegistrationRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/request/RegisterBreedingRegistrationRequest.kt
@@ -1,0 +1,25 @@
+package com.example.api.controller.breeding.request
+
+import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationCommand
+import java.util.UUID
+
+/**
+ * `POST /api/breedingRegistrations` のリクエストボディ。血統登録済みの個体を繁殖の用に供するための繁殖登録 Create。
+ *
+ * 繁殖登録する個体は登録済み軽種馬の ID で参照する。繁殖登録番号は VO で表すため素の文字列で受け取り、ユースケースで 検証する。付与されるロール（種牡馬／繁殖牝馬）は対象個体の性から
+ * 定まるため入力では受け取らない。
+ *
+ * @property bloodHorseId 繁殖登録する個体（血統登録済み）の軽種馬ID
+ * @property registrationNumber 交付される繁殖登録番号
+ */
+data class RegisterBreedingRegistrationRequest(
+    val bloodHorseId: UUID,
+    val registrationNumber: String,
+)
+
+/** リクエストを繁殖登録ユースケースの入力コマンドへ変換する。 */
+fun RegisterBreedingRegistrationRequest.toCommand(): RegisterBreedingRegistrationCommand =
+    RegisterBreedingRegistrationCommand(
+        bloodHorseId = bloodHorseId,
+        registrationNumber = registrationNumber,
+    )

--- a/src/test/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCaseTest.kt
@@ -1,0 +1,127 @@
+package com.example.api.application.studbook.breeding
+
+import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
+import com.example.api.domain.studbook.model.breeding.BreedingRole
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Instant
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class RegisterBreedingRegistrationUseCaseTest {
+
+    private fun command(
+        payload: RegisterBreedingRegistrationCommand
+    ): Command<RegisterBreedingRegistrationCommand> = Command(payload, Instant.now())
+
+    @Nested
+    inner class SuccessCase {
+        @Test
+        fun `雌馬を繁殖登録すると繁殖牝馬ロールの繁殖登録が永続化される`() {
+            val mare = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+            val bloodHorseRepository =
+                mockk<BloodHorseRepository> { every { findById(mare.id) } returns mare }
+            val breedingRegistrationRepository =
+                mockk<BreedingRegistrationRepository> {
+                    every { save(any()) } answers { firstArg() }
+                }
+            val useCase =
+                RegisterBreedingRegistrationUseCase(
+                    bloodHorseRepository,
+                    breedingRegistrationRepository,
+                )
+
+            val result =
+                useCase(command(RegisterBreedingRegistrationCommand(mare.id.value, "B-2024-0001")))
+                    .unwrap()
+
+            assert(result.registeredHorseId == mare.id)
+            assert(result.role == BreedingRole.BROODMARE)
+            assert(result.registrationNumber.value == "B-2024-0001")
+            assert(!result.isRetired)
+            verify(exactly = 1) { breedingRegistrationRepository.save(any()) }
+        }
+
+        @Test
+        fun `雄馬を繁殖登録すると種牡馬ロールになる`() {
+            val stallion = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
+            val bloodHorseRepository =
+                mockk<BloodHorseRepository> { every { findById(stallion.id) } returns stallion }
+            val breedingRegistrationRepository =
+                mockk<BreedingRegistrationRepository> {
+                    every { save(any()) } answers { firstArg() }
+                }
+            val useCase =
+                RegisterBreedingRegistrationUseCase(
+                    bloodHorseRepository,
+                    breedingRegistrationRepository,
+                )
+
+            val result =
+                useCase(
+                        command(
+                            RegisterBreedingRegistrationCommand(stallion.id.value, "B-2024-0002")
+                        )
+                    )
+                    .unwrap()
+
+            assert(result.role == BreedingRole.STALLION)
+        }
+    }
+
+    @Nested
+    inner class FailureCase {
+        @Test
+        fun `繁殖登録番号がブランクのとき InvalidRegistrationNumber を返し永続化されない`() {
+            val mare = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+            val bloodHorseRepository = mockk<BloodHorseRepository>()
+            val breedingRegistrationRepository = mockk<BreedingRegistrationRepository>()
+            val useCase =
+                RegisterBreedingRegistrationUseCase(
+                    bloodHorseRepository,
+                    breedingRegistrationRepository,
+                )
+
+            val result = useCase(command(RegisterBreedingRegistrationCommand(mare.id.value, "   ")))
+
+            assert(
+                result.getError() ==
+                    RegisterBreedingRegistrationUseCaseError.InvalidRegistrationNumber
+            )
+            verify(exactly = 0) { breedingRegistrationRepository.save(any()) }
+        }
+
+        @Test
+        fun `対象の軽種馬が存在しないとき HorseNotFound を返し永続化されない`() {
+            val bloodHorseId = UUID.randomUUID()
+            val bloodHorseRepository =
+                mockk<BloodHorseRepository> {
+                    every { findById(BloodHorseId(bloodHorseId)) } returns null
+                }
+            val breedingRegistrationRepository = mockk<BreedingRegistrationRepository>()
+            val useCase =
+                RegisterBreedingRegistrationUseCase(
+                    bloodHorseRepository,
+                    breedingRegistrationRepository,
+                )
+
+            val result =
+                useCase(command(RegisterBreedingRegistrationCommand(bloodHorseId, "B-2024-0001")))
+
+            assert(
+                result.getError() ==
+                    RegisterBreedingRegistrationUseCaseError.HorseNotFound(bloodHorseId)
+            )
+            verify(exactly = 0) { breedingRegistrationRepository.save(any()) }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
@@ -1,0 +1,102 @@
+package com.example.api.controller.breeding
+
+import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationCommand
+import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationUseCase
+import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationUseCaseError
+import com.example.api.config.ClockConfiguration
+import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.breeding.BreedingFixture
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import java.util.UUID
+import org.junit.jupiter.api.Test
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.context.TestConstructor.AutowireMode
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.assertj.MockMvcTester
+
+@WebMvcTest(BreedingRegistrationController::class)
+@Import(ClockConfiguration::class)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class BreedingRegistrationControllerTest(val mockMvc: MockMvc) {
+    @MockkBean
+    private lateinit var registerBreedingRegistration: RegisterBreedingRegistrationUseCase
+
+    private val tester = MockMvcTester.create(mockMvc)
+
+    private val uri = "/api/breedingRegistrations"
+
+    /** デシリアライズに通る正しい繁殖登録リクエストボディ。ユースケースはモックのため中身の整合は問われない。 */
+    private val validBody =
+        """
+        {
+            "blood_horse_id": "11111111-1111-1111-1111-111111111111",
+            "registration_number": "B-2024-0001"
+        }
+        """
+            .trimIndent()
+
+    @Test
+    fun `正常な入力で 201 Created と成立した繁殖登録が返ること`() {
+        val saved = BreedingFixture.breedingRegistration()
+        every {
+            registerBreedingRegistration(any<Command<RegisterBreedingRegistrationCommand>>())
+        } returns Ok(saved)
+
+        tester
+            .post()
+            .uri(uri)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validBody)
+            .assertThat()
+            .hasStatus(HttpStatus.CREATED)
+            .bodyJson()
+            .extractingPath("$.role")
+            .isEqualTo("BROODMARE")
+    }
+
+    @Test
+    fun `InvalidRegistrationNumber で 400 と problem+json が返ること`() {
+        every {
+            registerBreedingRegistration(any<Command<RegisterBreedingRegistrationCommand>>())
+        } returns Err(RegisterBreedingRegistrationUseCaseError.InvalidRegistrationNumber)
+
+        tester
+            .post()
+            .uri(uri)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validBody)
+            .assertThat()
+            .hasStatus(HttpStatus.BAD_REQUEST)
+            .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+            .bodyJson()
+            .extractingPath("$.error_code")
+            .isEqualTo("invalid-breeding-registration-number")
+    }
+
+    @Test
+    fun `HorseNotFound で 422 と bloodHorseId 付きの problem+json が返ること`() {
+        val id = UUID.fromString("11111111-1111-1111-1111-111111111111")
+        every {
+            registerBreedingRegistration(any<Command<RegisterBreedingRegistrationCommand>>())
+        } returns Err(RegisterBreedingRegistrationUseCaseError.HorseNotFound(id))
+
+        tester
+            .post()
+            .uri(uri)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validBody)
+            .assertThat()
+            .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+            .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+            .bodyJson()
+            .extractingPath("$.blood_horse_id")
+            .isEqualTo(id.toString())
+    }
+}

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationResponseTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationResponseTest.kt
@@ -1,0 +1,38 @@
+package com.example.api.controller.breeding
+
+import com.example.api.domain.studbook.model.breeding.BreedingFixture
+import com.example.api.domain.studbook.model.breeding.RetirementReason
+import com.github.michaelbull.result.unwrap
+import java.time.LocalDate
+import org.junit.jupiter.api.Test
+
+class BreedingRegistrationResponseTest {
+
+    @Test
+    fun `供用中の繁殖登録は retirement が null でロールが wire enum に写ること`() {
+        val stallion = BreedingFixture.stallionRegistration()
+
+        val response = stallion.toResponse()
+
+        assert(response.id == stallion.id.value)
+        assert(response.registeredHorseId == stallion.registeredHorseId.value)
+        assert(response.registrationNumber == stallion.registrationNumber.value)
+        assert(response.role == BreedingRoleDto.STALLION)
+        assert(response.retirement == null)
+    }
+
+    @Test
+    fun `供用停止済みの繁殖登録は事由と発生日が wire 表現に写ること`() {
+        val occurredOn = LocalDate.of(2024, 5, 1)
+        val retired =
+            BreedingFixture.breedingRegistration()
+                .retire(RetirementReason.DEATH, occurredOn)
+                .unwrap()
+
+        val response = retired.toResponse()
+
+        assert(response.role == BreedingRoleDto.BROODMARE)
+        assert(response.retirement?.reason == RetirementReasonDto.DEATH)
+        assert(response.retirement?.occurredOn == occurredOn)
+    }
+}


### PR DESCRIPTION
## 概要

繁殖登録（`BreedingRegistration`）を成立させる登録ユースケースと API 入口（controller）を整備する。Close #414。

これまで `BreedingRegistrationRepository.save()` を呼ぶ本番コードが存在せず、繁殖登録は実質テスト内でしか生成されていなかった（`RecordCovering` / `RecordUncovered` / `RegisterFoal` はいずれも `findById` の読み取りでしか使っていない）。本 PR で繁殖の書き込み経路（種付・分娩・供用停止）の起点となる繁殖登録の成立経路を通す。

## やったこと

| 層 | ファイル | 役割 |
|----|---------|------|
| application | `RegisterBreedingRegistrationUseCase.kt` | 入力コマンド・失敗バリアント（`InvalidRegistrationNumber` / `HorseNotFound`）・UC 本体。`BloodHorseRepository` で対象馬を引き当て、`BreedingRegistration.create` で成立させて `save` |
| controller | `BreedingRegistrationController.kt` | `POST /api/breedingRegistrations`（AIP-133 Create、201 でリソース表現を返す） |
| controller | `BreedingRegistrationResponse.kt` | 単一リソース表現（ADR-0008）。`retirement` は nullable で将来の `:retire`（#408）が同一表現を再利用可能 |
| controller | `BreedingRegistrationWireEnums.kt` | `BreedingRoleDto` / `RetirementReasonDto`。ドメイン enum を契約に晒さず `toApi()` でマッピング（ADR-0007） |
| controller/request | `RegisterBreedingRegistrationRequest.kt` | リクエスト DTO + `toCommand()` |
| controller/problem | `BreedingRegistrationProblem.kt` | 番号ブランクを 400、ボディ参照の馬不在を 422 に描画（api-design の 404/422 切り分け） |
| test | UC / controller slice / response マッパー | 成功・各失敗・retirement 両分岐を網羅 |

付与されるロール（種牡馬／繁殖牝馬）は対象個体の性から `BreedingRegistration.create` が定める。

## 設計判断

- **422 を採用**: リクエストボディで参照する軽種馬の不在は、URL パス対象の不在（404）と区別してボディ内参照先不在＝422（api-design.md「リソース不在のステータス（404 vs 422）」）。
- **wire enum**: `BreedingRole` / `RetirementReason` を contract に晒さず `〜Dto` enum へマッピング（ADR-0007、ArchUnit で強制）。
- **単一リソース表現**: `retirement` を nullable で含め、#408 の `:retire` が DTO を変えずに再利用できる形にした（ADR-0008）。

## スコープ外

- 制度上の前提条件（馬名登録済み・競走馬登録抹消済み 等）は対応集約が未モデル化のため未検証（`BreedingRegistration.create` の方針どおり）。
- 同一個体の重複繁殖登録の防止（集合制約）は本 PR の対象外。

## 影響

- **#408（供用停止 retire の API 配線）のブロッカーが解消**する。

## 検証

`./gradlew check` が BUILD SUCCESSFUL。ktfmt / detekt / ArchUnit（DTO enum・controller パッケージ規約含む）／全テスト／Kover mature 85% ゲートをすべて通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
