### PR TITLE
feat: 読み取りを集約非経由の Read Model 経路で実装する（軽量CQRS L2） (#293)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -39,6 +39,17 @@
 - **service**: **単一集約の構築ではない、複数集約をまたぐオーケストレーション／手続き**のドメインロジック（例: `registerFoal` は分娩結果の判定→`BloodHorse.create` へ橋渡し、`confirmRaceResult`）。**Kotlin のトップレベル関数で書く**（`object` でラップしない）。jMolecules の `@Service` は付けない（パッケージ配置で表現し、`service/` に居ることがドメインサービスの証）。役割分担は「構築時バリデーション＝ファクトリ／入力参照の解決・操作対象のロード・保存・オーケストレーション＝アプリケーション層」を基本とする。**例外: 集合制約（一意性・件数上限など、既存レコード集合への問い合わせが必要なドメイン不変条件）の検証に限り、ドメインサービスがリポジトリ「ポート」を引数で受け取って読み取り引き当てしてよい**（書き込みはしない・ポートは `domain.*.model` の interface に限る。例: `recordCovering` が `BreedingResultRepository` を受け取り種付年の一意性を検証）。経緯は [ADR-0022](../../docs/adr/0022-domain-service-repository-for-set-invariants.md)
 - 1 ファイルにモデルとサービスを混在させない（例: `confirmRaceResult` は `service/race/` に、入力 VO の `RaceResult` は `model/race/` に置く）
 
+### 読み取り経路（軽量 CQRS / L2）
+
+読み取り（クエリ）系は、書き込み側の集約を**経由しない**独立経路として実装する（軽量 CQRS = L2。ストア分離・結果整合・イベントソーシング = L3 は採らない）。決定経緯は [ADR-0031](../../docs/adr/0031-lightweight-cqrs-read-model.md)、リファレンス実装は `racing/jockey`（`FindJockeyUseCase`）。
+
+- **Read Model（View）とクエリポートは `application` に置く**（ドメインを汚さない）。書き込みの「集約 + Repository ポートは `domain.*.model`」と非対称だが、これは意図したもの。読みモデルは集約のライフサイクル（生成・状態遷移・整合性境界）を持たないため domain には置かない
+- **View には jMolecules の `@QueryModel`（`org.jmolecules.architecture.cqrs`）を付ける**。不変条件を持たないフラットな DTO で、値の等価性が自然なため `data class` でよい。`@QueryModel` が `application` に居ることは ArchUnit [`queryModelsResideInApplication`] で強制する（DDD ビルディングブロックを `domain.*.model` に縛る [`dddBuildingBlocksResideInDomainModel`] と対称）
+- **クエリポート（`〜Queries`）は plain interface とし、書き込みポートの jMolecules `@Repository` は付けない**。読み取りは Repository ビルディングブロックではないため
+- **infrastructure の実装は集約を組まずストアから直接 View へ詰める**（例: `JdbcJockeyQueries` が `JdbcClient` で `jockey` を直 SELECT し、書き込みの `JockeyRow`／集約を経由しない）。同じテーブルを読んでも、経路（write=集約復元 / read=View 直組み）とモデルを分離するのが L2 の価値であり、「write ポートに finder を生やす」誘惑には乗らない
+- **読み取りも write と対称に `application` を必ず通す**（現行オニオンの依存方向を維持。infrastructure → application のポート実装はアダプターの依存として onion ルールが許容する）
+- クエリ入力 DTO は `〜Query` サフィックス。書き込み系の `Command<T>` 封筒（発生時刻メタデータ）は読み取りでは**使わない**（発生時刻は書き込みイベントの概念）
+
 ## パッケージ構造
 
 ```
@@ -93,6 +104,7 @@ domain/
   - `@Entity` / `@AggregateRoot` は `@Identity` 付き識別子を持つ
   - **他の集約への参照は ID 値クラス（または `Association`）経由のみ**。集約オブジェクトを直接フィールドに持ってはならない（例: `Stallion` は `BloodHorse` ではなく `BloodHorseId` を持つ）
   - `@ValueObject` は Entity / AggregateRoot を参照しない
+- 軽量 CQRS の読みモデル `@QueryModel`（`org.jmolecules.architecture.cqrs`）は DDD ビルディングブロックではなく **CQRS アーキテクチャ注釈**。`domain.*.model` ではなく `application` に置き、ArchUnit `queryModelsResideInApplication` で強制する（読み取り経路の全体方針は「レイヤー依存ルール」の「読み取り経路（軽量 CQRS / L2）」、決定経緯は [ADR-0031](../../docs/adr/0031-lightweight-cqrs-read-model.md)）
 
 ## その他の強制ルール
 
@@ -104,6 +116,7 @@ domain/
 - **ドメインサービス（`domain.*.service`）はトップレベル関数で書く**（`object` / `class` でラップしない）。トップレベル関数はファイルごとのファサードクラス（`〜Kt`）へコンパイルされるため、service パッケージ内のクラスが `Kt` で終わることを ArchUnit で検証して `object` / `class` 宣言を排除する。ただしサービスの戻り値（`Result<_, 〜Error>`）の失敗側を表す失敗バリアント型（`〜Error`）はサービスと同居させてよく、対象から除外する
 - **`@RestController` のハンドラは成功レスポンスで `ResponseEntity` を返さない**。成功は `@ResponseStatus` ＋戻り値で resource を返す（[error-handling.md](error-handling.md) / [api-design.md](api-design.md)）。エラー描画 funnel の `GlobalExceptionHandler` は `@RestController` ではない（`ResponseEntityExceptionHandler` 継承）ため誤検出されない
 - **HTTP 契約（request / response DTO）はフィールド型にドメイン enum を持たない**。`controller` 層に契約専用の `〜Dto` enum を置き、`toDomain()` / `toApi()` でマッピングする（[api-design.md](api-design.md) / [ADR-0007](../../docs/adr/0007-wire-enum-dto-decoupling.md)）。`controller` 配下のフィールドがドメイン（`domain..`）の enum を raw type に持たないことを ArchUnit で検証する。マッパー関数はドメイン enum を引数・戻り値で扱うが、フィールド型のみを対象とするため誤検出されない（ルールが実際に違反を検出することは `DtoDomainEnumRuleTest` で別途担保）
+- **読み取りモデル（`@QueryModel`）は `application` 層に置く**。軽量 CQRS（L2）の読み取り側として、書き込み集約を経由しないフラットな Read Model を application に置く（[ADR-0031](../../docs/adr/0031-lightweight-cqrs-read-model.md)）。`@QueryModel` 付きクラスが `application` 配下に居ることを ArchUnit `queryModelsResideInApplication` で検証する（DDD ビルディングブロックを `domain.*.model` に縛る `dddBuildingBlocksResideInDomainModel` と対称）。詳細は「読み取り経路（軽量 CQRS / L2）」
 - **ドメイン / アプリケーション層では `throw` しない**。業務エラーは `Result<V, E>` で返し、プログラミングエラーは `require` / `check` を使う（[error-handling.md](error-handling.md)）。`domain..` / `application..` 配下の明示的な `throw` 式を **detekt カスタムルール** `NoThrowInDomainAndApplication`（`:detekt-rules` モジュール）で検出してビルドを失敗させる。例外送出は `infrastructure`（インフラ障害）と Controller 境界の `orThrowProblem()` に限るため、両者はパッケージ判定で対象外。`require` / `check` / `error` は `throw` 式ではないため検出されない。テストコードは detekt 設定の `excludes` で対象外
 - **コンパイラ警告をエラー化する（警告ゼロ運用）**。両モジュール（root `api` / `:detekt-rules`）の Kotlin `compilerOptions` に `allWarningsAsErrors = true` を設定し、コンパイラ警告が 1 件でもあればビルドを失敗させる（[ADR-0019](../../docs/adr/0019-compiler-warnings-as-errors.md)）。CI は ktfmt の後の専用コンパイルステップで明示ゲートする（detekt / test 内のコンパイルでも効くが原因可視化のため）。個別に許容する警告は `@Suppress` または `-Xwarning-level=<ID>:warning` で逃がす。注意: K2 では未使用ローカル変数は警告化されないため、ルールの空振り検証（ミューテーション）は `@Deprecated` 呼び出し等で行う
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,27 @@ fun assignName(horseName: HorseName): Result<StateTransition<BloodHorse, HorseNa
 
 決定経緯と現状のスコープ（Spring `ApplicationEventPublisher` 連携・publish-after-commit・発生時刻 enrichment は別イシュー送り）は [ADR-0029](docs/adr/0029-domain-events-via-state-transition-return.md) を参照。
 
+#### Query パターン（軽量 CQRS / L2）
+
+読み取り系は書き込み集約を**経由しない**独立経路として実装する（軽量 CQRS = L2。ストア分離・結果整合・イベントソーシング = L3 は採らない）。リファレンス実装は `racing/jockey` の `FindJockeyUseCase`。
+
+- **Read Model（View）とクエリポートは `application` に置く**（ドメインを汚さない）。View には jMolecules の `@QueryModel`（`org.jmolecules.architecture.cqrs`）を付け、不変条件のないフラットな `data class` とする
+- **クエリポート（`〜Queries`）は plain interface**。書き込みポートの jMolecules `@Repository` は付けない。実装（infrastructure）は集約を組まずストアから直接 View へ詰める（例: `JdbcJockeyQueries` が `JdbcClient` で直 SELECT）
+- クエリ入力 DTO は `〜Query` サフィックス。書き込み系の `Command<T>` 封筒は読み取りでは使わない
+
+```kotlin
+@QueryModel data class JockeyView(val id: UUID, val firstName: String, val lastName: String)
+
+interface JockeyQueries { fun findById(id: JockeyId): JockeyView? }
+
+@Service
+class FindJockeyUseCase(private val jockeyQueries: JockeyQueries) {
+    operator fun invoke(query: FindJockeyQuery): Result<JockeyView, JockeyNotFound> = ...
+}
+```
+
+`@QueryModel` が `application` に居ることは ArchUnit で強制する（`.claude/rules/architecture.md`「読み取り経路（軽量 CQRS / L2）」）。決定経緯は [ADR-0031](docs/adr/0031-lightweight-cqrs-read-model.md) を参照。
+
 ### パッケージ構成
 
 オニオンアーキテクチャの 4 リング（domainModel / domainService / applicationService / adapter）構成。`domain` 配下は各コンテキストを `model/` と `service/` に分割する。

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(libs.kotlin.result)
     implementation(libs.jmolecules.ddd)
     implementation(libs.jmolecules.events)
+    implementation(libs.jmolecules.cqrs.architecture)
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation(libs.springdoc.openapi.starter.webmvc.ui)
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/docs/adr/0031-lightweight-cqrs-read-model.md
+++ b/docs/adr/0031-lightweight-cqrs-read-model.md
@@ -1,0 +1,51 @@
+# 0031. 読み取りを集約非経由の Read Model 経路で実装する（軽量 CQRS / L2・レイヤー先）
+
+- Status: Accepted
+- Date: 2026-06-25
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+現状、application 層には書き込み系ユースケース（`JockeyRegistrationUseCase` / `RegisterInStudBookUseCase` 等）しか存在せず、読み取り経路が無い。読み取りを実装し始めるにあたり、何も方針を決めないと「クエリのたびに書き込み集約をリポジトリから復元して詰め替える」素朴な読み取りに倒れやすい。集約は不変条件・整合性境界・状態遷移を担う重い構造で、表示・参照のための読み取りにそのライフサイクルを通すのは過剰であり、表示要件が増えるほど集約 API が読み取り都合で歪む。
+
+一方で本プロジェクトはサンドボックスであり、読み取り専用ストア・プロジェクション・結果整合・イベントソーシング（いわゆるフル CQRS = L3）を導入する段階にはない。書き込みと読み取りで**モデルと経路は分けたい**が、**ストアは分けない**——この中間（L2）をどう構造に落とすかを決める必要がある。
+
+### 検討した構成案
+
+- **パターン1（機能スライス先で command/query 分割）**: 現行のオニオン（レイヤー先 + コンテキストスライス）を機能凝集へ組み替える必要があり、既存構造との不整合が大きい。**却下**。
+- **パターン2（レイヤー先・read を application の薄い query service として足す）**: 現行構成に最も素直に乗り、Spring + DDD 界隈で L2 lite のデファクト。**採用**。
+- **パターン3（write/read を高位／別モジュールで分離）**: フル CQRS 向けで L2 には過剰。**却下**。
+
+## Decision（決定）
+
+**読み取り（クエリ）系を、書き込み側の集約を経由しない独立経路として実装する軽量 CQRS（L2）を採用する。** 読み書きでモデルと経路を分離するが、ストア分離・結果整合・イベントソーシング（L3）は採らない。構成は **パターン2（レイヤー先・薄い read 経路）** とする。
+
+1. **Read Model（View）とクエリポートは `application` 層に置く。** 書き込みの「集約 + Repository ポートは `domain.*.model`」とは非対称だが、これは意図したもの。読みモデルは集約のライフサイクル（生成・状態遷移・整合性境界）を持たないため domain には置かず、ドメインを汚さない。
+2. **View には jMolecules の `@QueryModel`（`org.jmolecules.architecture.cqrs`）を付ける。** 不変条件を持たないフラットな DTO で、値の等価性が自然なため `data class` でよい。「概念は jMolecules で表明し ArchUnit で機械強制する」現行の文化を CQRS へ延長する。依存は `jmolecules-cqrs-architecture`（BOM 管理）。
+3. **クエリポート（`〜Queries`）は plain interface とし、書き込みポートの jMolecules `@Repository` は付けない。** 読み取りは Repository ビルディングブロックではない。
+4. **infrastructure の実装は集約を組まずストアから直接 View へ詰める。** 書き込みの Row／集約／Spring Data リポジトリを経由しない。同じテーブルを読んでも、経路（write=集約復元 / read=View 直組み）とモデルを分離するのが L2 の価値であり、「write ポートに finder を生やす」誘惑には乗らない。
+5. **読み取りも write と対称に `application` を必ず通す**（現行オニオンの依存方向を維持）。クエリ入力 DTO は `〜Query` サフィックス。書き込み系の `Command<T>` 封筒（発生時刻メタデータ）は読み取りでは使わない。
+
+### リファレンス実装
+
+`racing/jockey` で読み取り経路を 1 本通して型を確立する（以降はこれに倣う）。
+
+- `application/racing/jockey/JockeyView.kt`（`@QueryModel` 付き Read Model）
+- `application/racing/jockey/JockeyQueries.kt`（読み取りポート。plain interface）
+- `application/racing/jockey/FindJockeyUseCase.kt`（`@Service`。`Result<JockeyView, JockeyNotFound>` を返す）
+- `infrastructure/racing/jockey/JdbcJockeyQueries.kt`（`JdbcClient` で `jockey` を直 SELECT し View へ詰める）
+- `controller/jockey`（`GET /api/jockeys/{id}`。`JockeyView` を書き込み経路と同一のリソース表現 `JockeyResponse` に詰める。ADR-0008）
+
+### 機械強制
+
+`@QueryModel` 付きクラスが `application` 配下に居ることを ArchUnit `queryModelsResideInApplication` で検証する（DDD ビルディングブロックを `domain.*.model` に縛る `dddBuildingBlocksResideInDomainModel` と対称）。読み取り経路が application を通ること（infrastructure → application のポート実装）は既存の `onionLayers` がアダプターの依存として許容する。クエリポートの命名・`@Repository` 非付与は意味的規約としてレビューで担保する（[ADR-0008](0008-uniform-resource-representation-response.md) のグルーピング判断・#307 と同種で、名前ベースの機械強制は過剰）。
+
+## Consequences（結果・影響）
+
+- **良くなる点**: 表示・参照のための読み取りが集約のライフサイクルから切り離され、集約 API が読み取り都合で歪まない。読みモデルは要件に合わせてフラットに最適化でき、書き込み側の不変条件と独立に進化する。
+- **引き受けるトレードオフ**:
+  - 同一データに対し write（集約）と read（View）の 2 モデルを持つため、列の追加等で両方の写像を触る局面が出る。L2 はストアを共有するため二重化は写像層に限られ、L3 のような同期・結果整合の複雑さは負わない。
+  - read/write でポートの置き場所が非対称（write=domain / read=application）になる。これは「読みモデルは集約のライフサイクルを持たない」という性質の反映であり、architecture.md に明文化して意図を残す。
+- **対象外（L3 / 別 issue）**: 読み取り専用ストア・プロジェクション・結果整合・イベントソーシング（L3）、パターン3（write/read の高位／別モジュール分離）、`Command<T>` 封筒の改名（`@Command` 注釈との名前衝突回避）。
+- **結論の所在**: 守るべきルールは `.claude/rules/architecture.md`「読み取り経路（軽量 CQRS / L2）」と CLAUDE.md「Query パターン」に反映する。
+- **関連**: リソース表現の単一化は [ADR-0008](0008-uniform-resource-representation-response.md)。jMolecules による役割表明・ArchUnit 強制の文化は [ADR-0007](0007-wire-enum-dto-decoupling.md) / [ADR-0009](0009-immutable-aggregates.md)。永続化の JDBC 一本化（read 実装も JDBC で組む前提）は [ADR-0027](0027-persistence-spring-data-jdbc.md) / [ADR-0030](0030-jdbc-only-persistence-retire-inmemory.md)。エラー描画（`JockeyNotFound` → 404）は error-handling.md / api-design.md。実装は #293。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,3 +40,4 @@
 | [0028](0028-controller-adapter-dto-packaging.md) | controller アダプターの DTO を役割別サブパッケージ（request/ + problem/）へ整理する | Accepted |
 | [0029](0029-domain-events-via-state-transition-return.md) | イミュータブル集約のドメインイベントは状態遷移の戻り値に同梱して収集する | Accepted |
 | [0030](0030-jdbc-only-persistence-retire-inmemory.md) | 永続化実装を JDBC 一本に統一し InMemory リポジトリを廃止する（datasource を H2↔PostgreSQL で差し替える） | Accepted |
+| [0031](0031-lightweight-cqrs-read-model.md) | 読み取りを集約非経由の Read Model 経路で実装する（軽量 CQRS / L2・レイヤー先） | Accepted |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ springmockk = { module = "com.ninja-squad:springmockk", version.ref = "springmoc
 jmolecules-bom = { module = "org.jmolecules:jmolecules-bom", version.ref = "jmolecules-bom" }
 jmolecules-ddd = { module = "org.jmolecules:jmolecules-ddd" }
 jmolecules-events = { module = "org.jmolecules:jmolecules-events" }
+jmolecules-cqrs-architecture = { module = "org.jmolecules:jmolecules-cqrs-architecture" }
 
 # ArchUnit（アーキテクチャテスト）
 archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "archunit" }

--- a/src/main/kotlin/com/example/api/application/racing/jockey/FindJockeyUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/racing/jockey/FindJockeyUseCase.kt
@@ -1,0 +1,34 @@
+package com.example.api.application.racing.jockey
+
+import com.example.api.domain.racing.model.jockey.JockeyId
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.toResultOr
+import java.util.UUID
+import org.springframework.stereotype.Service
+
+/**
+ * ジョッキー照会クエリの入力。
+ *
+ * 読み取り系の入力は素の DTO とし、書き込み系の [com.example.api.domain.shared.Command] 封筒
+ * （発生時刻メタデータ）は使わない。発生時刻は書き込みイベントの概念であり、読み取りには不要（ADR-0031）。
+ *
+ * @property id 照会対象ジョッキーの生 UUID
+ */
+data class FindJockeyQuery(val id: UUID)
+
+/** 照会対象のジョッキーが存在しない。URL パス上の操作対象の不在として Controller 境界で 404 に写す（api-design.md）。 */
+data class JockeyNotFound(val id: UUID)
+
+/**
+ * ジョッキー照会ユースケース（軽量 CQRS（L2）の読み取り側。ADR-0031）。
+ *
+ * 書き込みユースケース（[JockeyRegistrationUseCase]）と同列に `@Service` で公開するが、依存するのは 書き込みポートではなく読み取りポート
+ * [JockeyQueries]。集約を組まずフラットな [JockeyView] を返す。
+ *
+ * @return 照会できた [JockeyView]、または対象不在を表す [JockeyNotFound]
+ */
+@Service
+class FindJockeyUseCase(private val jockeyQueries: JockeyQueries) {
+    operator fun invoke(query: FindJockeyQuery): Result<JockeyView, JockeyNotFound> =
+        jockeyQueries.findById(JockeyId(query.id)).toResultOr { JockeyNotFound(query.id) }
+}

--- a/src/main/kotlin/com/example/api/application/racing/jockey/JockeyQueries.kt
+++ b/src/main/kotlin/com/example/api/application/racing/jockey/JockeyQueries.kt
@@ -1,0 +1,19 @@
+package com.example.api.application.racing.jockey
+
+import com.example.api.domain.racing.model.jockey.JockeyId
+
+/**
+ * ジョッキーの読み取りポート（軽量 CQRS（L2）の Query 側。ADR-0031）。
+ *
+ * 書き込みポート [com.example.api.domain.racing.model.jockey.JockeyRepository] とは**別物として割る**。
+ * 同じストアを読んでも、経路（write=集約復元 / read=View 直組み）とモデルを分離するのが L2 の価値であり、 「同じテーブルなら write ポートに finder
+ * を生やせばよい」という誘惑には乗らない。
+ *
+ * 読み取りポートは集約のライフサイクル（生成・状態遷移・整合性境界）を持たないため、書き込みポートが付ける jMolecules `@Repository`（DDD
+ * ビルディングブロック）は**付けない**。読みモデル・クエリポートはドメインを 汚さず application 層に置き、実装は infrastructure 層に置く（オニオン依存方向は
+ * write と対称に維持）。
+ */
+interface JockeyQueries {
+    /** ID でジョッキービューを引く。存在しなければ null（単純 lookup は Result を強制しない。error-handling.md）。 */
+    fun findById(id: JockeyId): JockeyView?
+}

--- a/src/main/kotlin/com/example/api/application/racing/jockey/JockeyView.kt
+++ b/src/main/kotlin/com/example/api/application/racing/jockey/JockeyView.kt
@@ -1,0 +1,19 @@
+package com.example.api.application.racing.jockey
+
+import java.util.UUID
+import org.jmolecules.architecture.cqrs.QueryModel
+
+/**
+ * ジョッキーの読み取り専用ビュー（Read Model）。軽量 CQRS（L2）の読み取り側を表す（ADR-0031）。
+ *
+ * 書き込み側の集約 [com.example.api.domain.racing.model.jockey.Jockey] を**一切経由せず**、ストアから直接組む 平坦な
+ * DTO。不変条件を持たず（検証は書き込み側のファクトリの責務）、値としての等価性が自然なため `data class` を使う（集約の ID ベース `final equals` とは無関係）。
+ *
+ * `@QueryModel`（jMolecules CQRS）で読み取りモデルとしての役割を表明する。DDD ビルディングブロック （`@AggregateRoot` 等）と異なり読みモデルは
+ * domain.*.model ではなく application 層に置く（ArchUnit `queryModelsResideInApplication` で強制）。
+ *
+ * @property id ジョッキーの生 UUID
+ * @property firstName 名
+ * @property lastName 姓
+ */
+@QueryModel data class JockeyView(val id: UUID, val firstName: String, val lastName: String)

--- a/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
@@ -1,5 +1,7 @@
 package com.example.api.controller.jockey
 
+import com.example.api.application.racing.jockey.FindJockeyQuery
+import com.example.api.application.racing.jockey.FindJockeyUseCase
 import com.example.api.application.racing.jockey.JockeyRegistrationUseCase
 import com.example.api.application.racing.jockey.RegisterJockeyCommand
 import com.example.api.controller.jockey.problem.toProblemDetail
@@ -12,9 +14,12 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Clock
+import java.util.UUID
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ProblemDetail
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -29,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class JockeyController(
     private val registerJockey: JockeyRegistrationUseCase,
+    private val findJockey: FindJockeyUseCase,
     private val clock: Clock,
 ) {
     @Operation(
@@ -78,5 +84,44 @@ class JockeyController(
         val command = Command.now(RegisterJockeyCommand(request.firstName, request.lastName), clock)
         val jockey = registerJockey(command).mapError { it.toProblemDetail() }.orThrowProblem()
         return jockey.toResponse()
+    }
+
+    @Operation(
+        summary = "ジョッキーを取得する",
+        description =
+            "ID でジョッキーを取得する。軽量 CQRS（L2）の読み取り経路（集約を経由しない Read Model）で引く。" +
+                "対象が存在しなければ RFC 9457 形式の problem+json を返す。",
+        tags = ["Jockey"],
+        responses =
+            [
+                ApiResponse(
+                    responseCode = "200",
+                    description = "取得成功",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = JockeyResponse::class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "404",
+                    description = "指定 ID のジョッキーが存在しない",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+            ],
+    )
+    @GetMapping("/api/jockeys/{id}")
+    fun get(@PathVariable id: UUID): JockeyResponse {
+        val view =
+            findJockey(FindJockeyQuery(id)).mapError { it.toProblemDetail() }.orThrowProblem()
+        return view.toResponse()
     }
 }

--- a/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
@@ -88,9 +88,7 @@ class JockeyController(
 
     @Operation(
         summary = "ジョッキーを取得する",
-        description =
-            "ID でジョッキーを取得する。軽量 CQRS（L2）の読み取り経路（集約を経由しない Read Model）で引く。" +
-                "対象が存在しなければ RFC 9457 形式の problem+json を返す。",
+        description = "ID でジョッキーを取得する。対象が存在しなければ RFC 9457 形式の problem+json を返す。",
         tags = ["Jockey"],
         responses =
             [

--- a/src/main/kotlin/com/example/api/controller/jockey/JockeyResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/JockeyResponse.kt
@@ -1,5 +1,6 @@
 package com.example.api.controller.jockey
 
+import com.example.api.application.racing.jockey.JockeyView
 import com.example.api.domain.racing.model.jockey.Jockey
 import java.util.UUID
 
@@ -18,3 +19,12 @@ data class JockeyResponse(val id: UUID, val firstName: String, val lastName: Str
 /** [Jockey] をジョッキーリソースの表現へ変換する。各操作の成功レスポンスはこのリソース表現を一律で返す。 */
 fun Jockey.toResponse(): JockeyResponse =
     JockeyResponse(id = id.value, firstName = firstName, lastName = lastName)
+
+/**
+ * 読み取りビュー [JockeyView] をジョッキーリソースの表現へ変換する。
+ *
+ * 軽量 CQRS（L2）の読み取り経路（Get）も、書き込み経路（Create）と**同一の単一リソース表現**を返す （ADR-0008）。読みモデルと wire
+ * 表現の双方が平坦な同型のため写像は素直。
+ */
+fun JockeyView.toResponse(): JockeyResponse =
+    JockeyResponse(id = id, firstName = firstName, lastName = lastName)

--- a/src/main/kotlin/com/example/api/controller/jockey/problem/JockeyProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/problem/JockeyProblem.kt
@@ -1,5 +1,6 @@
 package com.example.api.controller.jockey.problem
 
+import com.example.api.application.racing.jockey.JockeyNotFound
 import com.example.api.application.racing.jockey.JockeyRegistrationError
 import com.example.api.controller.problem
 import com.example.api.domain.racing.model.jockey.JockeyValidationError
@@ -27,6 +28,20 @@ fun JockeyRegistrationError.toProblemDetail(): ProblemDetail =
                 )
                 .apply { setProperty("existing_id", existingId.value) }
     }
+
+/**
+ * [JockeyNotFound]（照会対象のジョッキー不在）を 404 Not Found の [ProblemDetail] に変換する。
+ *
+ * URL パス（`/api/jockeys/{id}`）で識別される操作対象そのものが無いため 404 とする（api-design.md 「リソース不在のステータス（404 vs 422）」）。
+ */
+fun JockeyNotFound.toProblemDetail(): ProblemDetail =
+    problem(
+            status = HttpStatus.NOT_FOUND,
+            code = "jockey-not-found",
+            title = "Jockey not found",
+            detail = "指定された ID のジョッキーは存在しません。",
+        )
+        .apply { setProperty("jockey_id", id) }
 
 private fun JockeyValidationError.toProblemDetail(): ProblemDetail =
     when (this) {

--- a/src/main/kotlin/com/example/api/infrastructure/racing/jockey/JdbcJockeyQueries.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/racing/jockey/JdbcJockeyQueries.kt
@@ -1,0 +1,36 @@
+package com.example.api.infrastructure.racing.jockey
+
+import com.example.api.application.racing.jockey.JockeyQueries
+import com.example.api.application.racing.jockey.JockeyView
+import com.example.api.domain.racing.model.jockey.JockeyId
+import java.util.UUID
+import org.springframework.jdbc.core.simple.JdbcClient
+import org.springframework.stereotype.Repository
+
+/**
+ * 読み取りポート [JockeyQueries] の実装（軽量 CQRS（L2）の Query 側。ADR-0031）。
+ *
+ * 書き込み側の [JdbcJockeyRepository]（集約 [com.example.api.domain.racing.model.jockey.Jockey] を
+ * [JockeyRow] 経由で復元する）とは**別経路**として、`jockey` テーブルを [JdbcClient] で直接 SELECT し、 集約を一切組まずに平坦な
+ * [JockeyView] へ詰める。Spring Data のリポジトリ（[JockeySpringDataRepository]）も
+ * 永続化モデル（[JockeyRow]）も経由しない——同じテーブルを読んでも経路とモデルを分離するのが L2 の要点。
+ *
+ * 楽観ロックの `version` 列は読み取りでは不要なため SELECT しない（read は整合性境界を持たない）。
+ */
+@Repository
+class JdbcJockeyQueries(private val jdbcClient: JdbcClient) : JockeyQueries {
+
+    override fun findById(id: JockeyId): JockeyView? =
+        jdbcClient
+            .sql("SELECT id, first_name, last_name FROM jockey WHERE id = :id")
+            .param("id", id.value)
+            .query { rs, _ ->
+                JockeyView(
+                    id = rs.getObject("id", UUID::class.java),
+                    firstName = rs.getString("first_name"),
+                    lastName = rs.getString("last_name"),
+                )
+            }
+            .optional()
+            .orElse(null)
+}

--- a/src/test/kotlin/com/example/api/application/racing/jockey/FindJockeyUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/racing/jockey/FindJockeyUseCaseTest.kt
@@ -1,0 +1,41 @@
+package com.example.api.application.racing.jockey
+
+import com.example.api.domain.racing.model.jockey.JockeyId
+import com.example.api.domain.shared.generateId
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+/**
+ * 照会ユースケース [FindJockeyUseCase] の単体テスト（軽量 CQRS（L2）の読み取り側。ADR-0031）。
+ *
+ * 読み取りポート [JockeyQueries] を mockk でスタブし、ヒット時は [JockeyView] を、不在時は [JockeyNotFound] を
+ * 返す分岐を検証する（testing.md: applicationService は Repository / Query ポート境界をモックする）。
+ */
+class FindJockeyUseCaseTest {
+    private val jockeyQueries = mockk<JockeyQueries>()
+    private val findJockey = FindJockeyUseCase(jockeyQueries)
+
+    @Test
+    fun `存在するIDなら対応するJockeyViewをOkで返す`() {
+        val id = generateId()
+        val view = JockeyView(id = id, firstName = "武", lastName = "豊")
+        every { jockeyQueries.findById(JockeyId(id)) } returns view
+
+        val result = findJockey(FindJockeyQuery(id))
+
+        assert(result.get() == view)
+    }
+
+    @Test
+    fun `存在しないIDならJockeyNotFoundをErrで返す`() {
+        val id = generateId()
+        every { jockeyQueries.findById(JockeyId(id)) } returns null
+
+        val result = findJockey(FindJockeyQuery(id))
+
+        assert(result.getError() == JockeyNotFound(id))
+    }
+}

--- a/src/test/kotlin/com/example/api/architecture/ArchitectureTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/ArchitectureTest.kt
@@ -20,6 +20,7 @@ import com.tngtech.archunit.library.dependencies.SliceAssignment
 import com.tngtech.archunit.library.dependencies.SliceIdentifier
 import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices
 import java.util.UUID
+import org.jmolecules.architecture.cqrs.QueryModel
 import org.jmolecules.archunit.JMoleculesDddRules
 import org.jmolecules.ddd.annotation.AggregateRoot
 import org.jmolecules.ddd.annotation.Entity as DddEntity
@@ -199,6 +200,24 @@ class ArchitectureTest {
             .areAnnotatedWith(DomainEvent::class.java)
             .should()
             .resideInAPackage(DOMAIN_MODEL)
+
+    /**
+     * 読み取りモデル（`@QueryModel`）は application 層に置くこと。
+     *
+     * 軽量 CQRS（L2）の読み取り側として、Read Model（View）は書き込み集約を経由せずストアから直接組む フラットな DTO である（ADR-0031）。DDD
+     * ビルディングブロック（`@AggregateRoot` 等）が domain.*.model に
+     * 居る（[dddBuildingBlocksResideInDomainModel]）のと対称に、読みモデルはドメインを汚さず application 層へ
+     * 置く。`@QueryModel` は jMolecules の CQRS アーキテクチャ注釈（`org.jmolecules.architecture.cqrs`）であり DDD
+     * ビルディングブロック注釈ではないため、[dddBuildingBlocksResideInDomainModel] とは独立して検証する。
+     */
+    @ArchTest
+    val queryModelsResideInApplication =
+        classes()
+            .that()
+            .areAnnotatedWith(QueryModel::class.java)
+            .should()
+            .resideInAPackage(APPLICATION)
+            .because("読み取りモデル（@QueryModel）は軽量 CQRS（L2）の読み取り側として application 層に置く（ADR-0031）")
 
     /**
      * 集約（@AggregateRoot / @Entity）はイミュータブルに保つこと（val のみ・var 禁止）。

--- a/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
@@ -1,5 +1,6 @@
 package com.example.api.controller
 
+import com.example.api.application.racing.jockey.FindJockeyUseCase
 import com.example.api.application.racing.jockey.JockeyRegistrationError
 import com.example.api.application.racing.jockey.JockeyRegistrationUseCase
 import com.example.api.application.racing.jockey.RegisterJockeyCommand
@@ -31,6 +32,8 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class GlobalExceptionHandlerTest(val mockMvc: MockMvc) {
     @MockkBean private lateinit var registerJockey: JockeyRegistrationUseCase
+
+    @MockkBean private lateinit var findJockey: FindJockeyUseCase
 
     private val tester = MockMvcTester.create(mockMvc)
 

--- a/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
@@ -1,12 +1,17 @@
 package com.example.api.controller.jockey
 
+import com.example.api.application.racing.jockey.FindJockeyQuery
+import com.example.api.application.racing.jockey.FindJockeyUseCase
+import com.example.api.application.racing.jockey.JockeyNotFound
 import com.example.api.application.racing.jockey.JockeyRegistrationError
 import com.example.api.application.racing.jockey.JockeyRegistrationUseCase
+import com.example.api.application.racing.jockey.JockeyView
 import com.example.api.application.racing.jockey.RegisterJockeyCommand
 import com.example.api.config.ClockConfiguration
 import com.example.api.domain.racing.model.jockey.Jockey
 import com.example.api.domain.racing.model.jockey.JockeyValidationError
 import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.generateId
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.unwrap
@@ -28,6 +33,8 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class JockeyControllerTest(val mockMvc: MockMvc) {
     @MockkBean private lateinit var registerJockey: JockeyRegistrationUseCase
+
+    @MockkBean private lateinit var findJockey: FindJockeyUseCase
 
     private val tester = MockMvcTester.create(mockMvc)
 
@@ -110,6 +117,40 @@ class JockeyControllerTest(val mockMvc: MockMvc) {
                 .bodyJson()
                 .extractingPath("$.existing_id")
                 .isEqualTo(existing.id.value.toString())
+        }
+    }
+
+    @Nested
+    inner class GetCase {
+        @Test
+        fun `存在するIDで 200 OK とリソース表現が返ること`() {
+            val id = generateId()
+            every { findJockey(FindJockeyQuery(id)) } returns
+                Ok(JockeyView(id = id, firstName = "武", lastName = "豊"))
+
+            val response =
+                tester.get().uri("/api/jockeys/{id}", id).assertThat().hasStatusOk().bodyJson()
+
+            // 読み取り経路（Get）も書き込み経路と同一のリソース表現を返す（ADR-0008）
+            response.extractingPath("$.id").isEqualTo(id.toString())
+            response.extractingPath("$.first_name").isEqualTo("武")
+            response.extractingPath("$.last_name").isEqualTo("豊")
+        }
+
+        @Test
+        fun `存在しないIDで 404 と jockey_id 付きの problem+json が返ること`() {
+            val id = generateId()
+            every { findJockey(FindJockeyQuery(id)) } returns Err(JockeyNotFound(id))
+
+            tester
+                .get()
+                .uri("/api/jockeys/{id}", id)
+                .assertThat()
+                .hasStatus(HttpStatus.NOT_FOUND)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.jockey_id")
+                .isEqualTo(id.toString())
         }
     }
 }

--- a/src/test/kotlin/com/example/api/infrastructure/racing/jockey/JdbcJockeyQueriesContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/racing/jockey/JdbcJockeyQueriesContractTest.kt
@@ -1,0 +1,61 @@
+package com.example.api.infrastructure.racing.jockey
+
+import com.example.api.domain.racing.model.jockey.JockeyId
+import com.example.api.domain.shared.generateId
+import com.example.api.support.PostgresContainerSupport
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.simple.JdbcClient
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.context.TestConstructor.AutowireMode
+
+/**
+ * 読み取りポート JockeyQueries の Spring Data JDBC とは別経路の実装 [JdbcJockeyQueries] の契約テスト （軽量 CQRS（L2）の Query
+ * 側。ADR-0031）。
+ *
+ * 書き込みの [JdbcJockeyRepositoryContractTest] と同じく本番ターゲットの PostgreSQL（Testcontainers、
+ * [PostgresContainerSupport] で共有）に対して検証する。コンテキスト構成も write 側の契約テストと同一 （`@SpringBootTest(NONE)` ＋
+ * 同じ動的プロパティ）のため、コンテキストキャッシュを共有する（testing.md）。
+ *
+ * 検証する契約:
+ * 1. `jockey` テーブルへ直接 SELECT し、集約を組まずに [com.example.api.application.racing.jockey.JockeyView]
+ *    へ平坦に詰められること（write の `JockeyRow`／集約を経由しない）
+ * 2. value class の `JockeyId` ↔ DB `uuid` 列を読み取り経路でも橋渡しできること
+ * 3. 該当行が無ければ null を返すこと
+ *
+ * 行の投入は infrastructure 内部の永続化詳細（[JockeySpringDataRepository]）で行い、読み取りは別経路の [JdbcJockeyQueries]
+ * で引く——投入と参照で経路を分けることで「別ポート・別実装」を実機で確かめる。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class JdbcJockeyQueriesContractTest(
+    private val jdbcClient: JdbcClient,
+    private val rows: JockeySpringDataRepository,
+) : PostgresContainerSupport() {
+
+    private val queries = JdbcJockeyQueries(jdbcClient)
+
+    @BeforeEach
+    fun cleanUp() {
+        rows.deleteAll()
+    }
+
+    @Test
+    fun `保存済みのジョッキーをIDでJockeyViewとして引ける`() {
+        val id = generateId()
+        rows.save(JockeyRow(id = id, firstName = "武", lastName = "豊"))
+
+        val view = queries.findById(JockeyId(id))
+
+        assert(view != null)
+        assert(view!!.id == id)
+        assert(view.firstName == "武")
+        assert(view.lastName == "豊")
+    }
+
+    @Test
+    fun `存在しないIDのfindByIdはnullを返す`() {
+        assert(queries.findById(JockeyId(generateId())) == null)
+    }
+}


### PR DESCRIPTION
## 概要

Closes #293。読み取り（クエリ）系を、書き込み側の集約を経由しない独立経路として実装する **軽量 CQRS（L2・レイヤー先/パターン2）** を導入した。読み書きでモデルと経路を分離するが、ストア分離・結果整合・イベントソーシング（L3）は採らない。決定は [ADR-0031](docs/adr/0031-lightweight-cqrs-read-model.md) に起票。

> [!NOTE]
> Issue 本文の前提を現状に合わせて補正した:
> - `horseracing` → `racing`（コンテキスト分割済み・ADR-0024）
> - InMemory → **JDBC**（Jockey は JDBC 一本化済み・ADR-0030）。読み取りは集約を組まず `JdbcClient` で `jockey` を直 SELECT する実装にした

## 実装（リファレンス = racing/jockey）

| 層 | 追加/変更 | 役割 |
|---|---|---|
| application | `JockeyView`（`@QueryModel`） | フラットな Read Model（不変条件なし） |
| application | `JockeyQueries` | 読み取りポート（plain interface・jMolecules `@Repository` は付けない） |
| application | `FindJockeyUseCase` | 照会ユースケース。`Result<JockeyView, JockeyNotFound>` |
| infrastructure | `JdbcJockeyQueries` | `JdbcClient` で直 SELECT、集約/`JockeyRow`/Spring Data を経由しない |
| controller | `GET /api/jockeys/{id}` | `JockeyView` を書き込みと同一表現 `JockeyResponse` に詰める（ADR-0008）。不在は 404 |

## 機械強制・ドキュメント

- ArchUnit `queryModelsResideInApplication`（`@QueryModel` は application に置く。`dddBuildingBlocksResideInDomainModel` と対称）
- `gradle/libs.versions.toml` / `build.gradle.kts` に `jmolecules-cqrs-architecture` を追加
- `.claude/rules/architecture.md`「読み取り経路（軽量 CQRS / L2）」・`CLAUDE.md`「Query パターン」を明文化

## テスト

- `FindJockeyUseCaseTest`: 読み取りポートを mockk、ヒット/不在の分岐
- `JockeyControllerTest`: GET の slice（200 / 404 problem+json）
- `JdbcJockeyQueriesContractTest`: Testcontainers(PostgreSQL) で直読みを検証
- `GlobalExceptionHandlerTest`: `JockeyController` を踏み台にするため `findJockey` の `@MockkBean` を追加

## 確認

`./gradlew check` 通過（ktfmt / detekt / 全テスト / koverVerifyMature 85% ゲート / 警告ゼロ）。

## 対象外（別 issue）

L3（読み取り専用ストア・プロジェクション・結果整合・ES）、パターン3、`Command<T>` の改名。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
