### PR TITLE
feat: HCP Terraform 操作 CLI として tfctl を採用する (#286)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,7 @@ Issue の優先度は **GitHub Projects（`toy-box` = Project #4）の `Priority
 - `sqlfluff`: SQL 書式・スタイル lint および自動整形（dialect=postgres、mise の `pipx:` backend を uv 駆動で管理）
 - `squawk`: Flyway マイグレーション SQL の安全性チェックと構文検証（libpg_query パース）
 - `terraform`: インフラ構成管理
+- `tfctl`: HCP Terraform / TFE 管理 CLI（run / variable / workspace 操作。レジストリ参照は MCP、操作は tfctl と棲み分け）。認証は `tfctl auth login`（tfctl 自身の資格情報ストア。`gh` CLI と同様に fnox は使わない）。採否と運用方針は [ADR-0034](docs/adr/0034-adopt-tfctl-cli.md) を参照
 - `zizmor`: GitHub Actions ワークフローのセキュリティ監査
 
 **Java バージョン管理について**: JDK のバージョン要件は `build.gradle.kts` の Gradle toolchain で宣言しています（`languageVersion = 21`）。実体の JDK は mise が提供し、Gradle の toolchain auto-detection が `JAVA_HOME` / `PATH` 経由で検出します。

--- a/docs/adr/0034-adopt-tfctl-cli.md
+++ b/docs/adr/0034-adopt-tfctl-cli.md
@@ -1,0 +1,52 @@
+# 0034. HCP Terraform 操作 CLI として tfctl を採用する
+
+- Status: Accepted
+- Date: 2026-06-27
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+本プロジェクトは `infra/` を Terraform で管理し、バックエンドに **HCP Terraform（旧 Terraform Cloud）** を採用している（`infra/terraform.tf`、org `ptiringo-tech` / workspace `toy-box`）。
+
+現状、ワークスペース・run・変数の状態確認や操作は **HCP Terraform の Web UI** か、Terraform MCP サーバー（`.mcp.json` の `terraform`）経由の**レジストリ参照**に限られ、**run / 変数 / ワークスペースを CLI から直接操作する手段がない**。
+
+[`tfctl`](https://github.com/hashicorp/tfctl-cli) は HashiCorp 公式の HCP Terraform / TFE 管理 CLI（MPL-2.0）。高レベルコマンド（`run start/status`・`variable import`・`workspace`）と API v2 直接アクセス（`tfctl api`）、複数プロファイル（組織・インスタンス切替）に対応する。AI コーディングエージェント向けの skill（harness）も同梱する。本プロジェクトは Claude Code を併用しており、運用との親和性が見込まれたため採否を評価した（#286）。
+
+評価時点の最新は **v0.3.0（2026-06-22 リリース、pre-1.0）**。
+
+## Decision（決定）
+
+tfctl を **HCP Terraform の run / 変数 / ワークスペース操作 CLI として採用する**。運用方針は以下。
+
+### ツール管理: mise の http バックエンドで管理する
+
+`mise.toml` に追加して `mise install` で全員に配布する。ただし通常の registry / aqua / ubi 経路は使えないため **http バックエンド**で `releases.hashicorp.com` を直接指す:
+
+- mise registry の短名 `tfctl` は**別物**（`flux-iac/tofu-controller` の tfctl）と衝突する。
+- aqua-registry に `hashicorp/tfctl` は**未登録**（新しすぎる）。
+- GitHub Releases に**バイナリ資産が無い**（HashiCorp は `releases.hashicorp.com` で配布）ため `ubi` も使えない。
+
+http バックエンドで `platforms.*` の URL を `{{version}}` テンプレートにし、**バージョン更新は version フィールド 1 箇所**で済むようにする。整合性は**公式 SHA256SUMS の値を各プラットフォームの `checksum` に固定**して担保する（http バックエンドは aqua/ubi と異なり `mise.lock` に per-platform SHA を埋めないため、`mise.toml` 側で明示する）。バージョン更新時は version と 4 つの checksum を SHA256SUMS から更新する。
+
+### 認証: `tfctl auth login`（tfctl 自身の資格情報ストア）を使い、fnox は使わない
+
+tfctl は `tfctl auth login`（ブラウザ経由）でトークンを発行し、自身の資格情報ストア（`~/.config/tfctl/`、フォールバックで Terraform の `~/.terraform.d/credentials.tfrc.json`）に保管する。これは **`gh` CLI が自前の資格情報で GitHub 認証するのと構造的に同じ**であり、本プロジェクトが GitHub 操作を gh CLI の自前認証に委ね fnox を使わない方針（[ADR-0001](0001-drop-github-mcp-use-gh-cli.md)）と整合する。
+
+したがって tfctl のトークンも **fnox + 1Password（[ADR-0004](0004-secrets-fnox-1password.md)）の対象外**とし、`tfctl auth login` の自前ストアに委ねる。fnox は「他プロセスへ env で注入するシークレット」（将来の GCP 認証情報など）に限定する役割を保つ。非対話環境で必要になれば env `TFCTL_TOKEN` で供給できる（その時点で fnox 連携を再検討）。
+
+### MCP との棲み分け
+
+Terraform MCP サーバー（`.mcp.json`）と tfctl は**用途が異なり補完的**。MCP = レジストリ / プロバイダ / モジュールの**ドキュメント参照（読み）**、tfctl = run / workspace / 変数の**操作**。重複しないので両立させる。
+
+### エージェント harness（skill）は本決定では導入しない（follow-up）
+
+`tfctl harness install claude` は `.claude/skills/tfctl/SKILL.md` を生成し、エージェント（Claude Code）の将来挙動を steer する。これは**ツールの採用とは別種の意思決定**（エージェントの behavioral config の追加）であり、本 issue の「ツール採用」の承認範囲に含めない。導入する場合は別途明示的に合意し、生成物をレビューのうえ ADR-0003（skill はリポジトリ管理で共有）に沿って取り込む。本 PR ではコマンドラインツールとしての tfctl 採用までに留める。
+
+## Consequences（結果・影響）
+
+- `mise install` で誰でも tfctl が入る。HCP Terraform の run 状態確認・起動、変数 import を CLI / スクリプトから扱えるようになる。
+- **保守コスト**: registry / Dependabot による自動更新は効かない。バージョン更新は `mise.toml` の version + 4 checksum を手動で更新する（手順をコメントに明記済み）。tfctl が aqua-registry に載るか 1.0 に達したら、より標準的な backend へ移行できないか再評価する。
+- **pre-1.0 リスク**: v0.x のためコマンド体系の変更余地がある。破壊的変更があればバージョン固定で受け止め、追従是非を都度判断する。
+- 認証は各開発者が `tfctl auth login` を一度行う（リポジトリには資格情報を載せない）。Claude Code の sandbox 内からは 1Password / ブラウザに到達できないため、認証や操作系コマンドは sandbox 外（`!` プレフィックス等）で実行する。
+- harness skill は未導入。必要になった時点で別 issue / PR で扱う。
+- 運用ルールの結論は CLAUDE.md「ツール管理」に記載（経緯は本 ADR）。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,3 +43,4 @@
 | [0031](0031-lightweight-cqrs-read-model.md) | 読み取りを集約非経由の Read Model 経路で実装する（軽量 CQRS / L2・レイヤー先） | Accepted |
 | [0032](0032-sql-lint-squawk-sqlfluff.md) | SQL lint に squawk + sqlfluff を採用する | Accepted |
 | [0033](0033-defer-production-db-selection.md) | 本番 DB プロダクトの選定を遅延し、当面ランタイムは H2 据え置きで進める | Accepted |
+| [0034](0034-adopt-tfctl-cli.md) | HCP Terraform 操作 CLI として tfctl を採用する | Accepted |

--- a/mise.lock
+++ b/mise.lock
@@ -188,6 +188,14 @@ url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8
 checksum = "sha256:d29144deff3a68aa93ced33dddf84b7fdc26070add4aa0f4513094c8332afc4e"
 url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_windows_x64.zip"
 
+[[tools."http:tfctl"]]
+version = "0.3.0"
+backend = "http:tfctl"
+
+[tools."http:tfctl"."platforms.macos-x64"]
+checksum = "blake3:e860c6cd3698a644712c5869ad6213603528d7e64e78b6921835c249e75f519f"
+url = "https://releases.hashicorp.com/tfctl/0.3.0/tfctl_0.3.0_darwin_amd64.zip"
+
 [[tools.java]]
 version = "temurin-21.0.11+10.0.LTS"
 backend = "core:java"

--- a/mise.toml
+++ b/mise.toml
@@ -14,3 +14,32 @@ terraform = "1.15.6"
 tflint = "0.63.1"
 uv = "0.11.24"
 zizmor = "1.26.1"
+
+# tfctl: HCP Terraform / TFE 管理 CLI（run / variable / workspace 操作）。採否は ADR-0034 参照。
+# mise registry の短名 `tfctl` は別物（flux-iac/tofu-controller の tfctl）と衝突し、aqua-registry にも
+# 未登録・GitHub Releases にバイナリ資産なし（HashiCorp は releases.hashicorp.com で配布）のため、
+# registry / aqua / ubi いずれの経路も使えない。よって http バックエンドで releases.hashicorp.com を
+# 直接指す。バージョン更新は version フィールド 1 箇所のみ（URL は {{version}} テンプレート）、整合性は
+# mise.lock（lockfile=true）が SHA256 で担保する。
+[tools."http:tfctl"]
+version = "0.3.0"
+bin = "tfctl"
+
+# checksum は公式 SHA256SUMS（releases.hashicorp.com/tfctl/<version>/tfctl_<version>_SHA256SUMS）の値を固定する。
+# http バックエンドは aqua/ubi と異なり mise.lock に per-platform SHA を埋めないため、ここで明示して整合性を担保する。
+# バージョン更新時は version と 4 つの checksum を SHA256SUMS から更新すること。
+[tools."http:tfctl".platforms.macos-x64]
+url = "https://releases.hashicorp.com/tfctl/{{version}}/tfctl_{{version}}_darwin_amd64.zip"
+checksum = "sha256:a12de01e640cb9dea6080b7e8a2cdb74c5efe466f3ff6ba19c520c03d383dac9"
+
+[tools."http:tfctl".platforms.macos-arm64]
+url = "https://releases.hashicorp.com/tfctl/{{version}}/tfctl_{{version}}_darwin_arm64.zip"
+checksum = "sha256:045a5d7ebf2913006213b485353acf7c832bbf28e1cf3a6a34313dd761d4f535"
+
+[tools."http:tfctl".platforms.linux-x64]
+url = "https://releases.hashicorp.com/tfctl/{{version}}/tfctl_{{version}}_linux_amd64.zip"
+checksum = "sha256:5526b438bb66c5bc872f55c4bbb7325bb3e9d162ddd392eed3d60f407598cf62"
+
+[tools."http:tfctl".platforms.linux-arm64]
+url = "https://releases.hashicorp.com/tfctl/{{version}}/tfctl_{{version}}_linux_arm64.zip"
+checksum = "sha256:1060b2903cd8f9cb0af5c878cf89790e0f588b735b6715d2eeadd52c5a71f8c5"


### PR DESCRIPTION
## 概要

HCP Terraform の run / 変数 / workspace 操作を CLI から行えるよう、HashiCorp 公式の **tfctl (v0.3.0)** を mise 管理ツールとして採用する。採否と運用方針は **ADR-0034** に記録した。Closes #286。

## 調査の要点（#286 の検討内容への回答）

| 論点 | 結論 |
|---|---|
| 機能適合 | HCP Terraform バックエンド運用に対し `run start/status`・`variable import`・`api` の CLI 操作が有用。採用。 |
| mise 管理 | registry 短名 `tfctl` は**別物（flux-iac/tofu-controller）と衝突**、aqua-registry 未登録、GitHub Releases に資産なし。よって **http バックエンド**で `releases.hashicorp.com` を直接指す。 |
| MCP との棲み分け | 補完的。MCP=レジストリ/プロバイダ参照（読み）、tfctl=run/workspace/変数操作。両立。 |
| 認証 | `tfctl auth login`（tfctl 自前の資格情報ストア）を使い **fnox は使わない**。`gh` CLI が自前認証する前例（ADR-0001）と整合。fnox は他プロセスへ注入するシークレット用途に限定。 |
| harness skill | **本 PR では非導入**。`tfctl harness install claude` はエージェント挙動を steer する自己改変であり、ツール採用とは別種の意思決定のため follow-up とする。 |

## 変更内容

- **mise.toml**: http バックエンドで tfctl を追加。URL は `{{version}}` テンプレートでバージョン更新を 1 箇所に集約し、公式 SHA256SUMS の値を各プラットフォーム（macos/linux × x64/arm64）の `checksum` に固定。
- **mise.lock**: `mise install` による `http:tfctl` エントリ追記。
- **CLAUDE.md**: ツール一覧に tfctl を追加（棲み分け・認証方針を明記し ADR-0034 へリンク）。
- **docs/adr/0034-adopt-tfctl-cli.md**: 採用決定の記録。
- **docs/adr/README.md**: ADR 一覧に 0034 を追加。

## 検証

- `mise install` で repo 設定経由のインストール成功（`tfctl --version` → `v0.3.0`）。公式 SHA256SUMS による checksum 検証も通過（install フローが `[1/4]→[4/4]` で検証ステップ込み）。
- pre-commit（editorconfig-checker / gitleaks）・commit-msg（commitizen）通過。
- 変更は mise 設定 + ドキュメントのみ（Kotlin / SQL / workflow / Terraform 変更なし）。

## 保守上の注記（ADR-0034 Consequences より）

- registry / Dependabot の自動更新は効かない。バージョン更新時は `mise.toml` の version + 4 checksum を公式 SHA256SUMS から手動更新する（手順をコメントに明記）。
- pre-1.0（v0.x）のためコマンド体系変更の余地あり。aqua-registry 掲載 or 1.0 到達で標準 backend への移行を再評価。
- 認証は各開発者が `tfctl auth login` を一度実行（資格情報はリポジトリに載せない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
