### PR TITLE
feat: MCP インターフェースアダプタ(FindJockey walking skeleton) (#287)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -8,7 +8,7 @@
 
 ```
                   ┌─────────────── adapter ───────────────┐
-                  │  controller / infrastructure          │
+                  │  controller / infrastructure / mcp    │
                   │   ┌────── applicationService ──────┐  │
                   │   │   ┌─── domainService ───┐       │  │
                   │   │   │  ┌ domainModel ┐    │       │  │
@@ -26,10 +26,12 @@
 | applicationService | `application` | domainModel / domainService | `org.springframework.stereotype`（`@Service` / `@Component`）のみ |
 | adapter (rest) | `controller` | 内側すべて | 可 |
 | adapter (persistence) | `infrastructure` | 内側すべて | 可 |
+| adapter (mcp) | `mcp` | 内側すべて | 可 |
 
 - **ドメインサービスはドメインモデルにのみ依存でき、その逆（モデル→サービス）は禁止**
-- アダプター同士（`controller` ⇔ `infrastructure`）の参照は禁止
+- アダプター同士（`controller` ⇔ `infrastructure` ⇔ `mcp`）の参照は禁止
 - `@RestController` は `controller`、`@Service` は `application`、Spring の `@Repository`（ポート実装）は `infrastructure` に置く
+- `@McpTool` を持つ Spring Bean は `mcp` に置く（application 層に直付けしない）。ArchUnit は `ArchSupport.kt` の `adapter("mcp", MCP)` で `mcp` を adapter リングとして強制する（[ADR-0035](../../docs/adr/0035-mcp-interface-adapter.md)）
 
 ### ドメインモデルとドメインサービスの分け方
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,8 +22,12 @@ dependencies {
     @Suppress("VulnerableLibrariesLocal", "RedundantSuppression")
     implementation(platform(libs.springdoc.openapi.bom))
     implementation(platform(libs.jmolecules.bom))
+    implementation(platform(libs.spring.ai.bom))
 
     implementation("org.springframework.boot:spring-boot-starter-web")
+    // MCP インターフェース（REST と並ぶ adapter）。Spring AI 2.0 の MCP server を WebMVC(SSE/Streamable)
+    // トランスポートで配線する。@McpTool 注釈付き Bean を annotation scanner が自動登録する。採否は ADR-NNNN。
+    implementation(libs.spring.ai.starter.mcp.server.webmvc)
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     // 永続化アクセス（Spring Data JDBC + Flyway）。集約 write は Spring Data JDBC（集約 = 永続化境界）。
     // ランタイムの datasource は当面 H2（PostgreSQL 互換モード）の組み込み DB のまま据え置く。実リポジトリは

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     // MCP インターフェース（REST と並ぶ adapter）。Spring AI 2.0 の MCP server を WebMVC(SSE/Streamable)
-    // トランスポートで配線する。@McpTool 注釈付き Bean を annotation scanner が自動登録する。採否は ADR-NNNN。
+    // トランスポートで配線する。@McpTool 注釈付き Bean を annotation scanner が自動登録する。採否は ADR-0035。
     implementation(libs.spring.ai.starter.mcp.server.webmvc)
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     // 永続化アクセス（Spring Data JDBC + Flyway）。集約 write は Spring Data JDBC（集約 = 永続化境界）。

--- a/docs/adr/0035-mcp-interface-adapter.md
+++ b/docs/adr/0035-mcp-interface-adapter.md
@@ -1,0 +1,53 @@
+# 0035. REST と並ぶ MCP インターフェースアダプタを adapter リングに追加する
+
+- Status: Accepted
+- Date: 2026-06-27
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+本プロジェクトの adapter リングは **`controller`（REST）** のみで構成されており、HTTP 以外のインターフェースから application 層のユースケースを呼び出す経路がなかった。
+
+[MCP（Model Context Protocol）](https://modelcontextprotocol.io/) は LLM エージェントとツール・データソースをつなぐ標準プロトコルであり、Claude Code 等の AI コーディングアシスタントがアプリケーションのユースケースを直接呼び出せるようにするための整備が求められていた（#287）。
+
+アプリは **Spring MVC（servlet）+ Virtual Thread** で構成されており、WebFlux / リアクティブ流派は採らない方針が確定している（[ADR-0002](0002-virtual-thread-over-reactive.md)）。MCP トランスポートもこのスタックと整合させる必要があった。
+
+同じ application 層のユースケースを REST と MCP の両 IF で公開したい。ただし domain / application 層への侵食は避け、`controller` との対称設計を保ちたい。
+
+## Decision（決定）
+
+adapter リングに **`mcp` パッケージ**を追加し、MCP インターフェースアダプタを実装する。
+
+### トランスポート: WebMVC (Streamable HTTP)
+
+Spring MVC + Virtual Thread スタックに整合するよう、トランスポートは `spring-ai-starter-mcp-server-webmvc`（SSE/Streamable HTTP）を採用する。`-webflux` は採らない（[ADR-0002](0002-virtual-thread-over-reactive.md) と一致）。
+
+### ライブラリ: Spring AI 2.0.0
+
+**Spring AI 2.0.0 GA**（2026-06-12 リリース）を採用する。Spring Boot 4.1 / Spring Framework 7.0 に対応した GA バージョンであり、バージョン整合リスクはない。Spring AI 2.0 は MCP Java SDK 2.0.0（MCP spec 2025-11-25）を同梱し、`@McpTool` アノテーションで Spring Bean を MCP ツールとして公開できる。
+
+### 設計原則: `@McpTool` を application 層に直付けしない
+
+`@McpTool` アノテーションは application のユースケースに直付けせず、`mcp` アダプタ（`JockeyMcpTools` 等）でラップする。`controller` が `Result<V, E> → ResponseEntity` 変換を担うのと対称に、`mcp` アダプタが `Result<V, E> → MCP tool result` 変換を担う（失敗は例外送出し、Spring AI が MCP の `isError` へ写す）。MCP 関心（ツール記述・引数スキーマ・エラー表現）は adapter の責務であり、application 層に漏らさない。
+
+### Walking skeleton: FindJockey 1 本から開始
+
+骨格として `FindJockeyUseCase`（読み取り系・軽量 CQRS L2・副作用なし）を MCP ツール 1 本として公開する。「Spring AI MCP server の配線」「`Result` → tool result 変換」「adapter リングとしての ArchUnit 適合」「slice テスト」を実証し、他ユースケースの公開は follow-up とする。
+
+### 認証: 当面入れない（follow-up）
+
+MCP エンドポイントに認証は当面設定しない（ローカル探索前提）。Spring AI には `spring-ai-community/mcp-security` があり OAuth2 / API-key による保護が可能であるが、本 skeleton では導入しない。本番デプロイ（Cloud Run）は `--no-allow-unauthenticated` により外部到達不可なため、全プロファイルで有効化しても即座のリスクはない。
+
+### ArchUnit への適合
+
+`ArchSupport.kt` に `adapter("mcp", MCP)` を追加する（`controller`=rest / `infrastructure`=persistence と並ぶ adapter として）。`mcp` パッケージはコンテキスト分離の `BoundedContextAssignment` 判定において `controller` / `infrastructure` と同様に扱い、コンテキスト循環チェックの対象外とする。
+
+## Consequences（結果・影響）
+
+- `FindJockey` が MCP ツールとして公開され、AI エージェントが騎手情報を取得できるようになる。
+- application / domain 層は無変更で再利用され、オニオンの依存方向は維持される。
+- ArchUnit のオニオン/コンテキスト分離ルールに `mcp` が正式な adapter として組み込まれ、`./gradlew test` で規約が強制される。
+- MCP エンドポイントは全プロファイルで有効になるが、本番 Cloud Run は `--no-allow-unauthenticated` で外部到達不可。
+- **書き込みユースケースの公開と副作用ガード**（AI からの副作用操作の確認・制限）は #463（Claude Code から GCP/副作用を安全に扱う）と連携した follow-up として別 issue/PR で扱う。
+- 他ユースケース公開・認証・MCP ツールスキーマのドキュメント化・MCP プロトコル E2E テストも follow-up。
+- `mcp` パッケージは Kover の成熟ゲート対象外（`total` レポートには出る）。成熟時点で `variant("mature")` の includes に追加する。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,3 +44,4 @@
 | [0032](0032-sql-lint-squawk-sqlfluff.md) | SQL lint に squawk + sqlfluff を採用する | Accepted |
 | [0033](0033-defer-production-db-selection.md) | 本番 DB プロダクトの選定を遅延し、当面ランタイムは H2 据え置きで進める | Accepted |
 | [0034](0034-adopt-tfctl-cli.md) | HCP Terraform 操作 CLI として tfctl を採用する | Accepted |
+| [0035](0035-mcp-interface-adapter.md) | REST と並ぶ MCP インターフェースアダプタを adapter リングに追加する | Accepted |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ detekt = "2.0.0-alpha.3"
 kover = "0.9.8"
 
 # ライブラリのバージョン
+spring-ai = "2.0.0"
 springdoc-openapi-bom = "3.0.3"
 java-uuid-generator = "5.2.0"
 kotlin-result = "2.3.1"
@@ -21,6 +22,10 @@ jmolecules-bom = "2025.0.2"
 junit = "6.1.0"
 
 [libraries]
+# Spring AI（MCP server。WebMVC SSE/Streamable トランスポート）
+spring-ai-bom = { module = "org.springframework.ai:spring-ai-bom", version.ref = "spring-ai" }
+spring-ai-starter-mcp-server-webmvc = { module = "org.springframework.ai:spring-ai-starter-mcp-server-webmvc" }
+
 # SpringDoc OpenAPI
 springdoc-openapi-bom = { module = "org.springdoc:springdoc-openapi-bom", version.ref = "springdoc-openapi-bom" }
 springdoc-openapi-starter-webmvc-ui = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui" }

--- a/src/main/kotlin/com/example/api/mcp/racing/jockey/JockeyMcpResult.kt
+++ b/src/main/kotlin/com/example/api/mcp/racing/jockey/JockeyMcpResult.kt
@@ -1,0 +1,9 @@
+package com.example.api.mcp.racing.jockey
+
+/**
+ * MCP ツール `find_jockey` の結果表現（adapter 所有のワイヤ DTO）。
+ *
+ * application の読みモデル [com.example.api.application.racing.jockey.JockeyView]（`@QueryModel`）を
+ * アダプタ境界の外へ漏らさないため、ここで素の DTO へ写す（controller の `JockeyResponse` と同じ役割）。 id はワイヤ上は文字列で扱う。
+ */
+data class JockeyMcpResult(val id: String, val firstName: String, val lastName: String)

--- a/src/main/kotlin/com/example/api/mcp/racing/jockey/JockeyMcpTools.kt
+++ b/src/main/kotlin/com/example/api/mcp/racing/jockey/JockeyMcpTools.kt
@@ -1,0 +1,37 @@
+package com.example.api.mcp.racing.jockey
+
+import com.example.api.application.racing.jockey.FindJockeyQuery
+import com.example.api.application.racing.jockey.FindJockeyUseCase
+import com.github.michaelbull.result.getOrElse
+import com.github.michaelbull.result.map
+import java.util.UUID
+import org.springframework.ai.mcp.annotation.McpTool
+import org.springframework.stereotype.Component
+
+/**
+ * ジョッキー照会を MCP ツールとして公開する adapter（REST の [com.example.api.controller.jockey.JockeyController] と対になる
+ * MCP アダプタ）。application の [FindJockeyUseCase] を再利用し、`Result` を MCP ツール結果へ写す。
+ *
+ * `@McpTool` を application 層に直付けすると MCP 関心がドメイン側へ漏れる（オニオン違反）ため、変換責務は
+ * 必ずこのアダプタが持つ。失敗（不在・不正入力）は例外として送出し、Spring AI が MCP の `isError` ツール 結果へ写す（controller の
+ * `orThrowProblem()` と同様、境界での throw は adapter に許される）。
+ */
+@Component
+class JockeyMcpTools(private val findJockeyUseCase: FindJockeyUseCase) {
+
+    @McpTool(name = "find_jockey", description = "ジョッキーIDで登録済みジョッキーを照会する")
+    fun findJockey(jockeyId: String): JockeyMcpResult {
+        val id = UUID.fromString(jockeyId)
+        return findJockeyUseCase(FindJockeyQuery(id))
+            .map { view ->
+                JockeyMcpResult(
+                    id = view.id.toString(),
+                    firstName = view.firstName,
+                    lastName = view.lastName,
+                )
+            }
+            .getOrElse { notFound ->
+                throw NoSuchElementException("jockey not found: ${notFound.id}")
+            }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,13 @@ spring:
     # URL=camelCase / ボディ=snake_case の命名規約は ADR-0012 を参照。
     # 注: ProblemDetail.properties は Map のため naming strategy が効かず、拡張キーは setProperty で個別に snake_case 指定する。
     property-naming-strategy: SNAKE_CASE
+  ai:
+    mcp:
+      server:
+        name: toy-box-mcp
+        version: 0.1.0
+        # WebMVC の Streamable HTTP トランスポート。SSE/STATELESS も選べるが現行 MCP の標準は STREAMABLE。
+        protocol: STREAMABLE
   mvc:
     problemdetails:
       # Spring MVC 標準例外（リクエストボディ不正・媒体型不一致等）を RFC 9457 形式に変換する

--- a/src/test/kotlin/com/example/api/architecture/ArchSupport.kt
+++ b/src/test/kotlin/com/example/api/architecture/ArchSupport.kt
@@ -23,6 +23,8 @@ internal const val DOMAIN_SERVICE = "com.example.api.domain..service.."
 internal const val APPLICATION = "com.example.api.application.."
 internal const val CONTROLLER = "com.example.api.controller.."
 internal const val INFRASTRUCTURE = "com.example.api.infrastructure.."
+// MCP アダプタ（Model Context Protocol 公開層）。adapter リングに属し、application 層を利用する。
+internal const val MCP = "com.example.api.mcp.."
 
 /**
  * ドメインサービスの失敗バリアント型（`〜Error` の sealed interface とその variant）であること。

--- a/src/test/kotlin/com/example/api/architecture/OnionLayerRulesTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/OnionLayerRulesTest.kt
@@ -37,6 +37,7 @@ class OnionLayerRulesTest {
             .applicationServices(APPLICATION)
             .adapter("rest", CONTROLLER)
             .adapter("persistence", INFRASTRUCTURE)
+            .adapter("mcp", MCP)
 
     /** domain 層はフレームワークに依存しないこと。 */
     @ArchTest

--- a/src/test/kotlin/com/example/api/mcp/McpServerWiringTest.kt
+++ b/src/test/kotlin/com/example/api/mcp/McpServerWiringTest.kt
@@ -1,0 +1,26 @@
+package com.example.api.mcp
+
+import com.example.api.mcp.racing.jockey.JockeyMcpTools
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * MCP アダプタの配線確認（最小 `@SpringBootTest`）。
+ *
+ * Spring AI MCP server オートコンフィグを足してもアプリケーションコンテキストが起動し、`@McpTool` を持つ [JockeyMcpTools] Bean
+ * が登録されることだけを確認する。MCP プロトコルの E2E（ツール一覧・呼び出し）は follow-up とし、ロジック網羅は slice
+ * テスト（JockeyMcpToolsTest）で済ませる（testing.md: 統合は最小限）。
+ */
+@SpringBootTest
+class McpServerWiringTest {
+    @Autowired private lateinit var jockeyMcpTools: JockeyMcpTools
+
+    @Test
+    fun `コンテキストが起動しMCPツールBeanが登録される`() {
+        // Power Assert は isInitialized を直接 assert() に渡すと IR lowering で失敗するため、
+        // 先に Boolean へ評価してから assert に渡す。
+        val initialized = this::jockeyMcpTools.isInitialized
+        assert(initialized)
+    }
+}

--- a/src/test/kotlin/com/example/api/mcp/racing/jockey/JockeyMcpToolsTest.kt
+++ b/src/test/kotlin/com/example/api/mcp/racing/jockey/JockeyMcpToolsTest.kt
@@ -39,7 +39,7 @@ class JockeyMcpToolsTest {
         every { findJockeyUseCase(FindJockeyQuery(id)) } returns Err(JockeyNotFound(id))
 
         val ex = assertThrows<NoSuchElementException> { tools.findJockey(id.toString()) }
-        assert(ex.message!!.contains(id.toString()))
+        assert(ex.message == "jockey not found: $id")
     }
 
     @Test

--- a/src/test/kotlin/com/example/api/mcp/racing/jockey/JockeyMcpToolsTest.kt
+++ b/src/test/kotlin/com/example/api/mcp/racing/jockey/JockeyMcpToolsTest.kt
@@ -1,0 +1,49 @@
+package com.example.api.mcp.racing.jockey
+
+import com.example.api.application.racing.jockey.FindJockeyQuery
+import com.example.api.application.racing.jockey.FindJockeyUseCase
+import com.example.api.application.racing.jockey.JockeyNotFound
+import com.example.api.application.racing.jockey.JockeyView
+import com.example.api.domain.shared.generateId
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * MCP アダプタ [JockeyMcpTools] の slice 相当ユニットテスト。
+ *
+ * adapter リングのため [FindJockeyUseCase] を mockk でスタブし、Result → MCP ツール結果（成功 DTO /
+ * 失敗時の例外送出）への変換のみを検証する（testing.md: adapter は slice 相当で入出力変換を検証）。
+ */
+class JockeyMcpToolsTest {
+    private val findJockeyUseCase = mockk<FindJockeyUseCase>()
+    private val tools = JockeyMcpTools(findJockeyUseCase)
+
+    @Test
+    fun `存在するIDならJockeyMcpResultを返す`() {
+        val id = generateId()
+        every { findJockeyUseCase(FindJockeyQuery(id)) } returns
+            Ok(JockeyView(id = id, firstName = "武", lastName = "豊"))
+
+        val result = tools.findJockey(id.toString())
+
+        assert(result == JockeyMcpResult(id = id.toString(), firstName = "武", lastName = "豊"))
+    }
+
+    @Test
+    fun `存在しないIDなら例外を送出する（MCPのisErrorへ写す）`() {
+        val id = generateId()
+        every { findJockeyUseCase(FindJockeyQuery(id)) } returns Err(JockeyNotFound(id))
+
+        val ex = assertThrows<NoSuchElementException> { tools.findJockey(id.toString()) }
+        assert(ex.message!!.contains(id.toString()))
+    }
+
+    @Test
+    fun `不正なUUID文字列なら例外を送出する`() {
+        assertThrows<IllegalArgumentException> { tools.findJockey("not-a-uuid") }
+    }
+}


### PR DESCRIPTION
## 概要

REST IF と並ぶ **MCP（Model Context Protocol）インターフェースアダプタ**を adapter リングに追加し、既存の `FindJockeyUseCase` を MCP ツール `find_jockey` として公開する **walking skeleton**。domain / application 層は無変更で再利用する。Closes #287。

設計は [ADR-0035](docs/adr/0035-mcp-interface-adapter.md)。ブレスト/計画の経緯は `docs/superpowers/`（gitignore 済みローカル成果物）。

## スコープ

- ✅ `FindJockeyUseCase`（読み取り・副作用なし）を MCP ツール 1 本として公開。
- ❌ 他ユースケース公開 / 書き込みツール / 認証 / MCP プロトコル E2E は **follow-up**（#287 にコメント、書き込み副作用ガードは #463 連携）。

## 変更内容

- **依存**: `gradle/libs.versions.toml` / `build.gradle.kts` に Spring AI 2.0.0 BOM + `spring-ai-starter-mcp-server-webmvc`。`application.yml` に `spring.ai.mcp.server.*`（name/version/protocol=STREAMABLE）。
- **アダプタ**: `com.example.api.mcp.racing.jockey` に `JockeyMcpTools`（`@McpTool find_jockey`、`@Component`）と `JockeyMcpResult`（アダプタ所有 DTO）。`@McpTool` は application に直付けせず、`Result<JockeyView, JockeyNotFound>` を成功 DTO / 失敗（例外→ MCP `isError`）に変換。`JockeyView`（`@QueryModel`）は境界外へ漏らさない。
- **ArchUnit**: `ArchSupport.MCP` + `OnionLayerRulesTest` の `.adapter("mcp", MCP)`。
- **テスト**: `JockeyMcpToolsTest`（成功 / not-found / 不正 UUID を mockk で検証）、`McpServerWiringTest`（最小 `@SpringBootTest` で配線確認）。
- **記録**: ADR-0035 / `docs/adr/README.md` / `.claude/rules/architecture.md`（onion 図・adapter 表・`@McpTool` 配置ルール）。

## 設計上のポイント

- トランスポートは **WebMVC(Streamable HTTP)**。Spring MVC + Virtual Thread スタックに整合し reactive を採らない（[ADR-0002](docs/adr/0002-virtual-thread-over-reactive.md)）。
- 失敗の例外送出は `mcp` アダプタ境界に限る（detekt `NoThrowInDomainAndApplication` は domain/application のみ対象。controller の `orThrowProblem()` と同様）。
- 未認証 MCP エンドポイントは全プロファイル有効だが、公開ツールは読み取り専用 1 本のみ・本番未デプロイ・Cloud Run は `--no-allow-unauthenticated`。**書き込みツール公開前に auth か #463 のガードを入れる**ことを ADR-0035 に明記。

## 検証

- `./gradlew check`（ktfmt + detekt + test + koverVerifyMature）**BUILD SUCCESSFUL**。
- slice テスト 3 ケース + 配線 `@SpringBootTest` PASS。
- Subagent-Driven Development（タスクごとに実装＋spec/品質レビュー＋最終ブランチレビュー）で実装。最終レビュー指摘（ビルドコメントの `ADR-NNNN`→`ADR-0035` backfill、not-found テストのメッセージ完全一致化）は修正済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
