### PR TITLE
feat: 馬名の一意性（重複＝完全一致）を照合する nameHorse ドメインサービスを追加 (#308)

### DIFF
--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -215,6 +215,7 @@ graph LR
 | BreedingRegistrationRepository | リポジトリポート | domain.studbook.model.breeding |
 | BreedingResultRepository | リポジトリポート | domain.studbook.model.breeding |
 | HorseNamed | ドメインイベント | domain.studbook.model.horse.bloodhorse |
+| nameHorse | ドメインサービス | domain.studbook.service.horse |
 | recordCovering | ドメインサービス | domain.studbook.service.breeding |
 | recordUncovered | ドメインサービス | domain.studbook.service.breeding |
 | registerFoal | ドメインサービス | domain.studbook.service.horse |

--- a/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
@@ -5,6 +5,8 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorse
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
 import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
+import com.example.api.domain.studbook.model.horse.bloodhorse.NameHorseError
+import com.example.api.domain.studbook.service.horse.nameHorse
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.mapError
@@ -38,6 +40,9 @@ sealed interface NameHorseUseCaseError {
      * @property currentName 既に付与されている馬名
      */
     data class AlreadyNamed(val currentName: String) : NameHorseUseCaseError
+
+    /** 申請された馬名が既に他の軽種馬で使用済み。 */
+    data class NameAlreadyTaken(val name: String) : NameHorseUseCaseError
 }
 
 /**
@@ -68,9 +73,15 @@ class NameHorseUseCase(private val bloodHorseRepository: BloodHorseRepository) {
                 .bind()
 
         val transition =
-            bloodHorse
-                .assignName(horseName)
-                .mapError { NameHorseUseCaseError.AlreadyNamed(it.currentName.value) }
+            nameHorse(bloodHorse, horseName, bloodHorseRepository)
+                .mapError { error ->
+                    when (error) {
+                        is NameHorseError.NameAlreadyTaken ->
+                            NameHorseUseCaseError.NameAlreadyTaken(error.name.value)
+                        is NameHorseError.AlreadyNamed ->
+                            NameHorseUseCaseError.AlreadyNamed(error.currentName.value)
+                    }
+                }
                 .bind()
 
         val named = bloodHorseRepository.save(transition.aggregate)

--- a/src/main/kotlin/com/example/api/controller/horse/problem/BloodHorseProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/problem/BloodHorseProblem.kt
@@ -21,6 +21,7 @@ import org.springframework.http.ProblemDetail
  * - 馬名の不変条件違反は入力不正として 400 Bad Request
  * - 対象軽種馬の不在は、URL で指し示したリソースが存在しないため 404 Not Found
  * - 既に命名済みは、リソースの状態と要求が衝突するため 409 Conflict
+ * - 申請馬名が既に使用済みは、原簿の既存馬名と衝突するため 409 Conflict
  */
 fun NameHorseUseCaseError.toProblemDetail(): ProblemDetail =
     when (this) {
@@ -47,6 +48,14 @@ fun NameHorseUseCaseError.toProblemDetail(): ProblemDetail =
                     detail = "対象の軽種馬は既に命名済みのため、再命名はできません。",
                 )
                 .apply { setProperty("current_name", currentName) }
+        is NameHorseUseCaseError.NameAlreadyTaken ->
+            problem(
+                    status = HttpStatus.CONFLICT,
+                    code = "horse-name-already-taken",
+                    title = "Horse name already taken",
+                    detail = "申請された馬名は既に他の軽種馬で使用されています。",
+                )
+                .apply { setProperty("name", name) }
     }
 
 /**

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseRepository.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseRepository.kt
@@ -22,4 +22,7 @@ interface BloodHorseRepository {
 
     /** 軽種馬を永続化する。 */
     fun save(bloodHorse: BloodHorse): BloodHorse
+
+    /** 指定の馬名が既に他の軽種馬に付与されているかを判定する（馬名の一意性照合用）。 */
+    fun existsByName(name: HorseName): Boolean
 }

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/NameHorseError.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/NameHorseError.kt
@@ -1,0 +1,14 @@
+package com.example.api.domain.studbook.model.horse.bloodhorse
+
+/**
+ * 馬名登録（[nameHorse] ドメインサービス）の前提条件違反。
+ *
+ * 失敗のしかたが複数あるため sealed interface とし、`when` の網羅性で漏れを防ぐ。
+ */
+sealed interface NameHorseError {
+    /** 申請馬名が既に他の軽種馬で使用済み（馬名登録原簿の一意性違反）。 */
+    data class NameAlreadyTaken(val name: HorseName) : NameHorseError
+
+    /** 対象が既に命名済みで再命名できない（集約内不変条件 [HorseAlreadyNamed] 由来）。 */
+    data class AlreadyNamed(val currentName: HorseName) : NameHorseError
+}

--- a/src/main/kotlin/com/example/api/domain/studbook/service/horse/NameHorse.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/service/horse/NameHorse.kt
@@ -1,0 +1,40 @@
+package com.example.api.domain.studbook.service.horse
+
+import com.example.api.domain.shared.StateTransition
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorse
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
+import com.example.api.domain.studbook.model.horse.bloodhorse.HorseNamed
+import com.example.api.domain.studbook.model.horse.bloodhorse.NameHorseError
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.mapError
+
+/**
+ * 馬名を登録するドメインサービス。
+ *
+ * 馬名登録の前提条件は性質が異なる2系統:
+ * - **馬名の一意性（馬名登録原簿に既存の馬名は不可）** … 既存の馬名集合をまたぐ集合制約で、単一インスタンスの構築では 完結しない。本サービスが
+ *   [bloodHorseRepository] から既存の使用を引き当てて検証する（[NameHorseError.NameAlreadyTaken]）。
+ * - **二重命名の禁止** … 対象集約自身の不変条件であり、集約の [BloodHorse.assignName] が担う （[NameHorseError.AlreadyNamed]）。
+ *
+ * 一意性は永続化された馬名集合に対する問い合わせが本質であるため、本サービスがリポジトリポート [bloodHorseRepository] を 直接受け取って引き当てる（リポジトリポートは
+ * domainModel に属するため、ドメインサービスからの依存はオニオンの 依存方向 service → model
+ * に反しない。ADR-0022）。一意性を満たせば集約の状態遷移へ委譲する。照合順は集合制約を 先に判定し、通過後に [BloodHorse.assignName]
+ * を呼ぶ（[recordCovering] と一貫）。
+ *
+ * @param bloodHorse 命名対象の軽種馬
+ * @param horseName 付与する馬名
+ * @param bloodHorseRepository 馬名の既存使用を引き当てる軽種馬ポート（読み取りのみ）
+ * @return 命名済みの [BloodHorse] と [HorseNamed] を同梱した [StateTransition]、または [NameHorseError]
+ */
+fun nameHorse(
+    bloodHorse: BloodHorse,
+    horseName: HorseName,
+    bloodHorseRepository: BloodHorseRepository,
+): Result<StateTransition<BloodHorse, HorseNamed>, NameHorseError> {
+    if (bloodHorseRepository.existsByName(horseName)) {
+        return Err(NameHorseError.NameAlreadyTaken(horseName))
+    }
+    return bloodHorse.assignName(horseName).mapError { NameHorseError.AlreadyNamed(it.currentName) }
+}

--- a/src/main/kotlin/com/example/api/domain/studbook/service/horse/NameHorse.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/service/horse/NameHorse.kt
@@ -23,6 +23,9 @@ import com.github.michaelbull.result.mapError
  * に反しない。ADR-0022）。一意性を満たせば集約の状態遷移へ委譲する。照合順は集合制約を 先に判定し、通過後に [BloodHorse.assignName]
  * を呼ぶ（[recordCovering] と一貫）。
  *
+ * 照合するのは **馬名登録原簿に既存の馬名との完全一致** のみ。保護馬名（GI 勝馬名・種牡馬名 等）の照合と、
+ * 紛らわしい馬名の曖昧一致はマスタ整備・類似判定を要するため本サービスの対象外とし、別途継続検討する（#478）。
+ *
  * @param bloodHorse 命名対象の軽種馬
  * @param horseName 付与する馬名
  * @param bloodHorseRepository 馬名の既存使用を引き当てる軽種馬ポート（読み取りのみ）

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/horse/BloodHorseSpringDataRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/horse/BloodHorseSpringDataRepository.kt
@@ -10,4 +10,7 @@ import org.springframework.data.repository.CrudRepository
  * [com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository] とは別物。
  * ドメインポートの実装は本リポジトリを委譲先に持つアダプタ [JdbcBloodHorseRepository] が担う。
  */
-interface BloodHorseSpringDataRepository : CrudRepository<BloodHorseRow, UUID>
+interface BloodHorseSpringDataRepository : CrudRepository<BloodHorseRow, UUID> {
+    /** 馬名（`blood_horse.name`）が一致する行が存在するか。馬名の一意性照合に用いる。 */
+    fun existsByName(name: String): Boolean
+}

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepository.kt
@@ -51,6 +51,8 @@ class JdbcBloodHorseRepository(private val rows: BloodHorseSpringDataRepository)
 
     override fun save(bloodHorse: BloodHorse): BloodHorse = rows.save(bloodHorse.toRow()).toDomain()
 
+    override fun existsByName(name: HorseName): Boolean = rows.existsByName(name.value)
+
     /**
      * 永続化モデルからドメイン集約を再構成する（検証・採番なし）。
      *

--- a/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCaseTest.kt
@@ -28,6 +28,7 @@ class NameHorseUseCaseTest {
             val repository =
                 mockk<BloodHorseRepository> {
                     every { findById(horse.id) } returns horse
+                    every { existsByName(any()) } returns false
                     every { save(any()) } answers { firstArg() }
                 }
             val useCase = NameHorseUseCase(repository)
@@ -68,6 +69,22 @@ class NameHorseUseCaseTest {
         }
 
         @Test
+        fun `馬名が既に使用済みのとき NameAlreadyTaken を返し永続化されない`() {
+            val horse = BloodHorseFixture.bloodHorse()
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { findById(horse.id) } returns horse
+                    every { existsByName(HorseName.create("オグリキャップ").unwrap()) } returns true
+                }
+            val useCase = NameHorseUseCase(repository)
+
+            val result = useCase(command(horse.id.value, "オグリキャップ"))
+
+            assert(result.getError() == NameHorseUseCaseError.NameAlreadyTaken("オグリキャップ"))
+            verify(exactly = 0) { repository.save(any()) }
+        }
+
+        @Test
         fun `既に命名済みのとき AlreadyNamed を返し永続化されない`() {
             val named =
                 BloodHorseFixture.bloodHorse()
@@ -75,7 +92,10 @@ class NameHorseUseCaseTest {
                     .unwrap()
                     .aggregate
             val repository =
-                mockk<BloodHorseRepository> { every { findById(named.id) } returns named }
+                mockk<BloodHorseRepository> {
+                    every { findById(named.id) } returns named
+                    every { existsByName(any()) } returns false
+                }
             val useCase = NameHorseUseCase(repository)
 
             val result = useCase(command(named.id.value, "トウカイテイオー"))

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -231,6 +231,24 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
                 .extractingPath("$.error_code")
                 .isEqualTo("horse-already-named")
         }
+
+        @Test
+        fun `NameAlreadyTaken で 409 と problem+json が返ること`() {
+            every { nameHorse(any<Command<NameHorseCommand>>()) } returns
+                Err(NameHorseUseCaseError.NameAlreadyTaken("オグリキャップ"))
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .assertThat()
+                .hasStatus(HttpStatus.CONFLICT)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.error_code")
+                .isEqualTo("horse-name-already-taken")
+        }
     }
 
     @Nested

--- a/src/test/kotlin/com/example/api/domain/studbook/service/horse/NameHorseTest.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/service/horse/NameHorseTest.kt
@@ -1,0 +1,49 @@
+package com.example.api.domain.studbook.service.horse
+
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
+import com.example.api.domain.studbook.model.horse.bloodhorse.NameHorseError
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+class NameHorseTest {
+
+    private val name = HorseName.create("オグリキャップ").unwrap()
+
+    @Test
+    fun `未使用の馬名なら命名済みの状態遷移を返す`() {
+        val horse = BloodHorseFixture.bloodHorse() // 未命名
+        val repository = mockk<BloodHorseRepository> { every { existsByName(name) } returns false }
+
+        val transition = nameHorse(horse, name, repository).unwrap()
+
+        assert(transition.aggregate.id == horse.id)
+        assert(transition.aggregate.name == name)
+        assert(transition.event.name == name)
+    }
+
+    @Test
+    fun `既に使用済みの馬名なら NameAlreadyTaken を返し命名しない`() {
+        val horse = BloodHorseFixture.bloodHorse() // 未命名
+        val repository = mockk<BloodHorseRepository> { every { existsByName(name) } returns true }
+
+        val error = nameHorse(horse, name, repository).getError()
+
+        assert(error == NameHorseError.NameAlreadyTaken(name))
+    }
+
+    @Test
+    fun `対象が既に命名済みなら AlreadyNamed を返す`() {
+        val existing = HorseName.create("トウカイテイオー").unwrap()
+        val named = BloodHorseFixture.bloodHorse().assignName(existing).unwrap().aggregate
+        val repository = mockk<BloodHorseRepository> { every { existsByName(name) } returns false }
+
+        val error = nameHorse(named, name, repository).getError()
+
+        assert(error == NameHorseError.AlreadyNamed(existing))
+    }
+}

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
@@ -172,4 +172,18 @@ class JdbcBloodHorseRepositoryContractTest(private val rows: BloodHorseSpringDat
     fun `存在しないIDのfindByIdはnullを返す`() {
         assert(repository.findById(BloodHorseId(generateId())) == null)
     }
+
+    @Test
+    fun `既に付与済みの馬名は existsByName が true を返す`() {
+        repository.save(namedDomesticFoal()) // "オグリキャップ" で命名済み
+
+        assert(repository.existsByName(HorseName.create("オグリキャップ").unwrap()))
+    }
+
+    @Test
+    fun `未使用の馬名は existsByName が false を返す`() {
+        repository.save(namedDomesticFoal()) // "オグリキャップ"
+
+        assert(!repository.existsByName(HorseName.create("トウカイテイオー").unwrap()))
+    }
 }


### PR DESCRIPTION
## 概要

馬名登録（#264, PR #305）で実装した `HorseName` VO は**形式の不変条件**のみを検証していた。本 PR は #308 で検討したレジストリ照合のうち、**馬名登録原簿に既存の馬名との完全一致（一意性）** を実装する。JAIRS「馬名登録実施基準1」の「原簿に既載の馬名は不可」のうち、機械化しやすい完全一致部分にスコープを絞った。

## 変更点

- **ドメインモデル**
  - `BloodHorseRepository.existsByName(name)` ポートを追加（既存馬名集合への問い合わせ）
  - `NameHorseError`（sealed interface）を追加: `NameAlreadyTaken` / `AlreadyNamed`
- **ドメインサービス**
  - `nameHorse(bloodHorse, horseName, bloodHorseRepository)` を追加。集合制約（一意性）を先に照合し、通過後に集約の `assignName` へ委譲する。リポジトリポートをドメインサービスが読み取り専用で受け取るのは集合制約のため許容（ADR-0022）
- **アプリケーション**
  - `NameHorseUseCase` を `nameHorse` 経由に変更し、`NameHorseUseCaseError.NameAlreadyTaken` を追加
- **アダプタ**
  - `BloodHorseProblem`: `NameAlreadyTaken` を 409 Conflict（`horse-name-already-taken`）として描画
  - `JdbcBloodHorseRepository` / `BloodHorseSpringDataRepository`: `existsByName` を実装（`blood_horse.name` の存在判定）
- **ドキュメント**
  - `ubiquitous-language.md` に `nameHorse` ドメインサービスを追記
  - `nameHorse` の KDoc に、照合スコープが完全一致のみであることと、保護馬名・紛らわしい馬名は対象外で #478 へ繰り越すことを明記

## スコープ（重複＝完全一致まで）

本 PR の照合は**完全一致の一意性のみ**。以下は審査・マスタ整備・曖昧一致を要するため対象外とし、フォローアップ #478 へ繰り越した:

- 保護馬名（GI 勝馬名・種牡馬名 等。実施基準5）
- 紛らわしい馬名の曖昧一致（実施基準1,3,4）
- 奇矯・公序良俗・著名人物 等の審査系（実施基準6,8）

## テスト

`./gradlew check` 全通過（Docker 起動の上で Testcontainers コントラクトテスト含む。ktfmt / detekt / koverVerifyMature ラチェット含む）。

- ドメインサービス `NameHorseTest`: 未使用なら遷移を返す／使用済みなら `NameAlreadyTaken`／既命名なら `AlreadyNamed`
- ユースケース `NameHorseUseCaseTest`: 使用済みで `NameAlreadyTaken` を返し永続化されないことを追加
- コントローラ `BloodHorseControllerTest`: `NameAlreadyTaken` で 409 + `application/problem+json`
- コントラクト `JdbcBloodHorseRepositoryContractTest`: 付与済み馬名で `existsByName` が true、未使用で false

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)
