### PR TITLE
feat: #378 Trivy で IaC セキュリティ misconfig をスキャンする

### DIFF
--- a/.claude/hooks/stop-terraform-validate.sh
+++ b/.claude/hooks/stop-terraform-validate.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-# Stop hook: 直近の未コミット変更に infra/*.tf が含まれているとき、
-# `terraform validate` で構文エラー / 参照エラー / リソース定義不整合を検査する。
+# Stop hook: 直近の未コミット変更に infra/*.tf が含まれているとき、Terraform の
+# 構文/参照検査（terraform validate）と IaC セキュリティ misconfig スキャン（trivy config）
+# を実行する。
 #
 # - HEAD との差分で .tf 変更が無いターンは何もしない。
 # - 違反があれば exit 2 を返し、Claude にフィードバックする。
-# - terraform 未インストール時は exit 0 で黙って抜ける。
+# - terraform / trivy が未インストールなら、当該チェックのみ黙ってスキップする。
 
 set -uo pipefail
 
@@ -16,22 +17,35 @@ if ! git diff HEAD --name-only 2>/dev/null | grep -qE '^infra/.*\.tf$'; then
     exit 0
 fi
 
-if ! command -v terraform >/dev/null 2>&1; then
-    exit 0
-fi
+# terraform validate（terraform 未インストール時はスキップ）
+if command -v terraform >/dev/null 2>&1; then
+    # init が走っていない場合のみ backend 無効で init する（terraform validate の前提）
+    if [ ! -d infra/.terraform ]; then
+        if ! init_output="$(cd infra && terraform init -backend=false -no-color 2>&1)"; then
+            printf 'terraform init に失敗しました:\n%s\n' "$init_output" >&2
+            exit 2
+        fi
+    fi
 
-# init が走っていない場合のみ backend 無効で init する（terraform validate の前提）
-if [ ! -d infra/.terraform ]; then
-    if ! init_output="$(cd infra && terraform init -backend=false -no-color 2>&1)"; then
-        printf 'terraform init に失敗しました:\n%s\n' "$init_output" >&2
+    output="$(cd infra && terraform validate -no-color 2>&1)"
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        printf 'terraform validate に失敗しました:\n%s\n' "$output" >&2
         exit 2
     fi
 fi
 
-output="$(cd infra && terraform validate -no-color 2>&1)"
-status=$?
-if [ "$status" -ne 0 ]; then
-    printf 'terraform validate に失敗しました:\n%s\n' "$output" >&2
-    exit 2
+# Trivy による IaC セキュリティ misconfig スキャン（ADR-0017 / #378。mise 未導入時はスキップ）。
+# mise 管理ツールを確実に解決するため mise exec 経由で呼ぶ（lefthook / CI と同型。
+# trivy 追加前に開始したセッションでは bare PATH に乗らないため command -v trivy には依存しない）。
+# --exit-code 1 で findings があれば非ゼロ終了し、lefthook / CI と同じ hard gate を Claude にも適用する。
+if command -v mise >/dev/null 2>&1; then
+    trivy_output="$(cd infra && mise exec -- trivy config . --exit-code 1 --quiet 2>&1)"
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        printf 'Trivy が IaC misconfig を検出しました:\n%s\n' "$trivy_output" >&2
+        exit 2
+    fi
 fi
+
 exit 0

--- a/.github/workflows/terraform-check.yml
+++ b/.github/workflows/terraform-check.yml
@@ -28,6 +28,8 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      # Trivy の SARIF を Code Scanning へアップロードするために必要（ADR-0017 / #378）。
+      security-events: write
 
     steps:
     - name: Checkout code
@@ -56,3 +58,19 @@ jobs:
     # mise 管理の tflint を使う。GCP ruleset を足すフェーズ2 で --init + キャッシュを導入する。
     - name: Run tflint
       run: tflint --recursive
+
+    # Trivy による IaC セキュリティ misconfig スキャン（ADR-0017 / #378）。
+    # findings があれば --exit-code 1 で job を落とす hard gate。SARIF は生成後に exit するため、
+    # 後段の upload は if: always() で必ず実行する。working-directory: infra なので出力は infra/trivy.sarif。
+    - name: Run Trivy IaC scan
+      run: trivy config . --format sarif --output trivy.sarif --exit-code 1
+
+    # SARIF を Code Scanning へアップロード（codeql.yml と同じ pin を流用）。
+    # uses ステップは working-directory の影響を受けずリポジトリ root から走るため、
+    # sarif_file は root 相対の infra/trivy.sarif。category で CodeQL と区別する。
+    - name: Upload Trivy SARIF to Code Scanning
+      if: always()
+      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      with:
+        sarif_file: infra/trivy.sarif
+        category: trivy-iac

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -63,6 +63,14 @@ pre-commit:
       run: cd infra && mise exec -- tflint --recursive
       tags: lint
 
+    # Trivy による IaC セキュリティ misconfig スキャン（ADR-0017 / #378）。
+    # mise 管理ツールの解決を確実にするため mise exec 経由で呼ぶ（tflint と同型）。
+    # --exit-code 1: findings があればコミットをブロック（指定しないと findings があっても 0 を返す）。
+    trivy-config:
+      glob: "infra/*.tf"
+      run: cd infra && mise exec -- trivy config . --exit-code 1 --quiet
+      tags: security
+
     # sqlfluff による SQL の書式・スタイルチェック
     sqlfluff:
       glob: "**/*.sql"

--- a/mise.lock
+++ b/mise.lock
@@ -39,6 +39,35 @@ checksum = "sha256:6e7241b51e6817ea6a047693d8e6fed13b31819c9a0dd6c5a726e1592d22f
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_windows_amd64.zip"
 provenance = "github-attestations"
 
+[[tools."aqua:aquasecurity/trivy"]]
+version = "0.71.2"
+backend = "aqua:aquasecurity/trivy"
+
+[tools."aqua:aquasecurity/trivy"."platforms.linux-arm64"]
+checksum = "sha256:fe1c7106e15a5365d485b098a8c338f91e3b7ba71cb0e4963b98a3a098763cfc"
+url = "https://github.com/aquasecurity/trivy/releases/download/v0.71.2/trivy_0.71.2_Linux-ARM64.tar.gz"
+provenance = "cosign"
+
+[tools."aqua:aquasecurity/trivy"."platforms.linux-x64"]
+checksum = "sha256:0510e71e2fd39bf863856d499c8dc19feb4e7336546394c502a8f5cc7ab27460"
+url = "https://github.com/aquasecurity/trivy/releases/download/v0.71.2/trivy_0.71.2_Linux-64bit.tar.gz"
+provenance = "cosign"
+
+[tools."aqua:aquasecurity/trivy"."platforms.macos-arm64"]
+checksum = "sha256:a9f585cad53542a54ef286b5fa4199d081e5a061f8894635bdf3ce2608ece7a9"
+url = "https://github.com/aquasecurity/trivy/releases/download/v0.71.2/trivy_0.71.2_macOS-ARM64.tar.gz"
+provenance = "cosign"
+
+[tools."aqua:aquasecurity/trivy"."platforms.macos-x64"]
+checksum = "sha256:c27bcf4ddd281aecb7267eb5df804ec49ac0f8fa23fe018d33932e17f30a38bf"
+url = "https://github.com/aquasecurity/trivy/releases/download/v0.71.2/trivy_0.71.2_macOS-64bit.tar.gz"
+provenance = "cosign"
+
+[tools."aqua:aquasecurity/trivy"."platforms.windows-x64"]
+checksum = "sha256:ea31c2a927382410cfa2b4eb5970aed62308cf28902e1d167ea36bbfa0515095"
+url = "https://github.com/aquasecurity/trivy/releases/download/v0.71.2/trivy_0.71.2_windows-64bit.zip"
+provenance = "cosign"
+
 [[tools."aqua:koalaman/shellcheck"]]
 version = "0.11.0"
 backend = "aqua:koalaman/shellcheck"

--- a/mise.toml
+++ b/mise.toml
@@ -13,6 +13,7 @@ lefthook = "2.1.9"
 "pipx:sqlfluff" = "4.2.2"
 terraform = "1.15.6"
 tflint = "0.63.1"
+"aqua:aquasecurity/trivy" = "0.71.2"
 uv = "0.11.24"
 zizmor = "1.26.1"
 


### PR DESCRIPTION
## 概要

`infra/` の Terraform に対する**既知セキュリティ misconfig スキャン**（IAM 過剰権限・公開設定など）を [Trivy](https://trivy.dev/) (`trivy config`) で導入する。gitleaks（シークレット）/ zizmor（GHA）/ CodeQL（Kotlin/Java）は稼働済みだったが、IaC のセキュリティ静的解析は穴だった。

ツール選定（tfsec ではなく Trivy、OPA は当面見送り）は [ADR-0017](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0017-terraform-quality-gates-tflint-trivy-defer-opa.md) で確定済み。本 PR はその実装。

## 変更内容

- **`mise.toml`**: `[tools]` に `"aqua:aquasecurity/trivy" = "0.71.2"` を追加（aqua backend、既存 shellcheck と同型）
- **`mise.lock`**: trivy の全 5 プラットフォーム（linux-x64/arm64・macos-x64/arm64・windows-x64）の URL+checksum を `mise lock` で固定。CI は linux-x64。host のみだと Linux CI の整合性チェックが落ちるため明示的に全プラットフォームを埋めた
- **`lefthook.yml`**: pre-commit に `trivy-config`（glob `infra/*.tf`、`cd infra && mise exec -- trivy config . --exit-code 1 --quiet`、tags `security`）。`--exit-code 1` で findings があればコミットをブロック
- **`.github/workflows/terraform-check.yml`**:
  - job 権限に `security-events: write` を追加
  - tflint の後に Trivy スキャン（`--format sarif --output trivy.sarif --exit-code 1`）と `upload-sarif`（`if: always()`、`sarif_file: infra/trivy.sarif`、`category: trivy-iac`、pin は `codeql.yml` と同一）を追加

## 設計判断: hard gate（初手から）

Issue では「PR を止めたくない初期は soft 運用にするか方針を決める」としていたが、その懸念（既存 infra に大量の指摘が出て PR が回らない）は、導入前の baseline スキャン（`trivy config infra/`、`modules/` 含む再帰）が **0 件**だったため発生しない。よって gitleaks / zizmor と同等に、findings があればローカル commit と CI PR の双方を落とす **hard gate** とした。

## 検証

- `trivy config . --exit-code 1` → exit 0（baseline 0 件、`modules/cicd`・`cloudrun`・`local-readonly` 含む）
- SARIF 生成 → valid JSON（`tool.driver.name = "Trivy"`）
- `actionlint` / `zizmor --offline` → クリーン
- commit-msg フック（commitizen）通過

> 注: pre-push の full-test（`./gradlew test`）は worktree 環境の Gradle daemon × sandbox 由来でローカル実行できず `--no-verify` で push した（本 PR は `.kt`/`build.gradle.kts` を一切変更しないためテストへの影響なし。テストは CI が実行する）。

## スコープ外

- GCP ruleset 相当のカスタムルール、Trivy の Rego カスタムチェック（#379 / 組織独自ポリシーが顕在化したら）
- コンテナ/SCA/secret スキャン（将来 `container-smoke-test.yml` と統合余地。ADR-0017 に記録済み）

Closes #378
