### PR TITLE
fix: #482 worktree の pre-push test で Gradle daemon を使わない

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -86,9 +86,23 @@ pre-commit:
 pre-push:
   commands:
     # プッシュ前に全体のテストを実行
+    #
+    # git worktree（リンクされた作業ツリー）では Gradle daemon を使わない（#482）。
+    # Gradle daemon は永続・プロジェクト横断で共有され、起動時の作業ディレクトリ／書込権限
+    # プロファイルを固定したまま再利用される。別コンテキスト（メインチェックアウト等）で
+    # 起動済みの daemon が当 worktree の `.gradle` へ書き込めず、pre-push が即失敗することがある。
+    # --no-daemon なら起動プロセス内でビルドが走り、この foreign daemon 再利用の非対称を回避する。
+    # メインチェックアウト（`.git` がディレクトリ＝git-dir と git-common-dir が一致）では
+    # 条件が偽となり、従来どおり daemon を使って高速化の恩恵を受ける。
+    #
+    # 上流根本原因: gradle/gradle#38054「Make the Gradle daemon sandbox-friendly」。
+    # サンドボックスが $TMPDIR をセッション固有パスに書き換える環境で、起動コンテキストの
+    # 異なる共有 daemon が当該セッションの書込先に到達できないことが本質。--no-daemon は
+    # そこで挙げられた暫定回避策。将来 org.gradle.daemon.scope（キャッシュ共有のまま daemon を
+    # スコープ分離）が実装されたら、性能を犠牲にしない形へ置き換えられる。
     full-test:
       glob: "**/*.{kt,kts,java}"
-      run: mise exec -- ./gradlew test
+      run: mise exec -- ./gradlew test $([ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ] && echo --no-daemon)
       tags: test
 
 commit-msg:


### PR DESCRIPTION
## 概要

git worktree セッションでの `git push` が pre-push フック（lefthook `full-test`）で即失敗する問題（#482）を修正する。

## 根本原因

Gradle daemon は**永続・プロジェクト横断で共有**され、起動時の作業ディレクトリ／サンドボックス書込権限プロファイルを固定したまま再利用される。worktree の `git push` → `mise exec -- ./gradlew test` 自体は `excludedCommands` でサンドボックス外で走るが、**別コンテキスト（メインチェックアウト等）で起動済みの foreign daemon を再利用**すると、その daemon プロセスのプロファイルに当 worktree のパスが含まれず `<worktree>/.gradle/...` を作成できずに失敗する。

`./gradlew --stop` で foreign daemon を消した直後にフレッシュな worktree daemon を起こすと成功することから、「daemon の有無」ではなく「**外来 daemon の再利用**」が原因と切り分けた。

上流の根本原因と将来の本命対応は [gradle/gradle#38054](https://github.com/gradle/gradle/issues/38054)（"Make the Gradle daemon sandbox-friendly" / サンドボックスが `$TMPDIR` をセッション固有パスに書き換える環境での daemon 分離 / `org.gradle.daemon.scope`）。`--no-daemon` は同 issue でも暫定回避策として挙げられている。

## 変更内容

`lefthook.yml` の pre-push `full-test` で、**リンクされた worktree のときだけ** `./gradlew test` に `--no-daemon` を付与する:

```
run: mise exec -- ./gradlew test $([ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ] && echo --no-daemon)
```

- 起動プロセス内でビルドが走り、foreign daemon 再利用の非対称を回避する。
- メインチェックアウト（`.git` がディレクトリ＝`git-dir` と `git-common-dir` が一致）では条件が偽となり、**従来どおり daemon を使って高速化の恩恵を維持**する。
- サンドボックス固有の前提を共有ファイルに書かず、汎用的な worktree 判定のみで実装（ポータブル）。

## 検証

- 検出ロジック: worktree → `--no-daemon` / メインチェックアウト → 空（daemon 維持）。
- 解決後コマンドの直接実行（worktree）: **BUILD SUCCESSFUL**。
- `lefthook run pre-push --force`: **✔️ full-test**。
- 実 `git push`（本 PR の push）でも pre-push `full-test` がグリーン通過。

## スコープ外（意図的）

Stop hook (`stop-kotlin-quality.sh`) は変更していない。これは hook スクリプト＝サンドボックス**内**で走るため `--no-daemon` にするとテストがサンドボックス内実行となり Testcontainers が Docker に到達できない別の破綻を招く。#482 は pre-push の問題なので分離した。

## 関連

- Closes #482
- 上流: gradle/gradle#38054
- 隣接（別問題・本 PR の対象外）: 並列 worktree で共有 build cache のロック競合が将来顕在化しうる（[gradle/gradle#8375](https://github.com/gradle/gradle/issues/8375) と同型）。必要になったら別 Issue 化する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
