### PR TITLE
feat: 審査集約 HorseInspection とその永続化を追加する（#312 土台 1/2）

### DIFF
--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -175,6 +175,7 @@ graph LR
 | BloodHorse | 集約ルート | domain.studbook.model.horse.bloodhorse |
 | BreedingRegistration | 集約ルート | domain.studbook.model.breeding |
 | BreedingResult | 集約ルート | domain.studbook.model.breeding |
+| HorseInspection | 集約ルート | domain.studbook.model.inspection |
 | BloodHorseId | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
 | BreedType | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
 | Breeder | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
@@ -187,7 +188,7 @@ graph LR
 | Covering | 値オブジェクト | domain.studbook.model.breeding |
 | CoveringCertificateNumber | 値オブジェクト | domain.studbook.model.breeding |
 | DateOfBirth | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
-| DnaParentageResult | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
+| DnaParentageResult | 値オブジェクト | domain.studbook.model.inspection |
 | FoalIdentity | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
 | FoalingOutcome.Abortion | 値オブジェクト | domain.studbook.model.breeding |
 | FoalingOutcome.LiveFoal | 値オブジェクト | domain.studbook.model.breeding |
@@ -198,14 +199,21 @@ graph LR
 | FoalingOutcome.TwinAbortion | 値オブジェクト | domain.studbook.model.breeding |
 | FoalingOutcome.TwinNeonatalDeath | 値オブジェクト | domain.studbook.model.breeding |
 | FoalingOutcome.TwinStillbirth | 値オブジェクト | domain.studbook.model.breeding |
+| HorseInspectionId | 値オブジェクト | domain.studbook.model.inspection |
 | HorseName | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
+| IdentificationFeatures | 値オブジェクト | domain.studbook.model.inspection |
 | ImportedHorseEntry | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
 | LandingDate | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
-| MicrochipNumber | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
+| MicrochipNumber | 値オブジェクト | domain.studbook.model.inspection |
 | Origin | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
 | Origin.Domestic | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
 | Origin.Imported | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
 | OriginCountry | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
+| ParentageDetermination | 値オブジェクト | domain.studbook.model.inspection |
+| ParentageDetermination.ByBloodType | 値オブジェクト | domain.studbook.model.inspection |
+| ParentageDetermination.ByDna | 値オブジェクト | domain.studbook.model.inspection |
+| ParentageDetermination.ByOverseasInstitution | 値オブジェクト | domain.studbook.model.inspection |
+| ParentageDetermination.NotApplicable | 値オブジェクト | domain.studbook.model.inspection |
 | PedigreeRegistrationNumber | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
 | StudBookEntry | 値オブジェクト | domain.studbook.model.horse.bloodhorse |
 | StudCertificate | 値オブジェクト | domain.studbook.model.breeding |
@@ -214,6 +222,7 @@ graph LR
 | BloodHorseRepository | リポジトリポート | domain.studbook.model.horse.bloodhorse |
 | BreedingRegistrationRepository | リポジトリポート | domain.studbook.model.breeding |
 | BreedingResultRepository | リポジトリポート | domain.studbook.model.breeding |
+| HorseInspectionRepository | リポジトリポート | domain.studbook.model.inspection |
 | HorseNamed | ドメインイベント | domain.studbook.model.horse.bloodhorse |
 | nameHorse | ドメインサービス | domain.studbook.service.horse |
 | recordCovering | ドメインサービス | domain.studbook.service.breeding |

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
@@ -10,11 +10,11 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseReposito
 import com.example.api.domain.studbook.model.horse.bloodhorse.BreedType
 import com.example.api.domain.studbook.model.horse.bloodhorse.Breeder
 import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
-import com.example.api.domain.studbook.model.horse.bloodhorse.DnaParentageResult
 import com.example.api.domain.studbook.model.horse.bloodhorse.FoalIdentity
-import com.example.api.domain.studbook.model.horse.bloodhorse.MicrochipNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.service.horse.RegisterFoalError
 import com.example.api.domain.studbook.service.horse.registerFoal
 import com.github.michaelbull.result.Result

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
@@ -9,10 +9,10 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
 import com.example.api.domain.studbook.model.horse.bloodhorse.DateOfBirth
 import com.example.api.domain.studbook.model.horse.bloodhorse.ImportedHorseEntry
 import com.example.api.domain.studbook.model.horse.bloodhorse.LandingDate
-import com.example.api.domain.studbook.model.horse.bloodhorse.MicrochipNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.OriginCountry
 import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.mapError

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
@@ -8,12 +8,12 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.BreedType
 import com.example.api.domain.studbook.model.horse.bloodhorse.Breeder
 import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
 import com.example.api.domain.studbook.model.horse.bloodhorse.DateOfBirth
-import com.example.api.domain.studbook.model.horse.bloodhorse.DnaParentageResult
-import com.example.api.domain.studbook.model.horse.bloodhorse.MicrochipNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.RegisterInStudBookError
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
 import com.example.api.domain.studbook.model.horse.bloodhorse.StudBookEntry
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.mapError

--- a/src/main/kotlin/com/example/api/controller/horse/BloodHorseWireEnums.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/BloodHorseWireEnums.kt
@@ -2,8 +2,8 @@ package com.example.api.controller.horse
 
 import com.example.api.domain.studbook.model.horse.bloodhorse.BreedType
 import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
-import com.example.api.domain.studbook.model.horse.bloodhorse.DnaParentageResult
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
 
 /*
  * 軽種馬リソースの HTTP 契約で用いる enum 群と、ドメイン enum との相互変換。

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorse.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorse.kt
@@ -3,6 +3,8 @@ package com.example.api.domain.studbook.model.horse.bloodhorse
 import com.example.api.domain.shared.Entity
 import com.example.api.domain.shared.StateTransition
 import com.example.api.domain.shared.generateId
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/FoalIdentity.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/FoalIdentity.kt
@@ -1,5 +1,7 @@
 package com.example.api.domain.studbook.model.horse.bloodhorse
 
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import org.jmolecules.ddd.annotation.ValueObject
 
 /**

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/ImportedHorseEntry.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/ImportedHorseEntry.kt
@@ -1,13 +1,13 @@
 package com.example.api.domain.studbook.model.horse.bloodhorse
 
+import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import org.jmolecules.ddd.annotation.ValueObject
 
 /**
  * 輸入馬・基礎輸入馬の血統登録申請に際して申請者が持ち込む、馬自身の個体識別情報の束。
  *
  * 通常の内国産馬（[StudBookEntry]）と異なり、**父・母が当システムに存在しない**ことを前提とする。このため父母 ID や 申告された親子関係の DNA
- * 判定結果（[DnaParentageResult]）は含めない。品種は承認海外機関の血統書・輸出証明書に依拠するため、
- * 父母の品種との整合検証も行わない（これらの輸入特有の審査は別途のモデリングに委ねる）。
+ * 型による親子判定結果は含めない。品種は承認海外機関の血統書・輸出証明書に依拠するため、 父母の品種との整合検証も行わない（これらの輸入特有の審査は別途のモデリングに委ねる）。
  *
  * 代わりに輸入馬固有の属性として、原産国（[originCountry]）と揚陸日（[landingDate]）を保持する。
  *

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/StudBookEntry.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/StudBookEntry.kt
@@ -1,23 +1,8 @@
 package com.example.api.domain.studbook.model.horse.bloodhorse
 
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import org.jmolecules.ddd.annotation.ValueObject
-
-/**
- * DNA 型による親子判定の結果。
- *
- * 血統登録では、申告された父・母との親子関係を DNA 型検査で確認する。矛盾がない（[CONSISTENT]）場合のみ血統登録できる。
- */
-@ValueObject
-enum class DnaParentageResult {
-    /** 申告どおりの親子関係と矛盾しない。 */
-    CONSISTENT,
-
-    /** 申告された親子関係と矛盾する。 */
-    INCONSISTENT,
-
-    /** 未検査。 */
-    UNTESTED,
-}
 
 /**
  * 血統登録申請に際して申請者が持ち込む、仔馬自身の個体識別情報の束。

--- a/src/main/kotlin/com/example/api/domain/studbook/model/inspection/DnaParentageResult.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/inspection/DnaParentageResult.kt
@@ -1,0 +1,20 @@
+package com.example.api.domain.studbook.model.inspection
+
+import org.jmolecules.ddd.annotation.ValueObject
+
+/**
+ * DNA 型による親子判定の結果。
+ *
+ * 血統登録では、申告された父・母との親子関係を DNA 型検査で確認する。矛盾がない（[CONSISTENT]）場合のみ血統登録できる。
+ */
+@ValueObject
+enum class DnaParentageResult {
+    /** 申告どおりの親子関係と矛盾しない。 */
+    CONSISTENT,
+
+    /** 申告された親子関係と矛盾する。 */
+    INCONSISTENT,
+
+    /** 未検査。 */
+    UNTESTED,
+}

--- a/src/main/kotlin/com/example/api/domain/studbook/model/inspection/HorseInspection.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/inspection/HorseInspection.kt
@@ -1,0 +1,53 @@
+package com.example.api.domain.studbook.model.inspection
+
+import com.example.api.domain.shared.Entity
+import com.example.api.domain.shared.generateId
+import org.jmolecules.ddd.annotation.AggregateRoot
+import org.jmolecules.ddd.annotation.Identity
+
+/**
+ * 登録に関する馬の審査を表す集約ルート（JAIRS 登録規程実施基準 第6〜7条の2）。
+ *
+ * 個体識別（マイクロチップ・特徴記述子）と親子判定（DNA 型／血液型／海外機関）を一体で記録する。検体・遺伝情報の 所有権が JAIRS に帰属し登録原簿に記載される＝固有同一性を持つため、
+ * [com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorse]
+ * の属性ではなく独立集約とする。審査は血統登録より前（原則離乳前）に行われ、登録（`BloodHorse.create`）が確定済みの
+ * 本集約を消費する。本スライスでは検体採取→検査中の状態機械は持たず、確定済み審査の記録に限る（軽量ライフサイクル）。
+ *
+ * 状態はイミュータブルに扱う。生成は [create]、永続化復元は [reconstitute] のみに限り、コンストラクタは private とする。
+ *
+ * @property id 審査ID（生成時に自動採番）
+ * @property microchipNumber マイクロチップ番号（ISO 11784/11785。第7条の2）
+ * @property features 特徴記述子（旋毛・白斑・鼻紋）。未記録なら null
+ * @property parentage 親子判定（DNA 基本／血液型・海外機関フォールバック／対象外）
+ */
+@AggregateRoot
+class HorseInspection
+private constructor(
+    @field:Identity override val id: HorseInspectionId,
+    val microchipNumber: MicrochipNumber,
+    val features: IdentificationFeatures?,
+    val parentage: ParentageDetermination,
+) : Entity<HorseInspectionId>() {
+    companion object {
+        /** 確定済みの審査を生成する。識別子・親子判定はいずれも検証済み VO であり、本ファクトリは追加の前提条件を 持たず生成する（ID を採番するのみ）。 */
+        fun create(
+            microchipNumber: MicrochipNumber,
+            parentage: ParentageDetermination,
+            features: IdentificationFeatures? = null,
+        ): HorseInspection =
+            HorseInspection(
+                id = HorseInspectionId(generateId()),
+                microchipNumber = microchipNumber,
+                features = features,
+                parentage = parentage,
+            )
+
+        /** 永続化層に保存済みの状態から再構成する（検証・採番なし）。infrastructure 層の復元専用。 */
+        fun reconstitute(
+            id: HorseInspectionId,
+            microchipNumber: MicrochipNumber,
+            parentage: ParentageDetermination,
+            features: IdentificationFeatures?,
+        ): HorseInspection = HorseInspection(id, microchipNumber, features, parentage)
+    }
+}

--- a/src/main/kotlin/com/example/api/domain/studbook/model/inspection/HorseInspectionId.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/inspection/HorseInspectionId.kt
@@ -1,0 +1,7 @@
+package com.example.api.domain.studbook.model.inspection
+
+import java.util.UUID
+import org.jmolecules.ddd.annotation.ValueObject
+
+/** 審査ID */
+@ValueObject @JvmInline value class HorseInspectionId(val value: UUID)

--- a/src/main/kotlin/com/example/api/domain/studbook/model/inspection/HorseInspectionRepository.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/inspection/HorseInspectionRepository.kt
@@ -1,0 +1,18 @@
+package com.example.api.domain.studbook.model.inspection
+
+import org.jmolecules.ddd.annotation.Repository
+
+/**
+ * 審査集約 [HorseInspection] の永続化ポート。
+ *
+ * 実装は infrastructure 層（Spring Data JDBC アダプタ）が担う。血統登録は確定済み審査を [save] で永続化してから 消費し、復元は [findById]
+ * で行う。
+ */
+@Repository
+interface HorseInspectionRepository {
+    /** ID で審査を取得する。存在しなければ null。 */
+    fun findById(id: HorseInspectionId): HorseInspection?
+
+    /** 審査を保存し、保存後の集約を返す。 */
+    fun save(inspection: HorseInspection): HorseInspection
+}

--- a/src/main/kotlin/com/example/api/domain/studbook/model/inspection/IdentificationFeatures.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/inspection/IdentificationFeatures.kt
@@ -1,0 +1,20 @@
+package com.example.api.domain.studbook.model.inspection
+
+import org.jmolecules.ddd.annotation.ValueObject
+
+/**
+ * 個体識別審査で記録する馬の特徴記述子（様式4号裏・1号裏）。
+ *
+ * 旋毛（[hairWhorl]）・白斑（四肢別の記述。[whiteMarkings]）・鼻紋（[nosePrint]）を保持する。本スライスでは 軽くモデル化し、いずれも任意（未記録なら
+ * null）。詳細な様式（馬体図・個体確認書, 様式8号）は対象外。
+ *
+ * @property hairWhorl 旋毛の記述
+ * @property whiteMarkings 白斑（四肢別）の記述
+ * @property nosePrint 鼻紋の記述
+ */
+@ValueObject
+data class IdentificationFeatures(
+    val hairWhorl: String?,
+    val whiteMarkings: String?,
+    val nosePrint: String?,
+)

--- a/src/main/kotlin/com/example/api/domain/studbook/model/inspection/MicrochipNumber.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/inspection/MicrochipNumber.kt
@@ -1,4 +1,4 @@
-package com.example.api.domain.studbook.model.horse.bloodhorse
+package com.example.api.domain.studbook.model.inspection
 
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok

--- a/src/main/kotlin/com/example/api/domain/studbook/model/inspection/ParentageDetermination.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/inspection/ParentageDetermination.kt
@@ -1,0 +1,40 @@
+package com.example.api.domain.studbook.model.inspection
+
+import org.jmolecules.ddd.annotation.ValueObject
+
+/**
+ * 親子判定の戦略。
+ *
+ * DNA 型検査（[ByDna]）を基本とし、父母死亡・血液型のみ確認・輸入馬では血液型検査（[ByBloodType]）や
+ * 承認海外機関の判定（[ByOverseasInstitution]）にフォールバックする。父母不明等で対象外なら [NotApplicable]。
+ * 本スライスでは区分（型）のみを表し、フォールバックの詳細な判定ロジックは別途（#267）に委ねる。相互排他を sealed で型強制する（[Origin] と同方針）。
+ */
+@ValueObject
+sealed interface ParentageDetermination {
+    /** DNA 型による親子判定（基本）。 */
+    @ValueObject data class ByDna(val result: DnaParentageResult) : ParentageDetermination
+
+    /** 血液型検査によるフォールバック（父母死亡・血液型のみ確認等）。詳細は #267。 */
+    @ValueObject data object ByBloodType : ParentageDetermination
+
+    /** 承認海外機関の判定によるフォールバック（輸入馬等）。詳細は #267。 */
+    @ValueObject data object ByOverseasInstitution : ParentageDetermination
+
+    /** 親子判定の対象外（父母不明等）。 */
+    @ValueObject data object NotApplicable : ParentageDetermination
+
+    /**
+     * 申告された父母との親子関係が確認できているか。内国産血統登録（[BloodHorse.create]）の前提条件判定に使う。
+     *
+     * [ByDna] は DNA 判定が [DnaParentageResult.CONSISTENT] のときのみ確認済み。フォールバック（[ByBloodType] /
+     * [ByOverseasInstitution]）は本スライスでは確認済みとして扱う（詳細条件は #267）。[NotApplicable] は父母不明等で 確認の対象外のため
+     * false（内国産登録の前提を満たさない）。
+     */
+    fun confirmsDeclaredParents(): Boolean =
+        when (this) {
+            is ByDna -> result == DnaParentageResult.CONSISTENT
+            ByBloodType -> true
+            ByOverseasInstitution -> true
+            NotApplicable -> false
+        }
+}

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepository.kt
@@ -9,11 +9,11 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
 import com.example.api.domain.studbook.model.horse.bloodhorse.DateOfBirth
 import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
 import com.example.api.domain.studbook.model.horse.bloodhorse.LandingDate
-import com.example.api.domain.studbook.model.horse.bloodhorse.MicrochipNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.Origin
 import com.example.api.domain.studbook.model.horse.bloodhorse.OriginCountry
 import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrThrow
 import org.springframework.stereotype.Repository

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/HorseInspectionRow.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/HorseInspectionRow.kt
@@ -1,0 +1,31 @@
+package com.example.api.infrastructure.studbook.inspection
+
+import java.util.UUID
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.Version
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+
+/**
+ * horse_inspection テーブルの行に対応する永続化モデル（#312。ADR-0027 / ADR-0030 / #435）。
+ *
+ * ドメイン集約 [com.example.api.domain.studbook.model.inspection.HorseInspection] は
+ * `org.springframework..` へ依存できない（ArchUnit）。Spring Data JDBC のマッピングアノテーションは本クラスに
+ * 閉じ込め、ドメインとは手書きマッパー（[JdbcHorseInspectionRepository]）で相互変換する。
+ *
+ * - [id] は外部採番の UUIDv7（ドメインの `HorseInspectionId` の生値）。`@Id` を付けるが DB 採番はしない。
+ * - 親子判定（sealed `ParentageDetermination`）は判別子 [parentageType] と、`ByDna` のみ持つ [dnaParentageResult] に
+ *   フラット化する。特徴記述子（nullable `IdentificationFeatures`）は feature_* 列に nullable でフラット化する。
+ * - [version] は楽観ロック用の `@Version` 列。null のとき Spring Data JDBC は「新規」とみなして insert する。
+ */
+@Table("horse_inspection")
+data class HorseInspectionRow(
+    @Id @Column("id") val id: UUID,
+    @Column("microchip_number") val microchipNumber: String,
+    @Column("parentage_type") val parentageType: String,
+    @Column("dna_parentage_result") val dnaParentageResult: String? = null,
+    @Column("feature_hair_whorl") val featureHairWhorl: String? = null,
+    @Column("feature_white_markings") val featureWhiteMarkings: String? = null,
+    @Column("feature_nose_print") val featureNosePrint: String? = null,
+    @Version @Column("version") val version: Long? = null,
+)

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/HorseInspectionSpringDataRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/HorseInspectionSpringDataRepository.kt
@@ -1,0 +1,13 @@
+package com.example.api.infrastructure.studbook.inspection
+
+import java.util.UUID
+import org.springframework.data.repository.CrudRepository
+
+/**
+ * Spring Data JDBC が実装を生成する [HorseInspectionRow] の CRUD リポジトリ（ADR-0027）。
+ *
+ * infrastructure 内部の永続化詳細であり、ドメインポート
+ * [com.example.api.domain.studbook.model.inspection.HorseInspectionRepository] とは別物。ドメインポートの実装は
+ * 本リポジトリを委譲先に持つアダプタ [JdbcHorseInspectionRepository] が担う。
+ */
+interface HorseInspectionSpringDataRepository : CrudRepository<HorseInspectionRow, UUID>

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionRepository.kt
@@ -1,0 +1,102 @@
+package com.example.api.infrastructure.studbook.inspection
+
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.HorseInspection
+import com.example.api.domain.studbook.model.inspection.HorseInspectionId
+import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
+import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
+import com.example.api.domain.studbook.model.inspection.MicrochipNumber
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrThrow
+import org.springframework.stereotype.Repository
+
+/** 検証済みで保存された VO 値を復元時に取り出すヘルパー（DB 由来の trusted データ。Err は復元データ破損）。 */
+private fun <V, E> Result<V, E>.orThrow(): V = getOrThrow {
+    IllegalStateException("永続化された値の復元に失敗しました: $it")
+}
+
+/**
+ * ドメインポート [HorseInspectionRepository] の唯一の実装。Spring Data JDBC で永続化する（ADR-0027 / ADR-0030）。
+ *
+ * ドメイン集約 [HorseInspection] と永続化モデル [HorseInspectionRow] を手書きマッパーで相互変換し、CRUD は
+ * [HorseInspectionSpringDataRepository] へ委譲する。value class ID・VO（`MicrochipNumber`）・sealed な親子判定
+ * [ParentageDetermination] の判別子フラット化・nullable な [IdentificationFeatures] のフラット化を本マッパーが担う。
+ */
+@Repository
+class JdbcHorseInspectionRepository(private val rows: HorseInspectionSpringDataRepository) :
+    HorseInspectionRepository {
+
+    override fun findById(id: HorseInspectionId): HorseInspection? =
+        rows.findById(id.value).map { it.toDomain() }.orElse(null)
+
+    override fun save(inspection: HorseInspection): HorseInspection =
+        rows.save(inspection.toRow()).toDomain()
+
+    /** 永続化モデルからドメイン集約を再構成する（検証・採番なし）。 */
+    private fun HorseInspectionRow.toDomain(): HorseInspection =
+        HorseInspection.reconstitute(
+            id = HorseInspectionId(id),
+            microchipNumber = MicrochipNumber.create(microchipNumber).orThrow(),
+            parentage = toParentage(),
+            features = toFeatures(),
+        )
+
+    /** 判別子 [HorseInspectionRow.parentageType] から sealed [ParentageDetermination] を復元する。 */
+    private fun HorseInspectionRow.toParentage(): ParentageDetermination =
+        when (parentageType) {
+            PARENTAGE_BY_DNA ->
+                ParentageDetermination.ByDna(
+                    DnaParentageResult.valueOf(
+                        checkNotNull(dnaParentageResult) { "DNA 判定結果が欠落: id=$id" }
+                    )
+                )
+            PARENTAGE_BY_BLOOD_TYPE -> ParentageDetermination.ByBloodType
+            PARENTAGE_BY_OVERSEAS_INSTITUTION -> ParentageDetermination.ByOverseasInstitution
+            PARENTAGE_NOT_APPLICABLE -> ParentageDetermination.NotApplicable
+            else -> error("未知の parentage_type です: $parentageType (id=$id)")
+        }
+
+    /** feature_* 列から nullable な [IdentificationFeatures] を復元する（全 NULL なら未記録＝null）。 */
+    private fun HorseInspectionRow.toFeatures(): IdentificationFeatures? =
+        if (featureHairWhorl == null && featureWhiteMarkings == null && featureNosePrint == null) {
+            null
+        } else {
+            IdentificationFeatures(
+                hairWhorl = featureHairWhorl,
+                whiteMarkings = featureWhiteMarkings,
+                nosePrint = featureNosePrint,
+            )
+        }
+
+    /** ドメイン集約を永続化モデルへ写す。version はドメインが持たないため常に null（insert 判定。更新系は #424）。 */
+    private fun HorseInspection.toRow(): HorseInspectionRow {
+        val (parentageType, dnaResult) = parentage.toTypeAndResult()
+        return HorseInspectionRow(
+            id = id.value,
+            microchipNumber = microchipNumber.value,
+            parentageType = parentageType,
+            dnaParentageResult = dnaResult,
+            featureHairWhorl = features?.hairWhorl,
+            featureWhiteMarkings = features?.whiteMarkings,
+            featureNosePrint = features?.nosePrint,
+        )
+    }
+
+    /** sealed [ParentageDetermination] を判別子と DNA 結果のペアへ写す。 */
+    private fun ParentageDetermination.toTypeAndResult(): Pair<String, String?> =
+        when (this) {
+            is ParentageDetermination.ByDna -> PARENTAGE_BY_DNA to result.name
+            ParentageDetermination.ByBloodType -> PARENTAGE_BY_BLOOD_TYPE to null
+            ParentageDetermination.ByOverseasInstitution ->
+                PARENTAGE_BY_OVERSEAS_INSTITUTION to null
+            ParentageDetermination.NotApplicable -> PARENTAGE_NOT_APPLICABLE to null
+        }
+
+    private companion object {
+        const val PARENTAGE_BY_DNA = "BY_DNA"
+        const val PARENTAGE_BY_BLOOD_TYPE = "BY_BLOOD_TYPE"
+        const val PARENTAGE_BY_OVERSEAS_INSTITUTION = "BY_OVERSEAS_INSTITUTION"
+        const val PARENTAGE_NOT_APPLICABLE = "NOT_APPLICABLE"
+    }
+}

--- a/src/main/resources/db/migration/V5__create_horse_inspection.sql
+++ b/src/main/resources/db/migration/V5__create_horse_inspection.sql
@@ -1,0 +1,26 @@
+-- horse_inspection テーブル（#312。ADR-0027 / ADR-0030 / #435 の方針に準拠）。
+-- スキーマは H2(PostgreSQL 互換モード) と PostgreSQL の双方で適用される
+-- （ランタイムは H2、永続化の契約テストは Testcontainers の PostgreSQL。型は両者で互換）。
+-- 識別子は外部採番の UUIDv7（ADR-0005）をアプリ側で採番して渡す（DB 採番ではない）。
+-- 個体識別審査（マイクロチップ・特徴記述子）と親子判定（sealed ParentageDetermination）を一体で記録する。
+-- 親子判定は子テーブルを設けず、判別子 parentage_type（BY_DNA/BY_BLOOD_TYPE/BY_OVERSEAS_INSTITUTION/
+-- NOT_APPLICABLE）と、BY_DNA のみが持つ dna_parentage_result にフラット化する。
+-- 特徴記述子（nullable な IdentificationFeatures）は feature_* 列に nullable でフラット化する（未記録なら全 NULL）。
+-- ParentageDetermination の不変条件（BY_DNA のときだけ DNA 結果を持つ）を CHECK 制約でスキーマ側にも強制する。
+-- version は楽観ロック兼「新規 insert 判定」用の列。
+CREATE TABLE horse_inspection (
+    id UUID NOT NULL PRIMARY KEY,
+    microchip_number VARCHAR(64) NOT NULL,
+    parentage_type VARCHAR(32) NOT NULL,
+    dna_parentage_result VARCHAR(16),
+    feature_hair_whorl VARCHAR(255), -- noqa: RF04
+    feature_white_markings VARCHAR(255), -- noqa: RF04
+    feature_nose_print VARCHAR(255), -- noqa: RF04
+    version BIGINT, -- noqa: RF04
+    -- 親子判定の整合: DNA 判定(BY_DNA)のときだけ dna_parentage_result を持ち、他区分は持たない。
+    CONSTRAINT chk_horse_inspection_parentage CHECK (
+        (parentage_type = 'BY_DNA' AND dna_parentage_result IS NOT NULL)
+        OR
+        (parentage_type <> 'BY_DNA' AND dna_parentage_result IS NULL)
+    )
+);

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCaseTest.kt
@@ -13,10 +13,10 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
 import com.example.api.domain.studbook.model.horse.bloodhorse.BreedType
 import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
-import com.example.api.domain.studbook.model.horse.bloodhorse.DnaParentageResult
 import com.example.api.domain.studbook.model.horse.bloodhorse.Origin
 import com.example.api.domain.studbook.model.horse.bloodhorse.RegisterInStudBookError
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
 import com.example.api.domain.studbook.service.horse.RegisterFoalError
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCaseTest.kt
@@ -6,10 +6,10 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
 import com.example.api.domain.studbook.model.horse.bloodhorse.BreedType
 import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
-import com.example.api.domain.studbook.model.horse.bloodhorse.DnaParentageResult
 import com.example.api.domain.studbook.model.horse.bloodhorse.Origin
 import com.example.api.domain.studbook.model.horse.bloodhorse.RegisterInStudBookError
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap
 import io.mockk.every

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseWireEnumsTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseWireEnumsTest.kt
@@ -2,8 +2,8 @@ package com.example.api.controller.horse
 
 import com.example.api.domain.studbook.model.horse.bloodhorse.BreedType
 import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
-import com.example.api.domain.studbook.model.horse.bloodhorse.DnaParentageResult
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
 import org.junit.jupiter.api.Test
 
 /**

--- a/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseCreateTest.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseCreateTest.kt
@@ -1,5 +1,6 @@
 package com.example.api.domain.studbook.model.horse.bloodhorse
 
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseFixture.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseFixture.kt
@@ -1,5 +1,7 @@
 package com.example.api.domain.studbook.model.horse.bloodhorse
 
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.github.michaelbull.result.unwrap
 import java.time.LocalDate
 

--- a/src/test/kotlin/com/example/api/domain/studbook/model/inspection/HorseInspectionTest.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/model/inspection/HorseInspectionTest.kt
@@ -1,0 +1,33 @@
+package com.example.api.domain.studbook.model.inspection
+
+import com.github.michaelbull.result.unwrap
+import org.junit.jupiter.api.Test
+
+/** [HorseInspection]（審査集約）のユニットテスト */
+class HorseInspectionTest {
+    private val microchip = MicrochipNumber.create("392140000000001").unwrap()
+
+    @Test
+    fun `審査を生成すると ID が採番され識別子と親子判定を保持する`() {
+        val parentage = ParentageDetermination.ByDna(DnaParentageResult.CONSISTENT)
+
+        val inspection = HorseInspection.create(microchip, parentage)
+
+        assert(inspection.microchipNumber == microchip)
+        assert(inspection.parentage == parentage)
+        assert(inspection.features == null)
+    }
+
+    @Test
+    fun `同じ ID なら等価であること`() {
+        val parentage = ParentageDetermination.NotApplicable
+        val features =
+            IdentificationFeatures(hairWhorl = "額", whiteMarkings = null, nosePrint = null)
+        val original = HorseInspection.create(microchip, parentage, features)
+
+        val restored = HorseInspection.reconstitute(original.id, microchip, parentage, features)
+
+        assert(original == restored)
+        assert(restored.features == features)
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/studbook/model/inspection/MicrochipNumberTest.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/model/inspection/MicrochipNumberTest.kt
@@ -1,4 +1,4 @@
-package com.example.api.domain.studbook.model.horse.bloodhorse
+package com.example.api.domain.studbook.model.inspection
 
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap

--- a/src/test/kotlin/com/example/api/domain/studbook/model/inspection/ParentageDeterminationTest.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/model/inspection/ParentageDeterminationTest.kt
@@ -1,0 +1,32 @@
+package com.example.api.domain.studbook.model.inspection
+
+import org.junit.jupiter.api.Test
+
+/** [ParentageDetermination.confirmsDeclaredParents] のユニットテスト */
+class ParentageDeterminationTest {
+    @Test
+    fun `DNA 判定が矛盾なしなら申告父母を確認済みとみなす`() {
+        val determination = ParentageDetermination.ByDna(DnaParentageResult.CONSISTENT)
+
+        assert(determination.confirmsDeclaredParents())
+    }
+
+    @Test
+    fun `DNA 判定が矛盾なし以外なら確認できていないとみなす`() {
+        val inconsistent = ParentageDetermination.ByDna(DnaParentageResult.INCONSISTENT)
+        val untested = ParentageDetermination.ByDna(DnaParentageResult.UNTESTED)
+        assert(!inconsistent.confirmsDeclaredParents())
+        assert(!untested.confirmsDeclaredParents())
+    }
+
+    @Test
+    fun `血液型・海外機関フォールバックは本スライスでは確認済みとして扱う`() {
+        assert(ParentageDetermination.ByBloodType.confirmsDeclaredParents())
+        assert(ParentageDetermination.ByOverseasInstitution.confirmsDeclaredParents())
+    }
+
+    @Test
+    fun `親子判定の対象外は確認できていないとみなす`() {
+        assert(!ParentageDetermination.NotApplicable.confirmsDeclaredParents())
+    }
+}

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionRepositoryContractTest.kt
@@ -1,0 +1,110 @@
+package com.example.api.infrastructure.studbook.inspection
+
+import com.example.api.domain.shared.generateId
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.HorseInspection
+import com.example.api.domain.studbook.model.inspection.HorseInspectionId
+import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
+import com.example.api.domain.studbook.model.inspection.MicrochipNumber
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.example.api.support.PostgresContainerSupport
+import com.github.michaelbull.result.unwrap
+import java.util.UUID
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.context.TestConstructor.AutowireMode
+
+/**
+ * ドメインポート HorseInspectionRepository の Spring Data JDBC 実装 [JdbcHorseInspectionRepository] の契約テスト。
+ *
+ * 検証する契約:
+ * 1. value class ID・VO（MicrochipNumber）を永続化モデル分離＋手書きマッパーで橋渡しできること
+ * 2. 外部採番（UUIDv7）で @Id が常に非 null でも @Version が null のとき insert と判定されること
+ * 3. sealed な親子判定（ByDna／ByBloodType／NotApplicable）が判別子フラット化を経て往復できること
+ * 4. 特徴記述子（IdentificationFeatures）の記録あり／なし（全 NULL）が往復できること
+ * 5. 親子判定の不変条件（BY_DNA のときだけ DNA 結果を持つ）が CHECK 制約で強制されること
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class JdbcHorseInspectionRepositoryContractTest(
+    private val rows: HorseInspectionSpringDataRepository
+) : PostgresContainerSupport() {
+
+    private val repository = JdbcHorseInspectionRepository(rows)
+    private val microchip = MicrochipNumber.create("392140000000001").unwrap()
+
+    @BeforeEach
+    fun cleanUp() {
+        rows.deleteAll()
+    }
+
+    private fun byDnaRow(id: UUID = generateId()) =
+        HorseInspectionRow(
+            id = id,
+            microchipNumber = "392140000000001",
+            parentageType = "BY_DNA",
+            dnaParentageResult = "CONSISTENT",
+        )
+
+    @Test
+    fun `外部採番のIDを持つ新規行はversionがnullなのでinsertされる`() {
+        val id = generateId()
+        val saved = rows.save(byDnaRow(id = id))
+
+        assert(saved.id == id)
+        assert(saved.version != null)
+        assert(rows.count() == 1L)
+    }
+
+    @Test
+    fun `DNA 親子判定の審査は判別子と DNA 結果ごと往復できる`() {
+        val inspection =
+            HorseInspection.create(
+                microchip,
+                ParentageDetermination.ByDna(DnaParentageResult.CONSISTENT),
+            )
+
+        val saved = repository.save(inspection)
+        val found = repository.findById(inspection.id)
+
+        assert(saved.id == inspection.id)
+        assert(found != null)
+        assert(found!!.id == inspection.id)
+        assert(found.microchipNumber == microchip)
+        assert(found.parentage == ParentageDetermination.ByDna(DnaParentageResult.CONSISTENT))
+        assert(found.features == null)
+    }
+
+    @Test
+    fun `フォールバック区分と特徴記述子ごと往復できる`() {
+        val features =
+            IdentificationFeatures(hairWhorl = "額上部", whiteMarkings = "左前白", nosePrint = null)
+        val inspection =
+            HorseInspection.create(microchip, ParentageDetermination.NotApplicable, features)
+
+        repository.save(inspection)
+        val found = repository.findById(inspection.id)
+
+        assert(found != null)
+        assert(found!!.parentage == ParentageDetermination.NotApplicable)
+        assert(found.features == features)
+    }
+
+    @Test
+    fun `存在しないIDのfindByIdはnullを返す`() {
+        assert(repository.findById(HorseInspectionId(generateId())) == null)
+    }
+
+    @Test
+    fun `DNA区分でないのにDNA結果を持つ行はCHECK制約で拒否される`() {
+        // NOT_APPLICABLE なのに dna_parentage_result を持つ＝ ParentageDetermination の不変条件違反。
+        val inconsistent =
+            byDnaRow().copy(parentageType = "NOT_APPLICABLE", dnaParentageResult = "CONSISTENT")
+
+        assertThrows<DataIntegrityViolationException> { rows.save(inconsistent) }
+    }
+}


### PR DESCRIPTION
## 概要

#312「審査サブドメイン」の **土台部分**（先行 PR / スタックの 1 段目）。個体識別・親子判定を担う独立集約 `HorseInspection` とその永続化を**加算的に**追加する。`BloodHorse` の形は変えないため単独でビルド・テストが緑（後続の再リンクは #485 を参照）。

JAIRS 登録規程実施基準の「登録に関する馬の審査」（第6〜7条の2）に対応するモデリング。

## 含む変更

- **審査ドメイン**（`domain/studbook/model/inspection/`）
  - `HorseInspection` 集約（固有 ID・`microchipNumber`・特徴記述子 `IdentificationFeatures`・親子判定 `ParentageDetermination`）。軽量ライフサイクル＝確定済み審査の記録。
  - `ParentageDetermination`(sealed): `ByDna(result)` / `ByBloodType` / `ByOverseasInstitution` / `NotApplicable`、`confirmsDeclaredParents()`。
  - `HorseInspectionRepository` ポート。
  - `MicrochipNumber` / `DnaParentageResult` を bloodhorse から inspection パッケージへ移設（識別子の出所を審査側へ一本化。参照元の import 追従のみ）。
- **永続化**（`infrastructure/studbook/inspection/` + `db/migration/V5`）
  - `horse_inspection` テーブル（親子判定の判別子フラット化＋CHECK 制約、特徴記述子の nullable フラット化）。
  - `HorseInspectionRow` / SpringData リポジトリ / `JdbcHorseInspectionRepository`（手書きマッパー）と契約テスト。

この PR の時点で `BloodHorse` は `HorseInspection` をまだ参照しない（審査集約は追加されるが未配線）。配線は後続 PR #485 で行う。

## テスト

`./gradlew check` 緑（ktfmtCheck + detekt + 全 test + ArchUnit + koverVerifyMature 85% ラチェット）。審査集約の単体・親子判定・往復＋CHECK 制約の契約テストを追加。

## スタック

これは #312 を 2 段に分割した 1 段目。2 段目（BloodHorse 再リンク＋ADR-0038）は #485（base をこの PR に設定）。

関連: #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)
