### PR TITLE
feat: BloodHorse を審査(HorseInspection)へ再リンクする（#312 再リンク 2/2・#485 再作成）

### DIFF
--- a/docs/adr/0038-inspection-subdomain-aggregate.md
+++ b/docs/adr/0038-inspection-subdomain-aggregate.md
@@ -1,0 +1,63 @@
+# 0038. 審査（個体識別・親子判定）を独立集約とし識別子の出所を審査側へ一本化する
+
+- Status: Accepted
+- Date: 2026-06-29
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+血統登録集約 `BloodHorse` は、登録馬の個体識別に必要な `MicrochipNumber`（マイクロチップ番号）と親子判定結果 `DnaParentageResult`（DNA 型鑑定）を自身の属性として保持していた。しかしこれらの情報は本来、JAIRS 登録規程実施基準（第 6〜7 条の 2）が「登録に関する馬の審査」として体系化する業務—個体識別・DNA 型/血液型検査・親子判定—に帰属する。同規程では検体・遺伝情報の所有権が JAIRS に帰属し、審査結果が登録原簿に記載されることが明示されており、「審査」と「登録」は時系列も所有権も異なる業務である。
+
+また、審査は離乳前（血統登録より前）に行われるため、審査が完了した時点では `BloodHorse` 集約はまだ存在しない。`MicrochipNumber` を `BloodHorse` に残すと、審査側でも個体識別のために同じ番号を保持せざるを得ず、二重管理が生じる。この構造では識別子の出所が曖昧になり、ライフサイクルの不整合を招く。
+
+## Decision（決定）
+
+審査を固有 ID（`HorseInspectionId`）を持つ独立集約 `HorseInspection` として切り出す（軽量ライフサイクル＝確定済み審査の記録）。識別子（マイクロチップ）の出所を審査側に一本化し、`BloodHorse` は `inspectionId: HorseInspectionId` で審査集約を参照する。
+
+### 集約の責務分担
+
+- **`HorseInspection`**: マイクロチップ番号・親子判定（`ParentageDetermination`）・個体特徴記述子（`IdentificationFeatures`）を所有する。審査が先に確定し、その審査 ID を血統登録が引用する。
+- **`BloodHorse`**: `inspectionId` で `HorseInspection` を参照する。マイクロチップ番号を直接保持しない。
+
+### 親子判定の表現
+
+親子判定は sealed `ParentageDetermination` で区分する。
+
+- `DnaBased`: DNA 型鑑定による親子判定（通常ルート）。`DnaParentageResult` を保持。
+- `Fallback`: 血液型鑑定または海外機関による判定（DNA 型鑑定が利用できない場合のフォールバック）。
+- `NotApplicable`: 輸入馬など、国内審査が対象外の場合。
+
+血統登録は `HorseInspection.confirmsDeclaredParents()` が `true` を返すことを前提条件とする（親子判定で申告通りの父母が確認されていなければ登録できない）。
+
+### パッケージ配置
+
+`DnaParentageResult`・`MicrochipNumber` は `domain.studbook.model` の inspection パッケージへ移設する。`BloodHorse` に残すのは `inspectionId` 参照のみとする。
+
+## Consequences（結果・影響）
+
+### 波及範囲
+
+- **`BloodHorse` 構造**: `microchipNumber` プロパティが `inspectionId` 参照に置き換わる。ファクトリ（`create` / `createImported` / `registerFoal`）の引数が `HorseInspection` を受け取る形に変わる。
+- **永続化**: `blood_horses` テーブルの `microchip_number` 列を `inspection_id` へ差し替え（Flyway V3 相当のマイグレーション改訂）。`horse_inspection` テーブルを新設してマイクロチップ・親子判定・特徴記述子を収容する。集約間の DB 外部キーは張らず ID 参照のみとする（[ADR-0027](0027-persistence-spring-data-jdbc.md)・[ADR-0030](0030-jdbc-only-persistence-retire-inmemory.md) 既存方針を踏襲）。
+- **登録ユースケース**: 審査集約を生成し、成功時に `HorseInspectionRepository` に保存してから `BloodHorse` を登録する 2 ステップ構造になる。
+- **レスポンス組み立て**: `RegisteredBloodHorse` が `BloodHorse` と `HorseInspection` の両方を受け取る構成に変わる。
+
+### フォローアップ
+
+以下は本 ADR のスコープ外とし、フォロー issue で対応する。
+
+- 審査の一級 API 配線（審査リソースの記録・参照エンドポイント、特徴記述子・フォールバック親子判定詳細の公開）
+- 親子判定フォールバックの詳細ロジック（#267）
+- DNA 再利用・繁殖登録時の再検査省略（#266）
+
+### 設計上の利点
+
+「審査が識別子を所有し、登録が審査を参照する」構図により、識別子の二重管理が解消し、業務実態（審査先行・登録後続）とモデル構造が対応する。審査を独立集約にすることで、将来的に審査単独でのライフサイクル管理（再審査・番号変更等）も収容しやすくなる。
+
+## 関連
+
+- Issue: #312 / #267 / #266
+- [ADR-0009](0009-immutable-aggregates.md): イミュータブル集約のパターン
+- [ADR-0020](0020-sealed-origin-and-discriminated-origin-subobject.md): sealed による出自区分の表現
+- [ADR-0027](0027-persistence-spring-data-jdbc.md): Spring Data JDBC による永続化
+- [ADR-0030](0030-jdbc-only-persistence-retire-inmemory.md): JDBC 一本化・InMemory 廃止

--- a/docs/adr/0038-inspection-subdomain-aggregate.md
+++ b/docs/adr/0038-inspection-subdomain-aggregate.md
@@ -23,11 +23,12 @@
 
 親子判定は sealed `ParentageDetermination` で区分する。
 
-- `DnaBased`: DNA 型鑑定による親子判定（通常ルート）。`DnaParentageResult` を保持。
-- `Fallback`: 血液型鑑定または海外機関による判定（DNA 型鑑定が利用できない場合のフォールバック）。
-- `NotApplicable`: 輸入馬など、国内審査が対象外の場合。
+- `ByDna`: DNA 型検査による親子判定（基本ルート）。`DnaParentageResult` を保持。
+- `ByBloodType`: 血液型検査によるフォールバック（父母死亡・血液型のみ確認等）。詳細条件は #267。
+- `ByOverseasInstitution`: 承認海外機関の判定によるフォールバック（輸入馬等）。詳細条件は #267。
+- `NotApplicable`: 父母不明等、親子判定の対象外の場合。
 
-血統登録は `HorseInspection.confirmsDeclaredParents()` が `true` を返すことを前提条件とする（親子判定で申告通りの父母が確認されていなければ登録できない）。
+血統登録は `ParentageDetermination.confirmsDeclaredParents()` が `true` を返すことを前提条件とする（親子判定で申告通りの父母が確認されていなければ登録できない）。
 
 ### パッケージ配置
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,3 +47,4 @@
 | [0035](0035-mcp-interface-adapter.md) | REST と並ぶ MCP インターフェースアダプタを adapter リングに追加する | Accepted |
 | [0036](0036-gcp-operation-guardrails.md) | Claude Code からの GCP 操作ガードレールを permissions + 最小権限 SA で構成する | Accepted |
 | [0037](0037-devcontainer-egress-firewall.md) | devcontainer の egress を firewall で default-deny + 許可リストに制限する | Accepted |
+| [0038](0038-inspection-subdomain-aggregate.md) | 審査（個体識別・親子判定）を独立集約とし識別子の出所を審査側へ一本化する | Accepted |

--- a/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
@@ -96,17 +96,23 @@ class NameHorseUseCase(
                 }
                 .bind()
 
+        // response（マイクロチップを露出）の組み立てに審査が要るため、改名の保存前に引き当てる。
+        // inspectionId は命名遷移で変わらないため save 前に引き当てて問題ない。
+        // 審査が欠落（InspectionNotFound）なら改名を save せず返す（エラーなのに改名済みになるのを避ける）。
+        // 血統登録時に審査を必ず生成・保存しているため、欠落は通常ありえない内部不整合相当。
+        val inspection =
+            horseInspectionRepository
+                .findById(transition.aggregate.inspectionId)
+                .toResultOr {
+                    NameHorseUseCaseError.InspectionNotFound(
+                        transition.aggregate.inspectionId.value
+                    )
+                }
+                .bind()
+
         val named = bloodHorseRepository.save(transition.aggregate)
         // ドメインイベントは当面 application 層内で最小ハンドリング（ログ）に留める。
         logger.info("ドメインイベント発生: {}", transition.event)
-
-        // response（マイクロチップを露出）の組み立てに審査が要るため、命名済みの inspectionId で読み込む。
-        // 血統登録時に審査を必ず生成・保存しているため、欠落は通常ありえない内部不整合相当（InspectionNotFound）。
-        val inspection =
-            horseInspectionRepository
-                .findById(named.inspectionId)
-                .toResultOr { NameHorseUseCaseError.InspectionNotFound(named.inspectionId.value) }
-                .bind()
 
         RegisteredBloodHorse(named, inspection)
     }

--- a/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
@@ -1,11 +1,11 @@
 package com.example.api.application.studbook.horse
 
 import com.example.api.domain.shared.Command
-import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorse
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
 import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
 import com.example.api.domain.studbook.model.horse.bloodhorse.NameHorseError
+import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
 import com.example.api.domain.studbook.service.horse.nameHorse
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
@@ -43,6 +43,15 @@ sealed interface NameHorseUseCaseError {
 
     /** 申請された馬名が既に他の軽種馬で使用済み。 */
     data class NameAlreadyTaken(val name: String) : NameHorseUseCaseError
+
+    /**
+     * 命名対象の軽種馬に紐づく審査が存在しない。
+     *
+     * 血統登録時に審査を必ず生成・保存するため、命名フローでは通常起こりえない内部不整合相当の状態。
+     *
+     * @property inspectionId 引き当てに失敗した審査の ID
+     */
+    data class InspectionNotFound(val inspectionId: UUID) : NameHorseUseCaseError
 }
 
 /**
@@ -54,13 +63,16 @@ sealed interface NameHorseUseCaseError {
  * 状態遷移が同梱して返すドメインイベント（`HorseNamed`）は、ここ application 層で受け取って最小限に扱う （現状はログ）。Spring の
  * `ApplicationEventPublisher` への接続や永続化と整合した publish-after-commit は スコープ外（別イシュー送り。ADR-0029）。
  *
- * @return 命名された [BloodHorse]、または業務ルール違反を表す [NameHorseUseCaseError]
+ * @return 命名された [RegisteredBloodHorse]、または業務ルール違反を表す [NameHorseUseCaseError]
  */
 @Service
-class NameHorseUseCase(private val bloodHorseRepository: BloodHorseRepository) {
+class NameHorseUseCase(
+    private val bloodHorseRepository: BloodHorseRepository,
+    private val horseInspectionRepository: HorseInspectionRepository,
+) {
     operator fun invoke(
         command: Command<NameHorseCommand>
-    ): Result<BloodHorse, NameHorseUseCaseError> = binding {
+    ): Result<RegisteredBloodHorse, NameHorseUseCaseError> = binding {
         val input = command.payload
 
         val horseName =
@@ -87,7 +99,16 @@ class NameHorseUseCase(private val bloodHorseRepository: BloodHorseRepository) {
         val named = bloodHorseRepository.save(transition.aggregate)
         // ドメインイベントは当面 application 層内で最小ハンドリング（ログ）に留める。
         logger.info("ドメインイベント発生: {}", transition.event)
-        named
+
+        // response（マイクロチップを露出）の組み立てに審査が要るため、命名済みの inspectionId で読み込む。
+        // 血統登録時に審査を必ず生成・保存しているため、欠落は通常ありえない内部不整合相当（InspectionNotFound）。
+        val inspection =
+            horseInspectionRepository
+                .findById(named.inspectionId)
+                .toResultOr { NameHorseUseCaseError.InspectionNotFound(named.inspectionId.value) }
+                .bind()
+
+        RegisteredBloodHorse(named, inspection)
     }
 
     private companion object {

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
@@ -157,12 +157,12 @@ class RegisterFoalUseCase(
                 breeder = breeder,
             )
 
+        // 審査をメモリ内で組み立てる。前提条件検証（registerFoal）を通った後にのみ永続化し、
+        // 業務ルール違反での却下時に孤児レコードが残るのを防ぐ。
         val inspection =
-            horseInspectionRepository.save(
-                HorseInspection.create(
-                    microchipNumber = microchipNumber,
-                    parentage = ParentageDetermination.ByDna(input.dnaParentage),
-                )
+            HorseInspection.create(
+                microchipNumber = microchipNumber,
+                parentage = ParentageDetermination.ByDna(input.dnaParentage),
             )
 
         val bloodHorse =
@@ -170,6 +170,7 @@ class RegisterFoalUseCase(
                 .mapError { RegisterFoalUseCaseError.PreconditionViolated(it) }
                 .bind()
 
+        horseInspectionRepository.save(inspection)
         RegisteredBloodHorse(bloodHorseRepository.save(bloodHorse), inspection)
     }
 

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
@@ -14,7 +14,10 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.FoalIdentity
 import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
 import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.HorseInspection
+import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
 import com.example.api.domain.studbook.service.horse.RegisterFoalError
 import com.example.api.domain.studbook.service.horse.registerFoal
 import com.github.michaelbull.result.Result
@@ -94,17 +97,18 @@ sealed interface RegisterFoalUseCaseError {
  * で前提条件（分娩結果が生産であること、および委譲先 registerInStudBook の父=雄・母=雌・DNA 親子整合・品種整合）を検証してから、誕生した [BloodHorse]
  * を永続化する。 Controller 層は本クラスのみに依存し、ポートやドメインサービスは知らない。
  *
- * @return 登録された [BloodHorse]、または業務ルール違反を表す [RegisterFoalUseCaseError]
+ * @return 登録された [RegisteredBloodHorse]、または業務ルール違反を表す [RegisterFoalUseCaseError]
  */
 @Service
 class RegisterFoalUseCase(
     private val breedingResultRepository: BreedingResultRepository,
     private val breedingRegistrationRepository: BreedingRegistrationRepository,
     private val bloodHorseRepository: BloodHorseRepository,
+    private val horseInspectionRepository: HorseInspectionRepository,
 ) {
     operator fun invoke(
         command: Command<RegisterFoalCommand>
-    ): Result<BloodHorse, RegisterFoalUseCaseError> = binding {
+    ): Result<RegisteredBloodHorse, RegisterFoalUseCaseError> = binding {
         val input = command.payload
 
         val registrationNumber =
@@ -151,16 +155,22 @@ class RegisterFoalUseCase(
                 coatColor = input.coatColor,
                 breedType = input.breedType,
                 breeder = breeder,
-                microchipNumber = microchipNumber,
-                dnaParentage = input.dnaParentage,
+            )
+
+        val inspection =
+            horseInspectionRepository.save(
+                HorseInspection.create(
+                    microchipNumber = microchipNumber,
+                    parentage = ParentageDetermination.ByDna(input.dnaParentage),
+                )
             )
 
         val bloodHorse =
-            registerFoal(breedingResult, sire, dam, foalIdentity, registrationNumber)
+            registerFoal(breedingResult, sire, dam, foalIdentity, inspection, registrationNumber)
                 .mapError { RegisterFoalUseCaseError.PreconditionViolated(it) }
                 .bind()
 
-        bloodHorseRepository.save(bloodHorse)
+        RegisteredBloodHorse(bloodHorseRepository.save(bloodHorse), inspection)
     }
 
     /**

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
@@ -170,6 +170,7 @@ class RegisterFoalUseCase(
                 .mapError { RegisterFoalUseCaseError.PreconditionViolated(it) }
                 .bind()
 
+        // 審査と軽種馬の2集約書き込みは現状トランザクション境界を持たず、インフラ障害時の原子性は #483 で対応。
         horseInspectionRepository.save(inspection)
         RegisteredBloodHorse(bloodHorseRepository.save(bloodHorse), inspection)
     }

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
@@ -12,7 +12,10 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.LandingDate
 import com.example.api.domain.studbook.model.horse.bloodhorse.OriginCountry
 import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.example.api.domain.studbook.model.inspection.HorseInspection
+import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.mapError
@@ -70,13 +73,16 @@ sealed interface RegisterImportedHorseUseCaseError {
  * 永続化する。父母が当システムに存在しないため、内国産馬の登録（[RegisterInStudBookUseCase]）のような父母の引き当て・前提条件検証は 行わない。Controller
  * 層は本クラスのみに依存し、ドメインの生成経路の詳細は知らない。
  *
- * @return 登録された [BloodHorse]、または業務ルール違反を表す [RegisterImportedHorseUseCaseError]
+ * @return 登録された [RegisteredBloodHorse]、または業務ルール違反を表す [RegisterImportedHorseUseCaseError]
  */
 @Service
-class RegisterImportedHorseUseCase(private val bloodHorseRepository: BloodHorseRepository) {
+class RegisterImportedHorseUseCase(
+    private val bloodHorseRepository: BloodHorseRepository,
+    private val horseInspectionRepository: HorseInspectionRepository,
+) {
     operator fun invoke(
         command: Command<RegisterImportedHorseCommand>
-    ): Result<BloodHorse, RegisterImportedHorseUseCaseError> = binding {
+    ): Result<RegisteredBloodHorse, RegisterImportedHorseUseCaseError> = binding {
         val input = command.payload
 
         val registrationNumber =
@@ -103,13 +109,20 @@ class RegisterImportedHorseUseCase(private val bloodHorseRepository: BloodHorseR
                 breedType = input.breedType,
                 dateOfBirth = DateOfBirth(input.dateOfBirth),
                 breeder = breeder,
-                microchipNumber = microchipNumber,
                 originCountry = originCountry,
                 landingDate = LandingDate(input.landingDate),
             )
 
-        val bloodHorse = BloodHorse.createImported(entry, registrationNumber)
+        val inspection =
+            horseInspectionRepository.save(
+                HorseInspection.create(
+                    microchipNumber = microchipNumber,
+                    parentage = ParentageDetermination.NotApplicable,
+                )
+            )
 
-        bloodHorseRepository.save(bloodHorse)
+        val bloodHorse = BloodHorse.createImported(entry, inspection, registrationNumber)
+
+        RegisteredBloodHorse(bloodHorseRepository.save(bloodHorse), inspection)
     }
 }

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
@@ -123,6 +123,7 @@ class RegisterImportedHorseUseCase(
 
         val bloodHorse = BloodHorse.createImported(entry, inspection, registrationNumber)
 
+        // 審査と軽種馬の2集約書き込みは現状トランザクション境界を持たず、インフラ障害時の原子性は #483 で対応。
         horseInspectionRepository.save(inspection)
         RegisteredBloodHorse(bloodHorseRepository.save(bloodHorse), inspection)
     }

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
@@ -113,16 +113,17 @@ class RegisterImportedHorseUseCase(
                 landingDate = LandingDate(input.landingDate),
             )
 
+        // 審査をメモリ内で組み立て、createImported 後に永続化する（登録系ユースケースで一貫した順序）。
+        // createImported は失敗しないが、内国産馬登録との一貫性のため「組み立て → create → save」の順に揃える。
         val inspection =
-            horseInspectionRepository.save(
-                HorseInspection.create(
-                    microchipNumber = microchipNumber,
-                    parentage = ParentageDetermination.NotApplicable,
-                )
+            HorseInspection.create(
+                microchipNumber = microchipNumber,
+                parentage = ParentageDetermination.NotApplicable,
             )
 
         val bloodHorse = BloodHorse.createImported(entry, inspection, registrationNumber)
 
+        horseInspectionRepository.save(inspection)
         RegisteredBloodHorse(bloodHorseRepository.save(bloodHorse), inspection)
     }
 }

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
@@ -13,7 +13,10 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.RegisterInStudBook
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
 import com.example.api.domain.studbook.model.horse.bloodhorse.StudBookEntry
 import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.HorseInspection
+import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.mapError
@@ -86,13 +89,16 @@ sealed interface RegisterInStudBookUseCaseError {
  * で前提条件（父=雄・母=雌・DNA 親子整合・品種整合）を検証してから、誕生した [BloodHorse] を 永続化する。Controller
  * 層は本クラスのみに依存し、ドメインの生成経路の詳細は知らない。
  *
- * @return 登録された [BloodHorse]、または業務ルール違反を表す [RegisterInStudBookUseCaseError]
+ * @return 登録された [RegisteredBloodHorse]、または業務ルール違反を表す [RegisterInStudBookUseCaseError]
  */
 @Service
-class RegisterInStudBookUseCase(private val bloodHorseRepository: BloodHorseRepository) {
+class RegisterInStudBookUseCase(
+    private val bloodHorseRepository: BloodHorseRepository,
+    private val horseInspectionRepository: HorseInspectionRepository,
+) {
     operator fun invoke(
         command: Command<RegisterInStudBookCommand>
-    ): Result<BloodHorse, RegisterInStudBookUseCaseError> = binding {
+    ): Result<RegisteredBloodHorse, RegisterInStudBookUseCaseError> = binding {
         val input = command.payload
 
         val registrationNumber =
@@ -128,15 +134,21 @@ class RegisterInStudBookUseCase(private val bloodHorseRepository: BloodHorseRepo
                 breedType = input.breedType,
                 dateOfBirth = DateOfBirth(input.dateOfBirth),
                 breeder = breeder,
-                microchipNumber = microchipNumber,
-                dnaParentage = input.dnaParentage,
+            )
+
+        val inspection =
+            horseInspectionRepository.save(
+                HorseInspection.create(
+                    microchipNumber = microchipNumber,
+                    parentage = ParentageDetermination.ByDna(input.dnaParentage),
+                )
             )
 
         val bloodHorse =
-            BloodHorse.create(sire, dam, entry, registrationNumber)
+            BloodHorse.create(sire, dam, entry, inspection, registrationNumber)
                 .mapError { RegisterInStudBookUseCaseError.PreconditionViolated(it) }
                 .bind()
 
-        bloodHorseRepository.save(bloodHorse)
+        RegisteredBloodHorse(bloodHorseRepository.save(bloodHorse), inspection)
     }
 }

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
@@ -136,12 +136,12 @@ class RegisterInStudBookUseCase(
                 breeder = breeder,
             )
 
+        // 審査をメモリ内で組み立てる。前提条件検証（BloodHorse.create）を通った後にのみ永続化し、
+        // 業務ルール違反での却下時に孤児レコードが残るのを防ぐ。
         val inspection =
-            horseInspectionRepository.save(
-                HorseInspection.create(
-                    microchipNumber = microchipNumber,
-                    parentage = ParentageDetermination.ByDna(input.dnaParentage),
-                )
+            HorseInspection.create(
+                microchipNumber = microchipNumber,
+                parentage = ParentageDetermination.ByDna(input.dnaParentage),
             )
 
         val bloodHorse =
@@ -149,6 +149,7 @@ class RegisterInStudBookUseCase(
                 .mapError { RegisterInStudBookUseCaseError.PreconditionViolated(it) }
                 .bind()
 
+        horseInspectionRepository.save(inspection)
         RegisteredBloodHorse(bloodHorseRepository.save(bloodHorse), inspection)
     }
 }

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
@@ -149,6 +149,7 @@ class RegisterInStudBookUseCase(
                 .mapError { RegisterInStudBookUseCaseError.PreconditionViolated(it) }
                 .bind()
 
+        // 審査と軽種馬の2集約書き込みは現状トランザクション境界を持たず、インフラ障害時の原子性は #483 で対応。
         horseInspectionRepository.save(inspection)
         RegisteredBloodHorse(bloodHorseRepository.save(bloodHorse), inspection)
     }

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisteredBloodHorse.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisteredBloodHorse.kt
@@ -1,0 +1,15 @@
+package com.example.api.application.studbook.horse
+
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorse
+import com.example.api.domain.studbook.model.inspection.HorseInspection
+
+/**
+ * 血統登録の結果として、軽種馬とその個体識別・親子判定審査を束ねた application 層の戻り値。
+ *
+ * 識別子（マイクロチップ）は審査（[HorseInspection]）側が保持するため、軽種馬リソース表現（マイクロチップを露出する
+ * `BloodHorseResponse`）の組み立てには審査が要る。controller へ両者を渡すための束。審査を一級リソースとして扱う 対外 API は別途（フォロー issue）。
+ *
+ * @property bloodHorse 登録された軽種馬
+ * @property inspection その個体識別・親子判定審査
+ */
+data class RegisteredBloodHorse(val bloodHorse: BloodHorse, val inspection: HorseInspection)

--- a/src/main/kotlin/com/example/api/controller/horse/BloodHorseResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/BloodHorseResponse.kt
@@ -1,6 +1,6 @@
 package com.example.api.controller.horse
 
-import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorse
+import com.example.api.application.studbook.horse.RegisteredBloodHorse
 import java.time.LocalDate
 import java.util.UUID
 
@@ -39,17 +39,17 @@ data class BloodHorseResponse(
     val name: String?,
 )
 
-/** [BloodHorse] を軽種馬リソースの表現へ変換する。各操作の成功レスポンスはこのリソース表現を一律で返す。 */
-fun BloodHorse.toResponse(): BloodHorseResponse =
+/** [RegisteredBloodHorse]（軽種馬＋審査）を軽種馬リソースの表現へ変換する。マイクロチップは審査から引く。 */
+fun RegisteredBloodHorse.toResponse(): BloodHorseResponse =
     BloodHorseResponse(
-        id = id.value,
-        registrationNumber = registrationNumber.value,
-        sex = sex.toApi(),
-        coatColor = coatColor.toApi(),
-        breedType = breedType.toApi(),
-        dateOfBirth = dateOfBirth.value,
-        breeder = breeder.name,
-        microchipNumber = microchipNumber.value,
-        origin = origin.toApi(),
-        name = name?.value,
+        id = bloodHorse.id.value,
+        registrationNumber = bloodHorse.registrationNumber.value,
+        sex = bloodHorse.sex.toApi(),
+        coatColor = bloodHorse.coatColor.toApi(),
+        breedType = bloodHorse.breedType.toApi(),
+        dateOfBirth = bloodHorse.dateOfBirth.value,
+        breeder = bloodHorse.breeder.name,
+        microchipNumber = inspection.microchipNumber.value,
+        origin = bloodHorse.origin.toApi(),
+        name = bloodHorse.name?.value,
     )

--- a/src/main/kotlin/com/example/api/controller/horse/problem/BloodHorseProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/problem/BloodHorseProblem.kt
@@ -22,6 +22,7 @@ import org.springframework.http.ProblemDetail
  * - 対象軽種馬の不在は、URL で指し示したリソースが存在しないため 404 Not Found
  * - 既に命名済みは、リソースの状態と要求が衝突するため 409 Conflict
  * - 申請馬名が既に使用済みは、原簿の既存馬名と衝突するため 409 Conflict
+ * - 命名後の審査欠落は、登録時に必ず生成する審査が見つからない内部不整合相当のため 422 Unprocessable Entity
  */
 fun NameHorseUseCaseError.toProblemDetail(): ProblemDetail =
     when (this) {
@@ -56,6 +57,14 @@ fun NameHorseUseCaseError.toProblemDetail(): ProblemDetail =
                     detail = "申請された馬名は既に他の軽種馬で使用されています。",
                 )
                 .apply { setProperty("name", name) }
+        is NameHorseUseCaseError.InspectionNotFound ->
+            problem(
+                    status = HttpStatus.UNPROCESSABLE_ENTITY,
+                    code = "inspection-not-found",
+                    title = "Inspection not found",
+                    detail = "命名対象の軽種馬に紐づく審査が見つかりません。",
+                )
+                .apply { setProperty("inspection_id", inspectionId) }
     }
 
 /**

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorse.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorse.kt
@@ -3,8 +3,8 @@ package com.example.api.domain.studbook.model.horse.bloodhorse
 import com.example.api.domain.shared.Entity
 import com.example.api.domain.shared.StateTransition
 import com.example.api.domain.shared.generateId
-import com.example.api.domain.studbook.model.inspection.DnaParentageResult
-import com.example.api.domain.studbook.model.inspection.MicrochipNumber
+import com.example.api.domain.studbook.model.inspection.HorseInspection
+import com.example.api.domain.studbook.model.inspection.HorseInspectionId
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
@@ -77,7 +77,7 @@ sealed interface RegisterInStudBookError {
  * @property breedType 品種
  * @property dateOfBirth 生年月日
  * @property breeder 生産者
- * @property microchipNumber マイクロチップ番号
+ * @property inspectionId 個体識別・親子判定を行った審査（[HorseInspection]）の ID。識別子（マイクロチップ）は審査側が保持する
  * @property origin 出自（内国産＝父母ID／輸入＝原産国・揚陸日）。相互排他を [Origin] で型強制する
  * @property name 馬名。未命名なら null。命名は [assignName] でのみ行う
  */
@@ -91,7 +91,7 @@ private constructor(
     val breedType: BreedType,
     val dateOfBirth: DateOfBirth,
     val breeder: Breeder,
-    val microchipNumber: MicrochipNumber,
+    val inspectionId: HorseInspectionId,
     val origin: Origin,
     val name: HorseName?,
 ) : Entity<BloodHorseId>() {
@@ -129,7 +129,7 @@ private constructor(
             breedType = breedType,
             dateOfBirth = dateOfBirth,
             breeder = breeder,
-            microchipNumber = microchipNumber,
+            inspectionId = inspectionId,
             origin = origin,
             name = name,
         )
@@ -141,7 +141,7 @@ private constructor(
          * 父・母は既に血統登録済みの [BloodHorse] であり、本ファクトリは集約をまたぐ前提条件を自己検証してから生成する。 検証する前提条件:
          * - 父が雄であること
          * - 母が雌であること
-         * - 申告された父母との DNA 型による親子判定に矛盾がないこと
+         * - 確定済み審査の親子判定が申告父母を確認していること
          * - 仔の品種が父母の品種と整合すること
          *
          * 検証を満たさなければ生成せず [RegisterInStudBookError] を返す。生成された [BloodHorse] は父母を ID
@@ -149,7 +149,8 @@ private constructor(
          *
          * @param sire 父（雄）の軽種馬
          * @param dam 母（雌）の軽種馬
-         * @param entry 仔馬自身の個体識別情報と DNA 親子判定結果
+         * @param entry 仔馬自身の個体識別情報（性・毛色・品種・生年月日・生産者）
+         * @param inspection 確定済みの個体識別・親子判定審査（親子判定が確認済みであること）
          * @param registrationNumber 交付される血統登録番号
          * @return 生成された [BloodHorse]、または前提条件違反を表す [RegisterInStudBookError]
          */
@@ -157,12 +158,13 @@ private constructor(
             sire: BloodHorse,
             dam: BloodHorse,
             entry: StudBookEntry,
+            inspection: HorseInspection,
             registrationNumber: PedigreeRegistrationNumber,
         ): Result<BloodHorse, RegisterInStudBookError> =
             when {
                 sire.sex != Sex.MALE -> Err(RegisterInStudBookError.SireNotMale)
                 dam.sex != Sex.FEMALE -> Err(RegisterInStudBookError.DamNotFemale)
-                entry.dnaParentage != DnaParentageResult.CONSISTENT ->
+                !inspection.parentage.confirmsDeclaredParents() ->
                     Err(RegisterInStudBookError.ParentageNotConfirmed)
                 !entry.breedType.isConsistentWith(sire.breedType, dam.breedType) ->
                     Err(RegisterInStudBookError.BreedMismatch)
@@ -176,7 +178,7 @@ private constructor(
                             breedType = entry.breedType,
                             dateOfBirth = entry.dateOfBirth,
                             breeder = entry.breeder,
-                            microchipNumber = entry.microchipNumber,
+                            inspectionId = inspection.id,
                             origin = Origin.Domestic(sireId = sire.id, damId = dam.id),
                             name = null,
                         )
@@ -192,6 +194,7 @@ private constructor(
          */
         fun createImported(
             entry: ImportedHorseEntry,
+            inspection: HorseInspection,
             registrationNumber: PedigreeRegistrationNumber,
         ): BloodHorse =
             BloodHorse(
@@ -202,7 +205,7 @@ private constructor(
                 breedType = entry.breedType,
                 dateOfBirth = entry.dateOfBirth,
                 breeder = entry.breeder,
-                microchipNumber = entry.microchipNumber,
+                inspectionId = inspection.id,
                 origin =
                     Origin.Imported(
                         originCountry = entry.originCountry,
@@ -227,7 +230,7 @@ private constructor(
             breedType: BreedType,
             dateOfBirth: DateOfBirth,
             breeder: Breeder,
-            microchipNumber: MicrochipNumber,
+            inspectionId: HorseInspectionId,
             origin: Origin,
             name: HorseName?,
         ): BloodHorse =
@@ -239,7 +242,7 @@ private constructor(
                 breedType = breedType,
                 dateOfBirth = dateOfBirth,
                 breeder = breeder,
-                microchipNumber = microchipNumber,
+                inspectionId = inspectionId,
                 origin = origin,
                 name = name,
             )

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/FoalIdentity.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/FoalIdentity.kt
@@ -1,7 +1,5 @@
 package com.example.api.domain.studbook.model.horse.bloodhorse
 
-import com.example.api.domain.studbook.model.inspection.DnaParentageResult
-import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import org.jmolecules.ddd.annotation.ValueObject
 
 /**
@@ -16,8 +14,6 @@ import org.jmolecules.ddd.annotation.ValueObject
  * @property coatColor 毛色
  * @property breedType 品種
  * @property breeder 生産者
- * @property microchipNumber マイクロチップ番号
- * @property dnaParentage 申告された父母との DNA 型による親子判定結果
  */
 @ValueObject
 data class FoalIdentity(
@@ -25,8 +21,6 @@ data class FoalIdentity(
     val coatColor: CoatColor,
     val breedType: BreedType,
     val breeder: Breeder,
-    val microchipNumber: MicrochipNumber,
-    val dnaParentage: DnaParentageResult,
 ) {
     /** [foalingDate] を生年月日として補い、血統登録の入力となる [StudBookEntry] を組み立てる。 */
     fun toStudBookEntry(foalingDate: DateOfBirth): StudBookEntry =
@@ -36,7 +30,5 @@ data class FoalIdentity(
             breedType = breedType,
             dateOfBirth = foalingDate,
             breeder = breeder,
-            microchipNumber = microchipNumber,
-            dnaParentage = dnaParentage,
         )
 }

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/ImportedHorseEntry.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/ImportedHorseEntry.kt
@@ -1,6 +1,5 @@
 package com.example.api.domain.studbook.model.horse.bloodhorse
 
-import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import org.jmolecules.ddd.annotation.ValueObject
 
 /**
@@ -16,7 +15,6 @@ import org.jmolecules.ddd.annotation.ValueObject
  * @property breedType 品種（承認海外機関の血統書・輸出証明書に基づく）
  * @property dateOfBirth 生年月日（海外血統書に基づく）
  * @property breeder 生産者
- * @property microchipNumber マイクロチップ番号
  * @property originCountry 原産国
  * @property landingDate 揚陸日（陸揚げされた日。登録の起算点）
  */
@@ -27,7 +25,6 @@ data class ImportedHorseEntry(
     val breedType: BreedType,
     val dateOfBirth: DateOfBirth,
     val breeder: Breeder,
-    val microchipNumber: MicrochipNumber,
     val originCountry: OriginCountry,
     val landingDate: LandingDate,
 )

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/StudBookEntry.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/StudBookEntry.kt
@@ -1,22 +1,19 @@
 package com.example.api.domain.studbook.model.horse.bloodhorse
 
-import com.example.api.domain.studbook.model.inspection.DnaParentageResult
-import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import org.jmolecules.ddd.annotation.ValueObject
 
 /**
  * 血統登録申請に際して申請者が持ち込む、仔馬自身の個体識別情報の束。
  *
- * 父・母（[BloodHorse]）は集約をまたぐ参照のため本束には含めず、ドメインサービス registerInStudBook に別途渡す。 本束は仔馬自身の属性と、申告された親子関係の
- * DNA 判定結果のみを保持する。
+ * 父・母（[BloodHorse]）は集約をまたぐ参照のため本束には含めず、ドメインサービス registerInStudBook に別途渡す。
+ * 識別子（マイクロチップ）・親子判定は審査（[com.example.api.domain.studbook.model.inspection.HorseInspection]）が
+ * 保持するため本束には含めず、仔馬自身の属性のみを保持する。
  *
  * @property sex 性
  * @property coatColor 毛色
  * @property breedType 品種
  * @property dateOfBirth 生年月日
  * @property breeder 生産者
- * @property microchipNumber マイクロチップ番号
- * @property dnaParentage 申告された父母との DNA 型による親子判定結果
  */
 @ValueObject
 data class StudBookEntry(
@@ -25,6 +22,4 @@ data class StudBookEntry(
     val breedType: BreedType,
     val dateOfBirth: DateOfBirth,
     val breeder: Breeder,
-    val microchipNumber: MicrochipNumber,
-    val dnaParentage: DnaParentageResult,
 )

--- a/src/main/kotlin/com/example/api/domain/studbook/service/horse/RegisterFoal.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/service/horse/RegisterFoal.kt
@@ -7,6 +7,7 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.DateOfBirth
 import com.example.api.domain.studbook.model.horse.bloodhorse.FoalIdentity
 import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.RegisterInStudBookError
+import com.example.api.domain.studbook.model.inspection.HorseInspection
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.mapError
@@ -29,6 +30,7 @@ import com.github.michaelbull.result.mapError
  * @param sire 父（雄）の軽種馬。`breedingResult.covering.stallionId` に対応する個体を上位で解決して渡す
  * @param dam 母（雌）の軽種馬。繁殖登録の `registeredHorseId` に対応する個体を上位で解決して渡す
  * @param foalIdentity 申請者が持ち込む仔馬自身の個体識別情報（生年月日を除く）
+ * @param inspection 確定済みの個体識別・親子判定審査
  * @param registrationNumber 交付される血統登録番号
  * @return 生成された [BloodHorse]、または前提条件違反を表す [RegisterFoalError]
  */
@@ -37,6 +39,7 @@ fun registerFoal(
     sire: BloodHorse,
     dam: BloodHorse,
     foalIdentity: FoalIdentity,
+    inspection: HorseInspection,
     registrationNumber: PedigreeRegistrationNumber,
 ): Result<BloodHorse, RegisterFoalError> {
     val outcome = breedingResult.outcome
@@ -44,7 +47,7 @@ fun registerFoal(
         return Err(RegisterFoalError.NotLiveFoal(outcome))
     }
     val entry = foalIdentity.toStudBookEntry(DateOfBirth(outcome.foalingDate))
-    return BloodHorse.create(sire, dam, entry, registrationNumber).mapError {
+    return BloodHorse.create(sire, dam, entry, inspection, registrationNumber).mapError {
         RegisterFoalError.RegistrationFailed(it)
     }
 }

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/horse/BloodHorseRow.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/horse/BloodHorseRow.kt
@@ -31,7 +31,7 @@ data class BloodHorseRow(
     @Column("breed_type") val breedType: String,
     @Column("date_of_birth") val dateOfBirth: LocalDate,
     @Column("breeder") val breeder: String,
-    @Column("microchip_number") val microchipNumber: String,
+    @Column("inspection_id") val inspectionId: UUID,
     @Column("name") val name: String? = null,
     @Column("origin_type") val originType: String,
     @Column("sire_id") val sireId: UUID? = null,

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepository.kt
@@ -13,7 +13,7 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.Origin
 import com.example.api.domain.studbook.model.horse.bloodhorse.OriginCountry
 import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
-import com.example.api.domain.studbook.model.inspection.MicrochipNumber
+import com.example.api.domain.studbook.model.inspection.HorseInspectionId
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrThrow
 import org.springframework.stereotype.Repository
@@ -68,7 +68,7 @@ class JdbcBloodHorseRepository(private val rows: BloodHorseSpringDataRepository)
             breedType = BreedType.valueOf(breedType),
             dateOfBirth = DateOfBirth(dateOfBirth),
             breeder = Breeder.create(breeder).orThrow(),
-            microchipNumber = MicrochipNumber.create(microchipNumber).orThrow(),
+            inspectionId = HorseInspectionId(inspectionId),
             origin = toOrigin(),
             name = name?.let { HorseName.create(it).orThrow() },
         )
@@ -102,7 +102,7 @@ class JdbcBloodHorseRepository(private val rows: BloodHorseSpringDataRepository)
                 breedType = breedType.name,
                 dateOfBirth = dateOfBirth.value,
                 breeder = breeder.name,
-                microchipNumber = microchipNumber.value,
+                inspectionId = inspectionId.value,
                 name = name?.value,
                 originType = "",
             )

--- a/src/main/resources/db/migration/V3__create_blood_horse.sql
+++ b/src/main/resources/db/migration/V3__create_blood_horse.sql
@@ -3,6 +3,7 @@
 -- （ランタイムは H2、永続化の契約テストは Testcontainers の PostgreSQL。型は両者で互換）。
 -- 識別子は外部採番の UUIDv7（ADR-0005）をアプリ側で採番して渡す（DB 採番ではない）。
 -- sex / coat_color / breed_type は対応するドメイン enum の名前を保持する。
+-- inspection_id は審査（horse_inspection）の ID。識別子は審査側が保持する。
 -- 出自（sealed Origin）は子テーブルを設けず、判別子 origin_type（DOMESTIC/IMPORTED）と各バリアントの属性列を
 -- フラットに並べて表す（1 集約 = 1 テーブルを保ち、1:1 子テーブルや JSON 列の迂回を避ける）。バリアント固有の列は
 -- 一方のバリアントにしか現れないため、列定義としては nullable にせざるを得ない（内国産は sire_id/dam_id を、
@@ -19,7 +20,7 @@ CREATE TABLE blood_horse (
     breed_type VARCHAR(32) NOT NULL,
     date_of_birth DATE NOT NULL,
     breeder VARCHAR(255) NOT NULL,
-    microchip_number VARCHAR(64) NOT NULL,
+    inspection_id UUID NOT NULL,
     name VARCHAR(255), -- noqa: RF04
     origin_type VARCHAR(16) NOT NULL,
     sire_id UUID,

--- a/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCaseTest.kt
@@ -112,13 +112,13 @@ class NameHorseUseCaseTest {
         }
 
         @Test
-        fun `命名後の審査が見つからないとき InspectionNotFound を返す`() {
+        fun `命名後の審査が見つからないとき InspectionNotFound を返し改名が保存されない`() {
             val horse = BloodHorseFixture.bloodHorse()
+            // save をスタブしない（strict mockk）: 審査欠落で save に到達した場合は例外で即時失敗させる
             val repository =
                 mockk<BloodHorseRepository> {
                     every { findById(horse.id) } returns horse
                     every { existsByName(any()) } returns false
-                    every { save(any()) } answers { firstArg() }
                 }
             val inspectionRepository =
                 mockk<HorseInspectionRepository> { every { findById(any()) } returns null }
@@ -130,6 +130,8 @@ class NameHorseUseCaseTest {
                 result.getError() ==
                     NameHorseUseCaseError.InspectionNotFound(horse.inspectionId.value)
             )
+            // 審査が欠落した場合、改名済みの集約は保存しない（エラーなのに命名状態だけ永続化されるのを防ぐ）
+            verify(exactly = 0) { repository.save(any()) }
         }
     }
 }

--- a/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
 import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
+import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap
 import io.mockk.every
@@ -20,6 +21,12 @@ class NameHorseUseCaseTest {
     private fun command(bloodHorseId: UUID, name: String): Command<NameHorseCommand> =
         Command(NameHorseCommand(bloodHorseId = bloodHorseId, name = name), Instant.now())
 
+    /** 審査ポートのスタブ。命名後の response 組み立て用に既定の審査を返す。 */
+    private fun inspectionRepository() =
+        mockk<HorseInspectionRepository> {
+            every { findById(any()) } returns BloodHorseFixture.inspection()
+        }
+
     @Nested
     inner class SuccessCase {
         @Test
@@ -31,12 +38,12 @@ class NameHorseUseCaseTest {
                     every { existsByName(any()) } returns false
                     every { save(any()) } answers { firstArg() }
                 }
-            val useCase = NameHorseUseCase(repository)
+            val useCase = NameHorseUseCase(repository, inspectionRepository())
 
-            val named = useCase(command(horse.id.value, "オグリキャップ")).unwrap()
+            val registered = useCase(command(horse.id.value, "オグリキャップ")).unwrap()
 
-            assert(named.id == horse.id)
-            assert(named.name?.value == "オグリキャップ")
+            assert(registered.bloodHorse.id == horse.id)
+            assert(registered.bloodHorse.name?.value == "オグリキャップ")
             verify(exactly = 1) { repository.save(any()) }
         }
     }
@@ -46,7 +53,7 @@ class NameHorseUseCaseTest {
         @Test
         fun `馬名が不正なとき InvalidName を返し引当も永続化もしない`() {
             val repository = mockk<BloodHorseRepository>()
-            val useCase = NameHorseUseCase(repository)
+            val useCase = NameHorseUseCase(repository, inspectionRepository())
 
             val result = useCase(command(UUID.randomUUID(), "ア"))
 
@@ -60,7 +67,7 @@ class NameHorseUseCaseTest {
             val id = UUID.randomUUID()
             val repository =
                 mockk<BloodHorseRepository> { every { findById(BloodHorseId(id)) } returns null }
-            val useCase = NameHorseUseCase(repository)
+            val useCase = NameHorseUseCase(repository, inspectionRepository())
 
             val result = useCase(command(id, "オグリキャップ"))
 
@@ -76,7 +83,7 @@ class NameHorseUseCaseTest {
                     every { findById(horse.id) } returns horse
                     every { existsByName(HorseName.create("オグリキャップ").unwrap()) } returns true
                 }
-            val useCase = NameHorseUseCase(repository)
+            val useCase = NameHorseUseCase(repository, inspectionRepository())
 
             val result = useCase(command(horse.id.value, "オグリキャップ"))
 
@@ -96,12 +103,33 @@ class NameHorseUseCaseTest {
                     every { findById(named.id) } returns named
                     every { existsByName(any()) } returns false
                 }
-            val useCase = NameHorseUseCase(repository)
+            val useCase = NameHorseUseCase(repository, inspectionRepository())
 
             val result = useCase(command(named.id.value, "トウカイテイオー"))
 
             assert(result.getError() == NameHorseUseCaseError.AlreadyNamed("オグリキャップ"))
             verify(exactly = 0) { repository.save(any()) }
+        }
+
+        @Test
+        fun `命名後の審査が見つからないとき InspectionNotFound を返す`() {
+            val horse = BloodHorseFixture.bloodHorse()
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { findById(horse.id) } returns horse
+                    every { existsByName(any()) } returns false
+                    every { save(any()) } answers { firstArg() }
+                }
+            val inspectionRepository =
+                mockk<HorseInspectionRepository> { every { findById(any()) } returns null }
+            val useCase = NameHorseUseCase(repository, inspectionRepository)
+
+            val result = useCase(command(horse.id.value, "オグリキャップ"))
+
+            assert(
+                result.getError() ==
+                    NameHorseUseCaseError.InspectionNotFound(horse.inspectionId.value)
+            )
         }
     }
 }

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCaseTest.kt
@@ -270,5 +270,26 @@ class RegisterFoalUseCaseTest {
             )
             verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
         }
+
+        @Test
+        fun `前提条件違反で登録が失敗したとき審査が保存されない`() {
+            // 父が雌のため registerFoal が RegistrationFailed(SireNotMale) を返す → 審査 save に到達しない
+            val w = Wiring()
+            val female = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+            every { w.bloodHorseRepository.findById(w.sire.id) } returns female
+            // inspectionRepository は save を許可しないで生成（呼ばれると例外）
+            val strictInspectionRepository = mockk<HorseInspectionRepository>()
+            val useCase =
+                RegisterFoalUseCase(
+                    w.breedingResultRepository,
+                    w.breedingRegistrationRepository,
+                    w.bloodHorseRepository,
+                    strictInspectionRepository,
+                )
+
+            useCase(command(w.breedingResult.id.value))
+
+            verify(exactly = 0) { strictInspectionRepository.save(any()) }
+        }
     }
 }

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCaseTest.kt
@@ -17,6 +17,7 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.Origin
 import com.example.api.domain.studbook.model.horse.bloodhorse.RegisterInStudBookError
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
 import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
 import com.example.api.domain.studbook.service.horse.RegisterFoalError
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap
@@ -83,12 +84,15 @@ class RegisterFoalUseCaseTest {
                 every { findById(dam.id) } returns dam
                 every { save(any()) } answers { firstArg() }
             }
+        val horseInspectionRepository =
+            mockk<HorseInspectionRepository> { every { save(any()) } answers { firstArg() } }
 
         fun useCase() =
             RegisterFoalUseCase(
                 breedingResultRepository,
                 breedingRegistrationRepository,
                 bloodHorseRepository,
+                horseInspectionRepository,
             )
     }
 
@@ -98,10 +102,12 @@ class RegisterFoalUseCaseTest {
         fun `産駒が血統登録され父母が繁殖記録から解決され出生日が分娩日になる`() {
             val w = Wiring()
 
-            val bloodHorse = w.useCase()(command(w.breedingResult.id.value)).unwrap()
+            val registered = w.useCase()(command(w.breedingResult.id.value)).unwrap()
 
+            val bloodHorse = registered.bloodHorse
             assert(bloodHorse.origin == Origin.Domestic(sireId = w.sire.id, damId = w.dam.id))
             assert(bloodHorse.dateOfBirth.value == foalingDate)
+            assert(bloodHorse.inspectionId == registered.inspection.id)
             verify(exactly = 1) { w.bloodHorseRepository.save(any()) }
         }
     }
@@ -148,7 +154,13 @@ class RegisterFoalUseCaseTest {
                 mockk<BreedingResultRepository> {
                     every { findById(BreedingResultId(breedingResultId)) } returns null
                 }
-            val useCase = RegisterFoalUseCase(repository, mockk(), mockk(relaxed = true))
+            val useCase =
+                RegisterFoalUseCase(
+                    repository,
+                    mockk(),
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                )
 
             val result = useCase(command(breedingResultId))
 

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.BreedType
 import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
 import com.example.api.domain.studbook.model.horse.bloodhorse.Origin
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap
 import io.mockk.every
@@ -36,21 +37,27 @@ class RegisterImportedHorseUseCaseTest {
         payload: RegisterImportedHorseCommand
     ): Command<RegisterImportedHorseCommand> = Command(payload, Instant.now())
 
+    /** 審査ポートのスタブ。`save` は引数（確定済み審査）をそのまま返す。 */
+    private fun inspectionRepository() =
+        mockk<HorseInspectionRepository> { every { save(any()) } answers { firstArg() } }
+
     @Nested
     inner class SuccessCase {
         @Test
         fun `正しい入力のとき父母不明の輸入馬が登録され永続化される`() {
             val repository =
                 mockk<BloodHorseRepository> { every { save(any()) } answers { firstArg() } }
-            val useCase = RegisterImportedHorseUseCase(repository)
+            val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
 
-            val bloodHorse = useCase(command(validPayload())).unwrap()
+            val registered = useCase(command(validPayload())).unwrap()
 
+            val bloodHorse = registered.bloodHorse
             val origin = bloodHorse.origin
             assert(origin is Origin.Imported)
             assert((origin as Origin.Imported).originCountry.name == "アイルランド")
             assert(origin.landingDate.value == LocalDate.of(2024, 9, 1))
             assert(bloodHorse.registrationNumber.value == "2020900001")
+            assert(registered.inspection.microchipNumber.value == "392140000000002")
             verify(exactly = 1) { repository.save(any()) }
         }
     }
@@ -60,7 +67,7 @@ class RegisterImportedHorseUseCaseTest {
         @Test
         fun `血統登録番号がブランクのとき InvalidRegistrationNumber を返し永続化されない`() {
             val repository = mockk<BloodHorseRepository>()
-            val useCase = RegisterImportedHorseUseCase(repository)
+            val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
 
             val result = useCase(command(validPayload().copy(registrationNumber = "")))
 
@@ -71,7 +78,7 @@ class RegisterImportedHorseUseCaseTest {
         @Test
         fun `マイクロチップ番号が不正なとき InvalidMicrochipNumber を返し永続化されない`() {
             val repository = mockk<BloodHorseRepository>()
-            val useCase = RegisterImportedHorseUseCase(repository)
+            val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
 
             val result = useCase(command(validPayload().copy(microchipNumber = "123")))
 
@@ -82,7 +89,7 @@ class RegisterImportedHorseUseCaseTest {
         @Test
         fun `原産国がブランクのとき BlankOriginCountry を返し永続化されない`() {
             val repository = mockk<BloodHorseRepository>()
-            val useCase = RegisterImportedHorseUseCase(repository)
+            val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
 
             val result = useCase(command(validPayload().copy(originCountry = "")))
 

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCaseTest.kt
@@ -167,5 +167,23 @@ class RegisterInStudBookUseCaseTest {
             )
             verify(exactly = 0) { repository.save(any()) }
         }
+
+        @Test
+        fun `前提条件違反で登録が失敗したとき審査が保存されない`() {
+            // 父が雌のため BloodHorse.create が SireNotMale を返す → 審査 save に到達しない
+            val sire = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+            val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+            val bloodHorseRepository =
+                mockk<BloodHorseRepository> {
+                    every { findAllById(setOf(sire.id, dam.id)) } returns
+                        mapOf(sire.id to sire, dam.id to dam)
+                }
+            val inspectionRepository = mockk<HorseInspectionRepository>()
+            val useCase = RegisterInStudBookUseCase(bloodHorseRepository, inspectionRepository)
+
+            useCase(command(validPayload(sire.id.value, dam.id.value)))
+
+            verify(exactly = 0) { inspectionRepository.save(any()) }
+        }
     }
 }

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCaseTest.kt
@@ -10,6 +10,7 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.Origin
 import com.example.api.domain.studbook.model.horse.bloodhorse.RegisterInStudBookError
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
 import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap
 import io.mockk.every
@@ -41,6 +42,10 @@ class RegisterInStudBookUseCaseTest {
     private fun command(payload: RegisterInStudBookCommand): Command<RegisterInStudBookCommand> =
         Command(payload, Instant.now())
 
+    /** 審査ポートのスタブ。`save` は引数（確定済み審査）をそのまま返す。 */
+    private fun inspectionRepository() =
+        mockk<HorseInspectionRepository> { every { save(any()) } answers { firstArg() } }
+
     @Nested
     inner class SuccessCase {
         @Test
@@ -53,13 +58,16 @@ class RegisterInStudBookUseCaseTest {
                         mapOf(sire.id to sire, dam.id to dam)
                     every { save(any()) } answers { firstArg() }
                 }
-            val useCase = RegisterInStudBookUseCase(repository)
+            val useCase = RegisterInStudBookUseCase(repository, inspectionRepository())
 
-            val bloodHorse = useCase(command(validPayload(sire.id.value, dam.id.value))).unwrap()
+            val registered = useCase(command(validPayload(sire.id.value, dam.id.value))).unwrap()
 
+            val bloodHorse = registered.bloodHorse
             assert(bloodHorse.origin == Origin.Domestic(sireId = sire.id, damId = dam.id))
             assert(bloodHorse.breedType == BreedType.THOROUGHBRED)
             assert(bloodHorse.registrationNumber.value == "2023104567")
+            assert(bloodHorse.inspectionId == registered.inspection.id)
+            assert(registered.inspection.microchipNumber.value == "392140000000001")
             // 父・母の引き当ては逐次 findById ではなく 1 回の一括 lookup で行う。
             verify(exactly = 1) { repository.findAllById(setOf(sire.id, dam.id)) }
             verify(exactly = 1) { repository.save(any()) }
@@ -71,7 +79,7 @@ class RegisterInStudBookUseCaseTest {
         @Test
         fun `血統登録番号がブランクのとき InvalidRegistrationNumber を返し永続化されない`() {
             val repository = mockk<BloodHorseRepository>()
-            val useCase = RegisterInStudBookUseCase(repository)
+            val useCase = RegisterInStudBookUseCase(repository, inspectionRepository())
 
             val result =
                 useCase(
@@ -88,7 +96,7 @@ class RegisterInStudBookUseCaseTest {
         @Test
         fun `マイクロチップ番号が不正なとき InvalidMicrochipNumber を返し永続化されない`() {
             val repository = mockk<BloodHorseRepository>()
-            val useCase = RegisterInStudBookUseCase(repository)
+            val useCase = RegisterInStudBookUseCase(repository, inspectionRepository())
 
             val result =
                 useCase(
@@ -112,7 +120,7 @@ class RegisterInStudBookUseCaseTest {
                     every { findAllById(setOf(BloodHorseId(sireId), BloodHorseId(damId))) } returns
                         mapOf(BloodHorseId(damId) to dam)
                 }
-            val useCase = RegisterInStudBookUseCase(repository)
+            val useCase = RegisterInStudBookUseCase(repository, inspectionRepository())
 
             val result = useCase(command(validPayload(sireId, damId)))
 
@@ -130,7 +138,7 @@ class RegisterInStudBookUseCaseTest {
                     every { findAllById(setOf(BloodHorseId(sireId), BloodHorseId(damId))) } returns
                         mapOf(BloodHorseId(sireId) to sire)
                 }
-            val useCase = RegisterInStudBookUseCase(repository)
+            val useCase = RegisterInStudBookUseCase(repository, inspectionRepository())
 
             val result = useCase(command(validPayload(sireId, damId)))
 
@@ -147,7 +155,7 @@ class RegisterInStudBookUseCaseTest {
                     every { findAllById(setOf(sire.id, dam.id)) } returns
                         mapOf(sire.id to sire, dam.id to dam)
                 }
-            val useCase = RegisterInStudBookUseCase(repository)
+            val useCase = RegisterInStudBookUseCase(repository, inspectionRepository())
 
             val result = useCase(command(validPayload(sire.id.value, dam.id.value)))
 

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -9,6 +9,7 @@ import com.example.api.application.studbook.horse.RegisterImportedHorseUseCaseEr
 import com.example.api.application.studbook.horse.RegisterInStudBookCommand
 import com.example.api.application.studbook.horse.RegisterInStudBookUseCase
 import com.example.api.application.studbook.horse.RegisterInStudBookUseCaseError
+import com.example.api.application.studbook.horse.RegisteredBloodHorse
 import com.example.api.config.ClockConfiguration
 import com.example.api.controller.horse.request.RegisterBloodHorseRequest
 import com.example.api.controller.horse.request.RegisterImportedHorseRequest
@@ -71,7 +72,11 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
     inner class SuccessCase {
         @Test
         fun `正常な入力で 201 Created と内国産の出自を持つ登録結果が返ること`() {
-            val saved = BloodHorseFixture.domesticBloodHorse()
+            val saved =
+                RegisteredBloodHorse(
+                    BloodHorseFixture.domesticBloodHorse(),
+                    BloodHorseFixture.inspection(),
+                )
             every { registerInStudBook(any<Command<RegisterInStudBookCommand>>()) } returns
                 Ok(saved)
 
@@ -163,7 +168,8 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
                     .assignName(HorseName.create("オグリキャップ").unwrap())
                     .unwrap()
                     .aggregate
-            every { nameHorse(any<Command<NameHorseCommand>>()) } returns Ok(named)
+            every { nameHorse(any<Command<NameHorseCommand>>()) } returns
+                Ok(RegisteredBloodHorse(named, BloodHorseFixture.inspection()))
 
             tester
                 .post()
@@ -273,7 +279,11 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
 
         @Test
         fun `正常な入力で 201 Created と父母不明の登録結果が返ること`() {
-            val saved = BloodHorseFixture.importedBloodHorse()
+            val saved =
+                RegisteredBloodHorse(
+                    BloodHorseFixture.importedBloodHorse(),
+                    BloodHorseFixture.inspection(),
+                )
             every { registerImportedHorse(any<Command<RegisterImportedHorseCommand>>()) } returns
                 Ok(saved)
 

--- a/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseCreateImportedTest.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseCreateImportedTest.kt
@@ -11,7 +11,8 @@ class BloodHorseCreateImportedTest {
     fun `父母不明の輸入馬が血統登録され父母 ID を持たず原産国と揚陸日を持つこと`() {
         val entry = BloodHorseFixture.importedHorseEntry(originCountry = "アイルランド")
 
-        val bloodHorse = BloodHorse.createImported(entry, registrationNumber)
+        val bloodHorse =
+            BloodHorse.createImported(entry, BloodHorseFixture.inspection(), registrationNumber)
 
         val expected =
             Origin.Imported(originCountry = entry.originCountry, landingDate = entry.landingDate)
@@ -28,7 +29,8 @@ class BloodHorseCreateImportedTest {
                 breedType = BreedType.THOROUGHBRED,
             )
 
-        val bloodHorse = BloodHorse.createImported(entry, registrationNumber)
+        val bloodHorse =
+            BloodHorse.createImported(entry, BloodHorseFixture.inspection(), registrationNumber)
 
         assert(bloodHorse.sex == Sex.FEMALE)
         assert(bloodHorse.breedType == BreedType.THOROUGHBRED)

--- a/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseCreateTest.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseCreateTest.kt
@@ -1,6 +1,7 @@
 package com.example.api.domain.studbook.model.horse.bloodhorse
 
 import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap
 import org.junit.jupiter.api.Test
@@ -13,17 +14,16 @@ class BloodHorseCreateTest {
     fun `前提条件を満たすと血統登録され父母を ID で参照する BloodHorse が生成されること`() {
         val sire = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
         val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
-        val entry =
-            BloodHorseFixture.studBookEntry(
-                breedType = BreedType.THOROUGHBRED,
-                dnaParentage = DnaParentageResult.CONSISTENT,
-            )
+        val entry = BloodHorseFixture.studBookEntry(breedType = BreedType.THOROUGHBRED)
+        val inspection = BloodHorseFixture.inspection()
 
-        val bloodHorse = BloodHorse.create(sire, dam, entry, registrationNumber).unwrap()
+        val bloodHorse =
+            BloodHorse.create(sire, dam, entry, inspection, registrationNumber).unwrap()
 
         assert(bloodHorse.origin == Origin.Domestic(sireId = sire.id, damId = dam.id))
         assert(bloodHorse.breedType == BreedType.THOROUGHBRED)
         assert(bloodHorse.registrationNumber == registrationNumber)
+        assert(bloodHorse.inspectionId == inspection.id)
     }
 
     @Test
@@ -32,7 +32,8 @@ class BloodHorseCreateTest {
         val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
         val entry = BloodHorseFixture.studBookEntry()
 
-        val result = BloodHorse.create(sire, dam, entry, registrationNumber)
+        val result =
+            BloodHorse.create(sire, dam, entry, BloodHorseFixture.inspection(), registrationNumber)
 
         assert(result.getError() == RegisterInStudBookError.SireNotMale)
     }
@@ -43,7 +44,8 @@ class BloodHorseCreateTest {
         val dam = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
         val entry = BloodHorseFixture.studBookEntry()
 
-        val result = BloodHorse.create(sire, dam, entry, registrationNumber)
+        val result =
+            BloodHorse.create(sire, dam, entry, BloodHorseFixture.inspection(), registrationNumber)
 
         assert(result.getError() == RegisterInStudBookError.DamNotFemale)
     }
@@ -52,9 +54,13 @@ class BloodHorseCreateTest {
     fun `DNA 親子判定が矛盾なし以外だと ParentageNotConfirmed を返すこと`() {
         val sire = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
         val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
-        val entry = BloodHorseFixture.studBookEntry(dnaParentage = DnaParentageResult.UNTESTED)
+        val entry = BloodHorseFixture.studBookEntry()
+        val inspection =
+            BloodHorseFixture.inspection(
+                parentage = ParentageDetermination.ByDna(DnaParentageResult.UNTESTED)
+            )
 
-        val result = BloodHorse.create(sire, dam, entry, registrationNumber)
+        val result = BloodHorse.create(sire, dam, entry, inspection, registrationNumber)
 
         assert(result.getError() == RegisterInStudBookError.ParentageNotConfirmed)
     }
@@ -65,7 +71,8 @@ class BloodHorseCreateTest {
         val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE, breedType = BreedType.THOROUGHBRED)
         val entry = BloodHorseFixture.studBookEntry(breedType = BreedType.THOROUGHBRED)
 
-        val result = BloodHorse.create(sire, dam, entry, registrationNumber)
+        val result =
+            BloodHorse.create(sire, dam, entry, BloodHorseFixture.inspection(), registrationNumber)
 
         assert(result.getError() == RegisterInStudBookError.BreedMismatch)
     }

--- a/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseFixture.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseFixture.kt
@@ -1,7 +1,9 @@
 package com.example.api.domain.studbook.model.horse.bloodhorse
 
 import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.HorseInspection
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
 import com.github.michaelbull.result.unwrap
 import java.time.LocalDate
 
@@ -13,12 +15,21 @@ import java.time.LocalDate
  * これを使えば検証を通さずに任意の馬を組み立てられる（テスト上は原産国・揚陸日が付くだけで、性・品種・ID は自由に指定できる）。
  */
 object BloodHorseFixture {
+    /** 既定の確定済み審査を生成する。親子判定は上書き可能。 */
+    fun inspection(
+        parentage: ParentageDetermination =
+            ParentageDetermination.ByDna(DnaParentageResult.CONSISTENT)
+    ): HorseInspection =
+        HorseInspection.create(
+            microchipNumber = MicrochipNumber.create("392140000000001").unwrap(),
+            parentage = parentage,
+        )
+
     /** 既定値を持つ [StudBookEntry] を生成する。必要な属性のみ上書きする。 */
     fun studBookEntry(
         sex: Sex = Sex.MALE,
         coatColor: CoatColor = CoatColor.BAY,
         breedType: BreedType = BreedType.THOROUGHBRED,
-        dnaParentage: DnaParentageResult = DnaParentageResult.CONSISTENT,
     ): StudBookEntry =
         StudBookEntry(
             sex = sex,
@@ -26,8 +37,6 @@ object BloodHorseFixture {
             breedType = breedType,
             dateOfBirth = DateOfBirth(LocalDate.of(2023, 3, 15)),
             breeder = Breeder.create("ノーザンファーム").unwrap(),
-            microchipNumber = MicrochipNumber.create("392140000000001").unwrap(),
-            dnaParentage = dnaParentage,
         )
 
     /** 既定値を持つ [FoalIdentity] を生成する。必要な属性のみ上書きする。 */
@@ -35,15 +44,12 @@ object BloodHorseFixture {
         sex: Sex = Sex.MALE,
         coatColor: CoatColor = CoatColor.BAY,
         breedType: BreedType = BreedType.THOROUGHBRED,
-        dnaParentage: DnaParentageResult = DnaParentageResult.CONSISTENT,
     ): FoalIdentity =
         FoalIdentity(
             sex = sex,
             coatColor = coatColor,
             breedType = breedType,
             breeder = Breeder.create("ノーザンファーム").unwrap(),
-            microchipNumber = MicrochipNumber.create("392140000000001").unwrap(),
-            dnaParentage = dnaParentage,
         )
 
     /**
@@ -55,6 +61,7 @@ object BloodHorseFixture {
     fun bloodHorse(sex: Sex = Sex.MALE, breedType: BreedType = BreedType.THOROUGHBRED): BloodHorse =
         BloodHorse.createImported(
             entry = importedHorseEntry(sex = sex, breedType = breedType),
+            inspection = inspection(parentage = ParentageDetermination.NotApplicable),
             registrationNumber = PedigreeRegistrationNumber.create("2023104567").unwrap(),
         )
 
@@ -71,7 +78,6 @@ object BloodHorseFixture {
             breedType = breedType,
             dateOfBirth = DateOfBirth(LocalDate.of(2020, 4, 10)),
             breeder = Breeder.create("Coolmore").unwrap(),
-            microchipNumber = MicrochipNumber.create("392140000000002").unwrap(),
             originCountry = OriginCountry.create(originCountry).unwrap(),
             landingDate = LandingDate(LocalDate.of(2024, 9, 1)),
         )
@@ -83,6 +89,7 @@ object BloodHorseFixture {
     ): BloodHorse =
         BloodHorse.createImported(
             entry = importedHorseEntry(sex = sex, breedType = breedType),
+            inspection = inspection(parentage = ParentageDetermination.NotApplicable),
             registrationNumber = PedigreeRegistrationNumber.create("2020900001").unwrap(),
         )
 
@@ -92,6 +99,7 @@ object BloodHorseFixture {
                 sire = bloodHorse(sex = Sex.MALE),
                 dam = bloodHorse(sex = Sex.FEMALE),
                 entry = studBookEntry(),
+                inspection = inspection(),
                 registrationNumber = PedigreeRegistrationNumber.create("2023104567").unwrap(),
             )
             .unwrap()

--- a/src/test/kotlin/com/example/api/domain/studbook/service/horse/RegisterFoalTest.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/service/horse/RegisterFoalTest.kt
@@ -30,7 +30,15 @@ class RegisterFoalTest {
         val foalIdentity = BloodHorseFixture.foalIdentity(breedType = BreedType.THOROUGHBRED)
 
         val bloodHorse =
-            registerFoal(liveFoalResult(), sire, dam, foalIdentity, registrationNumber).unwrap()
+            registerFoal(
+                    liveFoalResult(),
+                    sire,
+                    dam,
+                    foalIdentity,
+                    BloodHorseFixture.inspection(),
+                    registrationNumber,
+                )
+                .unwrap()
 
         assert(bloodHorse.origin == Origin.Domestic(sireId = sire.id, damId = dam.id))
         assert(bloodHorse.dateOfBirth.value == foalingDate)
@@ -48,6 +56,7 @@ class RegisterFoalTest {
                 sire,
                 dam,
                 BloodHorseFixture.foalIdentity(),
+                BloodHorseFixture.inspection(),
                 registrationNumber,
             )
 
@@ -67,6 +76,7 @@ class RegisterFoalTest {
                 sire,
                 dam,
                 BloodHorseFixture.foalIdentity(),
+                BloodHorseFixture.inspection(),
                 registrationNumber,
             )
 
@@ -84,6 +94,7 @@ class RegisterFoalTest {
                 sire,
                 dam,
                 BloodHorseFixture.foalIdentity(),
+                BloodHorseFixture.inspection(),
                 registrationNumber,
             )
 

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
@@ -57,7 +57,7 @@ class JdbcBloodHorseRepositoryContractTest(private val rows: BloodHorseSpringDat
             breedType = "THOROUGHBRED",
             dateOfBirth = LocalDate.of(2023, 3, 15),
             breeder = "ノーザンファーム",
-            microchipNumber = "392140000000001",
+            inspectionId = generateId(),
             originType = "DOMESTIC",
             sireId = generateId(),
             damId = generateId(),
@@ -72,6 +72,7 @@ class JdbcBloodHorseRepositoryContractTest(private val rows: BloodHorseSpringDat
                     sire = sire,
                     dam = dam,
                     entry = BloodHorseFixture.studBookEntry(sex = Sex.MALE),
+                    inspection = BloodHorseFixture.inspection(),
                     registrationNumber = PedigreeRegistrationNumber.create("2023109999").unwrap(),
                 )
                 .unwrap()

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionRepositoryContractTest.kt
@@ -95,6 +95,33 @@ class JdbcHorseInspectionRepositoryContractTest(
     }
 
     @Test
+    fun `血液型検査区分の審査は判別子ごと往復できる`() {
+        val inspection = HorseInspection.create(microchip, ParentageDetermination.ByBloodType)
+
+        repository.save(inspection)
+        val found = repository.findById(inspection.id)
+
+        assert(found != null)
+        assert(found!!.id == inspection.id)
+        assert(found.parentage == ParentageDetermination.ByBloodType)
+        assert(found.features == null)
+    }
+
+    @Test
+    fun `承認海外機関区分の審査は判別子ごと往復できる`() {
+        val inspection =
+            HorseInspection.create(microchip, ParentageDetermination.ByOverseasInstitution)
+
+        repository.save(inspection)
+        val found = repository.findById(inspection.id)
+
+        assert(found != null)
+        assert(found!!.id == inspection.id)
+        assert(found.parentage == ParentageDetermination.ByOverseasInstitution)
+        assert(found.features == null)
+    }
+
+    @Test
     fun `存在しないIDのfindByIdはnullを返す`() {
         assert(repository.findById(HorseInspectionId(generateId())) == null)
     }


### PR DESCRIPTION
## 概要

#312「審査サブドメイン」の **再リンク部分**（土台 PR #487 はマージ済み。本 PR はその続きで再作成）。`BloodHorse` から `microchipNumber` を外し、審査集約 `HorseInspection` を `inspectionId` で参照するよう再リンクする。集約の形を変える侵襲的な変更で、永続化・application・controller・テストが一斉に追従する。

> 補足: 当初スタック PR #485 として #487 を base にしていたが、#487 を `--delete-branch` でマージした際に GitHub が #485 をクローズしたため、同一 head ブランチから main 向けに作り直した（差分は再リンク分のみ）。

## 含む変更

- **`BloodHorse` 再リンク**: `microchipNumber` を削除し `inspectionId: HorseInspectionId` を追加。`create`/`createImported` は確定済み審査を消費し、親子判定を審査経由（`confirmsDeclaredParents()`）で検証。`StudBookEntry`/`FoalIdentity`/`ImportedHorseEntry` から識別子・DNA 判定を除去。`registerFoal` に審査を橋渡し。
- **永続化追従**: `blood_horse` の `microchip_number` 列を `inspection_id` へ差替（V3 編集。pre-prod・運用データなしのため許容）。`BloodHorseRow`・マッパー追従。
- **application/controller**: 登録系 use case は審査を生成し**成功時のみ保存**（前提条件却下時の孤児レコードを排除）、戻り値を `RegisteredBloodHorse`(軽種馬＋審査) に統一。`NameHorseUseCase` も審査を読み込み（`InspectionNotFound`→422）。**対外 API のワイヤ契約は据え置き**（`BloodHorseResponse.microchipNumber` は審査経由。新エンドポイントなし）。
- **ADR-0038**: 集約境界と識別子所有権（マイクロチップ一本化）の決定を記録。

## 設計判断

審査は血統登録より前（離乳前）に行われ、その時点で `BloodHorse` は未在。識別子を `BloodHorse` に残すと審査も識別のため持ち二重管理になるため、「審査が識別子を所有し登録が審査を参照する」構図に一本化（ADR-0038）。

## テスト

`./gradlew check` 緑（ktfmt+detekt+全 test+ArchUnit+koverVerifyMature 85%）。登録系の孤児防止テスト（`verify(exactly=0)`）・契約テストの inspectionId 往復・NameHorseUseCase のガードテストを含む。

## レビュー対応（subagent-driven ＋最終 whole-branch レビュー: With fixes・Critical 0）

- save 順序（孤児レコード）→ 成功時のみ save に修正
- ADR バリアント記述の実装一致
- NameHorseUseCase 孤児ガードのテスト保護・フォールバック区分の往復テスト追加

## フォロー issue（後回しを明示）

- #483: 複数集約書き込みのトランザクション境界（非Txな審査+軽種馬 save のインフラ障害時孤児ウィンドウ。コードに参照コメント残置, P3）
- #484: 審査を一級リソースとして API へ配線（特徴記述子・親子判定区分のワイヤ公開、422 slice テスト, P3）
- 親子判定フォールバック詳細は #267、DNA 再利用は #266 に接続

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)
