### PR TITLE
fix: Claude hook の相対パスを $CLAUDE_PROJECT_DIR 起点へ修正する (#480)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/session-start-mise.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start-mise.sh"
           }
         ]
       }
@@ -59,19 +59,19 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/post-edit-editorconfig.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-edit-editorconfig.sh",
             "timeout": 15,
             "statusMessage": "EditorConfig チェック中..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/post-edit-terraform-fmt.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-edit-terraform-fmt.sh",
             "timeout": 30,
             "statusMessage": "terraform fmt チェック中..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/post-edit-workflow-lint.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-edit-workflow-lint.sh",
             "timeout": 30,
             "statusMessage": "actionlint / zizmor チェック中..."
           }
@@ -83,13 +83,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/stop-kotlin-quality.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stop-kotlin-quality.sh",
             "timeout": 300,
             "statusMessage": "gradle check 実行中 (Kotlin/Java 変更時のみ)..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/stop-terraform-validate.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stop-terraform-validate.sh",
             "timeout": 60,
             "statusMessage": "terraform validate 実行中 (Terraform 変更時のみ)..."
           }


### PR DESCRIPTION
## 概要

git worktree セッション（`.claude/worktrees/<name>` 配下）で Claude Code の hook が空振りする問題を解消する。

`.claude/settings.json` の hook コマンドが相対パス `.claude/hooks/<name>.sh` で登録されているため、worktree セッションでは hook 実行時の cwd が worktree root にならず、相対参照が解決できずに `exit 127`（`No such file or directory`）で空振りしていた。`non-blocking` なので作業は止まらないが、**Stop hook の品質ゲート（`./gradlew check` / `terraform validate`）が worktree 作業では効かない**地味な安全性リグレッションになっていた。

## 変更内容

- `.claude/settings.json`: `SessionStart` / `PostToolUse` / `Stop` の全 hook コマンド（計 6 件）を相対パスから `$CLAUDE_PROJECT_DIR` 起点の絶対参照へ変更（Claude Code 公式推奨）。
  - 例: `"$CLAUDE_PROJECT_DIR"/.claude/hooks/stop-kotlin-quality.sh`
  - スペース対策で `$CLAUDE_PROJECT_DIR` をダブルクオートで囲む。
- hook スクリプト本体（`.claude/hooks/*.sh`）は変更不要。

## 検証

- 置換は 6 件すべてに適用され、JSON は妥当（`jq` でパース可）。
- worktree root 配下に 6 本の hook スクリプトが実在し実行権限あり。`$CLAUDE_PROJECT_DIR`（= この worktree root）起点なら cwd 非依存で解決することを確認。
- ※ `settings.json` の変更は実行中セッションには即時リロードされないため、実 hook 発火の最終確認（worktree セッションで `.kt` 変更 → Stop hook 発火、`infra/*.tf` 変更 → terraform validate 発火）は**次回セッションで行う**。

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)
