### PR TITLE
chore: breeding_registration.role を breeding_role へ改名し RF04 noqa を解消する

### DIFF
--- a/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/BreedingRegistrationRow.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/BreedingRegistrationRow.kt
@@ -15,7 +15,8 @@ import org.springframework.data.relational.core.mapping.Table
  * ドメインに付けず本クラスに閉じ込め、ドメイン集約とは手書きマッパーで相互変換する（[JdbcBreedingRegistrationRepository]）。
  *
  * - [id] は外部採番の UUIDv7（ドメインの `BreedingRegistrationId` の生値）。`@Id` を付けるが DB 採番はしない。
- * - [role] は [com.example.api.domain.studbook.model.breeding.BreedingRole] の enum 名を文字列で持つ。
+ * - [breedingRole] は [com.example.api.domain.studbook.model.breeding.BreedingRole] の enum 名を文字列で持つ
+ *   （列名 `breeding_role` は `role` が SQL キーワードのため接頭辞を付けたもの）。
  * - 供用停止（`BreedingRetirement`）は nullable な値オブジェクトのため、[retirementReason]（enum 名）と
  *   [retirementOccurredOn] の 2 列にフラット化する。両方とも null なら供用中、両方 non-null なら供用停止済み。
  * - [version] は楽観ロック用の `@Version` 列。null のとき Spring Data JDBC は「新規」とみなして insert する （外部採番で `@Id`
@@ -26,7 +27,7 @@ data class BreedingRegistrationRow(
     @Id @Column("id") val id: UUID,
     @Column("registration_number") val registrationNumber: String,
     @Column("registered_horse_id") val registeredHorseId: UUID,
-    @Column("role") val role: String,
+    @Column("breeding_role") val breedingRole: String,
     @Column("retirement_reason") val retirementReason: String? = null,
     @Column("retirement_occurred_on") val retirementOccurredOn: LocalDate? = null,
     @Version @Column("version") val version: Long? = null,

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepository.kt
@@ -47,7 +47,7 @@ class JdbcBreedingRegistrationRepository(
                     IllegalStateException("永続化された繁殖登録番号がブランクです: id=$id")
                 },
             registeredHorseId = BloodHorseId(registeredHorseId),
-            role = BreedingRole.valueOf(role),
+            role = BreedingRole.valueOf(breedingRole),
             retirement =
                 retirementReason?.let { reason ->
                     BreedingRetirement(
@@ -68,7 +68,7 @@ class JdbcBreedingRegistrationRepository(
             id = id.value,
             registrationNumber = registrationNumber.value,
             registeredHorseId = registeredHorseId.value,
-            role = role.name,
+            breedingRole = role.name,
             retirementReason = retirement?.reason?.name,
             retirementOccurredOn = retirement?.occurredOn,
         )

--- a/src/main/resources/db/migration/V2__create_breeding_registration.sql
+++ b/src/main/resources/db/migration/V2__create_breeding_registration.sql
@@ -2,7 +2,7 @@
 -- スキーマは H2(PostgreSQL 互換モード) と PostgreSQL の双方で適用される
 -- （ランタイムは H2、永続化の契約テストは Testcontainers の PostgreSQL。型は両者で互換）。
 -- 識別子は外部採番の UUIDv7（ADR-0005）をアプリ側で採番して渡す（DB 採番ではない）。
--- role は BreedingRole（STALLION/BROODMARE）の enum 名を保持する。
+-- breeding_role は BreedingRole（STALLION/BROODMARE）の enum 名を保持する（role は SQL キーワードのため接頭辞を付ける）。
 -- 供用停止（BreedingRetirement）は nullable な値オブジェクトのため事由と発生日の 2 列にフラット化する
 -- （両方 NULL なら供用中、両方 NOT NULL なら供用停止済み）。
 -- version は楽観ロック兼「新規 insert 判定」用の列（version が NULL のとき Spring Data JDBC が新規とみなす）。
@@ -10,7 +10,7 @@ CREATE TABLE breeding_registration (
     id UUID NOT NULL PRIMARY KEY,
     registration_number VARCHAR(255) NOT NULL,
     registered_horse_id UUID NOT NULL,
-    role VARCHAR(32) NOT NULL, -- noqa: RF04
+    breeding_role VARCHAR(32) NOT NULL,
     retirement_reason VARCHAR(32),
     retirement_occurred_on DATE,
     version BIGINT -- noqa: RF04

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepositoryContractTest.kt
@@ -55,7 +55,7 @@ class JdbcBreedingRegistrationRepositoryContractTest(
             id = id,
             registrationNumber = "B-0001",
             registeredHorseId = generateId(),
-            role = BreedingRole.STALLION.name,
+            breedingRole = BreedingRole.STALLION.name,
             retirementReason = retirementReason,
             retirementOccurredOn = retirementOccurredOn,
         )


### PR DESCRIPTION
## 概要

`breeding_registration` テーブルの `role` 列を `breeding_role` に改名し、行単位で抑制していた sqlfluff の `-- noqa: RF04`（キーワードを識別子に使用）を解消する。PR #445（SQL lint 体制 / ADR-0032）レビューでの合意（#449）に基づく小さな後追い PR。

Closes #449

## やったこと

- **マイグレーション** `V2__create_breeding_registration.sql`: 列 `role` → `breeding_role` に改名し `-- noqa: RF04` を削除。列コメントも追従（接頭辞を付けた理由を明記）。
- **永続化モデル** `BreedingRegistrationRow.kt`: テーブル行を映すモデルのため `@Column("breeding_role") val breedingRole` に改名。KDoc 参照 `[role]` → `[breedingRole]` に追従。
- **マッパー** `JdbcBreedingRegistrationRepository.kt`: 手書きマッパー 2 箇所をドメイン `role` ↔ Row `breedingRole` の対応に更新。
- **契約テスト** `JdbcBreedingRegistrationRepositoryContractTest.kt`: Row 構築の名前付き引数を `breedingRole` に更新。

## スコープ外

- `version` 列は Spring Data JDBC の楽観ロック列の慣習（`@Version` 既定プロパティ名）で V1（jockey）とも一貫するため改名せず、`-- noqa: RF04` を維持（#449 のスコープ外指定どおり）。
- ドメイン / DTO 側の `role` プロパティは SQL キーワード問題と無関係のため改名しない（DB 列のみ対象）。

## 検証

- `mise exec -- sqlfluff lint src/main/resources/db/migration` … noqa 無しで **All Finished!**（RF04 解消を確認）
- `mise exec -- squawk src/main/resources/db/migration/*.sql` … 0 issues
- `./gradlew check` … **BUILD SUCCESSFUL**（Testcontainers の実 PostgreSQL 契約テストで新列 `breeding_role` を端から端まで検証。ktfmt / detekt / koverVerifyMature 含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
