### PR TITLE
chore: ローカル/CI/smoke を PostgreSQL 化する（#451 Phase A）

### DIFF
--- a/.github/workflows/container-smoke-test.yml
+++ b/.github/workflows/container-smoke-test.yml
@@ -49,21 +49,37 @@ jobs:
       - name: Build Docker image with bootBuildImage
         run: ./gradlew bootBuildImage --imageName=api-smoke:test
 
-      # メモリ値は deploy.yml の --memory と揃えること。
-      # docker の `-m 1g` は 1 GiB (= 1024 MiB) を表し、gcloud の `--memory=1Gi` と等価。
-      # 単位表記が異なるため、片方だけを更新しないよう注意する。
-      - name: Smoke test container with prod-like memory limit
+      # smoke でも実 PostgreSQL を用意し、本番と同じ env 注入経路（SPRING_DATASOURCE_*）で
+      # 起動する。Flyway の起動時マイグレーション・DB health まで含めて本番相当を検証する。
+      # メモリ値は deploy.yml の --memory と揃えること（docker の -m 1g = gcloud の --memory=1Gi）。
+      - name: Smoke test container against PostgreSQL with prod-like memory limit
         run: |
-          docker run -d --name api-smoke -m 1g -p 8080:8080 -e PORT=8080 api-smoke:test
+          docker network create smoke
+          docker run -d --name pg --network smoke \
+            -e POSTGRES_DB=toybox -e POSTGRES_USER=toybox -e POSTGRES_PASSWORD=toybox \
+            postgres:17
+          # postgres が接続受付になるまで待つ
+          for _ in {1..30}; do
+            if docker exec pg pg_isready -U toybox -d toybox >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          docker run -d --name api-smoke --network smoke -m 1g -p 8080:8080 \
+            -e PORT=8080 \
+            -e SPRING_DATASOURCE_URL=jdbc:postgresql://pg:5432/toybox \
+            -e SPRING_DATASOURCE_USERNAME=toybox \
+            -e SPRING_DATASOURCE_PASSWORD=toybox \
+            api-smoke:test
+          ok=false
           for _ in {1..60}; do
             if curl -sf http://localhost:8080/actuator/health | grep -q '"status":"UP"'; then
-              echo "Container healthy"
-              docker rm -f api-smoke
-              exit 0
+              echo "Container healthy"; ok=true; break
             fi
             sleep 1
           done
-          echo "Container did not become healthy in 60s"
-          docker logs api-smoke
-          docker rm -f api-smoke
-          exit 1
+          if [ "$ok" != true ]; then
+            echo "Container did not become healthy in 60s"
+            docker logs api-smoke
+          fi
+          docker rm -f api-smoke pg
+          docker network rm smoke
+          [ "$ok" = true ]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,10 +30,9 @@ dependencies {
     implementation(libs.spring.ai.starter.mcp.server.webmvc)
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     // 永続化アクセス（Spring Data JDBC + Flyway）。集約 write は Spring Data JDBC（集約 = 永続化境界）。
-    // ランタイムの datasource は当面 H2（PostgreSQL 互換モード）の組み込み DB のまま据え置く。実リポジトリは
-    // まだ InMemory Bean のため datasource/Flyway は付随的に初期化されるだけで、本番 PostgreSQL 化（Cloud SQL
-    // 配線）は実永続化を使う #423 / インフラ作業に委ねる。一方、永続化の契約テストは本番ターゲットの
-    // PostgreSQL を Testcontainers で用意して検証する（ADR-0027 / #422。testing.md の宿題に対応）。
+    // 本番ランタイムの datasource は Prisma Postgres（実 PostgreSQL v17）へ配線する（#451 / ADR-0044）。
+    // ローカル/CI/smoke も PostgreSQL に寄せ、既定の組み込み H2 は cutover で全面脱却する。永続化の契約
+    // テストは本番ターゲットの PostgreSQL を Testcontainers で用意して検証する（ADR-0027 / #422）。
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
     // Flyway は starter で引く。Spring Boot 4 は autoconfig を機能別モジュールに分割しており、
     // FlywayAutoConfiguration は spring-boot-autoconfigure ではなく専用モジュール spring-boot-flyway
@@ -42,10 +41,11 @@ dependencies {
     // flyway-core を引き込む。
     implementation("org.springframework.boot:spring-boot-starter-flyway")
     runtimeOnly("com.h2database:h2")
-    // PostgreSQL ドライバと Flyway の PostgreSQL モジュール（Flyway 10+ は DB 別サポートをモジュール分割）は
-    // 契約テスト（Testcontainers）でのみ要るため testRuntimeOnly に置く。本番 jar・ランタイムには載らない。
-    testRuntimeOnly("org.postgresql:postgresql")
-    testRuntimeOnly("org.flywaydb:flyway-database-postgresql")
+    // PostgreSQL ドライバと Flyway の PostgreSQL モジュール（Flyway 10+ は DB 別サポートをモジュール分割）。
+    // 本番ランタイムは Prisma Postgres（実 PostgreSQL v17）へ接続するため runtimeOnly で本番 jar に載せる
+    // （#451 / ADR-0044）。契約テスト（Testcontainers）でも runtimeOnly は testRuntimeClasspath に含まれる。
+    runtimeOnly("org.postgresql:postgresql")
+    runtimeOnly("org.flywaydb:flyway-database-postgresql")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation(libs.java.uuid.generator)
     implementation(libs.kotlin.result)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,9 @@ dependencies {
     // flyway-core を引き込む。
     implementation("org.springframework.boot:spring-boot-starter-flyway")
     runtimeOnly("com.h2database:h2")
+    // ローカル開発（bootRun）時に compose.yaml の PostgreSQL を自動起動し datasource を自動配線する。
+    // developmentOnly のため本番イメージ（bootBuildImage）・テスト classpath には載らない（#451）。
+    developmentOnly("org.springframework.boot:spring-boot-docker-compose")
     // PostgreSQL ドライバと Flyway の PostgreSQL モジュール（Flyway 10+ は DB 別サポートをモジュール分割）。
     // 本番ランタイムは Prisma Postgres（実 PostgreSQL v17）へ接続するため runtimeOnly で本番 jar に載せる
     // （#451 / ADR-0044）。契約テスト（Testcontainers）でも runtimeOnly は testRuntimeClasspath に含まれる。

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,13 @@
+# ローカル開発（./gradlew bootRun）用の PostgreSQL。spring-boot-docker-compose が
+# このファイルを検出してコンテナを起動し、datasource（url/username/password）を
+# 自動配線する。本番は Prisma Postgres（#451 / ADR-0044）で、このファイルは開発専用。
+# バージョンは本番ターゲットの PostgreSQL v17 に揃える。
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_DB: toybox
+      POSTGRES_USER: toybox
+      POSTGRES_PASSWORD: toybox
+    ports:
+      - "5432:5432"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,12 +9,14 @@ spring:
       enabled: true
   # ランタイムの永続化データソース。永続化実装は JDBC 一本に統一し（ADR-0030）、JDBC リポジトリが実際に
   # 読み書きする。デフォルトは Docker 不要の組み込み H2 を PostgreSQL 互換モード（識別子は小文字へ畳む）で
-  # 使い、本番ターゲット DB（PostgreSQL）の挙動へ寄せる。本番は環境変数で datasource を PostgreSQL に
-  # 差し替える（Cloud SQL 新設・Cloud Run 配線は別途インフラ作業）。永続化の契約テストは本番ターゲットの
-  # PostgreSQL を Testcontainers で用意して検証する（PostgresContainerSupport が datasource を上書きする）。
+  # 使い、本番ターゲット DB（PostgreSQL）の挙動へ寄せる。本番は環境変数（SPRING_DATASOURCE_URL 等）で
+  # datasource を Prisma Postgres に差し替える（#451 / ADR-0044）。driver-class-name は明示せず JDBC URL
+  # から導出させる（H2 URL→H2 ドライバ / postgresql URL→PG ドライバ）。これにより env は URL の差し替え
+  # だけで DB を切り替えられる（driver をピンすると URL だけ上書きしたとき H2 ドライバが postgresql URL を
+  # 掴もうとして起動失敗する）。永続化の契約テストは本番ターゲットの PostgreSQL を Testcontainers で用意して
+  # 検証する（PostgresContainerSupport が datasource を上書きする）。
   datasource:
     url: jdbc:h2:mem:toybox;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1
-    driver-class-name: org.h2.Driver
     username: sa
     password: ""
   # マイグレーションは Flyway（plain SQL）。db/migration 配下の V*.sql を起動時に適用する。

--- a/src/test/kotlin/com/example/api/support/PostgresContainerSupport.kt
+++ b/src/test/kotlin/com/example/api/support/PostgresContainerSupport.kt
@@ -29,9 +29,8 @@ abstract class PostgresContainerSupport {
         @JvmStatic
         @DynamicPropertySource
         fun datasourceProperties(registry: DynamicPropertyRegistry) {
-            // app.yml は driver-class-name を H2 に固定しているため、URL だけ差し替えると
-            // ドライバ（H2）と URL（PostgreSQL）が食い違い datasource 初期化に失敗する。ドライバも上書きする。
-            registry.add("spring.datasource.driver-class-name", postgres::getDriverClassName)
+            // driver-class-name は app.yml で明示せず JDBC URL から導出させる方針（#451）。ここでも
+            // URL（PostgreSQL）だけ差し替えれば Spring がドライバを PostgreSQL に導出する（本番と同じ経路）。
             registry.add("spring.datasource.url", postgres::getJdbcUrl)
             registry.add("spring.datasource.username", postgres::getUsername)
             registry.add("spring.datasource.password", postgres::getPassword)


### PR DESCRIPTION
## 概要

#451「本番ランタイムを Prisma Postgres へ配線」の **Phase A**。**Prisma 非依存**で、ローカル/CI/smoke を PostgreSQL に寄せる段階。prod は本 PR ではまだ H2 フォールバックのまま（安全・main は常にデプロイ可能）。設計・位相は #451 本文（Phase A〜E）を参照。

## 変更

- **PG ドライバを本番ランタイムへ昇格**（`9e6aaea`）: `org.postgresql:postgresql` / `org.flywaydb:flyway-database-postgresql` を `testRuntimeOnly` → `runtimeOnly` へ。本番 jar に載る。`h2` は残す。
- **ローカル開発を docker-compose で PG 化**（`21be74b`）: `spring-boot-docker-compose`(developmentOnly) ＋ `compose.yaml`(postgres:17)。`./gradlew bootRun` が PG を自動起動・自動配線。本番イメージ・test classpath には非搭載。
- **smoke test を実 PostgreSQL 化**（`7ee40ce`）: `container-smoke-test.yml` を、ユーザー定義ネットワーク上の postgres:17 へ本番と同じ env 注入経路（`SPRING_DATASOURCE_*`）で接続して起動。Flyway 起動時マイグレーション・DB health まで本番相当を検証。

## 検証

- `./gradlew check` 全パス（ktfmt / detekt / test / koverVerifyMature）。
- ローカル `bootRun` で Docker Compose 起動・Flyway 5 件適用・`{"status":"UP"}`・PostgreSQL 17.10 接続を実地確認。
- 本番 fat jar に `spring-boot-docker-compose` 非搭載（`0`）・PG ドライバ搭載を確認。
- smoke workflow は本 PR の CI（`container-smoke-test`）で GitHub ランナーの実 docker により実地検証される。

## スコープ外（後続フェーズ）

- `application.yml` の H2 既定除去・`h2` 依存 drop は **cutover（Phase D）** で prod に Prisma env を与える切替と同一リリースで行う（main を常にデプロイ可能に保つ順序制約）。本 PR では H2 を残す。
- Prisma インスタンス新設（Terraform provider・Phase C）／de-risk spike（Phase B）は別 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
