### PR TITLE
chore: Claude Code の Kotlin LSP プラグインを採用する (#510)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "enabledPlugins": {
+    "kotlin-lsp@claude-plugins-official": true
+  },
   "permissions": {
     "deny": [
       "Bash(gcloud * deploy *)",

--- a/.devcontainer/allowed-domains.txt
+++ b/.devcontainer/allowed-domains.txt
@@ -46,6 +46,9 @@ download.jetbrains.com
 cache-redirector.jetbrains.com
 plugins.jetbrains.com
 data.services.jetbrains.com
+# kotlin-lsp（Claude Code の Kotlin LSP プラグインが要求する Language Server）を mise で取得する先。
+# 無いと devcontainer 内の `mise install` が http:kotlin-lsp のダウンロードで落ちる。採否は ADR-0046。
+download-cdn.jetbrains.com
 
 # --- Docker Hub（DinD の dockerd が pull する先）---
 # Testcontainers 契約テスト（postgres:17-alpine + Ryuk）と terraform MCP（docker run）の

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ Issue の優先度は **GitHub Projects（`toy-box` = Project #4）の `Priority
 
 ### mise
 
-セットアップは `mise install`、確認は `mise list`（未導入なら [mise インストール手順](https://mise.jdx.dev/getting-started.html)）。管理ツール（詳細は `mise.toml`）: ビルド用 JDK（`java` Temurin 21）、lint / 解析（`actionlint` / `editorconfig-checker` / `shellcheck` / `sqlfluff` / `squawk` / `zizmor` / `gitleaks`）、Git フック（`lefthook`）、シークレット（`fnox`）、インフラ（`terraform` と HCP Terraform 操作 CLI の `tfctl`。tfctl の採否は [ADR-0034](docs/adr/0034-adopt-tfctl-cli.md)）。
+セットアップは `mise install`、確認は `mise list`（未導入なら [mise インストール手順](https://mise.jdx.dev/getting-started.html)）。管理ツール（詳細は `mise.toml`）: ビルド用 JDK（`java` Temurin 21）、lint / 解析（`actionlint` / `editorconfig-checker` / `shellcheck` / `sqlfluff` / `squawk` / `zizmor` / `gitleaks`）、Git フック（`lefthook`）、シークレット（`fnox`）、インフラ（`terraform` と HCP Terraform 操作 CLI の `tfctl`。tfctl の採否は [ADR-0034](docs/adr/0034-adopt-tfctl-cli.md)）、コードインテリジェンス（`kotlin-lsp`＝Claude Code の Kotlin LSP プラグインが要求する JetBrains 公式 Language Server。採否と供給方法は [ADR-0046](docs/adr/0046-adopt-kotlin-lsp-plugin.md)）。
 
 **Java バージョン管理について**: JDK のバージョン要件は `build.gradle.kts` の Gradle toolchain で宣言（`languageVersion = 21`）。実体の JDK は mise が提供し、Gradle の toolchain auto-detection が `JAVA_HOME` / `PATH` 経由で検出する。
 
@@ -193,6 +193,8 @@ LEFTHOOK_EXCLUDE=ktfmt-check git commit -m "メッセージ"   # 特定コマン
 ## MCP サーバー設定
 
 必要な MCP は各自が `/plugin` 等でアドホックに入れず、**リポジトリ管理の設定ファイルに宣言**して共有する（クローンすれば同一構成・再現性が保たれる。経緯は [ADR-0003](docs/adr/0003-consolidate-mcp-config-in-repo.md)）。Claude Code 用は `.mcp.json`（リポジトリ root。採用は `context7`＝ライブラリ最新ドキュメント参照 / `terraform`＝レジストリ・プロバイダ参照）、VS Code・Copilot 用は `.vscode/mcp.json`（別フォーマット・別ファイルで併存。共通 MCP（例 `context7`）は両者を同期）。`.mcp.json` を唯一の出所とし、グローバル設定や `/plugin` で同名サーバーを二重定義しない（初回はクローン後の承認プロンプトに応じる。承認状態は各自の `~/.claude.json`）。
+
+同じ「リポジトリ管理で宣言・共有」の方針で、**Claude Code の LSP プラグインは `.claude/settings.json` の `enabledPlugins` に宣言**する（現状 `kotlin-lsp@claude-plugins-official`＝Kotlin の編集時診断・コードナビ）。要求バイナリ `kotlin-lsp`（JetBrains 公式）は mise 管理で供給する（`mise install`）。LSP はゲート（detekt / ArchUnit / gradle check）を置き換えない補助で、採否と供給方法は [ADR-0046](docs/adr/0046-adopt-kotlin-lsp-plugin.md)。
 
 **GitHub 操作は MCP ではなく `gh` CLI で行う**（[ADR-0001](docs/adr/0001-drop-github-mcp-use-gh-cli.md)）。サンドボックス下の TLS 問題（`OSStatus -26276`）は、`gh` を `.claude/settings.local.json` の `sandbox.excludedCommands` に `"gh"` と `"gh *"` の両方で登録して sandbox 外で実行し回避する。複合コマンド（`A && gh ...`）はマッチしないので `gh` は単体コマンドで実行する。
 

--- a/docs/adr/0046-adopt-kotlin-lsp-plugin.md
+++ b/docs/adr/0046-adopt-kotlin-lsp-plugin.md
@@ -1,0 +1,57 @@
+# 0046. Claude Code の Kotlin LSP プラグインを採用し kotlin-lsp を mise http バックエンドで配布する
+
+- Status: Accepted
+- Date: 2026-07-01
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+Claude Code は公式マーケットプレイス（`claude-plugins-official`）の言語別 LSP プラグインで、エージェント（Claude Code）向けの**コードインテリジェンス**を有効化できる（組み込み機能）。有効化するとエージェントは以下を得る:
+
+- **編集直後の自動診断**: 型エラー・import 不足・構文エラーを即報告し、誤りを入れても同ターン内に検出・修正できる（compile / linter の実走を待たない）。
+- **コードナビゲーション**: 定義ジャンプ・参照検索・型ホバー・呼び出し階層追跡。grep ベースより正確で、大規模コードでのファイル読み込みを削減する。
+
+本プロジェクトは Kotlin 主体であり、この補助が内側ループ（編集→検証）の速度・正確性に効くと見込まれたため採否を評価した（#510）。
+
+評価で確定した一次情報:
+
+- プラグイン `kotlin-lsp@claude-plugins-official` の実体（README / `marketplace.json`）は、PATH 上の `kotlin-lsp` を `--stdio` で起動する。要求バイナリは **JetBrains 公式 `Kotlin/kotlin-lsp`**（`brew install JetBrains/utils/kotlin-lsp` を案内。IntelliJ 解析エンジン基盤で K2 完全対応）。**fwcd/kotlin-language-server ではない**（fwcd は最終 1.3.13＝2025-01 で保守停滞・K2 追随が弱く、現行コード（K2 / value class / Spring）に誤診断を出してエージェントを誤誘導するため不適）。
+- JetBrains 公式の配布は `download-cdn.jetbrains.com`（mac は `.sit`、Linux は `.tar.gz`、Windows は `.zip`）で、**GitHub Releases にバイナリ資産が無い**。公式の brew tap（`JetBrains/utils`）は `depends_on :macos` で **macOS 限定**。
+- 現時点で JetBrains kotlin-lsp は experimental（pre-alpha）扱い・一部クローズドソース。版は JetBrains ビルド番号（評価時点 `262.8190.0`）。
+
+## Decision（決定）
+
+Kotlin LSP プラグインを**採用する**。運用方針は以下。
+
+### プラグインはリポジトリ管理で宣言する
+
+`.claude/settings.json` の `enabledPlugins` に `"kotlin-lsp@claude-plugins-official": true` を宣言し、**クローンすれば同一構成**にする（MCP をリポジトリ管理で共有する [ADR-0003](0003-consolidate-mcp-config-in-repo.md) と同じ思想）。`claude-plugins-official` は組み込みの公式マーケットプレイスのため追加登録は不要。プラグインの取り込みは初回にユーザーの信頼承認を経る（無確認では走らない）。
+
+### バイナリ供給: mise の http バックエンドでクロスプラットフォームに配布する
+
+公式導入路（brew tap）は macOS 限定で、GitHub Releases 資産が無く ubi / aqua も使えない。本プロジェクトのツールは mise で版管理し `mise.lock` でクロスプラットフォーム再現性を担保する方針のため、[tfctl（ADR-0034）](0034-adopt-tfctl-cli.md) と同様に **http バックエンド**で `download-cdn.jetbrains.com` を直接指す（`mise.toml` の `[tools."http:kotlin-lsp"]`）。
+
+- **形式**: mac の `.sit` は実体が zip のため `format = "zip"` で明示、Linux は `.tar.gz`（自動判定）。プラットフォーム別 URL を `{{version}}` テンプレートにし、**バージョン更新は version フィールド 1 箇所＋4 checksum**で済ませる。
+- **コマンド名**: アーカイブは version 付きトップディレクトリ（`kotlin-server-<version>/`）配下にランチャ `kotlin-lsp.sh` を持つ。`strip_components = 1` で剥がし `rename_exe = "kotlin-lsp"` でプラグイン期待名 `kotlin-lsp` として PATH に出す。
+- **整合性**: http バックエンドは aqua / ubi と異なり `mise.lock` に per-platform SHA を埋めないため、公式 `<asset>.sha256` の値を各プラットフォームの `checksum` に**インラインで固定**する（tfctl と同じ運用）。
+- **検証**: macOS arm64 で `mise install http:kotlin-lsp` が成功し、`kotlin-lsp --version` が `LS-262.8190.0` を返すことを確認済み。Linux 分は同型設定（`tar.gz`）だが未実機検証のため、devcontainer で使う際に確認する。
+
+### 役割: ゲートは置き換えない補助操舵
+
+LSP＝**編集時のリアルタイム診断・ナビ**、detekt / ArchUnit / gradle check（stop hook の check 含む）＝**バッチの品質検証（ゲート）**。両者は目的が異なり補完関係で、LSP はゲートを置き換えない。gradle check 前に誤りへ気づけて内側ループが速くなる、が狙い。
+
+### #462 との関係
+
+「必要な外部スキル / プラグインを設定ファイルで宣言して一括登録する仕組み」（#462）は別スコープ。本決定は当面 `enabledPlugins` に**この 1 プラグインを手動宣言**するに留め、一般化した宣言・一括登録の仕組みは #462 で扱う。
+
+## Consequences（結果・影響）
+
+- `mise install` で誰でも `kotlin-lsp` バイナリが入り、クローンすればプラグインが有効化候補になる（初回承認後）。編集直後にエージェントが型・import・構文の診断を得られ、定義/参照ナビでファイル読み込みを減らせる。
+- **保守コスト**: registry / Dependabot による自動更新は効かない。バージョン更新は `mise.toml` の version + 4 checksum を公式 `.sha256` から手動更新する（手順はコメントに明記）。JetBrains kotlin-lsp が aqua-registry 収載 / mise registry 短名化 / GA に達したら、より標準的な backend への移行を再評価する。
+- **pre-alpha リスク**: JetBrains kotlin-lsp は experimental・一部クローズドソースで、ビルド番号ごとに挙動差の余地がある。バージョン固定で受け止め、追従是非を都度判断する。誤診断が実害になる場合はプラグインを無効化（`enabledPlugins` を false / 削除）できる。
+- **負荷**: IntelliJ 解析エンジン基盤のためメモリ消費が大きく、Gradle daemon / Testcontainers との同時稼働時は負荷に注意（16GB クラスのマシンでは特に）。
+- **プラットフォーム**: 設定は 4 プラットフォーム対称だが実機検証は macOS arm64 のみ。Linux（devcontainer / CI）で LSP を使う場合は別途確認する（CI ゲートには LSP は不要）。
+- **devcontainer firewall**: egress 許可リスト（`.devcontainer/allowed-domains.txt`、[ADR-0037](0037-devcontainer-egress-firewall.md)）に配布ホスト `download-cdn.jetbrains.com` を追加した（無いと devcontainer 内 `mise install` が落ちる）。
+- **CI への波及**: mise-action を使う lint 系ジョブ（shellcheck / sql-check / terraform-check / copilot-setup）は mise.toml の全ツールを install するため kotlin-lsp も取得する（mise-action のキャッシュで初回以降は再ダウンロードされない）。gradle 系ジョブ（api-tests / e2e-tests 等）は mise を経由しないため対象外。CI は LSP を必要としないが、tfctl 同様「全ツールを mise.toml に集約し CI も install する」既存パターンに合わせて許容する。
+- **mise.lock**: http バックエンドは per-platform SHA を `mise.lock` に永続化しない（tfctl と同じく version + backend の stub のみ）。クロスプラットフォームの整合性は `mise.toml` インラインの 4 checksum が担保する。
+- 運用ルールの結論は CLAUDE.md「ツール管理」に記載（経緯は本 ADR）。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,3 +54,4 @@
 | [0042](0042-defer-external-id-policy-keep-raw-uuid.md) | 外部公開 ID は当面 生 UUID 据え置きとし、不透明化・別 ID 体系の導入を遅延する | Accepted |
 | [0043](0043-aggregate-to-table-mapping-guidelines.md) | 集約⇔テーブルのマッピング指針（sealed/埋め込み VO のフラット化・CHECK 必須・子テーブル化の境界）を定める | Accepted |
 | [0044](0044-adopt-prisma-postgres-for-production-db.md) | 本番 DB プロダクトに Prisma Postgres を採用する（H2 脱却・東京リージョン・標準 JDBC） | Accepted |
+| [0046](0046-adopt-kotlin-lsp-plugin.md) | Claude Code の Kotlin LSP プラグインを採用し kotlin-lsp を mise http バックエンドで配布する | Accepted |

--- a/mise.lock
+++ b/mise.lock
@@ -249,6 +249,10 @@ url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8
 checksum = "sha256:d29144deff3a68aa93ced33dddf84b7fdc26070add4aa0f4513094c8332afc4e"
 url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_windows_x64.zip"
 
+[[tools."http:kotlin-lsp"]]
+version = "262.8190.0"
+backend = "http:kotlin-lsp"
+
 [[tools."http:tfctl"]]
 version = "0.3.0"
 backend = "http:tfctl"

--- a/mise.toml
+++ b/mise.toml
@@ -45,3 +45,40 @@ checksum = "sha256:5526b438bb66c5bc872f55c4bbb7325bb3e9d162ddd392eed3d60f407598c
 [tools."http:tfctl".platforms.linux-arm64]
 url = "https://releases.hashicorp.com/tfctl/{{version}}/tfctl_{{version}}_linux_arm64.zip"
 checksum = "sha256:1060b2903cd8f9cb0af5c878cf89790e0f588b735b6715d2eeadd52c5a71f8c5"
+
+# kotlin-lsp: JetBrains 公式 Kotlin Language Server。Claude Code の `kotlin-lsp@claude-plugins-official`
+# プラグイン（.claude/settings.json で有効化）が要求するバイナリで、PATH 上の `kotlin-lsp --stdio` を起動する。
+# 役割は「編集時のリアルタイム診断・コードナビ」で、detekt / ArchUnit / gradle check（stop hook）等のゲートは
+# 置き換えない補助操舵。採否・設計は ADR-0046 参照。
+#
+# 供給経路: JetBrains 公式配布は download-cdn.jetbrains.com（GitHub Releases に資産なし → ubi / aqua 不可、
+# 公式 brew tap は macOS 限定）。クロスプラットフォーム再現性を保つため tfctl と同様に http バックエンドで
+# 直接指す。mac は `.sit`（実体は zip なので `format = "zip"` で明示）、Linux は `.tar.gz`。
+# 版は JetBrains ビルド番号（例 262.8190.0）。更新時は version と 4 checksum を差し替える。
+#
+# checksum は公式 <asset>.sha256（同 URL に `.sha256` を付けたファイル）の値を固定する。http バックエンドは
+# aqua / ubi と異なり mise.lock に per-platform SHA を埋めないため、ここで明示して整合性を担保する。
+# strip_components=1 で version 付きトップディレクトリ（kotlin-server-<version>/）を剥がし、その直下の
+# ランチャ `kotlin-lsp.sh` を rename_exe でコマンド名 `kotlin-lsp` として PATH に出す。
+[tools."http:kotlin-lsp"]
+version = "262.8190.0"
+strip_components = 1
+rename_exe = "kotlin-lsp"
+
+[tools."http:kotlin-lsp".platforms.macos-x64]
+url = "https://download-cdn.jetbrains.com/language-server/kotlin-server/{{version}}/kotlin-server-{{version}}.sit"
+format = "zip"
+checksum = "sha256:f3845ae9ee38c22ef5e436390d86a3d908f77073e9667fa643a5ae0957c19728"
+
+[tools."http:kotlin-lsp".platforms.macos-arm64]
+url = "https://download-cdn.jetbrains.com/language-server/kotlin-server/{{version}}/kotlin-server-{{version}}-aarch64.sit"
+format = "zip"
+checksum = "sha256:e20183262784bb7e665ce1aea4855872a8b16f211ebb478d452773553732d9fb"
+
+[tools."http:kotlin-lsp".platforms.linux-x64]
+url = "https://download-cdn.jetbrains.com/language-server/kotlin-server/{{version}}/kotlin-server-{{version}}.tar.gz"
+checksum = "sha256:8b4c70e95065420e7867c99aaf9f18e0b4e76311ec453e4c1a39e3f6ae774cbf"
+
+[tools."http:kotlin-lsp".platforms.linux-arm64]
+url = "https://download-cdn.jetbrains.com/language-server/kotlin-server/{{version}}/kotlin-server-{{version}}-aarch64.tar.gz"
+checksum = "sha256:c3edd59ef34a7faa4d04f3517afb7a932b19c3f9cf17d1a14e9da17b0b5440ad"


### PR DESCRIPTION
## 概要

Claude Code の Kotlin LSP プラグイン（`kotlin-lsp@claude-plugins-official`）を採用する（#510 の検討結果）。エージェントが**編集直後の自動診断（型・import・構文）とコードナビ**を得られるようにする。LSP はゲート（detekt / ArchUnit / gradle check）を置き換えない補助操舵。決定経緯は ADR-0046。

## 調査で確定した一次情報

- プラグインが要求するバイナリは **JetBrains 公式 `Kotlin/kotlin-lsp`**（PATH 上の `kotlin-lsp --stdio` を起動。IntelliJ エンジン基盤で K2 完全対応）。**fwcd/kotlin-language-server ではない**（fwcd は deprecated・K2 弱で誤診断リスク）。
- 公式配布は `download-cdn.jetbrains.com`（mac `.sit` / Linux `.tar.gz`）で GitHub Releases 資産なし。公式 brew tap は macOS 限定。→ クロスプラットフォーム再現性のため tfctl（ADR-0034）同様 **mise http バックエンド**で配布する。

## 変更点

- **mise.toml**: `[tools."http:kotlin-lsp"]` を追加。mac `.sit` は `format = "zip"`、Linux は `tar.gz`。`strip_components = 1` + `rename_exe = "kotlin-lsp"` でコマンド名 `kotlin-lsp` を PATH に出す。4 プラットフォームの checksum を公式 `.sha256` からインライン固定。
- **mise.lock**: http バックエンドの stub のみ（tfctl と同形。per-platform SHA は永続化されない → 整合性は mise.toml インライン checksum が担保）。
- **.claude/settings.json**: `enabledPlugins` に宣言しクローンで同一構成（初回は信頼承認を経る）。
- **.devcontainer/allowed-domains.txt**: 配布ホスト `download-cdn.jetbrains.com` を egress 許可リストに追加（無いと devcontainer の `mise install` が落ちる）。
- **docs/adr/0046**: 採否・供給方法・帰結を記録し索引へ追加。
- **CLAUDE.md**: ツール管理に `kotlin-lsp`、MCP 節に LSP プラグイン宣言方針を追記。

## 検証

- macOS arm64 で `mise install http:kotlin-lsp` 成功、`kotlin-lsp --version` → `LS-262.8190.0`（brew formula のテストと一致）を実機確認。
- `ec`（EditorConfig）変更ファイル全て合格。JSON 妥当性 OK。mise.lock 手編集後も `mise ls` / `kotlin-lsp --version` 正常。

## 既知の留意点

- **Linux / devcontainer は未実機検証**（設定は同型 `tar.gz`。firewall 許可は追加済み）。
- **pre-alpha**: JetBrains kotlin-lsp は experimental・一部クローズド。挙動差は version 固定で受け、追従是非を都度判断。誤診断が実害ならプラグインを無効化できる。
- **CI**: mise-action の lint 系ジョブが全ツール install するため kotlin-lsp も取得（キャッシュあり）。gradle 系ジョブは mise 非経由で対象外。
- **保守**: registry / Dependabot 自動更新は効かない。更新は version + 4 checksum を手動差し替え。

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
