### PR TITLE
docs: ADR-0047/0048 DB スキーマ設計（集約間 FK 安全網・コンテキスト別スキーマ）を記録

### DIFF
--- a/docs/adr/0047-cross-aggregate-foreign-keys-as-safety-net.md
+++ b/docs/adr/0047-cross-aggregate-foreign-keys-as-safety-net.md
@@ -1,0 +1,60 @@
+# 0047. 集約間参照に外部キー制約を安全網として張る（DB 参照整合性の多層防御）
+
+- Status: Accepted
+- Date: 2026-07-02
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+tbls 導入（#447）の crit レビューで、生成された ER 図に集約テーブル間の関連線が出ないのは **DB に外部キー(FK)制約を張っていない**ためと指摘された（#508）。現状、集約間の参照はすべて**アプリ側の UUID 列**で表し、FK を張っていない。
+
+参照関係（いずれも現状 FK なし）:
+
+- `breeding_registration.registered_horse_id` → `blood_horse`
+- `blood_horse.inspection_id` → `horse_inspection`（別サブドメイン集約、[0038](0038-inspection-subdomain-aggregate.md)）
+- `blood_horse.sire_id` / `dam_id` → `blood_horse`（父・母。自己参照）
+- `breeding_result.breeding_registration_id` → `breeding_registration`
+- `breeding_result.covering_stallion_id` → `blood_horse`（種付種牡馬）
+
+論点は「**DB レベルの参照整合性を担保すべきか**」。crit の関心は主に整合性担保（ER 図の可視化は副次）にある。
+
+### 技術的成立性
+
+現行ドメインモデルでは、これら参照先はすべて**自 DB の登録済み行**を指す（`registerInStudBook` は解決済みの `sire`/`dam: BloodHorse` を引数で要求し、`recordCovering` は種牡馬の `BreedingRegistration` を要求する）。よって FK は 6 本すべてで技術的に成立する。すなわち本 ADR の争点は「張れるか」ではなく、「**集約独立性を一部譲ってでも DB 安全網を得るか**」というトレードオフである。
+
+### 検討した代替案
+
+- **案A（FK を張らない・現状維持）**: 整合性はドメイン層（[0022](0022-domain-service-repository-for-set-invariants.md) の読み取り引き当て）＋ #483 のトランザクション境界で担保する。[0027](0027-persistence-spring-data-jdbc.md) / [0030](0030-jdbc-only-persistence-retire-inmemory.md) / [0043](0043-aggregate-to-table-mapping-guidelines.md) の「集約＝独立境界・ID 参照」路線に忠実だが、DB 単独の安全網が無く、バグで dangling reference を書きうる。
+- **案B（FK を安全網として張る・採用）**: [0043](0043-aggregate-to-table-mapping-guidelines.md) が既に採る「マッパーは整合した行を書くが、DB 単独でも不変条件を破らせない多層防御（CHECK 制約）」の**参照整合性版**として位置づける。DB 整合性が本丸という判断（crit の関心）に沿う。
+- **FK を一部だけ張る案**も検討したが、案B の根拠（DB 単独で整合性を保証）が中途半端になるため、成立する全参照に張る。
+
+### FK と #483 の役割分担
+
+FK は「**dangling reference**（存在しない親を指す子。例: 実在しない `blood_horse` を指す `breeding_registration`）」を防ぐが、「**orphan parent**（子に参照されない孤児親。例: 審査だけ作られ軽種馬が未作成）」は防げない。後者は #483 のトランザクション境界の担当であり、両者は**別々の失敗モードを補完**する。
+
+## Decision（決定）
+
+集約間参照 **6 本すべてに FK 制約を張り**、参照元 **6 列にインデックス**を張る（多層防御の参照整合性版）。
+
+- 対象列: `registered_horse_id` / `inspection_id` / `sire_id` / `dam_id` / `breeding_registration_id` / `covering_stallion_id`。
+- nullable 列（`sire_id` / `dam_id` / `covering_stallion_id`）は NULL 時に FK チェックが走らないため、輸入馬に父母が無い・種付なしで種牡馬 NULL 等を自然に表現できる。
+- **FK はコンテキスト内に限定する**。現状 6 本はすべて studbook コンテキスト内で閉じ、コンテキスト間（クロススキーマ、[0048](0048-per-context-db-schema-namespaces.md)）参照には FK を張らない＝コンテキスト間は ID 参照のまま。ArchUnit のコンテキスト分離と一直線に揃える。
+- 削除挙動は既定（RESTRICT / NO ACTION）。イミュータブル・追記のみ（[0009](0009-immutable-aggregates.md)）のため CASCADE は使わない。
+- FK 列にインデックスを張り、#447 の tbls `requireForeignKeyIndex` lint を有効化できるようにする（#447 マージ後）。
+
+### 実装タイミングと方式
+
+- 決定は本 ADR で確定し、**実装は #451（本番ランタイムを実 DB へ配線）の残る H2 cutover ステップに委ねる**。#451 は #511 で env 差し替え可能化・ローカル compose PostgreSQL まで landing 済みだが、H2 は Docker-less フォールバックとして残置しており、全面廃止（cutover）は #451 の残作業（`build.gradle.kts` に明記）。
+- 既存テーブル（V1–V5）への FK 追加は `ALTER TABLE ADD CONSTRAINT` となり、squawk の `constraint-missing-not-valid`（[0032](0032-sql-lint-squawk-sqlfluff.md)）に触れる。[0043](0043-aggregate-to-table-mapping-guidelines.md) が retirement CHECK で選んだのと同じ理由により、**暫定 H2 のために squawk を緩めず、H2 cutover 後（PostgreSQL 専用）に `ADD CONSTRAINT ... NOT VALID` ＋ `VALIDATE CONSTRAINT` で安全遡及**する。
+- cutover まで現状維持（FK なし）。cutover の協調マイグレーションで、スキーマ移設（[0048](0048-per-context-db-schema-namespaces.md)）と FK / インデックス追加を**一括実施**する。cutover 前に新設される表も public に置き、cutover で一緒に移す（移行期のクロススキーマ FK の混乱を避ける）。
+
+## Consequences（結果・影響）
+
+- **得られるもの**: DB 単独でも dangling reference を防ぐ多層防御。[0043](0043-aggregate-to-table-mapping-guidelines.md) の CHECK 制約と同じ「DB がマッパーと独立に不変条件を保証する」思想で一貫する。#447 の ER 図に関連線が出て `requireForeignKeyIndex` lint が活きる。
+- **引き受けるもの（集約ライフサイクル結合）**:
+  - 書き込み順序が硬直化する（親を先に commit）。#483 のトランザクション境界設計と整合を取る。
+  - 削除・アーカイブ順序が FK グラフに縛られる。契約テストの `deleteAll` 順序（子→親）に影響（#440）。
+  - `inspection`（別サブドメイン集約、[0038](0038-inspection-subdomain-aggregate.md)）を将来別 DB / 別サービスへ切り出す際は FK を落とす必要がある＝独立性を一部譲る。
+  - 将来「外国産駒の父（JAIRS 未登録）」を非登録 ID で持つ拡張時は、当該 FK の見直しが要る。
+- **案A（DDD 正統）との分岐点**: CHECK 制約（[0043](0043-aggregate-to-table-mapping-guidelines.md)）と異なり、FK は**行をまたぐ＝集約をまたぐ結合**を持ち込む。本 ADR は「DB 整合性が本丸」という判断に基づき案B を採る。
+- **関連**: [0048](0048-per-context-db-schema-namespaces.md)（コンテキスト別スキーマ。FK をコンテキスト内に閉じる・相互補強）、[0022](0022-domain-service-repository-for-set-invariants.md)（読み取り引き当て）、[0027](0027-persistence-spring-data-jdbc.md) / [0030](0030-jdbc-only-persistence-retire-inmemory.md)（集約＝永続化境界）、[0038](0038-inspection-subdomain-aggregate.md)（審査集約）、[0043](0043-aggregate-to-table-mapping-guidelines.md)（多層防御・CHECK）、[0032](0032-sql-lint-squawk-sqlfluff.md)（squawk）、#483 / #440 / #451 / #447。

--- a/docs/adr/0048-per-context-db-schema-namespaces.md
+++ b/docs/adr/0048-per-context-db-schema-namespaces.md
@@ -1,0 +1,43 @@
+# 0048. DB スキーマ名前空間を境界づけられたコンテキスト別に分割する
+
+- Status: Accepted
+- Date: 2026-07-02
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+tbls 導入（#447）の crit レビューで、生成された dbdoc の**全テーブルが `public` スキーマ**に置かれていると指摘された（#509）。DB スキーマ（名前空間）戦略を決める必要がある。
+
+現状: 全テーブルが `public`。テーブルを持つのは **studbook**（`blood_horse` / `breeding_registration` / `breeding_result` / `horse_inspection`）と **racing**（`jockey`）の 2 コンテキストのみ。`sakamichi` / `tennis` は永続化を持たない。境界づけられたコンテキストの分離は、コード層で ArchUnit により既に強制されている。
+
+### 検討した代替案
+
+- **案A（`public` 一択・明示的決定として記録）**: 最小構成で YAGNI。分離はコード層で既に効いており、多スキーマの複雑さを持ち込まない。
+- **案B（コンテキスト別スキーマに分割・採用）**: 分離を DB 層にも反映し、テーブル帰属を明示化する。tbls ドキュメントもスキーマ別に整理される。
+- **案C（`public` のままテーブル名にコンテキスト接頭辞）**: 既存命名の全面改名が要り、スキーマ分離より分離が弱い。
+
+本プロジェクトはコンテキスト分離を中核価値とし、それを **DB 層にも反映する**ことを選ぶ（案B）。多スキーマの複雑さ（Flyway・Spring Data JDBC・H2↔PostgreSQL パリティ・tbls）は引き受ける。
+
+## Decision（決定）
+
+境界づけられたコンテキストごとに DB スキーマを分ける。
+
+- **スキーマ割当**: `studbook`（`blood_horse` / `breeding_registration` / `breeding_result` / `horse_inspection`）、`racing`（`jockey`）。
+- `sakamichi` / `tennis` は**永続化を持ったとき初めてスキーマを作る**（空スキーマの投機的先行作成はしない）。
+- スキーマ名は**小文字**（`studbook` / `racing`）。H2 は `DATABASE_TO_LOWER=TRUE` で識別子を小文字化するため PostgreSQL と一致する。
+- **Flyway**: 各マイグレーションで `CREATE SCHEMA IF NOT EXISTS <ctx>;` ＋ 完全修飾 `CREATE TABLE <ctx>.<table>`。`search_path` 依存を避け H2 / PostgreSQL で可搬にする。`flyway_schema_history` は既定の `public` に残す（`spring.flyway.schemas` は設定しない）。
+- **Spring Data JDBC**: 各 Row に `@Table(schema = "<ctx>", name = "<table>")`（Spring Data Relational 3.x の `schema` 属性）。
+- **FK（[0047](0047-cross-aggregate-foreign-keys-as-safety-net.md)）はコンテキスト内（同一スキーマ内）に限定**。現状 FK 6 本はすべて studbook 内で閉じるため**クロススキーマ FK は発生しない**。コンテキスト間参照は ID 参照のまま FK を張らず、ArchUnit のコンテキスト分離を DB 層にも反映する。
+- tbls（#447）関連の便益（スキーマ別ドキュメント整理）は **#447 マージ後**に有効化（現状 `.tbls.yml` 未導入）。
+
+### 実装タイミングと方式
+
+- 決定は本 ADR で確定し、**実装は #451 の H2 cutover に委ね**、[0047](0047-cross-aggregate-foreign-keys-as-safety-net.md) の FK 追加と**同じ協調マイグレーションで一括実施**する。
+- 既存テーブルの移設は `ALTER TABLE ... SET SCHEMA`。H2 とのパリティ・移行安全性の観点から、H2 cutover 後（PostgreSQL 専用）に行う。cutover まで現状維持（`public`）。cutover 前に新設される表も `public` に置き、移行期のクロススキーマ FK の混乱を避けるため cutover で一括移設する。
+
+## Consequences（結果・影響）
+
+- **得られるもの**: テーブル帰属がスキーマで明示化され、コンテキスト分離が DB 層にも表れる。将来コンテキスト別のアクセス制御・別 DB 化・別デプロイへ発展させる余地。tbls ドキュメントがスキーマ別に整理される（#447 後）。「FK はコンテキスト内のみ」という規律が構造的に可視化される（[0047](0047-cross-aggregate-foreign-keys-as-safety-net.md) と相互補強）。
+- **引き受けるもの**: 多スキーマの複雑さ — Flyway のスキーマ作成順・完全修飾、Spring Data JDBC のスキーマ修飾（`@Table`）、H2↔PostgreSQL の挙動差の継続確認、tbls の対象スキーマ指定。テーブルを持つのが 2 コンテキストのみの現状に対し先行投資となる。cutover まで実装は保留。
+- **再検討・撤回条件**: 多スキーマの運用コストが便益を上回ると判明した場合、`public` 一択へ戻す ADR を起こす（本 ADR を Superseded）。
+- **関連**: [0047](0047-cross-aggregate-foreign-keys-as-safety-net.md)（コンテキスト内 FK・相互補強）、[0038](0038-inspection-subdomain-aggregate.md)（審査サブドメイン）、[0027](0027-persistence-spring-data-jdbc.md) / [0030](0030-jdbc-only-persistence-retire-inmemory.md)（永続化）、[0044](0044-adopt-prisma-postgres-for-production-db.md)（本番 Prisma Postgres）、[0043](0043-aggregate-to-table-mapping-guidelines.md)（マッピング指針）、#447 / #451 / #507 / #509。#507（Atlas 宣言的スキーマ）を採用する場合はスキーマ名前空間・FK を宣言的に表現できる。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,3 +55,5 @@
 | [0043](0043-aggregate-to-table-mapping-guidelines.md) | 集約⇔テーブルのマッピング指針（sealed/埋め込み VO のフラット化・CHECK 必須・子テーブル化の境界）を定める | Accepted |
 | [0044](0044-adopt-prisma-postgres-for-production-db.md) | 本番 DB プロダクトに Prisma Postgres を採用する（H2 脱却・東京リージョン・標準 JDBC） | Accepted |
 | [0046](0046-adopt-kotlin-lsp-plugin.md) | Claude Code の Kotlin LSP プラグインを採用し kotlin-lsp を mise http バックエンドで配布する | Accepted |
+| [0047](0047-cross-aggregate-foreign-keys-as-safety-net.md) | 集約間参照に外部キー制約を安全網として張る（DB 参照整合性の多層防御・コンテキスト内に限定） | Accepted |
+| [0048](0048-per-context-db-schema-namespaces.md) | DB スキーマ名前空間を境界づけられたコンテキスト別に分割する | Accepted |


### PR DESCRIPTION
## 概要

#447(tbls) の crit レビュー由来の DB スキーマ設計論点 #508 / #509 を決定し ADR 2 本に記録する。いずれも**実装は含まず**、決定と根拠のみを記録して実装は #451 の H2 cutover に委ねる。

## 決定

### ADR-0047: 集約間参照に FK 安全網を張る（#508）
- 集約間参照 **6 本すべてに FK 制約＋参照元 6 列にインデックス**（案B）。
- ADR-0043 の「CHECK 制約による多層防御」を**参照整合性へ延長**する位置づけ。
- **FK はコンテキスト内に限定**し、コンテキスト間は ID 参照のまま（ArchUnit のコンテキスト分離と整合）。
- 集約ライフサイクル結合（書き込み/削除順序・ #483 / #440・審査集約 ADR-0038 の独立性）を帰結として明記。
- FK は dangling reference を防ぎ、orphan parent は #483 の担当（補完関係）。

### ADR-0048: コンテキスト別 DB スキーマ名前空間（#509）
- コンテキスト別スキーマ `studbook` / `racing` へ分割（案B）。`sakamichi` / `tennis` は永続化取得時に作成。
- `CREATE SCHEMA` ＋完全修飾・`@Table(schema=)`・小文字スキーマ名で H2 ↔ PostgreSQL 可搬。
- FK が全て studbook 内で閉じるため**クロススキーマ FK は不発生**（ADR-0047 と相互補強）。

## 実装タイミング（両 ADR 共通）
- 決定は本 PR で確定。実装は **#451 の H2 cutover** に委譲（#451 は open・ #511 で env 差し替え可能化まで landing 済み、H2 全面廃止が残作業）。
- 既存表への遡及は squawk（ADR-0032）を緩めず、cutover 後（PostgreSQL 専用）に `SET SCHEMA` / `ADD CONSTRAINT ... NOT VALID` ＋ `VALIDATE` で安全実施。

## 補足
- 0045 は #447(tbls) ブランチが予約済みのため欠番とし 0047 / 0048 を採番。
- tbls 関連の便益（ER 図の関連線・`requireForeignKeyIndex` lint）は #447 マージ後に有効化。

Closes #508
Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)
