### PR TITLE
feat: 本番 DB(Prisma Postgres) を IaC で新設し接続情報を Secret Manager 管理にする (#451 Phase C)

### DIFF
--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -21,3 +21,25 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
+
+provider "registry.terraform.io/prisma/prisma-postgres" {
+  version     = "0.2.0"
+  constraints = "~> 0.2.0"
+  hashes = [
+    "h1:0/jXLeF9us0MJuxFC01VZGDBCvWfcs1aT21X17c+LAk=",
+    "zh:0ab48365d026bdf5002a8164e92e50f5cce18ee84387730e5b77b05cbbdd0a02",
+    "zh:1ce7ac37034236148e4100c458eaf1751b91ad40e05764b11d6dc9fea99dc7fd",
+    "zh:1f7f8622dd386c3b5bd58689bd834614a0281f511d131de61be9e95596b0195c",
+    "zh:2f3bad798f49d49fe38674fdfd5066d600b3c0584c396349286a8bfa51e1af3a",
+    "zh:318547dc00fd789a0e99895643002f583e02f126403f2ab6b9da5d07d3ba7a91",
+    "zh:5447c263793e7e24feab96da9e1bb1fb4c73ba28050d9d661dc94b6f00014741",
+    "zh:8b4bc8e8fe1e2f8b489cf08dfb34a3593cf9f5bf0b1b94d651422d24b8f228e3",
+    "zh:b49a4fca9fd94526279d71add471c419c18efe7b5568c737d17d30f11989554a",
+    "zh:b6f72f392e7384e152fca25de7aadc97dfd8c5714802612dfa23c55cc2fe8106",
+    "zh:d49021f4890614fe75fa011993fdf5664c7f234bf0068e0859dff0ccff82660a",
+    "zh:d6661e0f4f267098e56f8fe2c2fa2766b974be20cc0774c34277907e2ad0ccec",
+    "zh:d6ec89b35a48b5893301248c8ae9a55a97c7b6d7fd978f15fa863f3293c3bdee",
+    "zh:ec3d879c2a7a603dc52a63baa726ba95e3bde4d3e3750a00dec335d8111d16e3",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -45,6 +45,7 @@ module "prisma_postgres" {
   source = "./modules/prisma-postgres"
 
   api_runner_email = module.cloudrun.api_runner_email
+  project_name     = var.prisma_project_name
 
   depends_on = [google_project_service.project]
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -5,6 +5,7 @@ resource "google_project_service" "project" {
     "iamcredentials",
     "orgpolicy",
     "run",
+    "secretmanager",
   ])
   service = "${each.key}.googleapis.com"
 }
@@ -36,4 +37,14 @@ module "local_readonly" {
 
   project_id    = "ptiringo-toy-box"
   impersonators = var.local_readonly_impersonators
+}
+
+# 本番 DB（Prisma Postgres・東京）と、その接続情報を格納する Secret Manager。
+# secretmanager API 有効化に依存させ、初回 apply の順序レースを避ける。
+module "prisma_postgres" {
+  source = "./modules/prisma-postgres"
+
+  api_runner_email = module.cloudrun.api_runner_email
+
+  depends_on = [google_project_service.project]
 }

--- a/infra/modules/prisma-postgres/main.tf
+++ b/infra/modules/prisma-postgres/main.tf
@@ -1,0 +1,48 @@
+# Prisma Postgres 本番インスタンス（東京 ap-northeast-1・無料枠）。
+# 本物の PostgreSQL v17 へ direct TCP（標準 pgwire / JDBC）で接続する（ADR-0044 / #451 Phase B で de-risk 済み）。
+resource "prisma-postgres_project" "toy_box" {
+  name = var.project_name
+}
+
+resource "prisma-postgres_database" "production" {
+  project_id = prisma-postgres_project.toy_box.id
+  name       = var.database_name
+  region     = var.region
+}
+
+# Cloud Run へ注入する datasource 接続情報（SPRING_DATASOURCE_*）を Secret Manager に格納する。
+# direct_host は Prisma 共有の安定ホスト、direct_user / direct_password は per-DB（再作成で変わる）。
+# PG カタログのデータベース名は Prisma の表示名によらず postgres 固定（#451 Phase B の spike で確認）。
+locals {
+  datasource_secrets = {
+    "spring-datasource-url"      = "jdbc:postgresql://${prisma-postgres_database.production.direct_host}:5432/postgres?sslmode=require"
+    "spring-datasource-username" = prisma-postgres_database.production.direct_user
+    "spring-datasource-password" = prisma-postgres_database.production.direct_password
+  }
+}
+
+resource "google_secret_manager_secret" "datasource" {
+  for_each = local.datasource_secrets
+
+  secret_id = each.key
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "datasource" {
+  for_each = local.datasource_secrets
+
+  secret      = google_secret_manager_secret.datasource[each.key].id
+  secret_data = each.value
+}
+
+# api-runner SA へ、この 3 secret のみ参照権限を付与する（最小権限）。
+resource "google_secret_manager_secret_iam_member" "api_runner_accessor" {
+  for_each = google_secret_manager_secret.datasource
+
+  secret_id = each.value.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.api_runner_email}"
+}

--- a/infra/modules/prisma-postgres/outputs.tf
+++ b/infra/modules/prisma-postgres/outputs.tf
@@ -1,0 +1,11 @@
+# Phase D（cutover）で Cloud Run に --set-secrets 注入する際に参照する secret ID マップ。
+# 値（接続情報そのもの）は sensitive なので出力しない。
+output "datasource_secret_ids" {
+  description = "SPRING_DATASOURCE_* を格納した Secret Manager secret の ID マップ"
+  value       = { for key, secret in google_secret_manager_secret.datasource : key => secret.secret_id }
+}
+
+output "database_status" {
+  description = "Prisma Postgres データベースの現在の状態"
+  value       = prisma-postgres_database.production.status
+}

--- a/infra/modules/prisma-postgres/variables.tf
+++ b/infra/modules/prisma-postgres/variables.tf
@@ -4,9 +4,9 @@ variable "api_runner_email" {
 }
 
 variable "project_name" {
-  description = "Prisma Postgres プロジェクト名（データベースの上位コンテナ）"
+  description = "Prisma Postgres プロジェクト名（データベースの上位コンテナ）。機微情報として扱い、既定値は置かず HCP の sensitive 変数で供給する"
   type        = string
-  default     = "toy-box"
+  sensitive   = true
 }
 
 variable "database_name" {

--- a/infra/modules/prisma-postgres/variables.tf
+++ b/infra/modules/prisma-postgres/variables.tf
@@ -1,0 +1,22 @@
+variable "api_runner_email" {
+  description = "datasource secret への参照を許可する api-runner SA のメールアドレス"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Prisma Postgres プロジェクト名（データベースの上位コンテナ）"
+  type        = string
+  default     = "toy-box"
+}
+
+variable "database_name" {
+  description = "Prisma Postgres データベース名"
+  type        = string
+  default     = "production"
+}
+
+variable "region" {
+  description = "Prisma Postgres のデプロイ先リージョン（東京）。Prisma のリージョン表記であり GCP の asia-northeast1 とは別体系"
+  type        = string
+  default     = "ap-northeast-1"
+}

--- a/infra/modules/prisma-postgres/versions.tf
+++ b/infra/modules/prisma-postgres/versions.tf
@@ -1,23 +1,14 @@
 terraform {
-  cloud {
-    organization = "ptiringo-tech"
-
-    workspaces {
-      project = "toy-box-project"
-      name    = "toy-box"
-    }
-  }
+  required_version = ">= 1.12"
 
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.38.0"
+      version = ">= 7.36.0"
     }
     prisma-postgres = {
       source  = "prisma/prisma-postgres"
       version = "~> 0.2.0"
     }
   }
-
-  required_version = ">= 1.12"
 }

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -3,3 +3,9 @@ provider "google" {
   region  = "asia-northeast1"
   zone    = "asia-northeast1-a"
 }
+
+# Prisma Postgres の管理 API 認証。トークンは HCP workspace の sensitive 変数で供給する
+# （Prisma Console で発行/ローテーション。値はリポジトリに置かない）。
+provider "prisma-postgres" {
+  service_token = var.prisma_service_token
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -14,3 +14,9 @@ variable "prisma_service_token" {
   type        = string
   sensitive   = true
 }
+
+variable "prisma_project_name" {
+  description = "Prisma Postgres プロジェクト名（機微。HCP workspace の sensitive 変数で供給）"
+  type        = string
+  sensitive   = true
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -8,3 +8,9 @@ variable "local_readonly_impersonators" {
   type        = list(string)
   default     = []
 }
+
+variable "prisma_service_token" {
+  description = "Prisma Postgres 管理 API のサービストークン（HCP workspace の sensitive 変数で供給）"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## 概要

#451 の **Phase C（IaC 本番新設）**。ADR-0044 で採用した本番 DB = **Prisma Postgres** を Terraform で完全管理し、接続情報を GCP Secret Manager 管理にする。Phase B の de-risk spike（direct TCP GA・Hikari・Flyway V1–V5・RTT 9.2ms）でゲート GO を確認済み（[結果コメント](https://github.com/ptiringo/toy-box/issues/451#issuecomment-4857458498)）。

**本 PR はインフラ新設のみ。** Cloud Run の datasource 切替（cutover）は Phase D で別 PR。main は引き続き H2 既定で起動可能なまま。

## 変更内容

**新規モジュール `infra/modules/prisma-postgres/`**
- `prisma-postgres_project` ＋ `prisma-postgres_database`（東京 `ap-northeast-1`・無料枠）
- `database` の read-only 属性 `direct_host` / `direct_user` / `direct_password` から `SPRING_DATASOURCE_*` を組み立て、GCP Secret Manager（`spring-datasource-url` / `-username` / `-password`）へ格納
- api-runner SA へこの 3 secret のみ `roles/secretmanager.secretAccessor`（最小権限）
- PG カタログの DB 名は Prisma の表示名によらず `postgres` 固定（Phase B spike で確認）

**ルート**
- `google_project_service` に `secretmanager` 追加、`module "prisma_postgres"` 呼び出し（`depends_on` で API 有効化順を保証）
- `provider "prisma-postgres"`（`service_token = var.prisma_service_token`＝HCP sensitive 変数）
- `terraform.tf` に provider 追加、`.terraform.lock.hcl` を cross-platform で更新

## 設計判断

- 接続 env（URL/USERNAME/PASSWORD）を **全て Secret 化**し Phase D で `--set-secrets` 一括注入。DB 再作成で `direct_*` が変わっても secret version 更新で追従し、deploy.yml に host 等をハードコードしない。

## ローカル検証

- `terraform fmt` クリーン / `terraform validate` **Success** / `trivy config` **0 misconfig** / pre-commit フック全通過

## レビュー観点・後続

- HCP speculative plan で `prisma-postgres_project`＋`_database`＋Secret Manager 3件＋IAM 3件の add を確認（要 `prisma_service_token` の HCP sensitive 変数）。
- apply（＝本番 DB 作成）は HCP run で。cutover（Phase D）とは切り離し可。

Closes は付けない（#451 は Phase D/E 完了まで継続）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
