### PR TITLE
fix: kotlin-lsp の mise.lock に全プラットフォームの checksum を追記し Linux CI の --locked 失敗を解消する (#510)

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -253,6 +253,22 @@ url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8
 version = "262.8190.0"
 backend = "http:kotlin-lsp"
 
+[tools."http:kotlin-lsp"."platforms.linux-arm64"]
+checksum = "sha256:c3edd59ef34a7faa4d04f3517afb7a932b19c3f9cf17d1a14e9da17b0b5440ad"
+url = "https://download-cdn.jetbrains.com/language-server/kotlin-server/262.8190.0/kotlin-server-262.8190.0-aarch64.tar.gz"
+
+[tools."http:kotlin-lsp"."platforms.linux-x64"]
+checksum = "sha256:8b4c70e95065420e7867c99aaf9f18e0b4e76311ec453e4c1a39e3f6ae774cbf"
+url = "https://download-cdn.jetbrains.com/language-server/kotlin-server/262.8190.0/kotlin-server-262.8190.0.tar.gz"
+
+[tools."http:kotlin-lsp"."platforms.macos-arm64"]
+checksum = "sha256:e20183262784bb7e665ce1aea4855872a8b16f211ebb478d452773553732d9fb"
+url = "https://download-cdn.jetbrains.com/language-server/kotlin-server/262.8190.0/kotlin-server-262.8190.0-aarch64.sit"
+
+[tools."http:kotlin-lsp"."platforms.macos-x64"]
+checksum = "sha256:f3845ae9ee38c22ef5e436390d86a3d908f77073e9667fa643a5ae0957c19728"
+url = "https://download-cdn.jetbrains.com/language-server/kotlin-server/262.8190.0/kotlin-server-262.8190.0.sit"
+
 [[tools."http:tfctl"]]
 version = "0.3.0"
 backend = "http:tfctl"


### PR DESCRIPTION
## 概要

`kotlin-lsp`（#510 / ADR-0046 で採用した http backend ツール）の `mise.lock` エントリが **version / backend のスタブのみ**で、per-platform の `checksum` / `url` ブロックが欠落していた。mise は http backend の lock を自動永続化しないため、`tfctl` と同様に手動追記が必要。

この欠落により CI（linux）の `mise install --locked` が

```
mise ERROR  Failed to install http:kotlin-lsp@262.8190.0: http:kotlin-lsp@262.8190.0 is not in the lockfile
```

で失敗し、**infra 変更を含む PR の "Terraform Validation and Format Check" が赤くなる**（full `--locked` インストールで kotlin-lsp を入れるジョブが該当。#514 で顕在化）。`origin/main` でも同状態の先行バグ。

## 変更

`mise.lock` の `http:kotlin-lsp` に `platforms.linux-x64` / `linux-arm64` / `macos-x64` / `macos-arm64` を追記。checksum は `mise.toml` と同一の sha256、url は `{{version}}` を展開した実 URL。`tfctl` エントリと同型。

## 検証

- `mise install --locked http:kotlin-lsp` が exit 0（従来は「not in the lockfile」で失敗）。
- pre-commit（editorconfig / gitleaks）通過。

## 関連

- #510 / [ADR-0046](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0046-adopt-kotlin-lsp-plugin.md)（kotlin-lsp 採用）
- #514（Phase C・この修正のマージ後に main 取り込みで CI 緑化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
