### PR TITLE
feat: 本番 datasource を Prisma Postgres へ切り替え H2 を全面脱却する (#451 Phase D)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,10 +66,15 @@ jobs:
       # --memory: container-smoke-test.yml の docker run -m と揃えること。
       # gcloud の `--memory=1Gi` は 1 GiB (= 1024 MiB) を表し、docker の `-m 1g` と等価。
       # 単位表記が異なるため、片方だけを更新しないよう注意する。
+      #
+      # --set-secrets: datasource（Prisma Postgres・#451 / ADR-0044）の接続情報を Secret Manager から
+      # 環境変数 SPRING_DATASOURCE_* として注入する。secret の実体は Terraform 管理
+      # （infra/modules/prisma-postgres/）で、値は provider の direct_* 属性から自動配線される。
+      # api-runner SA には当該 secret の secretAccessor が付与済み。
       - name: Deploy to Cloud Run
         uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3.0.1
         with:
           service: api
           region: asia-northeast1
           image: ${{ vars.IMAGE }}:${{ github.sha }}
-          flags: '--service-account=api-runner@ptiringo-toy-box.iam.gserviceaccount.com --no-allow-unauthenticated --port=8080 --memory=1Gi --cpu=1 --cpu-boost --min-instances=0 --max-instances=3'
+          flags: '--service-account=api-runner@ptiringo-toy-box.iam.gserviceaccount.com --no-allow-unauthenticated --port=8080 --memory=1Gi --cpu=1 --cpu-boost --min-instances=0 --max-instances=3 --set-secrets=SPRING_DATASOURCE_URL=spring-datasource-url:latest,SPRING_DATASOURCE_USERNAME=spring-datasource-username:latest,SPRING_DATASOURCE_PASSWORD=spring-datasource-password:latest'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,14 +67,21 @@ jobs:
       # gcloud の `--memory=1Gi` は 1 GiB (= 1024 MiB) を表し、docker の `-m 1g` と等価。
       # 単位表記が異なるため、片方だけを更新しないよう注意する。
       #
-      # --set-secrets: datasource（Prisma Postgres・#451 / ADR-0044）の接続情報を Secret Manager から
+      # secrets: datasource（Prisma Postgres・#451 / ADR-0044）の接続情報を Secret Manager から
       # 環境変数 SPRING_DATASOURCE_* として注入する。secret の実体は Terraform 管理
       # （infra/modules/prisma-postgres/）で、値は provider の direct_* 属性から自動配線される。
       # api-runner SA には当該 secret の secretAccessor が付与済み。
+      # secrets_update_strategy=overwrite: 本ワークフローをサービスの secret 配線の唯一の出所とし、
+      # ここに列挙しない secret 配線はデプロイ時に取り除く（宣言的・削除追従）。
       - name: Deploy to Cloud Run
         uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3.0.1
         with:
           service: api
           region: asia-northeast1
           image: ${{ vars.IMAGE }}:${{ github.sha }}
-          flags: '--service-account=api-runner@ptiringo-toy-box.iam.gserviceaccount.com --no-allow-unauthenticated --port=8080 --memory=1Gi --cpu=1 --cpu-boost --min-instances=0 --max-instances=3 --set-secrets=SPRING_DATASOURCE_URL=spring-datasource-url:latest,SPRING_DATASOURCE_USERNAME=spring-datasource-username:latest,SPRING_DATASOURCE_PASSWORD=spring-datasource-password:latest'
+          secrets: |-
+            SPRING_DATASOURCE_URL=spring-datasource-url:latest
+            SPRING_DATASOURCE_USERNAME=spring-datasource-username:latest
+            SPRING_DATASOURCE_PASSWORD=spring-datasource-password:latest
+          secrets_update_strategy: overwrite
+          flags: '--service-account=api-runner@ptiringo-toy-box.iam.gserviceaccount.com --no-allow-unauthenticated --port=8080 --memory=1Gi --cpu=1 --cpu-boost --min-instances=0 --max-instances=3'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     // 永続化アクセス（Spring Data JDBC + Flyway）。集約 write は Spring Data JDBC（集約 = 永続化境界）。
     // 本番ランタイムの datasource は Prisma Postgres（実 PostgreSQL v17）へ配線する（#451 / ADR-0044）。
-    // ローカル/CI/smoke も PostgreSQL に寄せ、既定の組み込み H2 は cutover で全面脱却する。永続化の契約
+    // ローカル/CI/smoke/テストは全て PostgreSQL（組み込み H2 は cutover で全面脱却済み）。永続化の契約
     // テストは本番ターゲットの PostgreSQL を Testcontainers で用意して検証する（ADR-0027 / #422）。
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
     // Flyway は starter で引く。Spring Boot 4 は autoconfig を機能別モジュールに分割しており、
@@ -40,7 +40,6 @@ dependencies {
     // 走らない（#421）。starter-flyway が spring-boot-flyway(autoconfig) + spring-boot-jdbc +
     // flyway-core を引き込む。
     implementation("org.springframework.boot:spring-boot-starter-flyway")
-    runtimeOnly("com.h2database:h2")
     // ローカル開発（bootRun）時に compose.yaml の PostgreSQL を自動起動し datasource を自動配線する。
     // developmentOnly のため本番イメージ（bootBuildImage）・テスト classpath には載らない（#451）。
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepository.kt
@@ -30,8 +30,8 @@ private fun <V, E> Result<V, E>.orThrow(): V = getOrThrow {
  * [BreedingResultSpringDataRepository] へ委譲する。value class ID・nullable な種付 [Covering] のフラット化・ sealed
  * な分娩結果 [FoalingOutcome] の判別子フラット化も本マッパーが担う（永続化モデルを分離した帰結。ADR-0027）。
  *
- * 永続化実装は JDBC 一本に統一し、起動 datasource を H2(dev / Cloud Run) ↔ PostgreSQL(本番) で差し替える方針のため、 InMemory
- * 実装・プロファイル切替は持たない（ADR-0030）。デフォルト（H2・PostgreSQL 互換）でも本クラスが配線される。
+ * 永続化実装は JDBC 一本に統一し、datasource は実行環境が外部供給する（本番 = Prisma Postgres の env 注入、ローカル = docker-compose の
+ * PostgreSQL。H2 全面脱却・#451）ため、InMemory 実装・プロファイル切替は持たない（ADR-0030）。
  */
 @Repository
 class JdbcBreedingResultRepository(private val rows: BreedingResultSpringDataRepository) :

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
   # ランタイムの永続化データソース。永続化実装は JDBC 一本に統一し（ADR-0030）、JDBC リポジトリが実際に
   # 読み書きする。datasource はここに既定値を置かず、実行環境が外部から供給する（H2 全面脱却・#451 / ADR-0044）:
   #   - 本番（Cloud Run）: Secret Manager から env（SPRING_DATASOURCE_URL / _USERNAME / _PASSWORD）で
-  #     Prisma Postgres（実 PostgreSQL v17）の接続情報を注入（deploy.yml の --set-secrets）。
+  #     Prisma Postgres（実 PostgreSQL v17）の接続情報を注入（deploy.yml の deploy-cloudrun secrets 入力）。
   #   - ローカル bootRun: spring-boot-docker-compose が compose.yaml の PostgreSQL を自動起動・自動配線。
   #   - テスト: Testcontainers の PostgreSQL を PostgresContainerSupport が注入。
   # driver-class-name は明示せず JDBC URL から導出させる（URL の差し替えだけで接続先を切り替えられる）。

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,17 +8,12 @@ spring:
     virtual:
       enabled: true
   # ランタイムの永続化データソース。永続化実装は JDBC 一本に統一し（ADR-0030）、JDBC リポジトリが実際に
-  # 読み書きする。デフォルトは Docker 不要の組み込み H2 を PostgreSQL 互換モード（識別子は小文字へ畳む）で
-  # 使い、本番ターゲット DB（PostgreSQL）の挙動へ寄せる。本番は環境変数（SPRING_DATASOURCE_URL 等）で
-  # datasource を Prisma Postgres に差し替える（#451 / ADR-0044）。driver-class-name は明示せず JDBC URL
-  # から導出させる（H2 URL→H2 ドライバ / postgresql URL→PG ドライバ）。これにより env は URL の差し替え
-  # だけで DB を切り替えられる（driver をピンすると URL だけ上書きしたとき H2 ドライバが postgresql URL を
-  # 掴もうとして起動失敗する）。永続化の契約テストは本番ターゲットの PostgreSQL を Testcontainers で用意して
-  # 検証する（PostgresContainerSupport が datasource を上書きする）。
-  datasource:
-    url: jdbc:h2:mem:toybox;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1
-    username: sa
-    password: ""
+  # 読み書きする。datasource はここに既定値を置かず、実行環境が外部から供給する（H2 全面脱却・#451 / ADR-0044）:
+  #   - 本番（Cloud Run）: Secret Manager から env（SPRING_DATASOURCE_URL / _USERNAME / _PASSWORD）で
+  #     Prisma Postgres（実 PostgreSQL v17）の接続情報を注入（deploy.yml の --set-secrets）。
+  #   - ローカル bootRun: spring-boot-docker-compose が compose.yaml の PostgreSQL を自動起動・自動配線。
+  #   - テスト: Testcontainers の PostgreSQL を PostgresContainerSupport が注入。
+  # driver-class-name は明示せず JDBC URL から導出させる（URL の差し替えだけで接続先を切り替えられる）。
   # マイグレーションは Flyway（plain SQL）。db/migration 配下の V*.sql を起動時に適用する。
   flyway:
     enabled: true

--- a/src/test/kotlin/com/example/api/ApiApplicationTests.kt
+++ b/src/test/kotlin/com/example/api/ApiApplicationTests.kt
@@ -1,9 +1,12 @@
 package com.example.api
 
+import com.example.api.support.PostgresContainerSupport
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 
+// datasource は外部供給（H2 全面脱却・#451）のため、コンテキスト起動には
+// PostgresContainerSupport の Testcontainers PostgreSQL を注入する。
 @SpringBootTest
-class ApiApplicationTests {
+class ApiApplicationTests : PostgresContainerSupport() {
     @Test fun contextLoads() {}
 }

--- a/src/test/kotlin/com/example/api/OpenApiTest.kt
+++ b/src/test/kotlin/com/example/api/OpenApiTest.kt
@@ -1,5 +1,6 @@
 package com.example.api
 
+import com.example.api.support.PostgresContainerSupport
 import org.junit.jupiter.api.Test
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient
 import org.springframework.boot.test.context.SpringBootTest
@@ -10,12 +11,13 @@ import org.springframework.test.web.servlet.client.RestTestClient
 /**
  * OpenAPI ドキュメント生成機能のテストクラス
  *
- * springdoc-openapi による REST API ドキュメントの自動生成が正しく動作することを検証します。
+ * springdoc-openapi による REST API ドキュメントの自動生成が正しく動作することを検証します。 datasource は外部供給（H2 全面脱却・#451）のため
+ * PostgresContainerSupport を継承する。
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureRestTestClient
 @TestConstructor(autowireMode = AutowireMode.ALL)
-class OpenApiTest(private val restTestClient: RestTestClient) {
+class OpenApiTest(private val restTestClient: RestTestClient) : PostgresContainerSupport() {
     @Test
     fun `OpenAPI の JSON ドキュメントが取得できること`() {
         restTestClient

--- a/src/test/kotlin/com/example/api/actuator/HealthEndpointTest.kt
+++ b/src/test/kotlin/com/example/api/actuator/HealthEndpointTest.kt
@@ -1,5 +1,6 @@
 package com.example.api.actuator
 
+import com.example.api.support.PostgresContainerSupport
 import org.junit.jupiter.api.Test
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient
 import org.springframework.boot.test.context.SpringBootTest
@@ -7,10 +8,12 @@ import org.springframework.test.context.TestConstructor
 import org.springframework.test.context.TestConstructor.AutowireMode
 import org.springframework.test.web.servlet.client.RestTestClient
 
+// datasource は外部供給（H2 全面脱却・#451）のため、コンテキスト起動には
+// PostgresContainerSupport の Testcontainers PostgreSQL を注入する。
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureRestTestClient
 @TestConstructor(autowireMode = AutowireMode.ALL)
-class HealthEndpointTest(val restTestClient: RestTestClient) {
+class HealthEndpointTest(val restTestClient: RestTestClient) : PostgresContainerSupport() {
     @Test
     fun `ヘルスエンドポイントを呼び出すとUPステータスが返される`() {
         restTestClient

--- a/src/test/kotlin/com/example/api/mcp/McpServerWiringTest.kt
+++ b/src/test/kotlin/com/example/api/mcp/McpServerWiringTest.kt
@@ -1,6 +1,7 @@
 package com.example.api.mcp
 
 import com.example.api.mcp.racing.jockey.JockeyMcpTools
+import com.example.api.support.PostgresContainerSupport
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -10,10 +11,11 @@ import org.springframework.boot.test.context.SpringBootTest
  *
  * Spring AI MCP server オートコンフィグを足してもアプリケーションコンテキストが起動し、`@McpTool` を持つ [JockeyMcpTools] Bean
  * が登録されることだけを確認する。MCP プロトコルの E2E（ツール一覧・呼び出し）は follow-up とし、ロジック網羅は slice
- * テスト（JockeyMcpToolsTest）で済ませる（testing.md: 統合は最小限）。
+ * テスト（JockeyMcpToolsTest）で済ませる（testing.md: 統合は最小限）。 datasource は外部供給（H2 全面脱却・#451）のため
+ * PostgresContainerSupport を継承する。
  */
 @SpringBootTest
-class McpServerWiringTest {
+class McpServerWiringTest : PostgresContainerSupport() {
     @Autowired private lateinit var jockeyMcpTools: JockeyMcpTools
 
     @Test

--- a/src/test/kotlin/com/example/api/support/PostgresContainerSupport.kt
+++ b/src/test/kotlin/com/example/api/support/PostgresContainerSupport.kt
@@ -6,13 +6,14 @@ import org.testcontainers.postgresql.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
 
 /**
- * 永続化の契約テストが本番ターゲットの PostgreSQL に対して検証するための共有コンテナ（ADR-0027 / #422）。
+ * テストが本番ターゲットの PostgreSQL に対して検証するための共有コンテナ（ADR-0027 / #422）。
  *
- * ランタイムの datasource は当面 H2（PostgreSQL 互換モード）だが、永続化の契約テストは本番ターゲット DB と 同じ PostgreSQL
- * で検証したい。そこで本クラスを継承したテストには Testcontainers の実 PostgreSQL を割り当てる。 コンテナはプロセス内で 1
+ * ランタイムの datasource は外部供給（H2 全面脱却・#451。本番 = Prisma Postgres の env 注入、ローカル bootRun = docker-compose
+ * 自動配線）で、app.yml に既定値を持たない。そのため Spring コンテキストを起動するテスト （契約テスト・`@SpringBootTest` 統合）は本クラスを継承して
+ * Testcontainers の実 PostgreSQL を割り当てる。 コンテナはプロセス内で 1
  * つだけ起動して全テストで共有し（シングルトン）、明示停止はしない（Testcontainers の Ryuk が JVM 終了時に破棄する）。接続先は
- * `@DynamicPropertySource` で各コンテキストへ注入し、app.yml の既定 （H2）を上書きする。注入する値は全テストで同一なので distinct な
- * ApplicationContext を増やさず、コンテキスト キャッシュ方針（ADR-0015 / testing.md）を維持する。
+ * `@DynamicPropertySource` で各コンテキストへ注入する。注入する値は全テストで同一なので distinct な ApplicationContext
+ * を増やさず、コンテキスト キャッシュ方針（ADR-0015 / testing.md）を維持する。
  *
  * 本クラスを継承するテストでは、Flyway が起動時に `db/migration/V*.sql` をこの PostgreSQL コンテナへ適用する （Boot 4.1 + Flyway
  * 12 + flyway-database-postgresql で自動実行されることを併せて担保する）。


### PR DESCRIPTION
## 概要

#451 の **Phase D（cutover）**。マージ→自動デプロイで本番ランタイムの datasource が **H2 → Prisma Postgres（実 PostgreSQL v17・東京 `ap-northeast-1`）** に切り替わり、**H2 全面脱却が完了**する。初回起動時に Flyway が本番 DB へ V1–V5 を適用する。

前提は全て整備済み: Phase A（PR #511・ローカル/CI/smoke の PG 化）→ Phase B（de-risk spike ゲート GO・[実測記録](https://github.com/ptiringo/toy-box/issues/451#issuecomment-4857458498)）→ Phase C（PR #514・本番 DB と Secret Manager を Terraform で実作成、apply 済み）。

## 変更内容

**Secret 注入（deploy.yml）**
- `deploy-cloudrun` の flags に `--set-secrets` を追記。Secret Manager の `spring-datasource-url` / `-username` / `-password`（Terraform 管理、値は provider の `direct_*` から自動配線）を env `SPRING_DATASOURCE_URL` / `_USERNAME` / `_PASSWORD` として注入。api-runner SA には `secretAccessor` 付与済み（Phase C）。

**H2 全面脱却（同一リリース・順序制約）**
- `application.yml`: H2 既定 datasource を除去（H2 既定を先に消すと prod が起動不能になるため、Secret 注入と同一リリースで実施。#451 本文の順序制約）。
- `build.gradle.kts`: `h2` 依存 drop。
- datasource の供給元: 本番 = Secret Manager env / ローカル `bootRun` = `spring-boot-docker-compose` 自動配線 / テスト = Testcontainers。

**H2 既定に依存していたテストの PG 化**
- `ApiApplicationTests` / `OpenApiTest` / `McpServerWiringTest` / `HealthEndpointTest` を `PostgresContainerSupport` 継承に変更（これらだけ H2 既定でコンテキストを起動していた）。注入値は全テスト同一のためコンテキストキャッシュ方針（ADR-0015）は維持。
- `PostgresContainerSupport` / `JdbcBreedingResultRepository` の古い doc コメント（「当面 H2」等）を現状へ更新。

**残置（意図的）**
- `db/migration/V*.sql` ヘッダの H2 言及: 本番適用済み migration の checksum を変えると Flyway validate が壊れるため変更しない。

## 検証

- `actionlint`（deploy.yml）通過
- `./gradlew check`（ktfmt / detekt / 全テスト Testcontainers PG / koverVerifyMature）通過
- マージ後: Cloud Run の新リビジョン起動ログで Flyway V1–V5 適用と health UP を確認する（デプロイ確認は本 PR の後続作業）

## リスクとロールバック

- 切替後に起動不能となった場合は Cloud Run のリビジョンを旧に戻す（旧リビジョンは H2 内蔵で env 無しでも起動する）。
- Secret 値は Terraform state 由来（Phase C apply 済み）。値の不整合が疑われる場合は Secret Manager の version を確認。

Closes ではない（#451 は Phase E 完了まで継続）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
