### PR TITLE
fix: Cloud Run の実行環境を gen2 に明示し外部 DB への DNS 解決失敗を解消する (#451)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,12 @@ jobs:
       # api-runner SA には当該 secret の secretAccessor が付与済み。
       # secrets_update_strategy=overwrite: 本ワークフローをサービスの secret 配線の唯一の出所とし、
       # ここに列挙しない secret 配線はデプロイ時に取り除く（宣言的・削除追従）。
+      #
+      # --execution-environment=gen2: 実行環境を第2世代（フル Linux 互換）に明示固定する。
+      # 未指定（Cloud Run の自動選択）だと gen1（gVisor）が選ばれることがあり、外部 DB
+      # （Prisma Postgres）への接続時に JVM の DNS 解決が UnknownHostException で失敗した
+      # （#451 Phase D cutover 初回失敗の原因。Cloud Run Job=常時 gen2 の latency probe では
+      # 同一ホストへ接続できていた）。
       - name: Deploy to Cloud Run
         uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3.0.1
         with:
@@ -84,4 +90,4 @@ jobs:
             SPRING_DATASOURCE_USERNAME=spring-datasource-username:latest
             SPRING_DATASOURCE_PASSWORD=spring-datasource-password:latest
           secrets_update_strategy: overwrite
-          flags: '--service-account=api-runner@ptiringo-toy-box.iam.gserviceaccount.com --no-allow-unauthenticated --port=8080 --memory=1Gi --cpu=1 --cpu-boost --min-instances=0 --max-instances=3'
+          flags: '--service-account=api-runner@ptiringo-toy-box.iam.gserviceaccount.com --no-allow-unauthenticated --port=8080 --memory=1Gi --cpu=1 --cpu-boost --min-instances=0 --max-instances=3 --execution-environment=gen2'


### PR DESCRIPTION
## 概要

#518（Phase D cutover）マージ後の自動デプロイが、新リビジョン起動失敗で落ちた（**トラフィック未切替のため本番影響なし**・旧 H2 リビジョン稼働中）。本 PR はその修正。

## 原因

新リビジョンのログで、Flyway/Hikari の初回接続時に

```
Caused by: java.net.UnknownHostException: db.prisma.io:5432
```

= **Cloud Run サービスインスタンス内で Prisma ホストの DNS 解決に失敗**（`InetSocketAddress` 未解決）。URL・Secret・IAM は正常（メッセージの host:port 形式から URL の組み立ては正しい）。

一方、Phase B のレイテンシ probe（Cloud Run **Job**・同リージョン・同ホスト）は接続に成功していた。Job は常時 **gen2**（フル Linux）で走るのに対し、`api` サービスは実行環境が**未指定＝Cloud Run の自動選択**で、**gen1（gVisor）が選ばれ DNS 解決が失敗**したと判断。

## 変更

`deploy.yml` の flags に `--execution-environment=gen2` を追加（1 行）。実行環境を第2世代へ明示固定する。

## 検証

- actionlint 通過。
- マージ後の自動デプロイで、新リビジョンが起動（Flyway V1–V5 の本番適用・health UP）することを確認する。

関連: #518 / #451（Phase D）

🤖 Generated with [Claude Code](https://claude.com/claude-code)