### PR TITLE
fix: datasource URL のホスト組み立てで direct_host のポート重複を解消する (#451)

### DIFF
--- a/infra/modules/prisma-postgres/main.tf
+++ b/infra/modules/prisma-postgres/main.tf
@@ -14,8 +14,14 @@ resource "prisma-postgres_database" "production" {
 # direct_host は Prisma 共有の安定ホスト、direct_user / direct_password は per-DB（再作成で変わる）。
 # PG カタログのデータベース名は Prisma の表示名によらず postgres 固定（#451 Phase B の spike で確認）。
 locals {
+  # direct_host はポート込み（例: db.prisma.io:5432）で返る。そのまま :5432 を連結すると
+  # ホスト名が「db.prisma.io:5432」となり DNS 解決不能（UnknownHostException）で本番リビジョンが
+  # 起動しない（#451 Phase D cutover 初回失敗の原因）。ホスト部だけ取り出して組み立てる
+  # （将来 direct_host がポート無しに変わっても壊れない）。
+  direct_host_without_port = split(":", prisma-postgres_database.production.direct_host)[0]
+
   datasource_secrets = {
-    "spring-datasource-url"      = "jdbc:postgresql://${prisma-postgres_database.production.direct_host}:5432/postgres?sslmode=require"
+    "spring-datasource-url"      = "jdbc:postgresql://${local.direct_host_without_port}:5432/postgres?sslmode=require"
     "spring-datasource-username" = prisma-postgres_database.production.direct_user
     "spring-datasource-password" = prisma-postgres_database.production.direct_password
   }


### PR DESCRIPTION
## 概要

Phase D cutover のデプロイ失敗（新リビジョン起動不能）の**真の原因の修正**。

## 原因（Secret 値の xxd で確定）

```
jdbc:postgresql://db.prisma.io:5432:5432/postgres?sslmode=require
                              ^^^^^^^^^^ ポート重複
```

provider の `direct_host` 属性は**ポート込み**（`db.prisma.io:5432`）で返る。モジュールがさらに `:5432` を連結していたため、JDBC がホスト名「`db.prisma.io:5432`」を DNS 解決しようとして `UnknownHostException` → リビジョン起動失敗。ログのメッセージ `UnknownHostException: db.prisma.io:5432` は host:port 表示ではなく**壊れたホスト名そのもの**だった。

- `dig A db.prisma.io` は正常（IPv4 2 本）＝ DNS 側の問題ではない
- gen1/gen2 で同一失敗だったことと整合（#520 の gen2 明示は無害なので残置）

## 変更

`split(":", direct_host)[0]` でホスト部だけ取り出して URL を組み立てる（将来 `direct_host` がポート無しになっても壊れない）。

## 影響

apply（HCP auto-apply）で `spring-datasource-url` の secret version が正しい URL に更新される。**マージ後、Deploy ワークフローの再実行（workflow_dispatch）で cutover をリトライする**（deploy.yml は infra/** を paths-ignore しているため自動では走らない）。

関連: #518 / #520 / #451（Phase D）

🤖 Generated with [Claude Code](https://claude.com/claude-code)