### PR TITLE
feat: breeding_registration.retirement の共在 CHECK を NOT VALID + VALIDATE で遡及追加する (#522)

### DIFF
--- a/src/main/resources/db/migration/V6__add_breeding_registration_retirement_check.sql
+++ b/src/main/resources/db/migration/V6__add_breeding_registration_retirement_check.sql
@@ -1,0 +1,22 @@
+-- breeding_registration の供用停止（BreedingRetirement）の共在 CHECK を遡及追加する（#522 / ADR-0043）。
+-- 不変条件は「retirement_reason / retirement_occurred_on の両方 NULL（供用中）か両方 NOT NULL（供用停止済み）」。
+-- V2 作成当時は H2(PostgreSQL 互換モード) との両対応が必要で見送られていたが、
+-- #451 の H2 全面脱却（ADR-0044、実 PostgreSQL 一本化）で前提が消えたため追加する。
+-- 既存行があるテーブルへの CHECK 追加はフルスキャン検証で書き込みをブロックしうるため 2 段階で行う:
+-- NOT VALID で新規行への強制を即時開始（既存行は未検証・ロック最小）し、
+-- VALIDATE CONSTRAINT で既存行を後追い検証する（SHARE UPDATE EXCLUSIVE・書き込みを止めない）。
+-- timeout は squawk（require-timeout-settings）に従い設定する。Flyway は各マイグレーションを
+-- 1 トランザクションで適用するため、SET LOCAL でこのマイグレーション内に閉じる
+-- （ロック待ちで他セッションを長時間塞がない・想定外の長時間実行を打ち切る）。
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+ALTER TABLE breeding_registration
+ADD CONSTRAINT chk_breeding_registration_retirement_coexistence
+CHECK (
+    (retirement_reason IS NULL AND retirement_occurred_on IS NULL)
+    OR (retirement_reason IS NOT NULL AND retirement_occurred_on IS NOT NULL)
+) NOT VALID;
+
+ALTER TABLE breeding_registration
+VALIDATE CONSTRAINT chk_breeding_registration_retirement_coexistence;

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepositoryContractTest.kt
@@ -14,7 +14,9 @@ import java.time.LocalDate
 import java.util.UUID
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.test.context.TestConstructor
 import org.springframework.test.context.TestConstructor.AutowireMode
 
@@ -129,5 +131,16 @@ class JdbcBreedingRegistrationRepositoryContractTest(
     @Test
     fun `存在しないIDのfindByIdはnullを返す`() {
         assert(repository.findById(BreedingRegistrationId(generateId())) == null)
+    }
+
+    @Test
+    fun `供用停止の共在不変条件に反する行はCHECK制約で拒否される`() {
+        // 事由だけ在って発生日が欠落＝共在 VO（BreedingRetirement）の「両方 NULL か両方 NOT NULL」違反。
+        // マッパーは常に整合した行しか作らないが、スキーマ側の CHECK 制約
+        // （chk_breeding_registration_retirement_coexistence）が DB 単独でもこの不正な組合せを拒否することを担保する。
+        val inconsistent =
+            row(retirementReason = RetirementReason.DEATH.name, retirementOccurredOn = null)
+
+        assertThrows<DataIntegrityViolationException> { rows.save(inconsistent) }
     }
 }


### PR DESCRIPTION
Closes #522（親: #451 / ADR-0043）

## 概要

`breeding_registration` の供用停止（`BreedingRetirement`）は `retirement_reason` / `retirement_occurred_on` の 2 列にフラット化されており、不変条件は「両方 NULL（供用中）か両方 NOT NULL（供用停止済み）」。ADR-0043 は共在 VO の不変条件を CHECK 制約で必須強制する方針だが、V2 作成当時は H2(PostgreSQL 互換モード) 両対応の制約で見送られていた。#451 の H2 全面脱却（実 PostgreSQL 一本化）で前提が消えたため、遡及して追加する。

## 変更内容

- **V6 マイグレーション**: `chk_breeding_registration_retirement_coexistence` を追加。既存行のあるテーブルへの CHECK 追加のため 2 段階で適用する
  - `ADD CONSTRAINT ... NOT VALID`: 新規行への強制を即時開始（既存行は未検証・ロック最小）
  - `VALIDATE CONSTRAINT`: 既存行を後追い検証（SHARE UPDATE EXCLUSIVE・書き込みを止めない）
  - squawk（require-timeout-settings）に従い `SET LOCAL` で lock/statement timeout を設定
- **契約テスト**: 不変条件に反する行（事由のみ・発生日欠落）が CHECK で拒否されるケースを `JdbcBreedingRegistrationRepositoryContractTest` に追加（`JdbcBloodHorseRepositoryContractTest` の CHECK テストと同型）

## 検証

- TDD: テスト先行で RED（CHECK 不在により例外が投げられず失敗）を確認 → V6 追加で GREEN
- `sqlfluff` / `squawk`: 0 issues
- `./gradlew check`: BUILD SUCCESSFUL（ktfmt / detekt / test / koverVerifyMature）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
