### PR TITLE
chore: Stop hook の check を失敗指紋 dedup と並行実行ガードで空回りさせない (#519)

### DIFF
--- a/.claude/hooks/lib/stop-hook-dedup.sh
+++ b/.claude/hooks/lib/stop-hook-dedup.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Stop hook 共通ヘルパー: 失敗指紋の dedup（#519）
+#
+# 「前回失敗から作業ツリーが変わっていなければ check を再実行しない」ための
+# 指紋計算と状態ファイル操作。Stop hook から source して使う（単体では実行しない）。
+#
+# - 指紋は HEAD ＋ tracked の未コミット差分 ＋ untracked（gitignore 除外済み）の
+#   パスと内容から作る。untracked の「内容」まで含めるのは、新規ファイルは
+#   コミットまで untracked のままで、パス一覧だけでは修正しても指紋が変わらず
+#   再武装されないため。
+# - 状態ファイルは git-dir 配下（非コミット領域）。worktree では git-dir が
+#   .git/worktrees/<name> になるため worktree ごとに自然に分離される。
+# - 失敗時のみ記録し、成功時は削除する（失敗指紋だけを持つ）。
+
+# 作業ツリーの指紋を stdout へ出す。リポジトリ root で呼ぶこと。
+compute_tree_fingerprint() {
+    {
+        git rev-parse HEAD 2>/dev/null
+        git diff HEAD 2>/dev/null
+        git ls-files --others --exclude-standard 2>/dev/null
+        git ls-files --others --exclude-standard -z 2>/dev/null \
+            | xargs -0 -r git hash-object -- 2>/dev/null
+    } | git hash-object --stdin
+}
+
+# 指定 hook の状態ファイルパスを stdout へ出す（親ディレクトリ作成込み）。
+dedup_state_file() {
+    local hook_name="$1" state_dir
+    state_dir="$(git rev-parse --git-dir 2>/dev/null)/claude-stop-hooks"
+    mkdir -p "$state_dir" 2>/dev/null || return 1
+    printf '%s/%s.fingerprint' "$state_dir" "$hook_name"
+}
+
+# 記録済みの失敗指紋と一致するか（一致＝ツリー無変更なのでスキップしてよい）。
+should_skip_unchanged() {
+    local hook_name="$1" fingerprint="$2" state_file
+    state_file="$(dedup_state_file "$hook_name")" || return 1
+    [ -f "$state_file" ] && [ "$(cat "$state_file" 2>/dev/null)" = "$fingerprint" ]
+}
+
+# check 失敗時に現在の指紋を記録する。
+record_failure_fingerprint() {
+    local hook_name="$1" fingerprint="$2" state_file
+    state_file="$(dedup_state_file "$hook_name")" || return 0
+    printf '%s\n' "$fingerprint" > "$state_file" 2>/dev/null
+}
+
+# check 成功時に状態ファイルを削除する。
+clear_failure_fingerprint() {
+    local hook_name="$1" state_file
+    state_file="$(dedup_state_file "$hook_name")" || return 0
+    rm -f "$state_file" 2>/dev/null
+}

--- a/.claude/hooks/stop-kotlin-quality.sh
+++ b/.claude/hooks/stop-kotlin-quality.sh
@@ -8,8 +8,16 @@
 # - check はフォーマットの自動修正を行わない。ktfmtCheck の失敗は exit 2 の
 #   フィードバックを受けた Claude が ktfmtFormat を実行して解消する想定。
 # - 失敗時は exit 2 で Claude にフィードバックして修正を促す。
+# - 空回り・並行競合対策（#519）:
+#   - Gradle クライアント JVM（GradleWrapperMain）が走っている間はスキップする。
+#     常駐 daemon は一致しない。共有 build cache の競合を避けるためマシン全体で見る。
+#   - 前回失敗時から作業ツリーが変わっていなければ再実行しない（失敗指紋 dedup）。
 
 set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$script_dir/lib/stop-hook-dedup.sh"
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$repo_root" || exit 0
@@ -22,10 +30,27 @@ if [ ! -x ./gradlew ]; then
     exit 0
 fi
 
+if command -v pgrep >/dev/null 2>&1 \
+    && pgrep -f 'org\.gradle\.wrapper\.GradleWrapperMain' >/dev/null 2>&1; then
+    echo 'gradle 実行中のため check をスキップしました（並行実行ガード・#519）' >&2
+    exit 0
+fi
+
+hook_name="kotlin-quality"
+fingerprint="$(compute_tree_fingerprint)"
+
+if should_skip_unchanged "$hook_name" "$fingerprint"; then
+    printf '前回失敗時から作業ツリーに変化が無いため check をスキップしました（#519）。ツリーを変更するか %s を削除すると再実行されます。\n' \
+        "$(dedup_state_file "$hook_name")" >&2
+    exit 0
+fi
+
 output="$(./gradlew check --daemon --console=plain 2>&1)"
 status=$?
 if [ "$status" -ne 0 ]; then
+    record_failure_fingerprint "$hook_name" "$fingerprint"
     printf './gradlew check に失敗しました:\n%s\n' "$output" >&2
     exit 2
 fi
+clear_failure_fingerprint "$hook_name"
 exit 0

--- a/.claude/hooks/stop-terraform-validate.sh
+++ b/.claude/hooks/stop-terraform-validate.sh
@@ -6,8 +6,14 @@
 # - HEAD との差分で .tf 変更が無いターンは何もしない。
 # - 違反があれば exit 2 を返し、Claude にフィードバックする。
 # - terraform / trivy が未インストールなら、当該チェックのみ黙ってスキップする。
+# - 空回り対策（#519）: 前回失敗時から作業ツリーが変わっていなければ再実行しない
+#   （失敗指紋 dedup）。init 失敗（provider 未キャッシュ等）も失敗として記録する。
 
 set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$script_dir/lib/stop-hook-dedup.sh"
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$repo_root" || exit 0
@@ -17,11 +23,21 @@ if ! git diff HEAD --name-only 2>/dev/null | grep -qE '^infra/.*\.tf$'; then
     exit 0
 fi
 
+hook_name="terraform-validate"
+fingerprint="$(compute_tree_fingerprint)"
+
+if should_skip_unchanged "$hook_name" "$fingerprint"; then
+    printf '前回失敗時から作業ツリーに変化が無いため terraform validate / trivy をスキップしました（#519）。ツリーを変更するか %s を削除すると再実行されます。\n' \
+        "$(dedup_state_file "$hook_name")" >&2
+    exit 0
+fi
+
 # terraform validate（terraform 未インストール時はスキップ）
 if command -v terraform >/dev/null 2>&1; then
     # init が走っていない場合のみ backend 無効で init する（terraform validate の前提）
     if [ ! -d infra/.terraform ]; then
         if ! init_output="$(cd infra && terraform init -backend=false -no-color 2>&1)"; then
+            record_failure_fingerprint "$hook_name" "$fingerprint"
             printf 'terraform init に失敗しました:\n%s\n' "$init_output" >&2
             exit 2
         fi
@@ -30,6 +46,7 @@ if command -v terraform >/dev/null 2>&1; then
     output="$(cd infra && terraform validate -no-color 2>&1)"
     status=$?
     if [ "$status" -ne 0 ]; then
+        record_failure_fingerprint "$hook_name" "$fingerprint"
         printf 'terraform validate に失敗しました:\n%s\n' "$output" >&2
         exit 2
     fi
@@ -43,9 +60,11 @@ if command -v mise >/dev/null 2>&1; then
     trivy_output="$(cd infra && mise exec -- trivy config . --exit-code 1 --quiet 2>&1)"
     status=$?
     if [ "$status" -ne 0 ]; then
+        record_failure_fingerprint "$hook_name" "$fingerprint"
         printf 'Trivy が IaC misconfig を検出しました:\n%s\n' "$trivy_output" >&2
         exit 2
     fi
 fi
 
+clear_failure_fingerprint "$hook_name"
 exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ mise exec -- sqlfluff fix src/main/resources/db/migration    # 自動整形
 mise exec -- squawk src/main/resources/db/migration/*.sql    # マイグレーション安全性
 
 # シェルスクリプトの lint（ShellCheck）
-mise exec -- shellcheck .claude/hooks/*.sh .devcontainer/*.sh scripts/*.sh
+mise exec -- shellcheck .claude/hooks/*.sh .claude/hooks/lib/*.sh .devcontainer/*.sh scripts/*.sh
 ```
 
 ktfmt はフォーマッタ、detekt は静的解析ツール。detekt 設定は `config/detekt/detekt.yml`（`buildUponDefaultConfig = true` でデフォルトに上書き、雛形再生成は `./gradlew detektGenerateConfig`）、レポートは `build/reports/detekt/`。プロジェクト固有のカスタムルール（例: ドメイン / アプリケーション層で `throw` しない）は `:detekt-rules` モジュールで定義し `detektPlugins` で組み込む（詳細は `.claude/rules/architecture.md`）。


### PR DESCRIPTION
Closes #519

## 概要

Stop hook の check（`stop-kotlin-quality.sh` の `./gradlew check` / `stop-terraform-validate.sh` の `terraform validate`＋`trivy config`）が毎ターンフル実行されることによる 2 つの実害（環境要因の失敗を延々再確認する空回り／エージェント自身の gradle との並行競合）を、Issue 記載の方針どおり **失敗指紋 dedup** と **並行実行ガード** で解消する。

## 変更内容

### `.claude/hooks/lib/stop-hook-dedup.sh`（新規）

失敗指紋 dedup の共通ヘルパー。両 Stop hook から `source` する。

- **指紋** = `git rev-parse HEAD` ＋ `git diff HEAD` の内容 ＋ untracked（gitignore 除外済み）の**パスと内容ハッシュ**を `git hash-object --stdin` で要約。
  - untracked の「内容」まで含めるのは、新規ファイルはコミットまで untracked のままで、パス一覧（`git status --porcelain` 相当）だけでは修正しても指紋が変わらず再武装されない偽陰性があるため。
- **状態ファイル** = `$(git rev-parse --git-dir)/claude-stop-hooks/<hook名>.fingerprint`。worktree では git-dir が `.git/worktrees/<name>` になるため worktree ごとに自然に分離される（非コミット領域なので環境依存をリポジトリへ持ち込まない）。
- 失敗時のみ記録し、成功時は削除（失敗指紋だけを持つ）。

### `.claude/hooks/stop-kotlin-quality.sh`

- **並行実行ガード**: `pgrep -f 'org\.gradle\.wrapper\.GradleWrapperMain'` で Gradle クライアント JVM を検知したらスキップ（exit 0・指紋は触らない）。クライアントはビルド進行中にだけ存在し、常駐 daemon は一致しない。共有 build cache の競合（#488）も踏まえマシン全体で見る。
- **同一状態スキップ**: 前回失敗時と指紋一致なら再実行せず、再武装条件（ツリー変更 or 状態ファイル削除）を添えた注記のみで exit 0。
- 失敗時に指紋記録、成功時にクリア。

### `.claude/hooks/stop-terraform-validate.sh`

- 同一状態スキップを組み込み。`terraform init` 失敗（provider 未キャッシュ等）・`validate` 失敗・`trivy` 失敗のいずれの exit 2 経路でも指紋を記録する。

### `CLAUDE.md`

- 手動 shellcheck コマンド例に `.claude/hooks/lib/*.sh` を追加（lefthook / CI の glob は既に `**/*.sh` で対象）。

## 採らなかった代替案

- **回数上限カウンタ**: N 回目まで無駄走りし、修正後も諦めモードが残る（Issue 記載どおり不採用）。
- **Gradle ロックファイル検知**: 内部仕様依存で脆く、stale lock で誤スキップしうる。
- **hook 自身の flock のみ**: エージェントが Bash ツールで流す `./gradlew test` との競合（主症状）を防げない。

## 既知のトレードオフ

環境要因（Docker 未起動等）が**ツリー変更なしに**解消した場合は指紋が一致したままなので check が走らない。スキップ注記に再武装手順（状態ファイル削除）を出して運用でカバーする（Issue で許容済み）。

## 検証

scratch git リポジトリ＋fake `gradlew` / fake `terraform`（PATH 差し込み）で hook 本体を end-to-end 検証（検証スクリプトは scratchpad・非コミット）:

- lib 単体: 指紋が tracked 変更・untracked 追加・**untracked 内容変更**で変わり、同一ツリーで安定すること。記録→一致スキップ→クリアの状態遷移。
- kotlin hook: 失敗→exit 2＋指紋記録 → 無変更→スキップ exit 0＋注記 → ツリー変更→再武装 exit 2 → 成功→exit 0＋状態ファイル削除 → GradleWrapperMain を名乗るプロセス存在中→ガードで exit 0（指紋不変）。
- terraform hook: 同上（ガード以外）。
- `shellcheck .claude/hooks/*.sh .claude/hooks/lib/*.sh` クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
