### PR TITLE
feat: 審査(HorseInspection)を一級リソースとして API へ配線する(#484)

### DIFF
--- a/src/main/kotlin/com/example/api/application/studbook/inspection/FindHorseInspectionUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/inspection/FindHorseInspectionUseCase.kt
@@ -1,0 +1,38 @@
+package com.example.api.application.studbook.inspection
+
+import com.example.api.domain.studbook.model.inspection.HorseInspectionId
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.toResultOr
+import java.util.UUID
+import org.springframework.stereotype.Service
+
+/**
+ * 審査照会クエリの入力。
+ *
+ * 読み取り系の入力は素の DTO とし、書き込み系の [com.example.api.domain.shared.Command] 封筒
+ * （発生時刻メタデータ）は使わない。発生時刻は書き込みイベントの概念であり、読み取りには不要（ADR-0031）。
+ *
+ * @property id 照会対象審査の生 UUID
+ */
+data class FindHorseInspectionQuery(val id: UUID)
+
+/** 照会対象の審査が存在しない。URL パス上の操作対象の不在として Controller 境界で 404 に写す（api-design.md）。 */
+data class HorseInspectionNotFound(val id: UUID)
+
+/**
+ * 審査照会ユースケース（軽量 CQRS（L2）の読み取り側。ADR-0031）。
+ *
+ * 書き込みユースケース（[RecordHorseInspectionUseCase]）と同列に `@Service` で公開するが、依存するのは 書き込みポートではなく読み取りポート
+ * [HorseInspectionQueries]。集約を組まず [HorseInspectionView] を返す。
+ *
+ * @return 照会できた [HorseInspectionView]、または対象不在を表す [HorseInspectionNotFound]
+ */
+@Service
+class FindHorseInspectionUseCase(private val horseInspectionQueries: HorseInspectionQueries) {
+    operator fun invoke(
+        query: FindHorseInspectionQuery
+    ): Result<HorseInspectionView, HorseInspectionNotFound> =
+        horseInspectionQueries.findById(HorseInspectionId(query.id)).toResultOr {
+            HorseInspectionNotFound(query.id)
+        }
+}

--- a/src/main/kotlin/com/example/api/application/studbook/inspection/HorseInspectionQueries.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/inspection/HorseInspectionQueries.kt
@@ -1,0 +1,17 @@
+package com.example.api.application.studbook.inspection
+
+import com.example.api.domain.studbook.model.inspection.HorseInspectionId
+
+/**
+ * 審査の読み取りポート（軽量 CQRS（L2）の Query 側。ADR-0031）。
+ *
+ * 書き込みポート [com.example.api.domain.studbook.model.inspection.HorseInspectionRepository]
+ * とは**別物として割る**。同じストアを読んでも、経路（write=集約復元 / read=View 直組み）と モデルを分離するのが L2 の価値であり、「同じテーブルなら write
+ * ポートに finder を生やせばよい」 という誘惑には乗らない。
+ *
+ * 読み取りポートは集約のライフサイクルを持たないため、書き込みポートが付ける jMolecules `@Repository` は**付けない**。
+ */
+interface HorseInspectionQueries {
+    /** ID で審査ビューを引く。存在しなければ null（単純 lookup は Result を強制しない。error-handling.md）。 */
+    fun findById(id: HorseInspectionId): HorseInspectionView?
+}

--- a/src/main/kotlin/com/example/api/application/studbook/inspection/HorseInspectionView.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/inspection/HorseInspectionView.kt
@@ -1,0 +1,29 @@
+package com.example.api.application.studbook.inspection
+
+import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import java.util.UUID
+import org.jmolecules.architecture.cqrs.QueryModel
+
+/**
+ * 審査の読み取り専用ビュー（Read Model）。軽量 CQRS（L2）の読み取り側を表す（ADR-0031）。
+ *
+ * 書き込み側の集約 [com.example.api.domain.studbook.model.inspection.HorseInspection] を**一切経由せず**、
+ * ストアから直接組む DTO。不変条件を持たず（検証は書き込み側のファクトリの責務）、値としての等価性が自然なため `data class` を使う。
+ *
+ * [JockeyView][com.example.api.application.racing.jockey.JockeyView] は全プリミティブだが、本ビューは sealed な
+ * 親子判定の判別子語彙を application / controller に文字列で漏らさないため、検証を持たないドメイン VO （[ParentageDetermination] /
+ * [IdentificationFeatures]）をそのまま載せる（集約は経由しない＝L2 の要点は維持）。
+ *
+ * @property id 審査の生 UUID
+ * @property microchipNumber マイクロチップ番号（15 桁数字）
+ * @property parentage 親子判定
+ * @property features 特徴記述子。未記録なら null
+ */
+@QueryModel
+data class HorseInspectionView(
+    val id: UUID,
+    val microchipNumber: String,
+    val parentage: ParentageDetermination,
+    val features: IdentificationFeatures?,
+)

--- a/src/main/kotlin/com/example/api/application/studbook/inspection/RecordHorseInspectionUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/inspection/RecordHorseInspectionUseCase.kt
@@ -1,0 +1,61 @@
+package com.example.api.application.studbook.inspection
+
+import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.inspection.HorseInspection
+import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
+import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
+import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
+import com.example.api.domain.studbook.model.inspection.MicrochipNumber
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
+import org.springframework.stereotype.Service
+
+/**
+ * 審査記録ユースケースの入力コマンド。
+ *
+ * マイクロチップ番号は VO で表すため素の文字列で受け取り、ユースケース内で [MicrochipNumber] の `create` を 通して検証する。親子判定・特徴記述子は検証を持たない
+ * VO のためドメイン型のまま保持する（wire との変換は controller 境界の責務。ADR-0007 でドメイン enum をコマンドに保持する既存規約と同じ扱い）。
+ *
+ * @property microchipNumber マイクロチップ番号（15 桁数字）
+ * @property parentage 親子判定
+ * @property features 特徴記述子。未記録なら null
+ */
+data class RecordHorseInspectionCommand(
+    val microchipNumber: String,
+    val parentage: ParentageDetermination,
+    val features: IdentificationFeatures?,
+)
+
+/**
+ * 審査記録ユースケース。
+ *
+ * 血統登録の内部で審査を生成する経路（[com.example.api.application.studbook.horse.RegisterInStudBookUseCase]）とは
+ * 独立に、確定済みの審査を単独で記録する対外 API 経路（#484。登録フロー側は不変）。境界の生入力を [MicrochipNumber]
+ * に検証変換し、[HorseInspection.create] で採番・生成して保存する。
+ *
+ * 失敗のしかたはマイクロチップ形式不正の 1 種類のみのため、専用の sealed は作らずドメインの [InvalidMicrochipNumber]
+ * をそのまま返す（error-handling.md「1 種類なら単一型」。増えたら sealed へ昇格）。 単一集約の save のみでトランザクション論点はなく、`create`
+ * はドメインイベントを返さない。
+ *
+ * @return 保存後の [HorseInspection]、またはマイクロチップ形式不正を表す [InvalidMicrochipNumber]
+ */
+@Service
+class RecordHorseInspectionUseCase(
+    private val horseInspectionRepository: HorseInspectionRepository
+) {
+    operator fun invoke(
+        command: Command<RecordHorseInspectionCommand>
+    ): Result<HorseInspection, InvalidMicrochipNumber> {
+        val input = command.payload
+        return MicrochipNumber.create(input.microchipNumber).map { microchipNumber ->
+            horseInspectionRepository.save(
+                HorseInspection.create(
+                    microchipNumber = microchipNumber,
+                    parentage = input.parentage,
+                    features = input.features,
+                )
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/example/api/controller/horse/BloodHorseWireEnums.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/BloodHorseWireEnums.kt
@@ -15,8 +15,8 @@ import com.example.api.domain.studbook.model.inspection.DnaParentageResult
  * 列挙子名は現状ドメインと同一だが、それは「現時点で wire 名とドメイン名が一致している」だけであり、両者の独立性は
  * このマッピング層で担保する。ドメイン enum をリネームしても、本ファイルの when 節を直せば wire 契約は不変に保てる。
  *
- * `toApi` は成功レスポンス [BloodHorseResponse] が露出する項目（性・毛色・品種）のみ用意する。DNA 判定は
- * リクエスト専用項目のためレスポンス変換を持たない。
+ * `toApi` は成功レスポンスが露出する項目に用意する。DNA 判定は審査リソース（`controller.inspection`）の
+ * レスポンスでも露出するため双方向を持つ。
  */
 
 /** 性（HTTP 契約）。 */
@@ -151,4 +151,12 @@ fun DnaParentageResultDto.toDomain(): DnaParentageResult =
         DnaParentageResultDto.CONSISTENT -> DnaParentageResult.CONSISTENT
         DnaParentageResultDto.INCONSISTENT -> DnaParentageResult.INCONSISTENT
         DnaParentageResultDto.UNTESTED -> DnaParentageResult.UNTESTED
+    }
+
+/** ドメインの DNA 判定結果を HTTP 契約の判定結果へ変換する。 */
+fun DnaParentageResult.toApi(): DnaParentageResultDto =
+    when (this) {
+        DnaParentageResult.CONSISTENT -> DnaParentageResultDto.CONSISTENT
+        DnaParentageResult.INCONSISTENT -> DnaParentageResultDto.INCONSISTENT
+        DnaParentageResult.UNTESTED -> DnaParentageResultDto.UNTESTED
     }

--- a/src/main/kotlin/com/example/api/controller/inspection/HorseInspectionController.kt
+++ b/src/main/kotlin/com/example/api/controller/inspection/HorseInspectionController.kt
@@ -1,0 +1,115 @@
+package com.example.api.controller.inspection
+
+import com.example.api.application.studbook.inspection.FindHorseInspectionQuery
+import com.example.api.application.studbook.inspection.FindHorseInspectionUseCase
+import com.example.api.application.studbook.inspection.RecordHorseInspectionUseCase
+import com.example.api.controller.inspection.problem.toProblemDetail
+import com.example.api.controller.inspection.request.RecordHorseInspectionRequest
+import com.example.api.controller.inspection.request.toCommand
+import com.example.api.controller.orThrowProblem
+import com.example.api.domain.shared.Command
+import com.github.michaelbull.result.mapError
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import java.time.Clock
+import java.util.UUID
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ProblemDetail
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 審査リソースの HTTP アダプター（#484）。
+ *
+ * Google AIP のリソース指向設計に従い、コレクション `/api/horseInspections` に対する Create（審査の記録）と
+ * Get（審査の参照）を提供する。血統登録の内部で審査を生成する既存経路（`RegisterInStudBookUseCase`）は そのままに、審査を単独で記録・参照できる対外 API
+ * 経路を足す。エラーレスポンスは RFC 9457 (Problem Details) 形式で返す。
+ */
+@RestController
+class HorseInspectionController(
+    private val recordHorseInspection: RecordHorseInspectionUseCase,
+    private val findHorseInspection: FindHorseInspectionUseCase,
+    private val clock: Clock,
+) {
+    @Operation(
+        summary = "審査を記録する",
+        description = "確定済みの審査（個体識別・親子判定）を記録する。業務ルール違反時は RFC 9457 形式の problem+json を返す。",
+        tags = ["HorseInspection"],
+        responses =
+            [
+                ApiResponse(
+                    responseCode = "201",
+                    description = "記録成功（記録された審査リソースを返す）",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = HorseInspectionResponse::class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "400",
+                    description = "入力値が不正（マイクロチップ番号・親子判定区分など）",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+            ],
+    )
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/api/horseInspections")
+    fun record(@RequestBody request: RecordHorseInspectionRequest): HorseInspectionResponse =
+        recordHorseInspection(Command.now(request.toCommand(), clock))
+            .mapError { it.toProblemDetail() }
+            .orThrowProblem()
+            .toResponse()
+
+    @Operation(
+        summary = "審査を取得する",
+        description = "ID で審査を取得する。対象が存在しなければ RFC 9457 形式の problem+json を返す。",
+        tags = ["HorseInspection"],
+        responses =
+            [
+                ApiResponse(
+                    responseCode = "200",
+                    description = "取得成功",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = HorseInspectionResponse::class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "404",
+                    description = "指定 ID の審査が存在しない",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+            ],
+    )
+    @GetMapping("/api/horseInspections/{id}")
+    fun get(@PathVariable id: UUID): HorseInspectionResponse =
+        findHorseInspection(FindHorseInspectionQuery(id))
+            .mapError { it.toProblemDetail() }
+            .orThrowProblem()
+            .toResponse()
+}

--- a/src/main/kotlin/com/example/api/controller/inspection/HorseInspectionResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/inspection/HorseInspectionResponse.kt
@@ -1,0 +1,45 @@
+package com.example.api.controller.inspection
+
+import com.example.api.application.studbook.inspection.HorseInspectionView
+import com.example.api.domain.studbook.model.inspection.HorseInspection
+import java.util.UUID
+
+/**
+ * 審査リソースの表現（HTTP 契約）。
+ *
+ * 審査リソースに対する操作（Create / Get）は、AIP-133 / AIP-131 に倣い一律でこのリソース表現全体を返す （ADR-0008）。相互排他な親子判定は入れ子
+ * `parentage` の oneOf にする（ADR-0020）。
+ *
+ * @property id 審査の生 UUID
+ * @property microchipNumber マイクロチップ番号
+ * @property parentage 親子判定
+ * @property features 特徴記述子。未記録なら null
+ */
+data class HorseInspectionResponse(
+    val id: UUID,
+    val microchipNumber: String,
+    val parentage: ParentageDeterminationDto,
+    val features: IdentificationFeaturesDto?,
+)
+
+/** [HorseInspection] を審査リソースの表現へ変換する（書き込み経路。Create の成功レスポンス）。 */
+fun HorseInspection.toResponse(): HorseInspectionResponse =
+    HorseInspectionResponse(
+        id = id.value,
+        microchipNumber = microchipNumber.value,
+        parentage = parentage.toApi(),
+        features = features?.toApi(),
+    )
+
+/**
+ * 読み取りビュー [HorseInspectionView] を審査リソースの表現へ変換する。
+ *
+ * 軽量 CQRS（L2）の読み取り経路（Get）も、書き込み経路（Create）と**同一の単一リソース表現**を返す（ADR-0008）。
+ */
+fun HorseInspectionView.toResponse(): HorseInspectionResponse =
+    HorseInspectionResponse(
+        id = id,
+        microchipNumber = microchipNumber,
+        parentage = parentage.toApi(),
+        features = features?.toApi(),
+    )

--- a/src/main/kotlin/com/example/api/controller/inspection/IdentificationFeaturesDto.kt
+++ b/src/main/kotlin/com/example/api/controller/inspection/IdentificationFeaturesDto.kt
@@ -1,0 +1,44 @@
+package com.example.api.controller.inspection
+
+import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
+
+/**
+ * 審査リソースの「特徴記述子」の表現（HTTP 契約）。
+ *
+ * 旋毛・白斑・鼻紋を保持し、いずれも任意（未記録なら null）。ドメインの [IdentificationFeatures] と同形だが wire 契約として独立させる（ADR-0007
+ * と同趣旨）。
+ *
+ * @property hairWhorl 旋毛の記述
+ * @property whiteMarkings 白斑（四肢別）の記述
+ * @property nosePrint 鼻紋の記述
+ */
+data class IdentificationFeaturesDto(
+    val hairWhorl: String?,
+    val whiteMarkings: String?,
+    val nosePrint: String?,
+)
+
+/**
+ * HTTP 契約の特徴記述子をドメインへ変換する。
+ *
+ * **全フィールド null は不在（null）へ正規化する**。永続化が「feature_* 列すべて NULL＝未記録」で在不在を 表すため（ADR-0043
+ * の共在フラット化）、ここで正規化しないと Create 直後の応答（features あり）と Get の応答（features null）が食い違う。
+ */
+fun IdentificationFeaturesDto.toDomain(): IdentificationFeatures? =
+    if (hairWhorl == null && whiteMarkings == null && nosePrint == null) {
+        null
+    } else {
+        IdentificationFeatures(
+            hairWhorl = hairWhorl,
+            whiteMarkings = whiteMarkings,
+            nosePrint = nosePrint,
+        )
+    }
+
+/** ドメインの特徴記述子を HTTP 契約へ変換する。 */
+fun IdentificationFeatures.toApi(): IdentificationFeaturesDto =
+    IdentificationFeaturesDto(
+        hairWhorl = hairWhorl,
+        whiteMarkings = whiteMarkings,
+        nosePrint = nosePrint,
+    )

--- a/src/main/kotlin/com/example/api/controller/inspection/ParentageDeterminationDto.kt
+++ b/src/main/kotlin/com/example/api/controller/inspection/ParentageDeterminationDto.kt
@@ -1,0 +1,85 @@
+package com.example.api.controller.inspection
+
+import com.example.api.controller.horse.DnaParentageResultDto
+import com.example.api.controller.horse.toApi
+import com.example.api.controller.horse.toDomain
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 審査リソースの「親子判定」の表現（HTTP 契約）。
+ *
+ * DNA 型（判定結果あり）／血液型・海外機関フォールバック／対象外の相互排他を、判別子 `type` を持つ discriminated union
+ * として表す（ADR-0020、[com.example.api.controller.horse.OriginDto] と同方針）。ドメインの sealed
+ * [ParentageDetermination] と表裏一体だが、wire 契約として独立させ [toApi] / [toDomain] で往復する （ADR-0007 と整合）。DNA
+ * 判定結果の enum は軽種馬リソースと同一概念のため [DnaParentageResultDto] を共有する（契約が分岐したら分割する）。
+ *
+ * Jackson は [JsonTypeInfo] により `type` を出力し、springdoc は [Schema] の `oneOf` ＋ `discriminatorProperty`
+ * で polymorphic スキーマを生成する。
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = ParentageDeterminationDto.ByDna::class, name = "BY_DNA"),
+    JsonSubTypes.Type(value = ParentageDeterminationDto.ByBloodType::class, name = "BY_BLOOD_TYPE"),
+    JsonSubTypes.Type(
+        value = ParentageDeterminationDto.ByOverseasInstitution::class,
+        name = "BY_OVERSEAS_INSTITUTION",
+    ),
+    JsonSubTypes.Type(
+        value = ParentageDeterminationDto.NotApplicable::class,
+        name = "NOT_APPLICABLE",
+    ),
+)
+@Schema(
+    description =
+        "親子判定（DNA=BY_DNA / 血液型=BY_BLOOD_TYPE / 海外機関=BY_OVERSEAS_INSTITUTION / " +
+            "対象外=NOT_APPLICABLE の discriminated union）",
+    oneOf =
+        [
+            ParentageDeterminationDto.ByDna::class,
+            ParentageDeterminationDto.ByBloodType::class,
+            ParentageDeterminationDto.ByOverseasInstitution::class,
+            ParentageDeterminationDto.NotApplicable::class,
+        ],
+    discriminatorProperty = "type",
+)
+sealed interface ParentageDeterminationDto {
+    /**
+     * DNA 型による親子判定。
+     *
+     * @property dnaParentageResult DNA 型による判定結果
+     */
+    data class ByDna(val dnaParentageResult: DnaParentageResultDto) : ParentageDeterminationDto
+
+    /** 血液型検査によるフォールバック。追加フィールドなし（詳細は #267）。 */
+    data object ByBloodType : ParentageDeterminationDto
+
+    /** 承認海外機関の判定によるフォールバック。追加フィールドなし（詳細は #267）。 */
+    data object ByOverseasInstitution : ParentageDeterminationDto
+
+    /** 親子判定の対象外（父母不明等）。追加フィールドなし。 */
+    data object NotApplicable : ParentageDeterminationDto
+}
+
+/** HTTP 契約の親子判定をドメインの親子判定へ変換する。 */
+fun ParentageDeterminationDto.toDomain(): ParentageDetermination =
+    when (this) {
+        is ParentageDeterminationDto.ByDna ->
+            ParentageDetermination.ByDna(dnaParentageResult.toDomain())
+        ParentageDeterminationDto.ByBloodType -> ParentageDetermination.ByBloodType
+        ParentageDeterminationDto.ByOverseasInstitution ->
+            ParentageDetermination.ByOverseasInstitution
+        ParentageDeterminationDto.NotApplicable -> ParentageDetermination.NotApplicable
+    }
+
+/** ドメインの親子判定を HTTP 契約の親子判定へ変換する。 */
+fun ParentageDetermination.toApi(): ParentageDeterminationDto =
+    when (this) {
+        is ParentageDetermination.ByDna -> ParentageDeterminationDto.ByDna(result.toApi())
+        ParentageDetermination.ByBloodType -> ParentageDeterminationDto.ByBloodType
+        ParentageDetermination.ByOverseasInstitution ->
+            ParentageDeterminationDto.ByOverseasInstitution
+        ParentageDetermination.NotApplicable -> ParentageDeterminationDto.NotApplicable
+    }

--- a/src/main/kotlin/com/example/api/controller/inspection/problem/HorseInspectionProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/inspection/problem/HorseInspectionProblem.kt
@@ -1,0 +1,42 @@
+package com.example.api.controller.inspection.problem
+
+import com.example.api.application.studbook.inspection.HorseInspectionNotFound
+import com.example.api.controller.problem
+import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+
+/**
+ * 審査リソースの業務エラーを RFC 9457 (`application/problem+json`) の [ProblemDetail] へ変換するマッパー群。
+ *
+ * どのエラーをどの `status` / `errorCode` に描画するかの方針をここ（adapter 層の `problem/` パッケージ）へ 集約する。
+ */
+
+/**
+ * [InvalidMicrochipNumber]（マイクロチップ形式不正）を 400 Bad Request の [ProblemDetail] に変換する。
+ *
+ * VO 検証エラー（形式不正）は入力不正として 400 とする（api-design.md）。`errorCode` は血統登録の同種エラー
+ * （`BloodHorseProblem`）と同一文言を踏襲する。
+ */
+fun InvalidMicrochipNumber.toProblemDetail(): ProblemDetail =
+    problem(
+        status = HttpStatus.BAD_REQUEST,
+        code = "invalid-microchip-number",
+        title = "Invalid microchip number",
+        detail = "microchip_number は 15 桁の数字でなければなりません。",
+    )
+
+/**
+ * [HorseInspectionNotFound]（照会対象の審査不在）を 404 Not Found の [ProblemDetail] に変換する。
+ *
+ * URL パス（`/api/horseInspections/{id}`）で識別される操作対象そのものが無いため 404 とする（api-design.md 「リソース不在のステータス（404
+ * vs 422）」）。馬名登録のボディ内参照先不在（422 `inspection-not-found`）とは 発生箇所も意味も異なるため、`errorCode` を分ける。
+ */
+fun HorseInspectionNotFound.toProblemDetail(): ProblemDetail =
+    problem(
+            status = HttpStatus.NOT_FOUND,
+            code = "horse-inspection-not-found",
+            title = "Horse inspection not found",
+            detail = "指定された ID の審査は存在しません。",
+        )
+        .apply { setProperty("inspection_id", id) }

--- a/src/main/kotlin/com/example/api/controller/inspection/request/RecordHorseInspectionRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/inspection/request/RecordHorseInspectionRequest.kt
@@ -1,0 +1,33 @@
+package com.example.api.controller.inspection.request
+
+import com.example.api.application.studbook.inspection.RecordHorseInspectionCommand
+import com.example.api.controller.inspection.IdentificationFeaturesDto
+import com.example.api.controller.inspection.ParentageDeterminationDto
+import com.example.api.controller.inspection.toDomain
+
+/**
+ * `POST /api/horseInspections` のリクエストボディ。
+ *
+ * 審査の記録申請に相当する。親子判定は判別子 `type` 付きの [ParentageDeterminationDto] で受け、未知の 判別子は Jackson のデシリアライズで弾かれ
+ * `GlobalExceptionHandler` が 400 を返す。マイクロチップ番号は VO で表す項目のため素の文字列で受け取り、ユースケースで検証する（ADR-0026）。
+ *
+ * @property microchipNumber マイクロチップ番号（15 桁数字）
+ * @property parentage 親子判定
+ * @property features 特徴記述子（任意）
+ */
+data class RecordHorseInspectionRequest(
+    val microchipNumber: String,
+    val parentage: ParentageDeterminationDto,
+    val features: IdentificationFeaturesDto? = null,
+)
+
+/**
+ * リクエストボディを審査記録ユースケースの入力コマンドへ変換する。境界 DTO ↔ コマンドのフィールド対応は ここに集約する。features の「全フィールド null → 不在」正規化は
+ * [IdentificationFeaturesDto.toDomain] が担う。
+ */
+fun RecordHorseInspectionRequest.toCommand(): RecordHorseInspectionCommand =
+    RecordHorseInspectionCommand(
+        microchipNumber = microchipNumber,
+        parentage = parentage.toDomain(),
+        features = features?.toDomain(),
+    )

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/HorseInspectionColumnMapping.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/HorseInspectionColumnMapping.kt
@@ -1,0 +1,64 @@
+package com.example.api.infrastructure.studbook.inspection
+
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+
+/*
+ * horse_inspection テーブルの列表現とドメイン VO の相互変換（#312 / #484）。
+ *
+ * 判別子フラット化（sealed ParentageDetermination ⇔ parentage_type + dna_parentage_result）と
+ * 特徴記述子のフラット化（nullable IdentificationFeatures ⇔ feature_* 列）は、write 経路
+ * （JdbcHorseInspectionRepository の Row マッピング）と read 経路（JdbcHorseInspectionQueries の
+ * View 直組み。ADR-0031 の L2）の双方で必要になるため、パッケージ内共有のトップレベル関数に置く。
+ */
+
+internal const val PARENTAGE_BY_DNA = "BY_DNA"
+internal const val PARENTAGE_BY_BLOOD_TYPE = "BY_BLOOD_TYPE"
+internal const val PARENTAGE_BY_OVERSEAS_INSTITUTION = "BY_OVERSEAS_INSTITUTION"
+internal const val PARENTAGE_NOT_APPLICABLE = "NOT_APPLICABLE"
+
+/** 判別子と DNA 結果の列値から sealed [ParentageDetermination] を復元する。未知の判別子は復元データ破損として扱う。 */
+internal fun toParentageDetermination(
+    parentageType: String,
+    dnaParentageResult: String?,
+): ParentageDetermination =
+    when (parentageType) {
+        PARENTAGE_BY_DNA ->
+            ParentageDetermination.ByDna(
+                DnaParentageResult.valueOf(
+                    checkNotNull(dnaParentageResult) {
+                        "DNA 判定結果が欠落しています: parentage_type=$parentageType"
+                    }
+                )
+            )
+        PARENTAGE_BY_BLOOD_TYPE -> ParentageDetermination.ByBloodType
+        PARENTAGE_BY_OVERSEAS_INSTITUTION -> ParentageDetermination.ByOverseasInstitution
+        PARENTAGE_NOT_APPLICABLE -> ParentageDetermination.NotApplicable
+        else -> error("未知の parentage_type です: $parentageType")
+    }
+
+/** feature_* 列から nullable な [IdentificationFeatures] を復元する（全 NULL なら未記録＝null）。 */
+internal fun toIdentificationFeatures(
+    hairWhorl: String?,
+    whiteMarkings: String?,
+    nosePrint: String?,
+): IdentificationFeatures? =
+    if (hairWhorl == null && whiteMarkings == null && nosePrint == null) {
+        null
+    } else {
+        IdentificationFeatures(
+            hairWhorl = hairWhorl,
+            whiteMarkings = whiteMarkings,
+            nosePrint = nosePrint,
+        )
+    }
+
+/** sealed [ParentageDetermination] を判別子と DNA 結果のペアへ写す。 */
+internal fun ParentageDetermination.toTypeAndResult(): Pair<String, String?> =
+    when (this) {
+        is ParentageDetermination.ByDna -> PARENTAGE_BY_DNA to result.name
+        ParentageDetermination.ByBloodType -> PARENTAGE_BY_BLOOD_TYPE to null
+        ParentageDetermination.ByOverseasInstitution -> PARENTAGE_BY_OVERSEAS_INSTITUTION to null
+        ParentageDetermination.NotApplicable -> PARENTAGE_NOT_APPLICABLE to null
+    }

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionQueries.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionQueries.kt
@@ -1,0 +1,53 @@
+package com.example.api.infrastructure.studbook.inspection
+
+import com.example.api.application.studbook.inspection.HorseInspectionQueries
+import com.example.api.application.studbook.inspection.HorseInspectionView
+import com.example.api.domain.studbook.model.inspection.HorseInspectionId
+import java.util.UUID
+import org.springframework.jdbc.core.simple.JdbcClient
+import org.springframework.stereotype.Repository
+
+/**
+ * 読み取りポート [HorseInspectionQueries] の実装（軽量 CQRS（L2）の Query 側。ADR-0031）。
+ *
+ * 書き込みの [JdbcHorseInspectionRepository]（集約を [HorseInspectionRow] 経由で復元する）とは**別経路**として、
+ * `horse_inspection` テーブルを [JdbcClient] で直接 SELECT し、集約を一切組まずに [HorseInspectionView] へ詰める。
+ * 判別子・特徴記述子の列変換は write 経路と共有する（`HorseInspectionColumnMapping.kt`）。
+ *
+ * 楽観ロックの `version` 列は読み取りでは不要なため SELECT しない（read は整合性境界を持たない）。
+ */
+@Repository
+class JdbcHorseInspectionQueries(private val jdbcClient: JdbcClient) : HorseInspectionQueries {
+
+    override fun findById(id: HorseInspectionId): HorseInspectionView? =
+        jdbcClient
+            .sql(
+                """
+                SELECT id, microchip_number, parentage_type, dna_parentage_result,
+                    feature_hair_whorl, feature_white_markings, feature_nose_print
+                FROM horse_inspection
+                WHERE id = :id
+                """
+                    .trimIndent()
+            )
+            .param("id", id.value)
+            .query { rs, _ ->
+                HorseInspectionView(
+                    id = rs.getObject("id", UUID::class.java),
+                    microchipNumber = rs.getString("microchip_number"),
+                    parentage =
+                        toParentageDetermination(
+                            parentageType = rs.getString("parentage_type"),
+                            dnaParentageResult = rs.getString("dna_parentage_result"),
+                        ),
+                    features =
+                        toIdentificationFeatures(
+                            hairWhorl = rs.getString("feature_hair_whorl"),
+                            whiteMarkings = rs.getString("feature_white_markings"),
+                            nosePrint = rs.getString("feature_nose_print"),
+                        ),
+                )
+            }
+            .optional()
+            .orElse(null)
+}

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionRepository.kt
@@ -1,6 +1,5 @@
 package com.example.api.infrastructure.studbook.inspection
 
-import com.example.api.domain.studbook.model.inspection.DnaParentageResult
 import com.example.api.domain.studbook.model.inspection.HorseInspection
 import com.example.api.domain.studbook.model.inspection.HorseInspectionId
 import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
@@ -38,36 +37,10 @@ class JdbcHorseInspectionRepository(private val rows: HorseInspectionSpringDataR
         HorseInspection.reconstitute(
             id = HorseInspectionId(id),
             microchipNumber = MicrochipNumber.create(microchipNumber).orThrow(),
-            parentage = toParentage(),
-            features = toFeatures(),
+            parentage = toParentageDetermination(parentageType, dnaParentageResult),
+            features =
+                toIdentificationFeatures(featureHairWhorl, featureWhiteMarkings, featureNosePrint),
         )
-
-    /** 判別子 [HorseInspectionRow.parentageType] から sealed [ParentageDetermination] を復元する。 */
-    private fun HorseInspectionRow.toParentage(): ParentageDetermination =
-        when (parentageType) {
-            PARENTAGE_BY_DNA ->
-                ParentageDetermination.ByDna(
-                    DnaParentageResult.valueOf(
-                        checkNotNull(dnaParentageResult) { "DNA 判定結果が欠落: id=$id" }
-                    )
-                )
-            PARENTAGE_BY_BLOOD_TYPE -> ParentageDetermination.ByBloodType
-            PARENTAGE_BY_OVERSEAS_INSTITUTION -> ParentageDetermination.ByOverseasInstitution
-            PARENTAGE_NOT_APPLICABLE -> ParentageDetermination.NotApplicable
-            else -> error("未知の parentage_type です: $parentageType (id=$id)")
-        }
-
-    /** feature_* 列から nullable な [IdentificationFeatures] を復元する（全 NULL なら未記録＝null）。 */
-    private fun HorseInspectionRow.toFeatures(): IdentificationFeatures? =
-        if (featureHairWhorl == null && featureWhiteMarkings == null && featureNosePrint == null) {
-            null
-        } else {
-            IdentificationFeatures(
-                hairWhorl = featureHairWhorl,
-                whiteMarkings = featureWhiteMarkings,
-                nosePrint = featureNosePrint,
-            )
-        }
 
     /** ドメイン集約を永続化モデルへ写す。version はドメインが持たないため常に null（insert 判定。更新系は #424）。 */
     private fun HorseInspection.toRow(): HorseInspectionRow {
@@ -81,22 +54,5 @@ class JdbcHorseInspectionRepository(private val rows: HorseInspectionSpringDataR
             featureWhiteMarkings = features?.whiteMarkings,
             featureNosePrint = features?.nosePrint,
         )
-    }
-
-    /** sealed [ParentageDetermination] を判別子と DNA 結果のペアへ写す。 */
-    private fun ParentageDetermination.toTypeAndResult(): Pair<String, String?> =
-        when (this) {
-            is ParentageDetermination.ByDna -> PARENTAGE_BY_DNA to result.name
-            ParentageDetermination.ByBloodType -> PARENTAGE_BY_BLOOD_TYPE to null
-            ParentageDetermination.ByOverseasInstitution ->
-                PARENTAGE_BY_OVERSEAS_INSTITUTION to null
-            ParentageDetermination.NotApplicable -> PARENTAGE_NOT_APPLICABLE to null
-        }
-
-    private companion object {
-        const val PARENTAGE_BY_DNA = "BY_DNA"
-        const val PARENTAGE_BY_BLOOD_TYPE = "BY_BLOOD_TYPE"
-        const val PARENTAGE_BY_OVERSEAS_INSTITUTION = "BY_OVERSEAS_INSTITUTION"
-        const val PARENTAGE_NOT_APPLICABLE = "NOT_APPLICABLE"
     }
 }

--- a/src/test/kotlin/com/example/api/application/studbook/inspection/FindHorseInspectionUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/inspection/FindHorseInspectionUseCaseTest.kt
@@ -1,0 +1,49 @@
+package com.example.api.application.studbook.inspection
+
+import com.example.api.domain.shared.generateId
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.HorseInspectionId
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+/**
+ * 照会ユースケース [FindHorseInspectionUseCase] の単体テスト（軽量 CQRS（L2）の読み取り側。ADR-0031）。
+ *
+ * 読み取りポート [HorseInspectionQueries] を mockk でスタブし、ヒット時は [HorseInspectionView] を、不在時は
+ * [HorseInspectionNotFound] を返す分岐を検証する（testing.md: applicationService はポート境界をモックする）。
+ */
+class FindHorseInspectionUseCaseTest {
+    private val horseInspectionQueries = mockk<HorseInspectionQueries>()
+    private val findHorseInspection = FindHorseInspectionUseCase(horseInspectionQueries)
+
+    @Test
+    fun `存在するIDなら対応するHorseInspectionViewをOkで返す`() {
+        val id = generateId()
+        val view =
+            HorseInspectionView(
+                id = id,
+                microchipNumber = "392140000000001",
+                parentage = ParentageDetermination.ByDna(DnaParentageResult.CONSISTENT),
+                features = null,
+            )
+        every { horseInspectionQueries.findById(HorseInspectionId(id)) } returns view
+
+        val result = findHorseInspection(FindHorseInspectionQuery(id))
+
+        assert(result.get() == view)
+    }
+
+    @Test
+    fun `存在しないIDならHorseInspectionNotFoundをErrで返す`() {
+        val id = generateId()
+        every { horseInspectionQueries.findById(HorseInspectionId(id)) } returns null
+
+        val result = findHorseInspection(FindHorseInspectionQuery(id))
+
+        assert(result.getError() == HorseInspectionNotFound(id))
+    }
+}

--- a/src/test/kotlin/com/example/api/application/studbook/inspection/RecordHorseInspectionUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/inspection/RecordHorseInspectionUseCaseTest.kt
@@ -1,0 +1,73 @@
+package com.example.api.application.studbook.inspection
+
+import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.HorseInspection
+import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
+import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
+import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getError
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import java.time.Instant
+import org.junit.jupiter.api.Test
+
+/**
+ * 記録ユースケース [RecordHorseInspectionUseCase] の単体テスト。
+ *
+ * 書き込みポート [HorseInspectionRepository] を mockk（strict）でスタブし、正常系は save へ渡る集約の中身を、 マイクロチップ不正は Err と
+ * save 未到達（strict mockk が保証）を検証する（testing.md）。
+ */
+class RecordHorseInspectionUseCaseTest {
+    private val horseInspectionRepository = mockk<HorseInspectionRepository>()
+    private val recordHorseInspection = RecordHorseInspectionUseCase(horseInspectionRepository)
+
+    private fun command(
+        microchipNumber: String,
+        parentage: ParentageDetermination =
+            ParentageDetermination.ByDna(DnaParentageResult.CONSISTENT),
+        features: IdentificationFeatures? = null,
+    ): Command<RecordHorseInspectionCommand> =
+        Command(
+            RecordHorseInspectionCommand(
+                microchipNumber = microchipNumber,
+                parentage = parentage,
+                features = features,
+            ),
+            Instant.now(),
+        )
+
+    @Test
+    fun `正しい入力で審査が保存され保存後の集約がOkで返る`() {
+        val saved = slot<HorseInspection>()
+        every { horseInspectionRepository.save(capture(saved)) } answers { saved.captured }
+        val features = IdentificationFeatures("頭部正中", "左後一白", null)
+
+        val result =
+            recordHorseInspection(
+                command(
+                    microchipNumber = "392140000000001",
+                    parentage = ParentageDetermination.ByBloodType,
+                    features = features,
+                )
+            )
+
+        val inspection = result.get()
+        assert(inspection != null)
+        assert(inspection!!.microchipNumber.value == "392140000000001")
+        assert(inspection.parentage == ParentageDetermination.ByBloodType)
+        assert(inspection.features == features)
+        assert(saved.captured == inspection)
+    }
+
+    @Test
+    fun `マイクロチップ番号が15桁数字でなければInvalidMicrochipNumberを返し保存しない`() {
+        val result = recordHorseInspection(command(microchipNumber = "123"))
+
+        // save をスタブしていない strict mockk のため、save に到達すればここより前に失敗する
+        assert(result.getError() == InvalidMicrochipNumber)
+    }
+}

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -255,6 +255,25 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
                 .extractingPath("$.error_code")
                 .isEqualTo("horse-name-already-taken")
         }
+
+        @Test
+        fun `InspectionNotFound で 422 と inspection_id 付きの problem+json が返ること`() {
+            val inspectionId = UUID.fromString("55555555-5555-5555-5555-555555555555")
+            every { nameHorse(any<Command<NameHorseCommand>>()) } returns
+                Err(NameHorseUseCaseError.InspectionNotFound(inspectionId))
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .assertThat()
+                .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.error_code")
+                .isEqualTo("inspection-not-found")
+        }
     }
 
     @Nested

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -24,6 +24,7 @@ import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import java.time.LocalDate
 import java.util.UUID
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
@@ -262,17 +263,24 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
             every { nameHorse(any<Command<NameHorseCommand>>()) } returns
                 Err(NameHorseUseCaseError.InspectionNotFound(inspectionId))
 
-            tester
-                .post()
-                .uri(uri)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body)
-                .assertThat()
+            val result =
+                tester
+                    .post()
+                    .uri(uri)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body)
+                    .exchange()
+
+            assertThat(result)
                 .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
                 .extractingPath("$.error_code")
                 .isEqualTo("inspection-not-found")
+            assertThat(result)
+                .bodyJson()
+                .extractingPath("$.inspection_id")
+                .isEqualTo(inspectionId.toString())
         }
     }
 

--- a/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
@@ -24,6 +24,7 @@ import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.slot
 import java.util.UUID
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
@@ -216,15 +217,15 @@ class HorseInspectionControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMa
             every { findHorseInspection(FindHorseInspectionQuery(id)) } returns
                 Err(HorseInspectionNotFound(id))
 
-            tester
-                .get()
-                .uri("/api/horseInspections/$id")
-                .assertThat()
+            val result = tester.get().uri("/api/horseInspections/$id").exchange()
+
+            assertThat(result)
                 .hasStatus(HttpStatus.NOT_FOUND)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
                 .extractingPath("$.error_code")
                 .isEqualTo("horse-inspection-not-found")
+            assertThat(result).bodyJson().extractingPath("$.inspection_id").isEqualTo(id.toString())
         }
     }
 }

--- a/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
@@ -1,0 +1,230 @@
+package com.example.api.controller.inspection
+
+import com.example.api.application.studbook.inspection.FindHorseInspectionQuery
+import com.example.api.application.studbook.inspection.FindHorseInspectionUseCase
+import com.example.api.application.studbook.inspection.HorseInspectionNotFound
+import com.example.api.application.studbook.inspection.HorseInspectionView
+import com.example.api.application.studbook.inspection.RecordHorseInspectionCommand
+import com.example.api.application.studbook.inspection.RecordHorseInspectionUseCase
+import com.example.api.config.ClockConfiguration
+import com.example.api.controller.horse.DnaParentageResultDto
+import com.example.api.controller.inspection.request.RecordHorseInspectionRequest
+import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.generateId
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.HorseInspection
+import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
+import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
+import com.example.api.domain.studbook.model.inspection.MicrochipNumber
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.unwrap
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.slot
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.context.TestConstructor.AutowireMode
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.assertj.MockMvcTester
+import tools.jackson.databind.json.JsonMapper
+
+@WebMvcTest(HorseInspectionController::class)
+@Import(ClockConfiguration::class)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class HorseInspectionControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper) {
+    @MockkBean private lateinit var recordHorseInspection: RecordHorseInspectionUseCase
+    @MockkBean private lateinit var findHorseInspection: FindHorseInspectionUseCase
+
+    private val tester = MockMvcTester.create(mockMvc)
+
+    /** DNA 判定＋特徴記述子つきの審査集約を組む（レスポンス表現の検証用）。 */
+    private fun inspectionWithFeatures(): HorseInspection =
+        HorseInspection.create(
+            microchipNumber = MicrochipNumber.create("392140000000001").unwrap(),
+            parentage = ParentageDetermination.ByDna(DnaParentageResult.CONSISTENT),
+            features = IdentificationFeatures("頭部正中", "左後一白", null),
+        )
+
+    @Nested
+    inner class RecordCase {
+        private val uri = "/api/horseInspections"
+
+        /** DTO を実アプリと同じ [jsonMapper] でシリアライズし、契約とテストの二重管理を避ける。 */
+        private val validBody =
+            jsonMapper.writeValueAsString(
+                RecordHorseInspectionRequest(
+                    microchipNumber = "392140000000001",
+                    parentage = ParentageDeterminationDto.ByDna(DnaParentageResultDto.CONSISTENT),
+                    features =
+                        IdentificationFeaturesDto(
+                            hairWhorl = "頭部正中",
+                            whiteMarkings = "左後一白",
+                            nosePrint = null,
+                        ),
+                )
+            )
+
+        @Test
+        fun `正常な入力で 201 Created と DNA 判定つきの審査リソースが返ること`() {
+            every { recordHorseInspection(any<Command<RecordHorseInspectionCommand>>()) } returns
+                Ok(inspectionWithFeatures())
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.CREATED)
+                .bodyJson()
+                .extractingPath("$.parentage.dna_parentage_result")
+                .isEqualTo("CONSISTENT")
+        }
+
+        @Test
+        fun `判定対象外（フィールドなしバリアント）の審査を記録でき features 未指定は null になること`() {
+            val saved =
+                HorseInspection.create(
+                    microchipNumber = MicrochipNumber.create("392140000000002").unwrap(),
+                    parentage = ParentageDetermination.NotApplicable,
+                )
+            every { recordHorseInspection(any<Command<RecordHorseInspectionCommand>>()) } returns
+                Ok(saved)
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                        "microchip_number": "392140000000002",
+                        "parentage": { "type": "NOT_APPLICABLE" }
+                    }
+                    """
+                        .trimIndent()
+                )
+                .assertThat()
+                .hasStatus(HttpStatus.CREATED)
+                .bodyJson()
+                .extractingPath("$.features")
+                .isNull()
+        }
+
+        @Test
+        fun `全フィールド null の features はコマンドで不在（null）へ正規化されること`() {
+            val command = slot<Command<RecordHorseInspectionCommand>>()
+            every { recordHorseInspection(capture(command)) } returns Ok(inspectionWithFeatures())
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                        "microchip_number": "392140000000001",
+                        "parentage": { "type": "BY_BLOOD_TYPE" },
+                        "features": {
+                            "hair_whorl": null,
+                            "white_markings": null,
+                            "nose_print": null
+                        }
+                    }
+                    """
+                        .trimIndent()
+                )
+                .assertThat()
+                .hasStatus(HttpStatus.CREATED)
+
+            assert(command.captured.payload.features == null)
+        }
+
+        @Test
+        fun `InvalidMicrochipNumber で 400 と problem+json が返ること`() {
+            every { recordHorseInspection(any<Command<RecordHorseInspectionCommand>>()) } returns
+                Err(InvalidMicrochipNumber)
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.error_code")
+                .isEqualTo("invalid-microchip-number")
+        }
+
+        @Test
+        fun `未知の parentage type は Jackson デシリアライズで弾かれ 400 が返ること`() {
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                        "microchip_number": "392140000000001",
+                        "parentage": { "type": "BY_RUMOR" }
+                    }
+                    """
+                        .trimIndent()
+                )
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST)
+        }
+    }
+
+    @Nested
+    inner class GetCase {
+        @Test
+        fun `存在する ID で 200 OK と審査リソースが返ること`() {
+            val id = generateId()
+            val view =
+                HorseInspectionView(
+                    id = id,
+                    microchipNumber = "392140000000001",
+                    parentage = ParentageDetermination.ByDna(DnaParentageResult.CONSISTENT),
+                    features = IdentificationFeatures("頭部正中", null, null),
+                )
+            every { findHorseInspection(FindHorseInspectionQuery(id)) } returns Ok(view)
+
+            tester
+                .get()
+                .uri("/api/horseInspections/$id")
+                .assertThat()
+                .hasStatus(HttpStatus.OK)
+                .bodyJson()
+                .extractingPath("$.microchip_number")
+                .isEqualTo("392140000000001")
+        }
+
+        @Test
+        fun `存在しない ID で 404 と inspection_id 付きの problem+json が返ること`() {
+            val id = UUID.fromString("44444444-4444-4444-4444-444444444444")
+            every { findHorseInspection(FindHorseInspectionQuery(id)) } returns
+                Err(HorseInspectionNotFound(id))
+
+            tester
+                .get()
+                .uri("/api/horseInspections/$id")
+                .assertThat()
+                .hasStatus(HttpStatus.NOT_FOUND)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.error_code")
+                .isEqualTo("horse-inspection-not-found")
+        }
+    }
+}

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionQueriesContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionQueriesContractTest.kt
@@ -1,0 +1,123 @@
+package com.example.api.infrastructure.studbook.inspection
+
+import com.example.api.domain.shared.generateId
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.domain.studbook.model.inspection.HorseInspectionId
+import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.example.api.support.PostgresContainerSupport
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.simple.JdbcClient
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.context.TestConstructor.AutowireMode
+
+/**
+ * 読み取りポート HorseInspectionQueries の実装 [JdbcHorseInspectionQueries] の契約テスト （軽量 CQRS（L2）の Query
+ * 側。ADR-0031）。
+ *
+ * 書き込みの [JdbcHorseInspectionRepositoryContractTest] と同じく本番ターゲットの PostgreSQL（Testcontainers、
+ * [PostgresContainerSupport] で共有）に対して検証する。コンテキスト構成も write 側と同一（`@SpringBootTest(NONE)`）
+ * のためコンテキストキャッシュを共有する（testing.md）。
+ *
+ * 検証する契約:
+ * 1. `horse_inspection` テーブルへ直接 SELECT し、集約を組まずに View へ詰められること
+ * 2. 判別子（parentage_type / dna_parentage_result）から sealed [ParentageDetermination] を復元できること（全 4 区分）
+ * 3. feature_* 列が全 NULL なら features が null に、値があれば [IdentificationFeatures] に復元されること
+ * 4. 該当行が無ければ null を返すこと
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class JdbcHorseInspectionQueriesContractTest(
+    private val jdbcClient: JdbcClient,
+    private val rows: HorseInspectionSpringDataRepository,
+) : PostgresContainerSupport() {
+
+    private val queries = JdbcHorseInspectionQueries(jdbcClient)
+
+    @BeforeEach
+    fun cleanUp() {
+        rows.deleteAll()
+    }
+
+    @Test
+    fun `DNA判定と特徴記述子を持つ審査をIDでViewとして引ける`() {
+        val id = generateId()
+        rows.save(
+            HorseInspectionRow(
+                id = id,
+                microchipNumber = "392140000000001",
+                parentageType = "BY_DNA",
+                dnaParentageResult = "CONSISTENT",
+                featureHairWhorl = "頭部正中",
+                featureWhiteMarkings = "左後一白",
+                featureNosePrint = "渦紋",
+            )
+        )
+
+        val view = queries.findById(HorseInspectionId(id))
+
+        assert(view != null)
+        assert(view!!.id == id)
+        assert(view.microchipNumber == "392140000000001")
+        assert(view.parentage == ParentageDetermination.ByDna(DnaParentageResult.CONSISTENT))
+        assert(view.features == IdentificationFeatures("頭部正中", "左後一白", "渦紋"))
+    }
+
+    @Test
+    fun `血液型フォールバックの審査は特徴なし（全NULL）で features が null になる`() {
+        val id = generateId()
+        rows.save(
+            HorseInspectionRow(
+                id = id,
+                microchipNumber = "392140000000002",
+                parentageType = "BY_BLOOD_TYPE",
+            )
+        )
+
+        val view = queries.findById(HorseInspectionId(id))
+
+        assert(view!!.parentage == ParentageDetermination.ByBloodType)
+        assert(view.features == null)
+    }
+
+    @Test
+    fun `海外機関判定の審査を復元できる`() {
+        val id = generateId()
+        rows.save(
+            HorseInspectionRow(
+                id = id,
+                microchipNumber = "392140000000003",
+                parentageType = "BY_OVERSEAS_INSTITUTION",
+            )
+        )
+
+        assert(
+            queries.findById(HorseInspectionId(id))!!.parentage ==
+                ParentageDetermination.ByOverseasInstitution
+        )
+    }
+
+    @Test
+    fun `判定対象外の審査を復元できる`() {
+        val id = generateId()
+        rows.save(
+            HorseInspectionRow(
+                id = id,
+                microchipNumber = "392140000000004",
+                parentageType = "NOT_APPLICABLE",
+            )
+        )
+
+        assert(
+            queries.findById(HorseInspectionId(id))!!.parentage ==
+                ParentageDetermination.NotApplicable
+        )
+    }
+
+    @Test
+    fun `存在しないIDのfindByIdはnullを返す`() {
+        assert(queries.findById(HorseInspectionId(generateId())) == null)
+    }
+}


### PR DESCRIPTION
## 概要

#312 でドメイン＋永続化として切り出した審査サブドメイン（`HorseInspection`）を、一級リソースとして対外 API へ配線する。

Closes #484

## 変更内容

### API 契約

- `POST /api/horseInspections` → 201。審査（マイクロチップ・親子判定・特徴記述子）を単独で記録する
- `GET /api/horseInspections/{id}` → 200 / 404。Create と同一の単一リソース表現（ADR-0008）
- `parentage` は判別子 `type` 付き oneOf（`BY_DNA` / `BY_BLOOD_TYPE` / `BY_OVERSEAS_INSTITUTION` / `NOT_APPLICABLE`。ADR-0020、`OriginDto` と同型）。`dna_parentage_result` の wire enum は既存 `DnaParentageResultDto` を再利用
- `features` は任意。**全フィールド null は不在（null）へ正規化**（永続化の「全 NULL＝未記録」と往復整合させ、Create 直後と Get の応答が食い違わないように）
- エラー: 400 `invalid-microchip-number` / 404 `horse-inspection-not-found`（`inspection_id` 拡張プロパティ付き。ボディ内参照先不在の既存 422 `inspection-not-found` とはコードを分離）

### 実装（オニオン各リング）

- **application**: `RecordHorseInspectionUseCase`（失敗 1 種類のためドメインの `InvalidMicrochipNumber` をそのまま返す）／軽量 CQRS L2 の読み取り経路 `FindHorseInspectionUseCase` + `HorseInspectionView`(@QueryModel) + `HorseInspectionQueries` ポート（ADR-0031、`racing/jockey` と対称）
- **infrastructure**: `JdbcHorseInspectionQueries`（JdbcClient 直 SELECT、集約・Row 非経由）。判別子⇔sealed 変換を `HorseInspectionColumnMapping.kt` へ抽出し write/read で共有（write 側は振る舞い不変のリファクタ）
- **controller**: `controller/inspection/` 一式（Controller / Response / oneOf DTO / Request / Problem）。OpenAPI アノテーション付与
- **ドメイン・既存の血統登録フローは無変更**（`RegisterInStudBookUseCase` の内部生成経路はそのまま。マイグレーション追加なし）

### テスト

- slice: `HorseInspectionControllerTest`（201/400/404・oneOf 往復・features 正規化、7 件）
- Issue のやること 3: `BloodHorseControllerTest` に `InspectionNotFound → 422`（`inspection-not-found` + `inspection_id`）の slice テストを追補（#312 最終レビュー Minor #4）
- ユースケース: `RecordHorseInspectionUseCaseTest` / `FindHorseInspectionUseCaseTest`
- 契約: `JdbcHorseInspectionQueriesContractTest`（Testcontainers PostgreSQL、親子判定 4 区分×features 有無）
- 実機確認済み: `bootRun` + curl で POST 201 → GET 200（同一表現）→ 404 problem+json の往復を確認

## 設計上の判断（spec で確定済み）

1. **単独 Create を併設**し、既存の血統登録フロー（内部生成）は変えない（登録が既存審査 ID を受ける再編成は破壊的変更のため範囲外）
2. **Karate E2E は含めない**（#495「API E2E 横展開（GET-by-id 整備とセット）」の管轄）
3. **List は作らない**（Issue スコープは Create / Get のみ）

スコープ外の接続先: 親子判定フォールバック詳細 #267 / DNA 再利用・再検査省略 #266 / 複数集約トランザクション境界 #483 / E2E #495 / 更新系・楽観ロック #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
