### PR TITLE
chore: 永続化 spike の暫定依存を version catalog へ移管する(#425)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,21 +33,21 @@ dependencies {
     // 本番ランタイムの datasource は Prisma Postgres（実 PostgreSQL v17）へ配線する（#451 / ADR-0044）。
     // ローカル/CI/smoke/テストは全て PostgreSQL（組み込み H2 は cutover で全面脱却済み）。永続化の契約
     // テストは本番ターゲットの PostgreSQL を Testcontainers で用意して検証する（ADR-0027 / #422）。
-    implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
+    implementation(libs.spring.boot.starter.data.jdbc)
     // Flyway は starter で引く。Spring Boot 4 は autoconfig を機能別モジュールに分割しており、
     // FlywayAutoConfiguration は spring-boot-autoconfigure ではなく専用モジュール spring-boot-flyway
     // に移った。素の flyway-core だけだと autoconfig が classpath に無く、エラーも出さず migrate が
     // 走らない（#421）。starter-flyway が spring-boot-flyway(autoconfig) + spring-boot-jdbc +
     // flyway-core を引き込む。
-    implementation("org.springframework.boot:spring-boot-starter-flyway")
+    implementation(libs.spring.boot.starter.flyway)
     // ローカル開発（bootRun）時に compose.yaml の PostgreSQL を自動起動し datasource を自動配線する。
     // developmentOnly のため本番イメージ（bootBuildImage）・テスト classpath には載らない（#451）。
-    developmentOnly("org.springframework.boot:spring-boot-docker-compose")
+    developmentOnly(libs.spring.boot.docker.compose)
     // PostgreSQL ドライバと Flyway の PostgreSQL モジュール（Flyway 10+ は DB 別サポートをモジュール分割）。
     // 本番ランタイムは Prisma Postgres（実 PostgreSQL v17）へ接続するため runtimeOnly で本番 jar に載せる
     // （#451 / ADR-0044）。契約テスト（Testcontainers）でも runtimeOnly は testRuntimeClasspath に含まれる。
-    runtimeOnly("org.postgresql:postgresql")
-    runtimeOnly("org.flywaydb:flyway-database-postgresql")
+    runtimeOnly(libs.postgresql)
+    runtimeOnly(libs.flyway.database.postgresql)
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation(libs.java.uuid.generator)
     implementation(libs.kotlin.result)
@@ -67,7 +67,7 @@ dependencies {
     // コンテナはシングルトン起動し接続先を @DynamicPropertySource（spring-test）で注入するため、
     // @ServiceConnection 用の spring-boot-testcontainers や JUnit5 拡張モジュールは要らず postgresql モジュール
     // 1 本でよい（core は推移取得）。アーティファクト ID は Testcontainers 2.0 の testcontainers-<module> 体系。
-    testImplementation("org.testcontainers:testcontainers-postgresql")
+    testImplementation(libs.testcontainers.postgresql)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // プロジェクト固有の detekt カスタムルール（domain/application で throw しない 等）を detekt 実行時に組み込む

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,15 @@ spring-ai-starter-mcp-server-webmvc = { module = "org.springframework.ai:spring-
 springdoc-openapi-bom = { module = "org.springdoc:springdoc-openapi-bom", version.ref = "springdoc-openapi-bom" }
 springdoc-openapi-starter-webmvc-ui = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui" }
 
+# 永続化（Spring Data JDBC + Flyway + PostgreSQL。ADR-0027 / ADR-0044）。
+# バージョンは Spring Boot の依存管理（BOM）に委ねるため version は指定しない
+spring-boot-starter-data-jdbc = { module = "org.springframework.boot:spring-boot-starter-data-jdbc" }
+spring-boot-starter-flyway = { module = "org.springframework.boot:spring-boot-starter-flyway" }
+spring-boot-docker-compose = { module = "org.springframework.boot:spring-boot-docker-compose" }
+postgresql = { module = "org.postgresql:postgresql" }
+flyway-database-postgresql = { module = "org.flywaydb:flyway-database-postgresql" }
+testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql" }
+
 # UUID Generator
 java-uuid-generator = { module = "com.fasterxml.uuid:java-uuid-generator", version.ref = "java-uuid-generator" }
 


### PR DESCRIPTION
## 概要

spike（PR #420）以来 `build.gradle.kts` に文字列座標で直書きされていた永続化関連の依存を、version catalog（`gradle/libs.versions.toml`）へ移管する。

Closes #425

## 変更内容

- `gradle/libs.versions.toml`: 永続化関連 6 依存のエントリを追加
  - `spring-boot-starter-data-jdbc` / `spring-boot-starter-flyway` / `spring-boot-docker-compose` / `postgresql` / `flyway-database-postgresql` / `testcontainers-postgresql`
  - バージョンは Spring Boot の依存管理（BOM）に委ねるため `version` 指定なし（既存の `springdoc-openapi-starter-webmvc-ui` 等と同じ流儀）
- `build.gradle.kts`: 上記依存の文字列座標をカタログ参照（`libs.*`）へ置換。スコープ（`implementation` / `developmentOnly` / `runtimeOnly` / `testImplementation`）と既存コメントは変更なし

## Issue 記載事項との差分

- `com.h2database:h2` は #451 の PostgreSQL cutover で既に全面削除済みのため移管対象なし。同じく Issue の「H2 のスコープ整理」も #451 で解消済み
- `spring-boot-docker-compose`（#451 で追加）は Issue のリストには無いが、永続化関連の直書き依存なので併せて移管した

## 検証

- `./gradlew check` BUILD SUCCESSFUL（test / detekt / ktfmtCheck / koverVerifyMature 全緑）
- バージョン解決は移管前と同一（カタログ側に version を持たせず BOM 委譲のまま）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
