### PR TITLE
feat: ドメインイベント発行基盤を配線する（ApplicationEventPublisher + publish-after-commit）(#433)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -30,7 +30,7 @@ paths:
 |-------|-----------|--------------|------------|
 | domainModel | `domain.shared` + `domain.*.model` | 純粋ライブラリのみ（kotlin-result / java-uuid-generator / jMolecules） | 禁止（jakarta / Jackson も禁止） |
 | domainService | `domain.*.service` | domainModel | 禁止 |
-| applicationService | `application` | domainModel / domainService | `org.springframework.stereotype`（`@Service` / `@Component`）のみ |
+| applicationService | `application` | domainModel / domainService | 配線の語彙のみ: `org.springframework.stereotype`（DI）＋ `org.springframework.transaction.annotation`（宣言的 Tx 境界）＋ `ApplicationEventPublisher`（イベント発行。クラス単位で許可）（[ADR-0050](../../docs/adr/0050-domain-event-publication-after-commit.md)） |
 | adapter (rest) | `controller` | 内側すべて | 可 |
 | adapter (persistence) | `infrastructure` | 内側すべて | 可 |
 | adapter (mcp) | `mcp` | 内側すべて | 可 |
@@ -103,7 +103,7 @@ domain/
 
 ドメインサービス（`service/` のトップレベル関数）には jMolecules アノテーションを付けない。`@Service`（jMolecules）は型向けでトップレベル関数に付けられず、ドメインサービスであることは `service/` パッケージへの配置で表現する。
 
-**ドメインイベント**（`@DomainEvent`）は「起きたこと」を表すビルディングブロック。イミュータブル集約（`var` 禁止）は内部にイベントを溜め込めないため、状態遷移メソッドが遷移後の集約とイベントを `StateTransition<A, E>`（`domain.shared`）に同梱して返し、発行は application 層が担う（集約は純粋なまま保つ）。失敗しうる遷移は `Result<StateTransition<A, E>, エラー>` を返し失敗時はイベントを生成しない（例: `BloodHorse.assignName` → `HorseNamed`）。イベントは値としての等価性が自然なため `data class` を使ってよい（ID ベース `final equals` を持つ集約と異なり衝突しない）。他集約への参照は ID 値クラス経由。収集・発行方式の決定経緯は [ADR-0029](../../docs/adr/0029-domain-events-via-state-transition-return.md)（Spring `ApplicationEventPublisher` 連携・publish-after-commit・発生時刻 enrichment は別イシュー送り）。
+**ドメインイベント**（`@DomainEvent`）は「起きたこと」を表すビルディングブロック。イミュータブル集約（`var` 禁止）は内部にイベントを溜め込めないため、状態遷移メソッドが遷移後の集約とイベントを `StateTransition<A, E>`（`domain.shared`）に同梱して返し、発行は application 層が担う（集約は純粋なまま保つ）。失敗しうる遷移は `Result<StateTransition<A, E>, エラー>` を返し失敗時はイベントを生成しない（例: `BloodHorse.assignName` → `HorseNamed`）。イベントは値としての等価性が自然なため `data class` を使ってよい（ID ベース `final equals` を持つ集約と異なり衝突しない）。他集約への参照は ID 値クラス経由。収集方式の決定経緯は [ADR-0029](../../docs/adr/0029-domain-events-via-state-transition-return.md)。**発行**はユースケースが Spring `ApplicationEventPublisher` で行い（`@Transactional` のトランザクション内で発行）、購読はアダプタ（`infrastructure` 等）の `@TransactionalEventListener(phase = AFTER_COMMIT)` で受ける。イベントはコミット確定後にのみ届き、ロールバック時は破棄される（publish-after-commit）。リスナ内例外はコミットを取り消せないため、リスナに置けるのは失敗しても本体の書き込みに影響しない処理（通知・ログ等）に限る。決定経緯は [ADR-0050](../../docs/adr/0050-domain-event-publication-after-commit.md)（発生時刻 enrichment は #434 送り）。
 
 **コマンド**（`Command<T>`、`domain.shared`）はドメインイベント（「起きたこと」）と対をなすビルディングブロックで、ペイロード（何をしたいか）に発生時刻メタデータ（`issuedAt: Instant`、タイムゾーン非依存のドメインイベント時刻）を添える封筒。ペイロードと横断的メタデータを分離する。書き込みユースケースの入力に用い（例: `registerInStudBook(command: Command<StudBook>)`）、読み取り（クエリ）系では使わない（発生時刻は書き込みイベントの概念）。jMolecules アノテーションを持たない汎用キャリアのため `domain.shared` に置く。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ ktfmt はフォーマッタ、detekt は静的解析ツール。detekt 設定は
 
 ### ドメイン駆動設計
 
-ドメインモデルには [jMolecules](https://github.com/xmolecules/jmolecules) のアノテーション（`@AggregateRoot` / `@ValueObject` / `@field:Identity` / `@Repository` / `@DomainEvent` 等）で DDD ビルディングブロックの役割を表明し、整合性は ArchUnit（`JMoleculesDddRules`）で検証する。各パターン（Value Object は `@JvmInline value class`、Entity は ID 同一性＋自己検証ファクトリ＋イミュータブル、Command／Domain Event の封筒、軽量 CQRS の Query / Read Model）の規約とコード例は **`.claude/rules/architecture.md`**（`.kt` 編集時にロード）に集約している。決定経緯は ADR を参照: ID 生成 [ADR-0005](docs/adr/0005-time-based-uuid-generation.md) / イミュータブル集約 [ADR-0009](docs/adr/0009-immutable-aggregates.md) / 自己検証ファクトリ [ADR-0014](docs/adr/0014-self-validating-factory-over-confinement.md) / ドメインイベント [ADR-0029](docs/adr/0029-domain-events-via-state-transition-return.md) / 軽量 CQRS [ADR-0031](docs/adr/0031-lightweight-cqrs-read-model.md)。
+ドメインモデルには [jMolecules](https://github.com/xmolecules/jmolecules) のアノテーション（`@AggregateRoot` / `@ValueObject` / `@field:Identity` / `@Repository` / `@DomainEvent` 等）で DDD ビルディングブロックの役割を表明し、整合性は ArchUnit（`JMoleculesDddRules`）で検証する。各パターン（Value Object は `@JvmInline value class`、Entity は ID 同一性＋自己検証ファクトリ＋イミュータブル、Command／Domain Event の封筒、軽量 CQRS の Query / Read Model）の規約とコード例は **`.claude/rules/architecture.md`**（`.kt` 編集時にロード）に集約している。決定経緯は ADR を参照: ID 生成 [ADR-0005](docs/adr/0005-time-based-uuid-generation.md) / イミュータブル集約 [ADR-0009](docs/adr/0009-immutable-aggregates.md) / 自己検証ファクトリ [ADR-0014](docs/adr/0014-self-validating-factory-over-confinement.md) / ドメインイベント [ADR-0029](docs/adr/0029-domain-events-via-state-transition-return.md) / イベント発行（publish-after-commit）[ADR-0050](docs/adr/0050-domain-event-publication-after-commit.md) / 軽量 CQRS [ADR-0031](docs/adr/0031-lightweight-cqrs-read-model.md)。
 
 ### パッケージ構成
 

--- a/docs/adr/0050-domain-event-publication-after-commit.md
+++ b/docs/adr/0050-domain-event-publication-after-commit.md
@@ -1,0 +1,58 @@
+# 0050. ドメインイベントは ApplicationEventPublisher で発行し AFTER_COMMIT で購読する
+
+- Status: Accepted
+- Date: 2026-07-03
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+[ADR-0029](0029-domain-events-via-state-transition-return.md) はイミュータブル集約のドメインイベント収集方式（状態遷移メソッドが `StateTransition<A, E>` で集約とイベントを同梱して返し、発行は application 層が担う）を確立したが、発行そのものは「ログ出力の最小ハンドリング」に留め、Spring `ApplicationEventPublisher` への連携と publish-after-commit のトランザクション意味論を明示的にスコープ外（別イシュー #433 送り）としていた。当時は永続化層が InMemory で実 DB トランザクションを示せなかったためだが、永続化の本番化（#422 / #423 / #451、[ADR-0030](0030-jdbc-only-persistence-retire-inmemory.md)）が完了し前提は解消した。
+
+実装にあたり決めるべき論点が 3 つあった。
+
+1. **application 層からの発行経路**: Spring の `ApplicationEventPublisher` を直接注入するか、発行ポート（interface）を切って infrastructure 層に委譲実装を置くか。オニオン規約では application 層の Spring 依存は DI 用 stereotype のみに制限されており（ArchUnit `applicationDependsOnSpringOnlyForDi`）、どちらの案でも規約側の判断が要る。
+2. **トランザクション境界**: publish-after-commit（イベントは集約の永続化がコミットされた後にだけ届く）を成立させるには、発行元ユースケースにトランザクション境界が必要。現状リポジトリ全体で `@Transactional` は 1 件も無い。
+3. **購読側の配置と意味論**: 参考実装リスナをどのリングに置くか。リスナ内例外がコミット済みトランザクションへ与える影響（ロールバック不可）の整理。
+
+## Decision（決定）
+
+### 発行経路: `ApplicationEventPublisher` を application 層へ直接注入する
+
+発行ポートの抽象は導入せず、ユースケースが Spring の `ApplicationEventPublisher` をコンストラクタ DI で受け取り、永続化成功後に `publishEvent(transition.event)` する。
+
+- `ApplicationEventPublisher` は関数 1 つの発行インターフェースで、これ以上に薄い自作ポートを重ねてもボイラープレートにしかならない（実装が Spring の 1 つしかあり得ない抽象は YAGNI）。
+- プロセス内イベントの発行・購読・トランザクション同期は Spring のイベント基盤に乗り切る。将来 Spring Modulith（[ADR-0025](0025-defer-spring-modulith-adoption.md) で採用見送り・再評価余地あり）へ進む場合も、`ApplicationEventPublisher` 直接発行はそのまま Modulith のイベント externalization に接続できる。
+- テスト容易性はポート抽象と同等（mockk で `publishEvent` を検証できる）。
+
+これに伴い ArchUnit ルールを「application 層の Spring 依存は DI 用 stereotype のみ」から**精密 allowlist** へ更新する: `org.springframework.stereotype..`（DI）＋ `org.springframework.transaction.annotation..`（宣言的トランザクション境界）＋ `org.springframework.context.ApplicationEventPublisher`（クラス単位。イベント発行）。パッケージごと（`org.springframework.context..`）開けるのではなくクラス単位で許可し、`ApplicationContext` 等への依存が紛れ込む余地を塞ぐ。
+
+### トランザクション境界: 発行元ユースケースに `@Transactional` を導入する
+
+イベントを発行するユースケース（現状は `NameHorseUseCase` のみ）に `@Transactional` を付与し、「引当 → 状態遷移 → save → publishEvent」を 1 トランザクションに収める。`publishEvent` はトランザクション内で呼ばれるが、後述の `@TransactionalEventListener(phase = AFTER_COMMIT)` がイベントの配送をコミット確定まで遅延させるため、**コミットが成立した場合にのみ購読者へ届き、ロールバックされた場合は破棄される**（publish-after-commit）。
+
+`@Transactional` の導入は本決定では発行元ユースケースに限る。複数集約書き込みの原子性のための全面展開は #483 が別途扱う。
+
+### 購読側: リスナは infrastructure 層に置き、AFTER_COMMIT で同期実行する
+
+参考実装リスナ（`HorseNamedLoggingListener`）は `infrastructure` 配下に置く。イベント購読は REST / persistence / MCP と並ぶアダプタの一形態であり、Spring 依存可のリングに置くのが自然（参考実装 1 本のために新しい adapter リングは切らない）。
+
+```kotlin
+@Component
+class HorseNamedLoggingListener {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onHorseNamed(event: HorseNamed) { /* ログ出力 */ }
+}
+```
+
+トランザクション意味論は以下のとおり整理する。
+
+- **配送タイミング**: `AFTER_COMMIT` リスナはコミット確定後、発行元と同じスレッドで同期実行される（`@Async` は導入しない）。トランザクションがロールバックされた場合、イベントは配送されない。トランザクション外で `publishEvent` された場合は既定（`fallbackExecution = false`）で配送されない。
+- **リスナ内例外はコミットを取り消せない**: リスナが走る時点でコミットは確定済みであり、例外を投げてもロールバックは起こらない。リスナの処理は「本体の書き込みと運命を共にしない」副作用（通知・ログ・キャッシュ更新等）に限り、失敗が業務的に許されない処理をリスナへ置いてはならない。なお AFTER_COMMIT リスナの例外は呼び出し元へ伝播しうる（同期実行のため）ので、リスナ側で捕捉・ログするのを基本とする。
+- **at-least-once 配送は保証しない**: コミット直後のプロセスダウンでイベントは失われる。信頼性配送が要件化したら Outbox パターンを別途検討する（本決定のスコープ外）。
+
+## Consequences（結果・影響）
+
+- application 層の Spring 依存が「stereotype のみ」から「stereotype ＋ 宣言的 Tx ＋ イベント発行」へ広がる。いずれも DI・境界宣言・発行という**配線の語彙**であり、業務ロジックが Spring API に依存する形ではない。allowlist はクラス単位まで精密化して漏れ広がりを防ぐ（`.claude/rules/architecture.md` の依存表・ArchUnit `OnionLayerRulesTest` を同時更新）。
+- 発行タイミングの意味論が「save が返ったら」から「コミットが確定したら」へ確定し、購読者が未コミットの状態変更を観測する余地がなくなる。実 PostgreSQL（Testcontainers）上の統合テストで、コミット後配送・ロールバック時破棄の両方を検証する。
+- リスナに置けるのは失敗しても本体の書き込みに影響しない処理に限る、という設計制約を引き受ける（上記のとおり）。
+- イベントのメタデータ enrichment（発生時刻・イベント ID の封筒、#434）、複数イベント遷移、Outbox / 外部メッセージングは引き続きスコープ外。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -58,3 +58,4 @@
 | [0046](0046-adopt-kotlin-lsp-plugin.md) | Claude Code の Kotlin LSP プラグインを採用し kotlin-lsp を mise http バックエンドで配布する | Accepted |
 | [0047](0047-aggregate-version-for-optimistic-locking.md) | 楽観ロックの version は集約が保持し save を一本化する | Accepted |
 | [0049](0049-decline-atlas-keep-flyway-toolchain.md) | Atlas（schema-as-code）を現時点では不採用とし Flyway 中心のスキーマツールチェーンを維持する | Accepted |
+| [0050](0050-domain-event-publication-after-commit.md) | ドメインイベントは ApplicationEventPublisher で発行し AFTER_COMMIT で購読する | Accepted |

--- a/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
@@ -12,8 +12,9 @@ import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.mapError
 import com.github.michaelbull.result.toResultOr
 import java.util.UUID
-import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * 馬名登録ユースケースの入力コマンド。
@@ -70,15 +71,18 @@ sealed interface NameHorseUseCaseError {
  * で命名状態を遷移させてから楽観ロック付きで更新する（競合は [NameHorseUseCaseError.ConcurrentModification]）。血統登録 →
  * 馬名登録という順序関係は、対象が 既に永続化済みの [BloodHorse] であることを引当が要求することで自然に満たされる。
  *
- * 状態遷移が同梱して返すドメインイベント（`HorseNamed`）は、ここ application 層で受け取って最小限に扱う （現状はログ）。Spring の
- * `ApplicationEventPublisher` への接続や永続化と整合した publish-after-commit は スコープ外（別イシュー送り。ADR-0029）。
+ * 状態遷移が同梱して返すドメインイベント（`HorseNamed`）は、更新の保存後に [ApplicationEventPublisher] で発行する。 ユースケース全体を
+ * `@Transactional` で 1 トランザクションに収めており、`AFTER_COMMIT` 購読者へはコミット確定後にのみ届く
+ * （publish-after-commit。失敗遷移・業務エラー時はイベント自体を生成せず発行もされない）。決定経緯は ADR-0050。
  *
  * @return 命名された [RegisteredBloodHorse]、または業務ルール違反を表す [NameHorseUseCaseError]
  */
 @Service
+@Transactional
 class NameHorseUseCase(
     private val bloodHorseRepository: BloodHorseRepository,
     private val horseInspectionRepository: HorseInspectionRepository,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
     operator fun invoke(
         command: Command<NameHorseCommand>
@@ -125,13 +129,9 @@ class NameHorseUseCase(
                 .save(transition.aggregate)
                 .mapError { NameHorseUseCaseError.ConcurrentModification(input.bloodHorseId) }
                 .bind()
-        // ドメインイベントは当面 application 層内で最小ハンドリング（ログ）に留める。
-        logger.info("ドメインイベント発生: {}", transition.event)
+        // 発行はトランザクション内で行うが、AFTER_COMMIT 購読者への配送はコミット確定後（ADR-0050）。
+        eventPublisher.publishEvent(transition.event)
 
         RegisteredBloodHorse(named, inspection)
-    }
-
-    private companion object {
-        private val logger = LoggerFactory.getLogger(NameHorseUseCase::class.java)
     }
 }

--- a/src/main/kotlin/com/example/api/domain/shared/StateTransition.kt
+++ b/src/main/kotlin/com/example/api/domain/shared/StateTransition.kt
@@ -5,12 +5,13 @@ package com.example.api.domain.shared
  *
  * イミュータブル集約（[ADR-0009]）は自身の内部にイベントバッファをミュータブルに溜め込めない（`val` のみ・ 状態遷移は新インスタンス返却）。Spring/jMolecules
  * 定番の `AbstractAggregateRoot.registerEvent()` 方式は 集約を mutable
- * にする前提のため噛み合わない。そこで状態遷移メソッドは遷移後の集約とイベントをまとめて本型で返し、 イベントの発行（ログ・パブリッシュ等）は application
- * 層に委ねる。これにより集約は純粋なまま保たれる。 収集・発行方式の決定経緯は ADR-0029 を参照。
+ * にする前提のため噛み合わない。そこで状態遷移メソッドは遷移後の集約とイベントをまとめて本型で返し、 イベントの発行は application 層のユースケースが Spring の
+ * `ApplicationEventPublisher` で行う（publish-after-commit。ADR-0050）。これにより集約は純粋なまま保たれる。 収集方式の決定経緯は
+ * ADR-0029 を参照。
  *
  * 失敗しうる遷移は `Result<StateTransition<A, E>, エラー>` を返し、失敗時はイベントを生成しない （例:
  * `BloodHorse.assignName`）。発生時刻（[Command] の `issuedAt` に相当する横断メタデータ）や イベント ID
- * の付与は当面持たせない（最小スコープ。enrichment と Spring `ApplicationEventPublisher` への 接続は別イシュー送り）。
+ * の付与は当面持たせない（最小スコープ。enrichment は別イシュー #434 送り）。
  *
  * @param A 遷移後の集約の型
  * @param E 生成されるドメインイベントの型（`@org.jmolecules.event.annotation.DomainEvent` を付与した型）

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/event/HorseNamedLoggingListener.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/event/HorseNamedLoggingListener.kt
@@ -1,0 +1,28 @@
+package com.example.api.infrastructure.studbook.event
+
+import com.example.api.domain.studbook.model.horse.bloodhorse.HorseNamed
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * [HorseNamed] を購読してログ出力する参考実装リスナ。
+ *
+ * イベント購読は REST / persistence / MCP と並ぶアダプタの一形態として infrastructure 層に置く。 `AFTER_COMMIT`
+ * により、発行元トランザクションのコミットが確定した場合にのみ同期実行される （ロールバック時は配送されない =
+ * publish-after-commit）。リスナが走る時点でコミットは取り消せないため、 ここに置けるのは失敗しても本体の書き込みに影響しない処理（通知・ログ等）に限る。決定経緯は
+ * ADR-0050。
+ */
+@Component
+class HorseNamedLoggingListener {
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onHorseNamed(event: HorseNamed) {
+        logger.info("ドメインイベント受信: {}", event)
+    }
+
+    private companion object {
+        private val logger = LoggerFactory.getLogger(HorseNamedLoggingListener::class.java)
+    }
+}

--- a/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCasePublishAfterCommitTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCasePublishAfterCommitTest.kt
@@ -1,0 +1,125 @@
+package com.example.api.application.studbook.horse
+
+import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.generateId
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorse
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
+import com.example.api.domain.studbook.model.horse.bloodhorse.HorseNamed
+import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
+import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
+import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.example.api.support.PostgresContainerSupport
+import com.github.michaelbull.result.unwrap
+import java.time.Instant
+import java.util.concurrent.CopyOnWriteArrayList
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.Bean
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.context.TestConstructor.AutowireMode
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import org.springframework.transaction.support.TransactionTemplate
+
+/**
+ * ドメインイベント発行の publish-after-commit 意味論を実 PostgreSQL（Testcontainers）上で検証する統合テスト （ADR-0050 / #433）。
+ *
+ * 検証する意味論:
+ * 1. 発行元トランザクションのコミットが確定した場合にのみ、`AFTER_COMMIT` 購読者へイベントが届くこと
+ * 2. トランザクション内で発行した時点では配送されない（コミットまで遅延される）こと
+ * 3. ロールバックされた場合はイベントが破棄され、購読者へ届かないこと
+ *
+ * 記録用購読者の Bean を足すためコンテキストキャッシュのキーは他の `@SpringBootTest` と分かれる（意図した 最小限の分岐。ロジックの網羅は
+ * [NameHorseUseCaseTest] などの内側リングで済ませる）。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class NameHorseUseCasePublishAfterCommitTest(
+    private val nameHorse: NameHorseUseCase,
+    private val bloodHorseRepository: BloodHorseRepository,
+    private val horseInspectionRepository: HorseInspectionRepository,
+    private val eventPublisher: ApplicationEventPublisher,
+    private val recordingListener: RecordingHorseNamedListener,
+    transactionManager: PlatformTransactionManager,
+) : PostgresContainerSupport() {
+
+    private val transactionTemplate = TransactionTemplate(transactionManager)
+
+    @BeforeEach
+    fun resetRecordingListener() {
+        recordingListener.received.clear()
+    }
+
+    @Test
+    fun `馬名登録ユースケースが成功するとコミット後に HorseNamed が購読者へ届く`() {
+        val horse = persistUnnamedHorse()
+
+        nameHorse(Command(NameHorseCommand(horse.id.value, "アフターコミット"), Instant.now())).unwrap()
+
+        val event = recordingListener.received.single()
+        assert(event.bloodHorseId == horse.id)
+        assert(event.name.value == "アフターコミット")
+    }
+
+    @Test
+    fun `トランザクション内で発行した時点では配送されずコミット確定後に届く`() {
+        transactionTemplate.execute {
+            eventPublisher.publishEvent(horseNamed("コミットマエ"))
+            // 発行済みでもコミット前なので AFTER_COMMIT 購読者にはまだ届かない
+            assert(recordingListener.received.isEmpty())
+        }
+
+        assert(recordingListener.received.single().name.value == "コミットマエ")
+    }
+
+    @Test
+    fun `トランザクションがロールバックされるとイベントは購読者へ届かない`() {
+        transactionTemplate.execute { status ->
+            eventPublisher.publishEvent(horseNamed("ロールバック"))
+            status.setRollbackOnly()
+        }
+
+        assert(recordingListener.received.isEmpty())
+    }
+
+    /** 命名対象となる未命名の軽種馬を、参照整合を保って（審査ごと）永続化する。 */
+    private fun persistUnnamedHorse(): BloodHorse {
+        val inspection =
+            BloodHorseFixture.inspection(parentage = ParentageDetermination.NotApplicable)
+        horseInspectionRepository.save(inspection)
+        val horse =
+            BloodHorse.createImported(
+                entry = BloodHorseFixture.importedHorseEntry(),
+                inspection = inspection,
+                registrationNumber = PedigreeRegistrationNumber.create("2020900123").unwrap(),
+            )
+        return bloodHorseRepository.save(horse).unwrap()
+    }
+
+    private fun horseNamed(name: String): HorseNamed =
+        HorseNamed(BloodHorseId(generateId()), HorseName.create(name).unwrap())
+
+    /** AFTER_COMMIT で受信したイベントを記録するテスト用購読者。 */
+    class RecordingHorseNamedListener {
+        val received = CopyOnWriteArrayList<HorseNamed>()
+
+        @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+        fun onHorseNamed(event: HorseNamed) {
+            received += event
+        }
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    class RecordingListenerConfig {
+        @Bean
+        fun recordingHorseNamedListener(): RecordingHorseNamedListener =
+            RecordingHorseNamedListener()
+    }
+}

--- a/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
 import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
+import com.example.api.domain.studbook.model.horse.bloodhorse.HorseNamed
 import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
@@ -18,6 +19,7 @@ import java.time.Instant
 import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
 
 class NameHorseUseCaseTest {
 
@@ -30,6 +32,9 @@ class NameHorseUseCaseTest {
             every { findById(any()) } returns BloodHorseFixture.inspection()
         }
 
+    /** イベント発行のスパイ。発行の有無と発行されたイベントを verify で検証する。 */
+    private val eventPublisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
+
     @Nested
     inner class SuccessCase {
         @Test
@@ -41,7 +46,7 @@ class NameHorseUseCaseTest {
                     every { existsByName(any()) } returns false
                     every { save(any()) } answers { Ok(firstArg()) }
                 }
-            val useCase = NameHorseUseCase(repository, inspectionRepository())
+            val useCase = NameHorseUseCase(repository, inspectionRepository(), eventPublisher)
 
             val registered = useCase(command(horse.id.value, "オグリキャップ")).unwrap()
 
@@ -49,6 +54,12 @@ class NameHorseUseCaseTest {
             assert(registered.bloodHorse.name?.value == "オグリキャップ")
             // save には命名済み（assignName 反映後）の集約が渡ること
             verify(exactly = 1) { repository.save(match { it.name?.value == "オグリキャップ" }) }
+            // 保存成功後に HorseNamed が発行されること
+            verify(exactly = 1) {
+                eventPublisher.publishEvent(
+                    match<HorseNamed> { it.bloodHorseId == horse.id && it.name.value == "オグリキャップ" }
+                )
+            }
         }
     }
 
@@ -57,13 +68,14 @@ class NameHorseUseCaseTest {
         @Test
         fun `馬名が不正なとき InvalidName を返し引当も永続化もしない`() {
             val repository = mockk<BloodHorseRepository>()
-            val useCase = NameHorseUseCase(repository, inspectionRepository())
+            val useCase = NameHorseUseCase(repository, inspectionRepository(), eventPublisher)
 
             val result = useCase(command(UUID.randomUUID(), "ア"))
 
             assert(result.getError() == NameHorseUseCaseError.InvalidName)
             verify(exactly = 0) { repository.findById(any()) }
             verify(exactly = 0) { repository.save(any()) }
+            verify(exactly = 0) { eventPublisher.publishEvent(any()) }
         }
 
         @Test
@@ -71,12 +83,13 @@ class NameHorseUseCaseTest {
             val id = UUID.randomUUID()
             val repository =
                 mockk<BloodHorseRepository> { every { findById(BloodHorseId(id)) } returns null }
-            val useCase = NameHorseUseCase(repository, inspectionRepository())
+            val useCase = NameHorseUseCase(repository, inspectionRepository(), eventPublisher)
 
             val result = useCase(command(id, "オグリキャップ"))
 
             assert(result.getError() == NameHorseUseCaseError.HorseNotFound(id))
             verify(exactly = 0) { repository.save(any()) }
+            verify(exactly = 0) { eventPublisher.publishEvent(any()) }
         }
 
         @Test
@@ -87,12 +100,13 @@ class NameHorseUseCaseTest {
                     every { findById(horse.id) } returns horse
                     every { existsByName(HorseName.create("オグリキャップ").unwrap()) } returns true
                 }
-            val useCase = NameHorseUseCase(repository, inspectionRepository())
+            val useCase = NameHorseUseCase(repository, inspectionRepository(), eventPublisher)
 
             val result = useCase(command(horse.id.value, "オグリキャップ"))
 
             assert(result.getError() == NameHorseUseCaseError.NameAlreadyTaken("オグリキャップ"))
             verify(exactly = 0) { repository.save(any()) }
+            verify(exactly = 0) { eventPublisher.publishEvent(any()) }
         }
 
         @Test
@@ -107,12 +121,13 @@ class NameHorseUseCaseTest {
                     every { findById(named.id) } returns named
                     every { existsByName(any()) } returns false
                 }
-            val useCase = NameHorseUseCase(repository, inspectionRepository())
+            val useCase = NameHorseUseCase(repository, inspectionRepository(), eventPublisher)
 
             val result = useCase(command(named.id.value, "トウカイテイオー"))
 
             assert(result.getError() == NameHorseUseCaseError.AlreadyNamed("オグリキャップ"))
             verify(exactly = 0) { repository.save(any()) }
+            verify(exactly = 0) { eventPublisher.publishEvent(any()) }
         }
 
         @Test
@@ -126,7 +141,7 @@ class NameHorseUseCaseTest {
                 }
             val inspectionRepository =
                 mockk<HorseInspectionRepository> { every { findById(any()) } returns null }
-            val useCase = NameHorseUseCase(repository, inspectionRepository)
+            val useCase = NameHorseUseCase(repository, inspectionRepository, eventPublisher)
 
             val result = useCase(command(horse.id.value, "オグリキャップ"))
 
@@ -136,6 +151,7 @@ class NameHorseUseCaseTest {
             )
             // 審査が欠落した場合、改名済みの集約は保存しない（エラーなのに命名状態だけ永続化されるのを防ぐ）
             verify(exactly = 0) { repository.save(any()) }
+            verify(exactly = 0) { eventPublisher.publishEvent(any()) }
         }
 
         @Test
@@ -147,13 +163,15 @@ class NameHorseUseCaseTest {
                     every { existsByName(any()) } returns false
                     every { save(any()) } returns Err(UpdateConflict)
                 }
-            val useCase = NameHorseUseCase(repository, inspectionRepository())
+            val useCase = NameHorseUseCase(repository, inspectionRepository(), eventPublisher)
 
             val result = useCase(command(horse.id.value, "オグリキャップ"))
 
             assert(
                 result.getError() == NameHorseUseCaseError.ConcurrentModification(horse.id.value)
             )
+            // 保存に失敗した以上、イベントは発行しない
+            verify(exactly = 0) { eventPublisher.publishEvent(any()) }
         }
     }
 }

--- a/src/test/kotlin/com/example/api/architecture/OnionLayerRulesTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/OnionLayerRulesTest.kt
@@ -3,12 +3,14 @@ package com.example.api.architecture
 import com.example.api.ApiApplication
 import com.tngtech.archunit.base.DescribedPredicate.not
 import com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage
+import com.tngtech.archunit.core.domain.JavaClass.Predicates.type
 import com.tngtech.archunit.core.importer.ImportOption
 import com.tngtech.archunit.junit.AnalyzeClasses
 import com.tngtech.archunit.junit.ArchTest
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
 import com.tngtech.archunit.library.Architectures.onionArchitecture
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Repository
 import org.springframework.stereotype.Service
 
@@ -67,9 +69,16 @@ class OnionLayerRulesTest {
             .haveSimpleNameEndingWith("Kt")
             .because("ドメインサービスは object / class でラップせずトップレベル関数で書く。" + "service/ への配置でドメインサービスを表現する")
 
-    /** application 層の Spring 依存は DI 用 stereotype アノテーションのみに留めること。 */
+    /**
+     * application 層の Spring 依存は「配線の語彙」の精密 allowlist に留めること。
+     *
+     * 許可するのは DI 用 stereotype（`org.springframework.stereotype..`）、宣言的トランザクション境界
+     * （`org.springframework.transaction.annotation..`）、ドメインイベント発行（[ApplicationEventPublisher]
+     * クラス単位。`org.springframework.context..` をパッケージごと開けて `ApplicationContext` 等への依存が
+     * 紛れ込むのを防ぐ）のみ。業務ロジックを Spring API に依存させないための制限（ADR-0050）。
+     */
     @ArchTest
-    val applicationDependsOnSpringOnlyForDi =
+    val applicationDependsOnSpringOnlyForWiring =
         noClasses()
             .that()
             .resideInAPackage(APPLICATION)
@@ -77,6 +86,8 @@ class OnionLayerRulesTest {
             .dependOnClassesThat(
                 resideInAPackage("org.springframework..")
                     .and(not(resideInAPackage("org.springframework.stereotype..")))
+                    .and(not(resideInAPackage("org.springframework.transaction.annotation..")))
+                    .and(not(type(ApplicationEventPublisher::class.java)))
             )
 
     /** ユースケース（@Service）は application 層に置くこと。 */


### PR DESCRIPTION
## 概要

ADR-0029 でスコープ外（別イシュー送り）としていたドメインイベントの**発行側**を実装する（Closes #433）。

- application 層のユースケース（`NameHorseUseCase`）が Spring `ApplicationEventPublisher` でイベントを発行する経路を配線（従来のログ出力を置換）
- `@Transactional` によるトランザクション境界を発行元ユースケースへ導入
- 購読側の参考実装 `HorseNamedLoggingListener`（`@TransactionalEventListener(phase = AFTER_COMMIT)`）を infrastructure 層へ新設
- **publish-after-commit の意味論**（コミット確定後にのみ配送・コミット前は未配送・ロールバック時は破棄）を実 PostgreSQL（Testcontainers）上の統合テストで実証

## 設計判断（ADR-0050 新設）

- **発行経路は `ApplicationEventPublisher` の直接注入**。実装が 1 つしかあり得ない発行ポート抽象は導入しない（YAGNI）。将来 Spring Modulith へ進む場合もそのまま接続できる（ADR-0025 と整合）
- **ArchUnit の application 層 Spring 依存ルールを精密 allowlist へ更新**: `stereotype`（DI）＋ `transaction.annotation`（宣言的 Tx 境界）＋ `ApplicationEventPublisher`（クラス単位。`context` パッケージごとは開けない）。ルール名を `applicationDependsOnSpringOnlyForWiring` へ改名し、`.claude/rules/architecture.md` の依存表も同時更新
- **リスナ内例外はコミットを取り消せない**: リスナに置けるのは失敗しても本体の書き込みに影響しない処理（通知・ログ等）に限る、という設計制約を ADR に明記
- `@Transactional` の導入は発行元ユースケースのみ。複数集約書き込みの原子性のための全面展開は #483 が別途扱う

## スコープ外（Issue どおり）

- Outbox / 外部メッセージング連携（at-least-once 配送は保証しない）
- イベントメタデータ enrichment（発生時刻・イベント ID）→ #434
- 複数イベントを返す遷移

## テスト

- 単体（`NameHorseUseCaseTest`）: 成功時の `HorseNamed` 発行と、全失敗経路（業務エラー・楽観ロック競合）で発行されないことを検証
- 統合（`NameHorseUseCasePublishAfterCommitTest`、新設）: 実 PostgreSQL 上で publish-after-commit の 3 意味論を検証
- `./gradlew check` パス（ktfmt / detekt / ArchUnit 含む全テスト / koverVerifyMature）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
