### PR TITLE
test: 並行削除の楽観ロック契約テストを BreedingRegistration / BloodHorse にも展開する(#529)

### DIFF
--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepositoryContractTest.kt
@@ -39,6 +39,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode
  * 6. save は集約の version（null なら insert、非 null なら楽観ロック付き update）で判別すること
  * 7. 古い version での save が UpdateConflict を返し先行の書き込みを保つこと（楽観ロック）
  * 8. 供用停止の共在不変条件が CHECK 制約でスキーマ側にも強制されること
+ * 9. 並行削除された集約への save が UpdateConflict を返すこと
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)
@@ -183,6 +184,28 @@ class JdbcBreedingRegistrationRepositoryContractTest(
 
         assert(conflicted.getError() == UpdateConflict)
         assert(repository.findById(inserted.id)?.retirement?.reason == RetirementReason.DEATH)
+    }
+
+    @Test
+    fun `並行削除された保存済み集約のsaveはUpdateConflictを返す`() {
+        val mare = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        val inserted =
+            repository
+                .save(
+                    BreedingRegistration.create(
+                        BreedingRegistrationNumber.create("B-1234").unwrap(),
+                        mare,
+                    )
+                )
+                .unwrap()
+        rows.deleteAll()
+
+        val conflicted =
+            repository.save(
+                inserted.retire(RetirementReason.DEATH, LocalDate.of(2026, 4, 1)).unwrap()
+            )
+
+        assert(conflicted.getError() == UpdateConflict)
     }
 
     @Test

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
@@ -39,6 +39,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode
  * 7. [BloodHorseRepository.findAllById] が複数IDをまとめて引き当てられること
  * 8. save は集約の version（null なら insert、非 null なら楽観ロック付き update）で判別すること
  * 9. 古い version での save が UpdateConflict を返し先行の書き込みを保つこと（楽観ロック）
+ * 10. 並行削除された集約への save が UpdateConflict を返すこと
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)
@@ -219,5 +220,18 @@ class JdbcBloodHorseRepositoryContractTest(private val rows: BloodHorseSpringDat
 
         assert(conflicted.getError() == UpdateConflict)
         assert(repository.findById(inserted.id)?.name?.value == "オグリキャップ")
+    }
+
+    @Test
+    fun `並行削除された保存済み集約のsaveはUpdateConflictを返す`() {
+        val inserted = repository.save(BloodHorseFixture.bloodHorse()).unwrap()
+        rows.deleteAll()
+
+        val conflicted =
+            repository.save(
+                inserted.assignName(HorseName.create("オグリキャップ").unwrap()).unwrap().aggregate
+            )
+
+        assert(conflicted.getError() == UpdateConflict)
     }
 }


### PR DESCRIPTION
Closes #529

## 概要

#424 / PR #526 で `JdbcBreedingResultRepositoryContractTest` にのみ追加した「並行削除された保存済み集約の save は `UpdateConflict` を返す」契約テストを、残る 2 アダプタへ展開する（PR #526 最終レビューの Minor 指摘のフォローアップ）。

ポート KDoc は 3 リポジトリとも「行が消えていた場合は UpdateConflict」を約束しており、契約テストは「アダプタごとの契約の文書」なので検証も 3 つ揃える。

## 変更内容

- `JdbcBreedingRegistrationRepositoryContractTest`
  - 並行削除テストを追加（insert → `deleteAll` → `retire` 済み集約を save → `Err(UpdateConflict)`）
  - KDoc「検証する契約」リストへ項目 9 を追記
- `JdbcBloodHorseRepositoryContractTest`
  - 並行削除テストを追加（insert → `deleteAll` → `assignName` 済み集約を save → `Err(UpdateConflict)`）
  - KDoc「検証する契約」リストへ項目 10 を追記

いずれも BreedingResult 版と同型。

## 検証

- `./gradlew :test --tests "JdbcBreedingRegistrationRepositoryContractTest" --tests "JdbcBloodHorseRepositoryContractTest"` 成功（Testcontainers PostgreSQL）
- `./gradlew check` 成功（ktfmt / detekt / test / koverVerifyMature）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
