### PR TITLE
feat: 書き込みユースケースに @Transactional のトランザクション境界を与える(#483)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -30,7 +30,7 @@ paths:
 |-------|-----------|--------------|------------|
 | domainModel | `domain.shared` + `domain.*.model` | 純粋ライブラリのみ（kotlin-result / java-uuid-generator / jMolecules） | 禁止（jakarta / Jackson も禁止） |
 | domainService | `domain.*.service` | domainModel | 禁止 |
-| applicationService | `application` | domainModel / domainService | `org.springframework.stereotype`（`@Service` / `@Component`）のみ |
+| applicationService | `application` | domainModel / domainService | `org.springframework.stereotype`（`@Service` / `@Component`）と `org.springframework.transaction.annotation`（`@Transactional`）のみ |
 | adapter (rest) | `controller` | 内側すべて | 可 |
 | adapter (persistence) | `infrastructure` | 内側すべて | 可 |
 | adapter (mcp) | `mcp` | 内側すべて | 可 |
@@ -39,6 +39,7 @@ paths:
 - アダプター同士（`controller` ⇔ `infrastructure` ⇔ `mcp`）の参照は禁止
 - `@RestController` は `controller`、`@Service` は `application`、Spring の `@Repository`（ポート実装）は `infrastructure` に置く
 - `@McpTool` を持つ Spring Bean は `mcp` に置く（application 層に直付けしない）。ArchUnit は `ArchSupport.kt` の `adapter("mcp", MCP)` で `mcp` を adapter リングとして強制する（[ADR-0035](../../docs/adr/0035-mcp-interface-adapter.md)）
+- **書き込みユースケース（`Command` を受ける `invoke`）には `@Transactional` を付与しトランザクション境界とする**（複数集約書き込みの失敗時原子性。ArchUnit `commandHandlingInvokesAreTransactional` で強制、読み取り系は対象外。[ADR-0050](../../docs/adr/0050-transactional-use-case-boundary.md)）。実行機構（`TransactionTemplate` 等）への依存は引き続き禁止
 
 ### ドメインモデルとドメインサービスの分け方
 

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -39,7 +39,7 @@ paths:
 - アダプター同士（`controller` ⇔ `infrastructure` ⇔ `mcp`）の参照は禁止
 - `@RestController` は `controller`、`@Service` は `application`、Spring の `@Repository`（ポート実装）は `infrastructure` に置く
 - `@McpTool` を持つ Spring Bean は `mcp` に置く（application 層に直付けしない）。ArchUnit は `ArchSupport.kt` の `adapter("mcp", MCP)` で `mcp` を adapter リングとして強制する（[ADR-0035](../../docs/adr/0035-mcp-interface-adapter.md)）
-- **書き込みユースケース（`Command` を受ける `invoke`）には `@Transactional` を付与しトランザクション境界とする**（複数集約書き込みの失敗時原子性。ArchUnit `commandHandlingInvokesAreTransactional` で強制、読み取り系は対象外。[ADR-0050](../../docs/adr/0050-transactional-use-case-boundary.md)）。実行機構（`TransactionTemplate` 等）への依存は引き続き禁止
+- **書き込みユースケース（`Command` を受ける `invoke`）には `@Transactional` を付与しトランザクション境界とする**（複数集約書き込みの失敗時原子性。ArchUnit `commandHandlingInvokesAreTransactional` で強制、読み取り系は対象外。[ADR-0051](../../docs/adr/0051-transactional-use-case-boundary.md)）。実行機構（`TransactionTemplate` 等）への依存は引き続き禁止
 
 ### ドメインモデルとドメインサービスの分け方
 

--- a/docs/adr/0051-transactional-use-case-boundary.md
+++ b/docs/adr/0051-transactional-use-case-boundary.md
@@ -1,0 +1,31 @@
+# 0051. トランザクション境界は application 層ユースケースの宣言的 @Transactional で置く
+
+- Status: Accepted
+- Date: 2026-07-03
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+血統登録系ユースケースは審査（`HorseInspection`）と軽種馬（`BloodHorse`）の 2 集約を連続 save しており、トランザクション境界が無かった（#312 で入ったプロジェクト初の複数集約書き込み）。業務ルール却下時の孤児は「成功時のみ save」で排除済みだが、2 番目の save がインフラ障害で失敗すると先行した審査 save が孤児として残る（失敗時原子性の欠落。#483）。
+
+一方、オニオン規約（ArchUnit `applicationDependsOnSpringOnlyForDi`）は application 層の Spring 依存を `org.springframework.stereotype` のみに制限しており、`@org.springframework.transaction.annotation.Transactional` の直付けは違反だった。
+
+## Decision（決定）
+
+**書き込みユースケース（`Command` を受ける `invoke`）に宣言的 `@Transactional` を付与し、ユースケース＝トランザクション境界とする。** これを成立させるため、application 層の Spring 依存許可へ `org.springframework.transaction.annotation..`（アノテーションパッケージのみ）を追加する。
+
+- 緩和は「宣言的メタデータのみ許可」という stereotype と同型の線引きであり、`TransactionTemplate` / `PlatformTransactionManager` 等の実行機構への依存は引き続き禁止する。
+- 付け忘れは ArchUnit `commandHandlingInvokesAreTransactional`（`Command` を受ける `invoke` は `@Transactional` 必須）で構造的に防ぐ。読み取り系（`〜Query` 入力）は対象外（readOnly トランザクションは YAGNI で導入しない）。
+- ユースケースは例外でなく `Result` を返す規約だが、業務失敗（`Err`）時は save に到達しない設計のため「実行時例外でロールバック」という `@Transactional` の既定と整合する。インフラ障害は `DataAccessException`（RuntimeException）として伝播しロールバックを引き起こす。
+- Virtual Thread + ブロッキング JDBC 構成（ADR-0002）で宣言的トランザクションは素直に機能する（接続のスレッド束縛は ThreadLocal ベースで、Virtual Thread でも機能する）。`kotlin("plugin.spring")` により `@Service` クラスは open で CGLIB プロキシが効く。
+
+## Alternatives（検討した代替案）
+
+- **Tx ポート抽象（`TransactionRunner` を application が受け、infrastructure が `TransactionTemplate` で実装）**: application 層の純度は保てるが、間接層が増え全ユースケースにブロックネストが入る。将来の publish-after-commit（#433）で `TransactionSynchronization` 相当の概念がポートへ漏れがち。不採用。
+- **adapter 層（controller / デコレータ）に境界を置く**: HTTP アダプタとトランザクションの関心が混在し、MCP 等の別アダプタ経由の呼び出しで境界が消える。不採用。
+
+## Consequences（帰結）
+
+- 審査＋軽種馬の 2 集約書き込み（`RegisterInStudBookUseCase` / `RegisterFoalUseCase` / `RegisterImportedHorseUseCase`）はインフラ障害時も原子的になる。ロールバックは統合テスト（`RegisterHorseTransactionRollbackTest`、Testcontainers PostgreSQL）で検証する。
+- ドメインイベント発行基盤（#433 / [ADR-0029](0029-domain-events-via-state-transition-return.md)）が想定する publish-after-commit（`ApplicationEventPublisher` + `@TransactionalEventListener(AFTER_COMMIT)`）は「発行時点でアクティブなトランザクションが存在する」ことを前提とし、本決定はその前提をそのまま満たす。
+- 同一トランザクションで触る集約が増えるほど楽観ロック競合（[ADR-0047](0047-aggregate-version-for-optimistic-locking.md)）の面は広がる。「1 トランザクション 1 集約」の古典則は、集約境界を疑う設計圧力としては引き続き意識する（本プロジェクトは単一 DB のモジュラーモノリスであり、結果整合性・saga の複雑さを払う理由がない）。

--- a/docs/adr/0051-transactional-use-case-boundary.md
+++ b/docs/adr/0051-transactional-use-case-boundary.md
@@ -27,5 +27,5 @@
 ## Consequences（帰結）
 
 - 審査＋軽種馬の 2 集約書き込み（`RegisterInStudBookUseCase` / `RegisterFoalUseCase` / `RegisterImportedHorseUseCase`）はインフラ障害時も原子的になる。ロールバックは統合テスト（`RegisterHorseTransactionRollbackTest`、Testcontainers PostgreSQL）で検証する。
-- ドメインイベント発行基盤（#433 / [ADR-0029](0029-domain-events-via-state-transition-return.md)）が想定する publish-after-commit（`ApplicationEventPublisher` + `@TransactionalEventListener(AFTER_COMMIT)`）は「発行時点でアクティブなトランザクションが存在する」ことを前提とし、本決定はその前提をそのまま満たす。
+- ドメインイベント発行基盤（#433）は publish-after-commit（`ApplicationEventPublisher` + `@TransactionalEventListener(AFTER_COMMIT)`）で [ADR-0050](0050-domain-event-publication-after-commit.md) として実装済みであり、「発行時点でアクティブなトランザクションが存在する」ことを前提とする。本決定はその前提を全書き込みユースケースへ広げる。
 - 同一トランザクションで触る集約が増えるほど楽観ロック競合（[ADR-0047](0047-aggregate-version-for-optimistic-locking.md)）の面は広がる。「1 トランザクション 1 集約」の古典則は、集約境界を疑う設計圧力としては引き続き意識する（本プロジェクトは単一 DB のモジュラーモノリスであり、結果整合性・saga の複雑さを払う理由がない）。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -58,3 +58,4 @@
 | [0046](0046-adopt-kotlin-lsp-plugin.md) | Claude Code の Kotlin LSP プラグインを採用し kotlin-lsp を mise http バックエンドで配布する | Accepted |
 | [0047](0047-aggregate-version-for-optimistic-locking.md) | 楽観ロックの version は集約が保持し save を一本化する | Accepted |
 | [0049](0049-decline-atlas-keep-flyway-toolchain.md) | Atlas（schema-as-code）を現時点では不採用とし Flyway 中心のスキーマツールチェーンを維持する | Accepted |
+| [0051](0051-transactional-use-case-boundary.md) | トランザクション境界は application 層ユースケースの宣言的 @Transactional で置く | Accepted |

--- a/src/main/kotlin/com/example/api/application/racing/jockey/JockeyRegistrationUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/racing/jockey/JockeyRegistrationUseCase.kt
@@ -11,6 +11,7 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.andThen
 import com.github.michaelbull.result.mapError
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * ジョッキー登録ユースケースの入力コマンド。
@@ -46,6 +47,7 @@ sealed interface JockeyRegistrationError {
  */
 @Service
 class JockeyRegistrationUseCase(private val jockeyRepository: JockeyRepository) {
+    @Transactional
     operator fun invoke(
         command: Command<RegisterJockeyCommand>
     ): Result<Jockey, JockeyRegistrationError> {

--- a/src/main/kotlin/com/example/api/application/studbook/breeding/RecordCoveringUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/RecordCoveringUseCase.kt
@@ -20,6 +20,7 @@ import com.github.michaelbull.result.toResultOr
 import java.time.LocalDate
 import java.util.UUID
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * 種付記録ユースケースの入力コマンド。
@@ -109,6 +110,7 @@ class RecordCoveringUseCase(
     private val breedingRegistrationRepository: BreedingRegistrationRepository,
     private val breedingResultRepository: BreedingResultRepository,
 ) {
+    @Transactional
     operator fun invoke(
         command: Command<RecordCoveringCommand>
     ): Result<BreedingResult, RecordCoveringUseCaseError> = binding {

--- a/src/main/kotlin/com/example/api/application/studbook/breeding/RecordUncoveredUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/RecordUncoveredUseCase.kt
@@ -15,6 +15,7 @@ import com.github.michaelbull.result.toResultOr
 import java.time.Year
 import java.util.UUID
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * 種付せず（種付しなかった年次成績）記録ユースケースの入力コマンド。
@@ -56,6 +57,7 @@ class RecordUncoveredUseCase(
     private val breedingRegistrationRepository: BreedingRegistrationRepository,
     private val breedingResultRepository: BreedingResultRepository,
 ) {
+    @Transactional
     operator fun invoke(
         command: Command<RecordUncoveredCommand>
     ): Result<BreedingResult, RecordUncoveredUseCaseError> = binding {

--- a/src/main/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCase.kt
@@ -13,6 +13,7 @@ import com.github.michaelbull.result.mapError
 import com.github.michaelbull.result.toResultOr
 import java.util.UUID
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * 繁殖登録ユースケースの入力コマンド。
@@ -54,6 +55,7 @@ class RegisterBreedingRegistrationUseCase(
     private val bloodHorseRepository: BloodHorseRepository,
     private val breedingRegistrationRepository: BreedingRegistrationRepository,
 ) {
+    @Transactional
     operator fun invoke(
         command: Command<RegisterBreedingRegistrationCommand>
     ): Result<BreedingRegistration, RegisterBreedingRegistrationUseCaseError> = binding {

--- a/src/main/kotlin/com/example/api/application/studbook/breeding/ReportFoalingUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/ReportFoalingUseCase.kt
@@ -11,6 +11,7 @@ import com.github.michaelbull.result.mapError
 import com.github.michaelbull.result.toResultOr
 import java.util.UUID
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * 分娩結果報告ユースケースの入力コマンド。
@@ -58,6 +59,7 @@ sealed interface ReportFoalingUseCaseError {
  */
 @Service
 class ReportFoalingUseCase(private val breedingResultRepository: BreedingResultRepository) {
+    @Transactional
     operator fun invoke(
         command: Command<ReportFoalingCommand>
     ): Result<BreedingResult, ReportFoalingUseCaseError> = binding {

--- a/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
@@ -14,6 +14,7 @@ import com.github.michaelbull.result.toResultOr
 import java.util.UUID
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * 馬名登録ユースケースの入力コマンド。
@@ -80,6 +81,7 @@ class NameHorseUseCase(
     private val bloodHorseRepository: BloodHorseRepository,
     private val horseInspectionRepository: HorseInspectionRepository,
 ) {
+    @Transactional
     operator fun invoke(
         command: Command<NameHorseCommand>
     ): Result<RegisteredBloodHorse, NameHorseUseCaseError> = binding {

--- a/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
@@ -78,7 +78,6 @@ sealed interface NameHorseUseCaseError {
  * @return 命名された [RegisteredBloodHorse]、または業務ルール違反を表す [NameHorseUseCaseError]
  */
 @Service
-@Transactional
 class NameHorseUseCase(
     private val bloodHorseRepository: BloodHorseRepository,
     private val horseInspectionRepository: HorseInspectionRepository,

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
@@ -27,6 +27,7 @@ import com.github.michaelbull.result.mapError
 import com.github.michaelbull.result.toResultOr
 import java.util.UUID
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * 生産産駒登録ユースケースの入力コマンド。
@@ -107,6 +108,7 @@ class RegisterFoalUseCase(
     private val bloodHorseRepository: BloodHorseRepository,
     private val horseInspectionRepository: HorseInspectionRepository,
 ) {
+    @Transactional
     operator fun invoke(
         command: Command<RegisterFoalCommand>
     ): Result<RegisteredBloodHorse, RegisterFoalUseCaseError> = binding {
@@ -171,7 +173,7 @@ class RegisterFoalUseCase(
                 .mapError { RegisterFoalUseCaseError.PreconditionViolated(it) }
                 .bind()
 
-        // 審査と軽種馬の2集約書き込みは現状トランザクション境界を持たず、インフラ障害時の原子性は #483 で対応。
+        // 審査と軽種馬の 2 集約書き込みは invoke の @Transactional 境界内で原子的に行う（#483）。
         horseInspectionRepository.save(inspection)
         val saved =
             bloodHorseRepository.save(bloodHorse).getOrElse {

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
@@ -22,6 +22,7 @@ import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.mapError
 import java.time.LocalDate
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * 輸入馬血統登録ユースケースの入力コマンド。
@@ -81,6 +82,7 @@ class RegisterImportedHorseUseCase(
     private val bloodHorseRepository: BloodHorseRepository,
     private val horseInspectionRepository: HorseInspectionRepository,
 ) {
+    @Transactional
     operator fun invoke(
         command: Command<RegisterImportedHorseCommand>
     ): Result<RegisteredBloodHorse, RegisterImportedHorseUseCaseError> = binding {
@@ -124,7 +126,7 @@ class RegisterImportedHorseUseCase(
 
         val bloodHorse = BloodHorse.createImported(entry, inspection, registrationNumber)
 
-        // 審査と軽種馬の2集約書き込みは現状トランザクション境界を持たず、インフラ障害時の原子性は #483 で対応。
+        // 審査と軽種馬の 2 集約書き込みは invoke の @Transactional 境界内で原子的に行う（#483）。
         horseInspectionRepository.save(inspection)
         val saved =
             bloodHorseRepository.save(bloodHorse).getOrElse {

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
@@ -25,6 +25,7 @@ import com.github.michaelbull.result.toResultOr
 import java.time.LocalDate
 import java.util.UUID
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * 血統登録ユースケースの入力コマンド。
@@ -97,6 +98,7 @@ class RegisterInStudBookUseCase(
     private val bloodHorseRepository: BloodHorseRepository,
     private val horseInspectionRepository: HorseInspectionRepository,
 ) {
+    @Transactional
     operator fun invoke(
         command: Command<RegisterInStudBookCommand>
     ): Result<RegisteredBloodHorse, RegisterInStudBookUseCaseError> = binding {
@@ -150,7 +152,7 @@ class RegisterInStudBookUseCase(
                 .mapError { RegisterInStudBookUseCaseError.PreconditionViolated(it) }
                 .bind()
 
-        // 審査と軽種馬の2集約書き込みは現状トランザクション境界を持たず、インフラ障害時の原子性は #483 で対応。
+        // 審査と軽種馬の 2 集約書き込みは invoke の @Transactional 境界内で原子的に行う（#483）。
         horseInspectionRepository.save(inspection)
         val saved =
             bloodHorseRepository.save(bloodHorse).getOrElse {

--- a/src/main/kotlin/com/example/api/application/studbook/inspection/RecordHorseInspectionUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/inspection/RecordHorseInspectionUseCase.kt
@@ -10,6 +10,7 @@ import com.example.api.domain.studbook.model.inspection.ParentageDetermination
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.map
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * 審査記録ユースケースの入力コマンド。
@@ -44,6 +45,7 @@ data class RecordHorseInspectionCommand(
 class RecordHorseInspectionUseCase(
     private val horseInspectionRepository: HorseInspectionRepository
 ) {
+    @Transactional
     operator fun invoke(
         command: Command<RecordHorseInspectionCommand>
     ): Result<HorseInspection, InvalidMicrochipNumber> {

--- a/src/main/kotlin/com/example/api/application/studbook/inspection/RecordHorseInspectionUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/inspection/RecordHorseInspectionUseCase.kt
@@ -36,8 +36,8 @@ data class RecordHorseInspectionCommand(
  * に検証変換し、[HorseInspection.create] で採番・生成して保存する。
  *
  * 失敗のしかたはマイクロチップ形式不正の 1 種類のみのため、専用の sealed は作らずドメインの [InvalidMicrochipNumber]
- * をそのまま返す（error-handling.md「1 種類なら単一型」。増えたら sealed へ昇格）。 単一集約の save のみでトランザクション論点はなく、`create`
- * はドメインイベントを返さない。
+ * をそのまま返す（error-handling.md「1 種類なら単一型」。増えたら sealed へ昇格）。単一集約の save のみで
+ * トランザクション論点はないが、書き込みユースケースの規約一様性（ADR-0051）のため `@Transactional` を付与する。`create` はドメインイベントを返さない。
  *
  * @return 保存後の [HorseInspection]、またはマイクロチップ形式不正を表す [InvalidMicrochipNumber]
  */

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterHorseTransactionRollbackTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterHorseTransactionRollbackTest.kt
@@ -35,8 +35,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode
  *
  * 審査（HorseInspection）→ 軽種馬（BloodHorse）の 2 集約書き込みで、2 番目の save がインフラ障害で 失敗したとき、先行した審査 save
  * がロールバックされ孤児が残らないことを、実 PostgreSQL （Testcontainers）と実トランザクションマネージャで検証する。障害は BloodHorseRepository の
- *
- * @Primary デコレータ Bean で注入する（microchip_number に一意制約が無く実 DB 制約では再現できないため）。
+ * `@Primary` デコレータ Bean で注入する（microchip_number に一意制約が無く実 DB 制約では再現できないため）。
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterHorseTransactionRollbackTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterHorseTransactionRollbackTest.kt
@@ -1,0 +1,143 @@
+package com.example.api.application.studbook.horse
+
+import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.UpdateConflict
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorse
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.studbook.model.horse.bloodhorse.BreedType
+import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
+import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
+import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.infrastructure.studbook.horse.BloodHorseSpringDataRepository
+import com.example.api.infrastructure.studbook.horse.JdbcBloodHorseRepository
+import com.example.api.infrastructure.studbook.inspection.HorseInspectionSpringDataRepository
+import com.example.api.support.PostgresContainerSupport
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.unwrap
+import java.time.Instant
+import java.time.LocalDate
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.dao.DataAccessResourceFailureException
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.context.TestConstructor.AutowireMode
+
+/**
+ * 血統登録系ユースケースのトランザクション境界（#483）の統合テスト。
+ *
+ * 審査（HorseInspection）→ 軽種馬（BloodHorse）の 2 集約書き込みで、2 番目の save がインフラ障害で 失敗したとき、先行した審査 save
+ * がロールバックされ孤児が残らないことを、実 PostgreSQL （Testcontainers）と実トランザクションマネージャで検証する。障害は BloodHorseRepository の
+ *
+ * @Primary デコレータ Bean で注入する（microchip_number に一意制約が無く実 DB 制約では再現できないため）。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class RegisterHorseTransactionRollbackTest(
+    private val registerInStudBook: RegisterInStudBookUseCase,
+    private val registerImportedHorse: RegisterImportedHorseUseCase,
+    private val failingRepository: FailingBloodHorseRepository,
+    private val inspectionRows: HorseInspectionSpringDataRepository,
+    private val bloodHorseRows: BloodHorseSpringDataRepository,
+) : PostgresContainerSupport() {
+
+    @TestConfiguration
+    class FailingSaveConfiguration {
+        @Bean
+        @Primary
+        fun failingBloodHorseRepository(
+            delegate: JdbcBloodHorseRepository
+        ): FailingBloodHorseRepository = FailingBloodHorseRepository(delegate)
+    }
+
+    @BeforeEach
+    fun cleanUp() {
+        failingRepository.failOnSave = false
+        inspectionRows.deleteAll()
+        bloodHorseRows.deleteAll()
+    }
+
+    @Test
+    fun `輸入馬血統登録で軽種馬の保存がインフラ障害で失敗すると先行する審査の保存もロールバックされる`() {
+        failingRepository.failOnSave = true
+
+        assertThrows<DataAccessResourceFailureException> {
+            registerImportedHorse(command(importedHorseCommand()))
+        }
+
+        assert(inspectionRows.count() == 0L) { "審査が孤児として残っている" }
+        assert(bloodHorseRows.count() == 0L)
+    }
+
+    @Test
+    fun `内国産血統登録で軽種馬の保存がインフラ障害で失敗すると先行する審査の保存もロールバックされる`() {
+        val sire = failingRepository.save(BloodHorseFixture.bloodHorse(sex = Sex.MALE)).unwrap()
+        val dam = failingRepository.save(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)).unwrap()
+        failingRepository.failOnSave = true
+
+        assertThrows<DataAccessResourceFailureException> {
+            registerInStudBook(command(domesticCommand(sire, dam)))
+        }
+
+        assert(inspectionRows.count() == 0L) { "審査が孤児として残っている" }
+        assert(bloodHorseRows.count() == 2L) { "父・母の 2 頭だけが残るはず" }
+    }
+
+    private fun <T> command(payload: T) = Command(payload, Instant.parse("2026-07-03T00:00:00Z"))
+
+    private fun importedHorseCommand() =
+        RegisterImportedHorseCommand(
+            sex = Sex.MALE,
+            coatColor = CoatColor.BAY,
+            breedType = BreedType.THOROUGHBRED,
+            dateOfBirth = LocalDate.of(2020, 4, 10),
+            breeder = "Coolmore",
+            microchipNumber = "392140000000002",
+            originCountry = "アイルランド",
+            landingDate = LocalDate.of(2024, 9, 1),
+            registrationNumber = "2020900002",
+        )
+
+    private fun domesticCommand(sire: BloodHorse, dam: BloodHorse) =
+        RegisterInStudBookCommand(
+            sireId = sire.id.value,
+            damId = dam.id.value,
+            sex = Sex.MALE,
+            coatColor = CoatColor.BAY,
+            breedType = BreedType.THOROUGHBRED,
+            dateOfBirth = LocalDate.of(2025, 3, 1),
+            breeder = "ノーザンファーム",
+            microchipNumber = "392140000000003",
+            dnaParentage = DnaParentageResult.CONSISTENT,
+            registrationNumber = "2025100001",
+        )
+}
+
+/**
+ * 実装（[JdbcBloodHorseRepository]）へ委譲しつつ、指示されたとき save でインフラ障害を注入する テスト用デコレータ。トランザクションロールバックの検証に使う。
+ */
+class FailingBloodHorseRepository(private val delegate: BloodHorseRepository) :
+    BloodHorseRepository {
+    var failOnSave = false
+
+    override fun findById(id: BloodHorseId): BloodHorse? = delegate.findById(id)
+
+    override fun findAllById(ids: Set<BloodHorseId>): Map<BloodHorseId, BloodHorse> =
+        delegate.findAllById(ids)
+
+    override fun save(bloodHorse: BloodHorse): Result<BloodHorse, UpdateConflict> {
+        if (failOnSave) {
+            throw DataAccessResourceFailureException("インフラ障害を注入（ロールバック検証用）")
+        }
+        return delegate.save(bloodHorse)
+    }
+
+    override fun existsByName(name: HorseName): Boolean = delegate.existsByName(name)
+}

--- a/src/test/kotlin/com/example/api/architecture/OnionLayerRulesTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/OnionLayerRulesTest.kt
@@ -1,16 +1,19 @@
 package com.example.api.architecture
 
 import com.example.api.ApiApplication
+import com.example.api.domain.shared.Command
 import com.tngtech.archunit.base.DescribedPredicate.not
 import com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage
 import com.tngtech.archunit.core.importer.ImportOption
 import com.tngtech.archunit.junit.AnalyzeClasses
 import com.tngtech.archunit.junit.ArchTest
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
 import com.tngtech.archunit.library.Architectures.onionArchitecture
 import org.springframework.stereotype.Repository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * オニオンアーキテクチャの 4 リングに関する規約を強制するテスト。
@@ -104,4 +107,28 @@ class OnionLayerRulesTest {
             .areAnnotatedWith(Repository::class.java)
             .should()
             .resideInAPackage(INFRASTRUCTURE)
+
+    /**
+     * 書き込みユースケース（`Command` を受ける `invoke`）はトランザクション境界（`@Transactional`）を持つこと。
+     *
+     * 複数集約を書き込むユースケースでインフラ障害時の原子性が欠ける（先行 save が孤児として残る）ことを 構造的に防ぐ（#483 / ADR-0050）。入力 DTO
+     * 規約（書き込み=`Command` 封筒 / 読み取り=`〜Query`）により 書き込み系を静的に判別する。読み取り系ユースケースは対象外（readOnly
+     * トランザクションは導入しない）。
+     *
+     * `invoke` は完全一致 (`haveName`) ではなく前方一致 (`haveNameStartingWith`) で照合する。戻り値 `Result<V,
+     * E>`（kotlin-result）が inline value class のため、Kotlin コンパイラがプラットフォーム宣言の衝突回避で メソッド名をマングルする（例:
+     * `invoke-Zyo9ksc`）。完全一致では実バイトコード名と食い違い空振りする （ミューテーション検証で確認済み）。
+     */
+    @ArchTest
+    val commandHandlingInvokesAreTransactional =
+        methods()
+            .that()
+            .areDeclaredInClassesThat()
+            .resideInAPackage(APPLICATION)
+            .and()
+            .haveNameStartingWith("invoke")
+            .and()
+            .haveRawParameterTypes(Command::class.java)
+            .should()
+            .beAnnotatedWith(Transactional::class.java)
 }

--- a/src/test/kotlin/com/example/api/architecture/OnionLayerRulesTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/OnionLayerRulesTest.kt
@@ -123,6 +123,10 @@ class OnionLayerRulesTest {
      * `invoke` は完全一致 (`haveName`) ではなく前方一致 (`haveNameStartingWith`) で照合する。戻り値 `Result<V,
      * E>`（kotlin-result）が inline value class のため、Kotlin コンパイラがプラットフォーム宣言の衝突回避で メソッド名をマングルする（例:
      * `invoke-Zyo9ksc`）。完全一致では実バイトコード名と食い違い空振りする （ミューテーション検証で確認済み）。
+     *
+     * 前方一致に加えて `haveRawParameterTypes(Command)` を AND 条件に置くことで、前方一致の広すぎる当たりを `Command`
+     * 封筒を受け取るメソッドだけに絞り安全にしている。裏返すと、`Command` 封筒を受けない書き込みメソッドや 多引数の `invoke` はこのガードの対象外（規約＝「書き込みは
+     * `Command` 単項 `invoke`」に依存する）。
      */
     @ArchTest
     val commandHandlingInvokesAreTransactional =

--- a/src/test/kotlin/com/example/api/architecture/OnionLayerRulesTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/OnionLayerRulesTest.kt
@@ -67,7 +67,14 @@ class OnionLayerRulesTest {
             .haveSimpleNameEndingWith("Kt")
             .because("ドメインサービスは object / class でラップせずトップレベル関数で書く。" + "service/ への配置でドメインサービスを表現する")
 
-    /** application 層の Spring 依存は DI 用 stereotype アノテーションのみに留めること。 */
+    /**
+     * application 層の Spring 依存は宣言的アノテーション（DI 用 stereotype と @Transactional）のみに留めること。
+     *
+     * `org.springframework.transaction.annotation`（`@Transactional` 等）はメタデータのみで実行機構への
+     * 依存ではないため、stereotype と同様に許可する（#483 / ADR-0050）。`TransactionTemplate` /
+     * `PlatformTransactionManager` 等の実行機構（`org.springframework.transaction` 直下・`.support`）は
+     * 引き続き禁止する。
+     */
     @ArchTest
     val applicationDependsOnSpringOnlyForDi =
         noClasses()
@@ -77,6 +84,7 @@ class OnionLayerRulesTest {
             .dependOnClassesThat(
                 resideInAPackage("org.springframework..")
                     .and(not(resideInAPackage("org.springframework.stereotype..")))
+                    .and(not(resideInAPackage("org.springframework.transaction.annotation..")))
             )
 
     /** ユースケース（@Service）は application 層に置くこと。 */


### PR DESCRIPTION
## 概要

Closes #483

軽種馬登録系ユースケースは審査（`HorseInspection`）→ 軽種馬（`BloodHorse`）の 2 集約を非トランザクションで連続 save しており、2 番目の save がインフラ障害で失敗すると先行した審査が孤児として残っていた（#312 の最終レビュー Important #1）。書き込みユースケースに宣言的 `@Transactional` のトランザクション境界を与えて解消する。

## 変更内容

- **`@Transactional` 付与**: `Command` を受ける `invoke` を持つ全書き込みユースケース 10 個（studbook horse 4 / breeding 4 / inspection 1 / racing jockey 1）のメソッドへ付与。読み取り系（`Find〜`）は対象外（readOnly Tx は YAGNI で見送り）
- **ロールバック統合テスト**: `RegisterHorseTransactionRollbackTest`（Testcontainers PostgreSQL・実 Tx マネージャ）。`BloodHorseRepository` の `@Primary` デコレータで 2 番目の save に障害を注入し、先行した審査 save がロールバックされることを TDD（RED→GREEN）で検証。代表 2 UC（輸入馬=最小 fixture・内国産=父母引き当て込みの旗艦ケース）
- **ArchUnit**: 依存許可の限定緩和（`org.springframework.transaction.annotation..`。実行機構パッケージは引き続き禁止）と、付け忘れを構造的に防ぐ新ガード `commandHandlingInvokesAreTransactional`。kotlin-result の inline value class 戻り値によるメソッド名マングリング（`invoke-Zyo9ksc`）を `haveNameStartingWith` で回避し、ミューテーション検証（アノテーション除去→FAIL→復元→PASS）済み
- **ドキュメント**: `.claude/rules/architecture.md` のリング表・規約更新、決定の記録は [ADR-0051](docs/adr/0051-transactional-use-case-boundary.md)（0050 は並行の #433 決定が使用したため改番）

## #433（ADR-0050）との統合

作業中に origin/main へマージされた #433（ドメインイベント発行基盤・publish-after-commit）を統合済み。ArchUnit ルールは main 側の精密 allowlist 版 `applicationDependsOnSpringOnlyForWiring` に合流し、`NameHorseUseCase` の `@Transactional` はメソッドレベルへ一本化。ADR-0050 の publish-after-commit 前提（発行時にアクティブな Tx）を、本 PR が全書き込みユースケースへ広げる関係になる。

## 検証

- `./gradlew check` 全ゲート通過（ktfmt / detekt / 全テスト（ArchUnit・ロールバック統合テスト含む）/ koverVerifyMature）
- `Result` 規約との整合: 業務失敗（`Err`）は save 前に確定するため「実行時例外でロールバック」の既定で十分（`rollbackFor` 不要）。インフラ障害は `DataAccessException` が伝播してロールバック

🤖 Generated with [Claude Code](https://claude.com/claude-code)
