### PR TITLE
chore: version 列に NOT NULL 制約を遡及付与する(#531)

### DIFF
--- a/dbdoc/public.blood_horse.md
+++ b/dbdoc/public.blood_horse.md
@@ -22,7 +22,7 @@
 | dam_id | uuid |  | true |  |  | 母馬 ID（内国産のみ） |
 | origin_country | varchar(255) |  | true |  |  | 原産国（輸入のみ） |
 | landing_date | date |  | true |  |  | 輸入上陸日（輸入のみ） |
-| version | bigint |  | true |  |  | 楽観ロック兼新規 insert 判定（NULL のとき新規） |
+| version | bigint |  | false |  |  | 楽観ロック用バージョン（新規判定の NULL はエンティティ側のみ。保存済み行は常に非 NULL） |
 
 ## Constraints
 

--- a/dbdoc/public.breeding_registration.md
+++ b/dbdoc/public.breeding_registration.md
@@ -14,7 +14,7 @@
 | breeding_role | varchar(32) |  | false |  |  | 繁殖の役割（STALLION/BROODMARE） |
 | retirement_reason | varchar(32) |  | true |  |  | 供用停止事由（供用中は NULL） |
 | retirement_occurred_on | date |  | true |  |  | 供用停止発生日（供用中は NULL） |
-| version | bigint |  | true |  |  | 楽観ロック兼新規 insert 判定（NULL のとき新規） |
+| version | bigint |  | false |  |  | 楽観ロック用バージョン（新規判定の NULL はエンティティ側のみ。保存済み行は常に非 NULL） |
 
 ## Constraints
 

--- a/dbdoc/public.breeding_result.md
+++ b/dbdoc/public.breeding_result.md
@@ -17,7 +17,7 @@
 | covering_certificate_number | varchar(255) |  | true |  |  | 種付証明書番号（種付なしは NULL） |
 | outcome_type | varchar(32) |  | true |  |  | 分娩結果の判別子（NOT_COVERED/LIVE_FOAL 等） |
 | outcome_foaling_date | date |  | true |  |  | 分娩日（生産 LIVE_FOAL のときのみ） |
-| version | bigint |  | true |  |  | 楽観ロック兼新規 insert 判定（NULL のとき新規） |
+| version | bigint |  | false |  |  | 楽観ロック用バージョン（新規判定の NULL はエンティティ側のみ。保存済み行は常に非 NULL） |
 
 ## Constraints
 

--- a/dbdoc/public.horse_inspection.md
+++ b/dbdoc/public.horse_inspection.md
@@ -15,7 +15,7 @@
 | feature_hair_whorl | varchar(255) |  | true |  |  | 特徴記述子: 旋毛（未記録なら NULL） |
 | feature_white_markings | varchar(255) |  | true |  |  | 特徴記述子: 白徴（未記録なら NULL） |
 | feature_nose_print | varchar(255) |  | true |  |  | 特徴記述子: 鼻紋（未記録なら NULL） |
-| version | bigint |  | true |  |  | 楽観ロック兼新規 insert 判定（NULL のとき新規） |
+| version | bigint |  | false |  |  | 楽観ロック用バージョン（新規判定の NULL はエンティティ側のみ。保存済み行は常に非 NULL） |
 
 ## Constraints
 

--- a/dbdoc/public.jockey.md
+++ b/dbdoc/public.jockey.md
@@ -11,7 +11,7 @@
 | id | uuid |  | false |  |  | 識別子（外部採番の UUIDv7） |
 | first_name | varchar(255) |  | false |  |  | 名 |
 | last_name | varchar(255) |  | false |  |  | 姓 |
-| version | bigint |  | true |  |  | 楽観ロック兼新規 insert 判定（NULL のとき新規） |
+| version | bigint |  | false |  |  | 楽観ロック用バージョン（新規判定の NULL はエンティティ側のみ。保存済み行は常に非 NULL） |
 
 ## Constraints
 

--- a/src/main/resources/db/migration/V9__add_version_not_null.sql
+++ b/src/main/resources/db/migration/V9__add_version_not_null.sql
@@ -1,0 +1,93 @@
+-- 全テーブルの version 列（楽観ロック用、V1〜V5 で導入）へ NOT NULL を遡及付与する（#531 / ADR-0047）。
+-- アプリ経由の insert では Spring Data JDBC が必ず 0 以上を書くため既存行は非 NULL のはずだが、
+-- 手動シード・外部ツール経由の NULL 混入をスキーマ側でも強制して多層防御にする（PR #526 最終レビューの指摘）。
+-- 既存行があるテーブルへの遡及付与は V6（#522）と同じ 2 段階の作法で行う:
+-- NOT VALID の CHECK で新規行への強制を即時開始（既存行は未検証・ロック最小）し、
+-- VALIDATE CONSTRAINT で既存行を後追い検証する（SHARE UPDATE EXCLUSIVE・書き込みを止めない。
+-- NULL 行が存在すればここで失敗し、混入の見逃しを防ぐ）。
+-- そのうえで SET NOT NULL を付与する。PostgreSQL 12+ は検証済み CHECK があると
+-- フルスキャンを省略するため、テーブルロック時間は最小で済む。
+-- 目的を果たした中間 CHECK は同一制約の重複になるため最後に削除する。
+-- timeout は squawk（require-timeout-settings）に従い設定する。Flyway は各マイグレーションを
+-- 1 トランザクションで適用するため、SET LOCAL でこのマイグレーション内に閉じる。
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+-- jockey
+ALTER TABLE jockey
+ADD CONSTRAINT chk_jockey_version_not_null
+CHECK (version IS NOT NULL) NOT VALID; -- noqa: RF04
+
+ALTER TABLE jockey
+VALIDATE CONSTRAINT chk_jockey_version_not_null;
+
+ALTER TABLE jockey
+ALTER COLUMN version SET NOT NULL; -- noqa: RF04
+
+ALTER TABLE jockey
+DROP CONSTRAINT chk_jockey_version_not_null;
+
+-- breeding_registration
+ALTER TABLE breeding_registration
+ADD CONSTRAINT chk_breeding_registration_version_not_null
+CHECK (version IS NOT NULL) NOT VALID; -- noqa: RF04
+
+ALTER TABLE breeding_registration
+VALIDATE CONSTRAINT chk_breeding_registration_version_not_null;
+
+ALTER TABLE breeding_registration
+ALTER COLUMN version SET NOT NULL; -- noqa: RF04
+
+ALTER TABLE breeding_registration
+DROP CONSTRAINT chk_breeding_registration_version_not_null;
+
+-- blood_horse
+ALTER TABLE blood_horse
+ADD CONSTRAINT chk_blood_horse_version_not_null
+CHECK (version IS NOT NULL) NOT VALID; -- noqa: RF04
+
+ALTER TABLE blood_horse
+VALIDATE CONSTRAINT chk_blood_horse_version_not_null;
+
+ALTER TABLE blood_horse
+ALTER COLUMN version SET NOT NULL; -- noqa: RF04
+
+ALTER TABLE blood_horse
+DROP CONSTRAINT chk_blood_horse_version_not_null;
+
+-- breeding_result
+ALTER TABLE breeding_result
+ADD CONSTRAINT chk_breeding_result_version_not_null
+CHECK (version IS NOT NULL) NOT VALID; -- noqa: RF04
+
+ALTER TABLE breeding_result
+VALIDATE CONSTRAINT chk_breeding_result_version_not_null;
+
+ALTER TABLE breeding_result
+ALTER COLUMN version SET NOT NULL; -- noqa: RF04
+
+ALTER TABLE breeding_result
+DROP CONSTRAINT chk_breeding_result_version_not_null;
+
+-- horse_inspection
+ALTER TABLE horse_inspection
+ADD CONSTRAINT chk_horse_inspection_version_not_null
+CHECK (version IS NOT NULL) NOT VALID; -- noqa: RF04
+
+ALTER TABLE horse_inspection
+VALIDATE CONSTRAINT chk_horse_inspection_version_not_null;
+
+ALTER TABLE horse_inspection
+ALTER COLUMN version SET NOT NULL; -- noqa: RF04
+
+ALTER TABLE horse_inspection
+DROP CONSTRAINT chk_horse_inspection_version_not_null;
+
+-- V7 のコメント「NULL のとき新規」は NOT NULL 化と矛盾して読めるため更新する。
+-- （Spring Data JDBC の新規 insert 判定はエンティティ側の version が NULL かどうかで行われ、
+-- 保存済み行の列値は常に非 NULL。）
+COMMENT ON COLUMN jockey.version IS '楽観ロック用バージョン（新規判定の NULL はエンティティ側のみ。保存済み行は常に非 NULL）';
+COMMENT ON COLUMN breeding_registration.version IS '楽観ロック用バージョン（新規判定の NULL はエンティティ側のみ。保存済み行は常に非 NULL）';
+COMMENT ON COLUMN blood_horse.version IS '楽観ロック用バージョン（新規判定の NULL はエンティティ側のみ。保存済み行は常に非 NULL）';
+COMMENT ON COLUMN breeding_result.version IS '楽観ロック用バージョン（新規判定の NULL はエンティティ側のみ。保存済み行は常に非 NULL）';
+COMMENT ON COLUMN horse_inspection.version IS '楽観ロック用バージョン（新規判定の NULL はエンティティ側のみ。保存済み行は常に非 NULL）';


### PR DESCRIPTION
## 概要

Closes #531（親: #424 / [ADR-0047](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0047-aggregate-version-for-optimistic-locking.md)）

全 5 テーブル（jockey / breeding_registration / blood_horse / breeding_result / horse_inspection）の `version BIGINT` 列へ NOT NULL 制約を遡及付与し、手動シード・外部ツール経由の NULL 混入をスキーマ側でも強制する多層防御にする（PR #526 最終レビューの指摘）。アプリ経由の insert では Spring Data JDBC が常に値を書くため、Kotlin コードの変更はない。

## 変更内容

- **`V9__add_version_not_null.sql`**: V6（#522）と同じ作法で各テーブルに 2 段階＋仕上げの遡及付与
  1. `CHECK (version IS NOT NULL) NOT VALID` — 新規行への強制を即時開始（ロック最小）
  2. `VALIDATE CONSTRAINT` — 既存行を後追い検証（書き込みを止めない）。**NULL 行が存在すればここで失敗**し、Issue の「NULL 行が無いことを確認」を宣言的に実施
  3. `SET NOT NULL` — PostgreSQL 12+ は検証済み CHECK によりフルスキャンを省略
  4. 目的を果たした中間 CHECK は削除（同一制約の重複を残さない）

  冒頭に V6 と同じ `SET LOCAL lock_timeout = '5s'` / `statement_timeout = '5min'`（squawk require-timeout-settings 対応）。

  あわせて V7 のカラムコメント「NULL のとき新規」を更新。NOT NULL 化と矛盾して読めるため、「新規判定の NULL はエンティティ側のみ（保存済み行は常に非 NULL）」へ改めた。
- **`dbdoc/public.*.md`**: tbls 再生成（nullable false 化とコメント更新の反映）

## 採番について

**V8 ではなく V9 を採番**。In Progress の #455 ブランチ（`feat/455-breeding-report-deadline`）が `V8__add_breeding_result_report_submission.sql` を既に使用しているため、同番衝突（Flyway duplicate version）を回避した。本 PR が先にマージされた場合、#455 側は V8 のままだと out-of-order になるため V10 への振り直しが必要（逆順なら双方そのまま通る）。

## 検証

- `sqlfluff lint` / `squawk`: クリーン
- `./gradlew generateDbDoc` / `checkDbDoc`: 再生成・鮮度検査 OK
- `./gradlew check`: 成功（Testcontainers PostgreSQL の全契約テストで V9 適用込みの Flyway マイグレーションが実行される）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
