### PR TITLE
feat: 繁殖成績報告の提出期限（翌年5/31）制約を実装する(#455)

### DIFF
--- a/dbdoc/README.md
+++ b/dbdoc/README.md
@@ -7,7 +7,7 @@
 | [public.jockey](public.jockey.md) | 4 | 騎手（JRA 競馬コンテキスト） | BASE TABLE |
 | [public.breeding_registration](public.breeding_registration.md) | 7 | 繁殖登録（軽種馬登録コンテキスト） | BASE TABLE |
 | [public.blood_horse](public.blood_horse.md) | 15 | 血統馬（軽種馬登録コンテキスト） | BASE TABLE |
-| [public.breeding_result](public.breeding_result.md) | 10 | 繁殖成績（軽種馬登録コンテキスト） | BASE TABLE |
+| [public.breeding_result](public.breeding_result.md) | 11 | 繁殖成績（軽種馬登録コンテキスト） | BASE TABLE |
 | [public.horse_inspection](public.horse_inspection.md) | 8 | 個体識別審査・親子判定（軽種馬登録コンテキスト） | BASE TABLE |
 
 ## Relations
@@ -59,6 +59,7 @@ erDiagram
   varchar_32_ outcome_type
   date outcome_foaling_date
   bigint version
+  date report_submitted_on
 }
 "public.horse_inspection" {
   uuid id

--- a/dbdoc/public.breeding_result.md
+++ b/dbdoc/public.breeding_result.md
@@ -18,6 +18,7 @@
 | outcome_type | varchar(32) |  | true |  |  | 分娩結果の判別子（NOT_COVERED/LIVE_FOAL 等） |
 | outcome_foaling_date | date |  | true |  |  | 分娩日（生産 LIVE_FOAL のときのみ） |
 | version | bigint |  | true |  |  | 楽観ロック兼新規 insert 判定（NULL のとき新規） |
+| report_submitted_on | date |  | true |  |  | 繁殖成績報告書（様式第14号）の提出日（未提出は NULL） |
 
 ## Constraints
 
@@ -26,6 +27,7 @@
 | chk_breeding_result_covering | CHECK | CHECK ((((covering_stallion_id IS NULL) AND (covering_date IS NULL) AND (covering_certificate_number IS NULL) AND (covering_place IS NULL)) OR ((covering_stallion_id IS NOT NULL) AND (covering_date IS NOT NULL) AND (covering_certificate_number IS NOT NULL)))) |
 | chk_breeding_result_foaling_date | CHECK | CHECK (((outcome_foaling_date IS NULL) OR ((outcome_type)::text = 'LIVE_FOAL'::text))) |
 | chk_breeding_result_outcome_covering | CHECK | CHECK ((((covering_date IS NULL) AND ((outcome_type)::text = 'NOT_COVERED'::text)) OR ((covering_date IS NOT NULL) AND ((outcome_type IS NULL) OR ((outcome_type)::text <> 'NOT_COVERED'::text))))) |
+| chk_breeding_result_report_needs_outcome | CHECK | CHECK (((report_submitted_on IS NULL) OR (outcome_type IS NOT NULL))) |
 | breeding_result_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## Indexes
@@ -51,6 +53,7 @@ erDiagram
   varchar_32_ outcome_type
   date outcome_foaling_date
   bigint version
+  date report_submitted_on
 }
 ```
 

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -56,7 +56,8 @@
 | --- | --- | --- | --- | --- |
 | BreedingRegistration | 繁殖登録 | 集約ルート | 馬を繁殖に供するための登録（JAIRS）。**雄雌共通の単一の登録**で、繁殖登録証明書の `性` によって担うロール（種牡馬／繁殖牝馬）が決まる。 | 雄雌で別集約にしない（種牡馬も繁殖登録の対象） |
 | BreedingRole | 繁殖ロール | （enum） | 繁殖登録で付与されるロール。雄=種牡馬（`STALLION`）／雌=繁殖牝馬（`BROODMARE`）。性から定まる。 | jMolecules 非付与のためカタログには出ない。Stallion/Broodmare は別個体でなくこのロール |
-| BreedingResult | 繁殖成績 | 集約ルート | 種付年ごとの「種付〜分娩」の年次レコード。「繁殖成績報告書」（様式第14号）1 行に対応。 | — |
+| BreedingResult | 繁殖成績 | 集約ルート | 種付年ごとの「種付〜分娩」の年次レコード。「繁殖成績報告書」（様式第14号）1 行に対応。年次提出（`submitReport`）の提出日と期限超過の導出を持つ。 | — |
+| BreedingReportDeadline | 繁殖成績報告の提出期限 | 値オブジェクト | 繁殖成績報告書（様式第14号）の提出期限＝繁殖年の翌年5/31（登録規程第25条）。期限超過の提出は拒否せず受理し、超過をドメインの事実として記録する（同条ただし書き）。 | 期限は日本の暦日（Asia/Tokyo）で締まる |
 | Covering | 種付 | 値オブジェクト | 種牡馬を繁殖牝馬に交配したという事実。種牡馬は `BloodHorseId` 参照。種付日・種付場所（`coveringPlace`）を持つ。 | — |
 | CoveringCertificateNumber | 種付証明書番号 | 値オブジェクト | 種付の**事実**を証明する種付証明書の番号。 | 禁止: 種畜証明書（`StudCertificate`）と混同しない。別書面 |
 | StudCertificate | 種畜証明書 | 値オブジェクト | 種雄馬が繁殖に供されることを証する書面。有効区域（`validRegions`）と有効期間（`validPeriod`）を持ち、種付がその内側で行われたかを `authorizes` で検証する（第9条第1項(1)）。 | 禁止: 種付証明書（`CoveringCertificateNumber`）と混同しない |
@@ -182,6 +183,7 @@ graph LR
 | BreedingRegion | 値オブジェクト | domain.studbook.model.breeding |
 | BreedingRegistrationId | 値オブジェクト | domain.studbook.model.breeding |
 | BreedingRegistrationNumber | 値オブジェクト | domain.studbook.model.breeding |
+| BreedingReportDeadline | 値オブジェクト | domain.studbook.model.breeding |
 | BreedingResultId | 値オブジェクト | domain.studbook.model.breeding |
 | BreedingRetirement | 値オブジェクト | domain.studbook.model.breeding |
 | CoatColor | 値オブジェクト | domain.studbook.model.horse.bloodhorse |

--- a/src/main/kotlin/com/example/api/application/studbook/breeding/SubmitBreedingReportUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/SubmitBreedingReportUseCase.kt
@@ -12,6 +12,7 @@ import com.github.michaelbull.result.mapError
 import com.github.michaelbull.result.toResultOr
 import java.util.UUID
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * 繁殖成績報告提出ユースケースの入力コマンド。
@@ -59,6 +60,7 @@ sealed interface SubmitBreedingReportUseCaseError {
  */
 @Service
 class SubmitBreedingReportUseCase(private val breedingResultRepository: BreedingResultRepository) {
+    @Transactional
     operator fun invoke(
         command: Command<SubmitBreedingReportCommand>
     ): Result<BreedingResult, SubmitBreedingReportUseCaseError> = binding {

--- a/src/main/kotlin/com/example/api/application/studbook/breeding/SubmitBreedingReportUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/SubmitBreedingReportUseCase.kt
@@ -1,0 +1,88 @@
+package com.example.api.application.studbook.breeding
+
+import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.breeding.BreedingReportDeadline
+import com.example.api.domain.studbook.model.breeding.BreedingResult
+import com.example.api.domain.studbook.model.breeding.BreedingResultId
+import com.example.api.domain.studbook.model.breeding.BreedingResultRepository
+import com.example.api.domain.studbook.model.breeding.SubmitBreedingReportError
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.binding
+import com.github.michaelbull.result.mapError
+import com.github.michaelbull.result.toResultOr
+import java.util.UUID
+import org.springframework.stereotype.Service
+
+/**
+ * 繁殖成績報告提出ユースケースの入力コマンド。
+ *
+ * 繁殖成績報告書（様式第14号）の年次提出に相当する境界の入力。提出対象の繁殖成績を ID で参照する。提出日時は ペイロードでは受けず、封筒
+ * [Command.issuedAt]（発生時刻メタデータ）を用いる。
+ *
+ * @property breedingResultId 提出対象の繁殖成績ID
+ */
+data class SubmitBreedingReportCommand(val breedingResultId: UUID)
+
+/** 繁殖成績報告提出時に発生しうる業務ルール違反。 */
+sealed interface SubmitBreedingReportUseCaseError {
+    /** 提出対象として指定された繁殖成績が存在しない。 */
+    data class BreedingResultNotFound(val breedingResultId: UUID) : SubmitBreedingReportUseCaseError
+
+    /**
+     * ドメインの前提条件違反（分娩結果が未確定、または既に提出済み）。
+     *
+     * @property cause 前提条件違反の内容
+     */
+    data class PreconditionViolated(val cause: SubmitBreedingReportError) :
+        SubmitBreedingReportUseCaseError
+
+    /**
+     * 読み取りから提出確定までの間に、対象の繁殖成績が他の更新と競合した。
+     *
+     * 楽観ロック（読み取り時点の version との不一致）による検出。最新の状態を取得して再操作すれば解消しうる。
+     *
+     * @property breedingResultId 競合した繁殖成績ID
+     */
+    data class ConcurrentModification(val breedingResultId: UUID) : SubmitBreedingReportUseCaseError
+}
+
+/**
+ * 繁殖成績報告提出ユースケース。
+ *
+ * 提出対象の繁殖成績を [BreedingResultRepository] で引き当て、[Command.issuedAt] を
+ * [BreedingReportDeadline.submissionDateOf] で日本の暦日（提出日）に写してから、集約の [BreedingResult.submitReport]
+ * で提出を記録し、楽観ロック付きで更新する（競合は
+ * [SubmitBreedingReportUseCaseError.ConcurrentModification]）。期限（翌年5/31）超過でも拒否せず、超過は
+ * 集約が導出する事実として残る（登録規程第25条ただし書き。#455）。Controller 層は本クラスのみに依存する。
+ *
+ * @return 提出済みの [BreedingResult]、または業務ルール違反を表す [SubmitBreedingReportUseCaseError]
+ */
+@Service
+class SubmitBreedingReportUseCase(private val breedingResultRepository: BreedingResultRepository) {
+    operator fun invoke(
+        command: Command<SubmitBreedingReportCommand>
+    ): Result<BreedingResult, SubmitBreedingReportUseCaseError> = binding {
+        val input = command.payload
+
+        val breedingResult =
+            breedingResultRepository
+                .findById(BreedingResultId(input.breedingResultId))
+                .toResultOr {
+                    SubmitBreedingReportUseCaseError.BreedingResultNotFound(input.breedingResultId)
+                }
+                .bind()
+
+        val submitted =
+            breedingResult
+                .submitReport(BreedingReportDeadline.submissionDateOf(command.issuedAt))
+                .mapError { SubmitBreedingReportUseCaseError.PreconditionViolated(it) }
+                .bind()
+
+        breedingResultRepository
+            .save(submitted)
+            .mapError {
+                SubmitBreedingReportUseCaseError.ConcurrentModification(input.breedingResultId)
+            }
+            .bind()
+    }
+}

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultController.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultController.kt
@@ -4,6 +4,8 @@ import com.example.api.application.studbook.breeding.RecordCoveringUseCase
 import com.example.api.application.studbook.breeding.RecordUncoveredUseCase
 import com.example.api.application.studbook.breeding.ReportFoalingCommand
 import com.example.api.application.studbook.breeding.ReportFoalingUseCase
+import com.example.api.application.studbook.breeding.SubmitBreedingReportCommand
+import com.example.api.application.studbook.breeding.SubmitBreedingReportUseCase
 import com.example.api.controller.breeding.problem.toProblemDetail
 import com.example.api.controller.breeding.request.RecordBreedingResultRequest
 import com.example.api.controller.breeding.request.ReportFoalingRequest
@@ -41,6 +43,7 @@ class BreedingResultController(
     private val recordCovering: RecordCoveringUseCase,
     private val recordUncovered: RecordUncoveredUseCase,
     private val reportFoaling: ReportFoalingUseCase,
+    private val submitReport: SubmitBreedingReportUseCase,
     private val clock: Clock,
 ) {
     @Operation(
@@ -181,4 +184,68 @@ class BreedingResultController(
             .orThrowProblem()
             .toResponse()
     }
+
+    @Operation(
+        summary = "繁殖成績報告を提出する",
+        description =
+            "繁殖成績報告書（様式第14号）の年次提出を記録し、更新後の繁殖成績リソースを返す。提出日時はサーバー時刻" +
+                "（コマンドの発生時刻）を日本の暦日に写した提出日として扱う。期限（繁殖年の翌年5/31）超過の提出も" +
+                "拒否せず受理し、期限超過（report_submitted_late）として応答に表れる。業務ルール違反時は RFC 9457 " +
+                "形式の problem+json を返す。",
+        tags = ["BreedingResult"],
+        responses =
+            [
+                ApiResponse(
+                    responseCode = "200",
+                    description = "提出成功（更新後の繁殖成績リソースを返す。期限超過でも成功する）",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = BreedingResultResponse::class),
+                                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "404",
+                    description = "提出対象の繁殖成績が存在しない",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "409",
+                    description = "既に提出済み（二重提出）、または他の更新と競合した",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+                ApiResponse(
+                    responseCode = "422",
+                    description = "分娩結果が未確定のため提出できない",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ProblemDetail::class),
+                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            )
+                        ],
+                ),
+            ],
+    )
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/api/breedingResults/{breedingResultId}:submitReport")
+    fun submitReport(@PathVariable breedingResultId: UUID): BreedingResultResponse =
+        submitReport(Command.now(SubmitBreedingReportCommand(breedingResultId), clock))
+            .mapError { it.toProblemDetail() }
+            .orThrowProblem()
+            .toResponse()
 }

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultController.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultController.kt
@@ -33,10 +33,10 @@ import org.springframework.web.bind.annotation.RestController
 /**
  * 繁殖成績リソースの HTTP アダプター。
  *
- * Google AIP のリソース指向設計に従い、コレクション `/api/breedingResults` に対する Create（年次レコードの起票）と、 個体へのカスタムメソッド
- * `:reportFoaling`（分娩結果報告、[AIP-136](https://google.aip.dev/136)）を提供する。Create は
- * 様式第14号の年次成績の2種類（種付した年・種付しなかった年）を、リクエストの `covering` の有無で判別する単一の Create として受ける。エラーレスポンスは RFC 9457
- * (Problem Details) 形式で返す。
+ * Google AIP のリソース指向設計に従い、コレクション `/api/breedingResults` に対する Create と、 個体へのカスタムメソッド
+ * `:reportFoaling`（分娩結果報告）・`:submitReport`（繁殖成績報告提出） （いずれも
+ * [AIP-136](https://google.aip.dev/136)）を提供する。 Create は様式第14号の年次成績2種類をリクエストの `covering` 有無で判別する単一
+ * Create として受ける。 エラーレスポンスは RFC 9457 (Problem Details) 形式で返す。
  */
 @RestController
 class BreedingResultController(

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
@@ -21,6 +21,8 @@ import java.util.UUID
  * @property coveringPlace 種付が行われた場所。種付せずの年は null
  * @property certificateNumber 種付証明書番号。種付せずの年は null
  * @property outcome 分娩結果。種付した年で未報告なら null
+ * @property reportSubmittedOn 繁殖成績報告書（様式第14号）の提出日。未提出は null
+ * @property reportSubmittedLate 提出が期限（繁殖年の翌年5/31）超過だったか。未提出は null
  */
 data class BreedingResultResponse(
     val id: UUID,
@@ -31,6 +33,8 @@ data class BreedingResultResponse(
     val coveringPlace: String?,
     val certificateNumber: String?,
     val outcome: FoalingOutcomeResponse?,
+    val reportSubmittedOn: LocalDate?,
+    val reportSubmittedLate: Boolean?,
 )
 
 /** [BreedingResult] を繁殖成績リソースの表現へ変換する。各操作の成功レスポンスはこのリソース表現を一律で返す。 */
@@ -44,4 +48,6 @@ fun BreedingResult.toResponse(): BreedingResultResponse =
         coveringPlace = covering?.coveringPlace?.value,
         certificateNumber = covering?.certificateNumber?.value,
         outcome = outcome?.toResponse(),
+        reportSubmittedOn = reportSubmittedOn,
+        reportSubmittedLate = reportSubmittedLate,
     )

--- a/src/main/kotlin/com/example/api/controller/breeding/problem/BreedingResultProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/problem/BreedingResultProblem.kt
@@ -3,10 +3,12 @@ package com.example.api.controller.breeding.problem
 import com.example.api.application.studbook.breeding.RecordCoveringUseCaseError
 import com.example.api.application.studbook.breeding.RecordUncoveredUseCaseError
 import com.example.api.application.studbook.breeding.ReportFoalingUseCaseError
+import com.example.api.application.studbook.breeding.SubmitBreedingReportUseCaseError
 import com.example.api.controller.problem
 import com.example.api.domain.studbook.model.breeding.CoveringValidityError
 import com.example.api.domain.studbook.model.breeding.RecordCoveringError
 import com.example.api.domain.studbook.model.breeding.RecordUncoveredError
+import com.example.api.domain.studbook.model.breeding.SubmitBreedingReportError
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 
@@ -221,4 +223,52 @@ fun ReportFoalingUseCaseError.toProblemDetail(): ProblemDetail =
                     detail = "対象の繁殖成績が他の更新と競合しました。最新の状態を取得してやり直してください。",
                 )
                 .apply { setProperty("breeding_result_id", breedingResultId) }
+    }
+
+/**
+ * [SubmitBreedingReportUseCaseError] を RFC 9457 (`application/problem+json`) の [ProblemDetail]
+ * に変換する。
+ *
+ * - 提出対象（URL パスの繁殖成績）の不在は 404 Not Found
+ * - 分娩結果の未確定は、整った入力だが意味的に処理できないため 422 Unprocessable Entity
+ * - 二重提出・更新競合（楽観ロック）は状態の競合として 409 Conflict
+ */
+fun SubmitBreedingReportUseCaseError.toProblemDetail(): ProblemDetail =
+    when (this) {
+        is SubmitBreedingReportUseCaseError.BreedingResultNotFound ->
+            problem(
+                    status = HttpStatus.NOT_FOUND,
+                    code = "breeding-result-not-found",
+                    title = "Breeding result not found",
+                    detail = "提出対象として指定された繁殖成績が存在しません。",
+                )
+                .apply { setProperty("breeding_result_id", breedingResultId) }
+        is SubmitBreedingReportUseCaseError.PreconditionViolated -> cause.toProblemDetail()
+        is SubmitBreedingReportUseCaseError.ConcurrentModification ->
+            problem(
+                    status = HttpStatus.CONFLICT,
+                    code = "concurrent-modification",
+                    title = "Concurrent modification",
+                    detail = "対象の繁殖成績が他の更新と競合しました。最新の状態を取得してやり直してください。",
+                )
+                .apply { setProperty("breeding_result_id", breedingResultId) }
+    }
+
+private fun SubmitBreedingReportError.toProblemDetail(): ProblemDetail =
+    when (this) {
+        SubmitBreedingReportError.OutcomeNotRecorded ->
+            problem(
+                status = HttpStatus.UNPROCESSABLE_ENTITY,
+                code = "breeding-report-outcome-not-recorded",
+                title = "Foaling outcome not recorded",
+                detail = "分娩結果が未確定のため繁殖成績報告を提出できません。",
+            )
+        is SubmitBreedingReportError.ReportAlreadySubmitted ->
+            problem(
+                    status = HttpStatus.CONFLICT,
+                    code = "breeding-report-already-submitted",
+                    title = "Breeding report already submitted",
+                    detail = "この繁殖成績の報告は既に提出されています。",
+                )
+                .apply { setProperty("report_submitted_on", submittedOn) }
     }

--- a/src/main/kotlin/com/example/api/domain/studbook/model/breeding/BreedingReportDeadline.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/breeding/BreedingReportDeadline.kt
@@ -1,0 +1,40 @@
+package com.example.api.domain.studbook.model.breeding
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.Month
+import java.time.Year
+import java.time.ZoneId
+import org.jmolecules.ddd.annotation.ValueObject
+
+/**
+ * 繁殖成績報告書（様式第14号）の提出期限。
+ *
+ * 登録規程第25条は、種雌馬の繁殖成績報告書を「毎年5月31日までに」提出することを求める。報告対象は前年の種付 （とその帰結の分娩）なので、繁殖年 Y の成績の提出期限は翌年 Y+1 の
+ * 5/31 となる（[of]）。期限は日本の暦日で 締まるため、提出日時（[Instant]）は [REPORTING_ZONE]（Asia/Tokyo）の暦日に写してから照合する
+ * （[submissionDateOf]。与えられた時刻の純粋な写像であり、現在時刻の取得はドメインでは行わない）。
+ *
+ * 期限超過の提出は拒否しない（第25条ただし書き＝成績確定後の速やかな提出義務があり、受理される）。超過か どうかは [isMissedBy]
+ * で判定し、ドメインの事実として記録する（#455。原典確認は Issue コメント参照）。
+ */
+@ValueObject
+@JvmInline
+value class BreedingReportDeadline private constructor(val date: LocalDate) {
+
+    /** [submittedOn]（提出日）が期限を過ぎているかを返す。期限日（5/31）当日は期限内。 */
+    fun isMissedBy(submittedOn: LocalDate): Boolean = submittedOn.isAfter(date)
+
+    companion object {
+        /** 提出期限の暦日が属するタイムゾーン（JAIRS への提出は日本の暦日で締まる）。 */
+        val REPORTING_ZONE: ZoneId = ZoneId.of("Asia/Tokyo")
+
+        /** 繁殖年 [breedingYear] の報告書の提出期限（翌年 5/31）を返す純粋関数。 */
+        @Suppress("MagicNumber")
+        fun of(breedingYear: Year): BreedingReportDeadline =
+            BreedingReportDeadline(LocalDate.of(breedingYear.value + 1, Month.MAY, 31))
+
+        /** 提出日時 [issuedAt] を [REPORTING_ZONE] の暦日（提出日）に写す純粋関数。 */
+        fun submissionDateOf(issuedAt: Instant): LocalDate =
+            issuedAt.atZone(REPORTING_ZONE).toLocalDate()
+    }
+}

--- a/src/main/kotlin/com/example/api/domain/studbook/model/breeding/BreedingResult.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/breeding/BreedingResult.kt
@@ -27,6 +27,26 @@ import org.jmolecules.ddd.annotation.ValueObject
 data class FoalingAlreadyRecorded(val current: FoalingOutcome)
 
 /**
+ * 繁殖成績報告の提出（[BreedingResult.submitReport]）の前提条件違反。
+ *
+ * 提出の前提は2系統ある。(1) 分娩結果（成績）が確定していること — 登録規程第25条ただし書き（成績が確定しない
+ * ため期限内に提出できない場合は確定後速やかに提出する）の裏返しで、未確定のまま提出はできない （[OutcomeNotRecorded]）。(2) 未提出であること —
+ * 年次の報告書の提出は繁殖年ごとに一度 （[ReportAlreadySubmitted]）。なお期限（翌年5/31）超過は前提条件違反ではない（拒否せず受理して記録する。
+ * [BreedingReportDeadline] 参照）。
+ */
+sealed interface SubmitBreedingReportError {
+    /** 分娩結果が未確定（outcome が null）のため提出できない。 */
+    data object OutcomeNotRecorded : SubmitBreedingReportError
+
+    /**
+     * 既に提出済みの繁殖成績へ重ねて提出しようとした。
+     *
+     * @property submittedOn 既に記録されている提出日
+     */
+    data class ReportAlreadySubmitted(val submittedOn: LocalDate) : SubmitBreedingReportError
+}
+
+/**
  * 種付記録（ドメインサービス recordCovering）の前提条件違反。
  *
  * 種付記録の前提は3系統ある。(1) 配合の登録ロール（繁殖牝馬 × 種牡馬）＝単一インスタンスの構築時不変条件で、 ファクトリ [BreedingResult.create]
@@ -123,6 +143,7 @@ sealed interface RecordUncoveredError {
  * @property covering その年の種付。種付せずの年は null
  * @property outcome その年の分娩結果。種付した年は未報告なら null・報告は [recordFoaling] で行う。種付せずの年は
  *   [FoalingOutcome.NotCovered]
+ * @property reportSubmittedOn 繁殖成績報告書（様式第14号）の提出日。未提出は null。提出は [submitReport] で行う
  */
 @AggregateRoot
 class BreedingResult
@@ -132,6 +153,7 @@ private constructor(
     val breedingYear: Year,
     val covering: Covering?,
     val outcome: FoalingOutcome?,
+    val reportSubmittedOn: LocalDate? = null,
     override val version: Long? = null,
 ) : Entity<BreedingResultId>() {
     init {
@@ -144,6 +166,9 @@ private constructor(
                 "種付した年の繁殖年は種付日の年と一致しなければならない。"
             }
             require(outcome != FoalingOutcome.NotCovered) { "種付した繁殖成績の区分は NotCovered であってはならない。" }
+        }
+        if (reportSubmittedOn != null) {
+            require(outcome != null) { "繁殖成績報告の提出済みの成績は分娩結果が確定していなければならない。" }
         }
     }
 
@@ -169,14 +194,42 @@ private constructor(
         }
     }
 
+    /** 提出が期限（翌年5/31、[BreedingReportDeadline]）超過だったか。未提出なら null。導出値であり保存しない。 */
+    val reportSubmittedLate: Boolean?
+        get() = reportSubmittedOn?.let { BreedingReportDeadline.of(breedingYear).isMissedBy(it) }
+
+    /**
+     * 繁殖成績報告書（様式第14号）の年次提出を記録した新しい [BreedingResult] を返す。
+     *
+     * 提出は繁殖年ごとに一度だけ行える。既に提出済みなら [SubmitBreedingReportError.ReportAlreadySubmitted]、
+     * 分娩結果が未確定（outcome が null）なら [SubmitBreedingReportError.OutcomeNotRecorded] を返し、写像を 行わない（元の
+     * [BreedingResult] も不変）。期限（翌年5/31）超過の提出は拒否せず受理する（登録規程第25条 ただし書き。超過かどうかは [reportSubmittedLate]
+     * が導出する）。成功時は [reportSubmittedOn] のみ差し替え、 [id] を含む他の属性は引き継ぐ。
+     *
+     * @param submittedOn 提出日（日本の暦日。[BreedingReportDeadline.submissionDateOf] で写した値を渡す）
+     * @return 提出済みの新しい [BreedingResult]、または前提条件違反を表す [SubmitBreedingReportError]
+     */
+    fun submitReport(submittedOn: LocalDate): Result<BreedingResult, SubmitBreedingReportError> {
+        val current = reportSubmittedOn
+        return when {
+            current != null -> Err(SubmitBreedingReportError.ReportAlreadySubmitted(current))
+            outcome == null -> Err(SubmitBreedingReportError.OutcomeNotRecorded)
+            else -> Ok(copy(reportSubmittedOn = submittedOn))
+        }
+    }
+
     /** [id] と未指定の属性を引き継ぎ、指定された属性だけを差し替えた新しい [BreedingResult] を返す。 */
-    private fun copy(outcome: FoalingOutcome? = this.outcome): BreedingResult =
+    private fun copy(
+        outcome: FoalingOutcome? = this.outcome,
+        reportSubmittedOn: LocalDate? = this.reportSubmittedOn,
+    ): BreedingResult =
         BreedingResult(
             id = id,
             breedingRegistrationId = breedingRegistrationId,
             breedingYear = breedingYear,
             covering = covering,
             outcome = outcome,
+            reportSubmittedOn = reportSubmittedOn,
             version = version,
         )
 
@@ -278,6 +331,7 @@ private constructor(
          * を使うこと。なお covering と区分の整合（covering の有無と [FoalingOutcome.NotCovered]）は
          * コンストラクタの不変条件（init）が引き続き保証する。
          *
+         * @param reportSubmittedOn 繁殖成績報告書の提出日（未提出は null）
          * @param version DB の version 列の値（楽観ロック）
          */
         fun reconstitute(
@@ -286,8 +340,17 @@ private constructor(
             breedingYear: Year,
             covering: Covering?,
             outcome: FoalingOutcome?,
+            reportSubmittedOn: LocalDate? = null,
             version: Long?,
         ): BreedingResult =
-            BreedingResult(id, breedingRegistrationId, breedingYear, covering, outcome, version)
+            BreedingResult(
+                id,
+                breedingRegistrationId,
+                breedingYear,
+                covering,
+                outcome,
+                reportSubmittedOn,
+                version,
+            )
     }
 }

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/BreedingResultRow.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/BreedingResultRow.kt
@@ -22,6 +22,8 @@ import org.springframework.data.relational.core.mapping.Table
  *   null。
  * - 分娩結果（sealed `FoalingOutcome?`）は判別子 [outcomeType]（enum 名）と、`LiveFoal` のみが持つ分娩日
  *   [outcomeFoalingDate] にフラット化する。種付した年で未報告なら outcomeType は null。
+ * - [reportSubmittedOn] は繁殖成績報告書（様式第14号）の提出日（未提出は null）。「提出済みなら分娩結果確定済み」の整合は CHECK
+ *   制約でスキーマ側にも強制する（V8 参照）。
  * - covering の有無と区分（NotCovered）・分娩日の整合は CHECK 制約でスキーマ側にも強制する（V4 参照）。
  * - [version] は楽観ロック用の `@Version` 列。null のとき Spring Data JDBC は「新規」とみなして insert する。
  */
@@ -36,5 +38,6 @@ data class BreedingResultRow(
     @Column("covering_certificate_number") val coveringCertificateNumber: String? = null,
     @Column("outcome_type") val outcomeType: String? = null,
     @Column("outcome_foaling_date") val outcomeFoalingDate: LocalDate? = null,
+    @Column("report_submitted_on") val reportSubmittedOn: LocalDate? = null,
     @Version @Column("version") val version: Long? = null,
 )

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepository.kt
@@ -71,6 +71,7 @@ class JdbcBreedingResultRepository(private val rows: BreedingResultSpringDataRep
             breedingYear = Year.of(breedingYear),
             covering = toCovering(),
             outcome = toOutcome(),
+            reportSubmittedOn = reportSubmittedOn,
             version = version,
         )
 
@@ -123,6 +124,7 @@ class JdbcBreedingResultRepository(private val rows: BreedingResultSpringDataRep
             coveringCertificateNumber = covering?.certificateNumber?.value,
             outcomeType = outcomeType,
             outcomeFoalingDate = foalingDate,
+            reportSubmittedOn = reportSubmittedOn,
             version = version,
         )
     }

--- a/src/main/resources/db/migration/V8__add_breeding_result_report_submission.sql
+++ b/src/main/resources/db/migration/V8__add_breeding_result_report_submission.sql
@@ -1,0 +1,20 @@
+-- 繁殖成績報告書（様式第14号）の年次提出（#455）。提出日を breeding_result にフラット化して追加する（ADR-0043）。
+-- 期限（翌年5/31、登録規程第25条）超過かどうかは繁殖年からの導出値のため保存しない。
+-- 「提出は分娩結果（成績）確定後」（第25条ただし書きの裏返し）の不変条件を CHECK でスキーマ側にも強制する。
+-- 既存行があるテーブルへの CHECK 追加はフルスキャン検証で書き込みをブロックしうるため
+-- NOT VALID で新規行への強制を即時開始し、VALIDATE CONSTRAINT で既存行を後追い検証する 2 段階で行う（V6 と同様）。
+-- timeout は squawk（require-timeout-settings）に従い設定する。Flyway は各マイグレーションを 1 トランザクションで
+-- 適用するため、SET LOCAL でこのマイグレーション内に閉じる。
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+ALTER TABLE breeding_result ADD COLUMN report_submitted_on DATE;
+
+COMMENT ON COLUMN breeding_result.report_submitted_on IS '繁殖成績報告書（様式第14号）の提出日（未提出は NULL）';
+
+ALTER TABLE breeding_result
+ADD CONSTRAINT chk_breeding_result_report_needs_outcome
+CHECK (report_submitted_on IS NULL OR outcome_type IS NOT NULL) NOT VALID;
+
+ALTER TABLE breeding_result
+VALIDATE CONSTRAINT chk_breeding_result_report_needs_outcome;

--- a/src/test/kotlin/com/example/api/application/studbook/breeding/SubmitBreedingReportUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/breeding/SubmitBreedingReportUseCaseTest.kt
@@ -1,0 +1,140 @@
+package com.example.api.application.studbook.breeding
+
+import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.UpdateConflict
+import com.example.api.domain.studbook.model.breeding.BreedingFixture
+import com.example.api.domain.studbook.model.breeding.BreedingResult
+import com.example.api.domain.studbook.model.breeding.BreedingResultId
+import com.example.api.domain.studbook.model.breeding.BreedingResultRepository
+import com.example.api.domain.studbook.model.breeding.FoalingOutcome
+import com.example.api.domain.studbook.model.breeding.SubmitBreedingReportError
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class SubmitBreedingReportUseCaseTest {
+
+    /** 分娩結果確定済み（提出可能）な繁殖成績。繁殖年 2024 → 提出期限は 2025-05-31。 */
+    private fun reportedResult(): BreedingResult =
+        BreedingFixture.breedingResult()
+            .recordFoaling(FoalingOutcome.LiveFoal(LocalDate.of(2025, 3, 20)))
+            .unwrap()
+
+    private fun command(
+        breedingResultId: UUID,
+        issuedAt: Instant,
+    ): Command<SubmitBreedingReportCommand> =
+        Command(SubmitBreedingReportCommand(breedingResultId), issuedAt)
+
+    @Nested
+    inner class SuccessCase {
+        @Test
+        fun `issuedAtがJSTの提出日として消費され提出済みの成績が楽観ロック付きで更新される`() {
+            val reported = reportedResult()
+            val repository =
+                mockk<BreedingResultRepository> {
+                    every { findById(reported.id) } returns reported
+                    every { save(any()) } answers { Ok(firstArg()) }
+                }
+            val useCase = SubmitBreedingReportUseCase(repository)
+            // UTC 15:00 = JST 翌日 0:00 → 提出日は 6/1（期限 5/31 を超過）
+            val issuedAt = Instant.parse("2025-05-31T15:00:00Z")
+
+            val result = useCase(command(reported.id.value, issuedAt)).unwrap()
+
+            assert(result.reportSubmittedOn == LocalDate.of(2025, 6, 1))
+            assert(result.reportSubmittedLate == true)
+            // save には提出済みの集約が渡ること
+            verify(exactly = 1) { repository.save(match { it.reportSubmittedOn != null }) }
+        }
+    }
+
+    @Nested
+    inner class FailureCase {
+        @Test
+        fun `対象成績が見つからないとき BreedingResultNotFound を返し永続化されない`() {
+            val breedingResultId = UUID.randomUUID()
+            val repository =
+                mockk<BreedingResultRepository> {
+                    every { findById(BreedingResultId(breedingResultId)) } returns null
+                }
+            val useCase = SubmitBreedingReportUseCase(repository)
+
+            val result = useCase(command(breedingResultId, Instant.parse("2025-05-01T00:00:00Z")))
+
+            assert(
+                result.getError() ==
+                    SubmitBreedingReportUseCaseError.BreedingResultNotFound(breedingResultId)
+            )
+            verify(exactly = 0) { repository.save(any()) }
+        }
+
+        @Test
+        fun `分娩結果未確定のとき PreconditionViolated を返し永続化されない`() {
+            val unreported = BreedingFixture.breedingResult()
+            val repository =
+                mockk<BreedingResultRepository> {
+                    every { findById(unreported.id) } returns unreported
+                }
+            val useCase = SubmitBreedingReportUseCase(repository)
+
+            val result =
+                useCase(command(unreported.id.value, Instant.parse("2025-05-01T00:00:00Z")))
+
+            assert(
+                result.getError() ==
+                    SubmitBreedingReportUseCaseError.PreconditionViolated(
+                        SubmitBreedingReportError.OutcomeNotRecorded
+                    )
+            )
+            verify(exactly = 0) { repository.save(any()) }
+        }
+
+        @Test
+        fun `提出済みのとき PreconditionViolated を返し永続化されない`() {
+            val submitted = reportedResult().submitReport(LocalDate.of(2025, 5, 1)).unwrap()
+            val repository =
+                mockk<BreedingResultRepository> {
+                    every { findById(submitted.id) } returns submitted
+                }
+            val useCase = SubmitBreedingReportUseCase(repository)
+
+            val result = useCase(command(submitted.id.value, Instant.parse("2025-05-02T00:00:00Z")))
+
+            assert(
+                result.getError() ==
+                    SubmitBreedingReportUseCaseError.PreconditionViolated(
+                        SubmitBreedingReportError.ReportAlreadySubmitted(LocalDate.of(2025, 5, 1))
+                    )
+            )
+            verify(exactly = 0) { repository.save(any()) }
+        }
+
+        @Test
+        fun `更新が競合したとき ConcurrentModification を返す`() {
+            val reported = reportedResult()
+            val repository =
+                mockk<BreedingResultRepository> {
+                    every { findById(reported.id) } returns reported
+                    every { save(any()) } returns Err(UpdateConflict)
+                }
+            val useCase = SubmitBreedingReportUseCase(repository)
+
+            val result = useCase(command(reported.id.value, Instant.parse("2025-05-01T00:00:00Z")))
+
+            assert(
+                result.getError() ==
+                    SubmitBreedingReportUseCaseError.ConcurrentModification(reported.id.value)
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
@@ -602,6 +602,16 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 .bodyJson()
                 .extractingPath("$.error_code")
                 .isEqualTo("breeding-report-already-submitted")
+
+            tester
+                .post()
+                .uri(uri)
+                .assertThat()
+                .hasStatus(HttpStatus.CONFLICT)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.report_submitted_on")
+                .isEqualTo("2025-05-01")
         }
 
         @Test

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
@@ -9,6 +9,9 @@ import com.example.api.application.studbook.breeding.RecordUncoveredUseCaseError
 import com.example.api.application.studbook.breeding.ReportFoalingCommand
 import com.example.api.application.studbook.breeding.ReportFoalingUseCase
 import com.example.api.application.studbook.breeding.ReportFoalingUseCaseError
+import com.example.api.application.studbook.breeding.SubmitBreedingReportCommand
+import com.example.api.application.studbook.breeding.SubmitBreedingReportUseCase
+import com.example.api.application.studbook.breeding.SubmitBreedingReportUseCaseError
 import com.example.api.config.ClockConfiguration
 import com.example.api.domain.shared.Command
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
@@ -17,6 +20,7 @@ import com.example.api.domain.studbook.model.breeding.CoveringValidityError
 import com.example.api.domain.studbook.model.breeding.FoalingOutcome
 import com.example.api.domain.studbook.model.breeding.RecordCoveringError
 import com.example.api.domain.studbook.model.breeding.RecordUncoveredError
+import com.example.api.domain.studbook.model.breeding.SubmitBreedingReportError
 import com.example.api.domain.studbook.model.breeding.ValidityPeriod
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
@@ -44,6 +48,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
     @MockkBean private lateinit var recordCovering: RecordCoveringUseCase
     @MockkBean private lateinit var recordUncovered: RecordUncoveredUseCase
     @MockkBean private lateinit var reportFoaling: ReportFoalingUseCase
+    @MockkBean private lateinit var submitReport: SubmitBreedingReportUseCase
 
     private val tester = MockMvcTester.create(mockMvc)
 
@@ -490,6 +495,124 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 .uri(uri)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(liveFoalBody)
+                .assertThat()
+                .hasStatus(HttpStatus.CONFLICT)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.error_code")
+                .isEqualTo("concurrent-modification")
+        }
+    }
+
+    @Nested
+    inner class SubmitReportCase {
+        private val breedingResultId = "44444444-4444-4444-4444-444444444444"
+        private val uri = "/api/breedingResults/$breedingResultId:submitReport"
+
+        /** 分娩結果確定済み・提出済み（2025-06-01 = 期限超過）の繁殖成績。 */
+        private fun submittedResult() =
+            BreedingFixture.breedingResult()
+                .recordFoaling(FoalingOutcome.LiveFoal(LocalDate.of(2025, 3, 20)))
+                .unwrap()
+                .submitReport(LocalDate.of(2025, 6, 1))
+                .unwrap()
+
+        @Test
+        fun `正常な提出で 200 OK と提出日・期限超過付きの繁殖成績が返ること`() {
+            every { submitReport(any<Command<SubmitBreedingReportCommand>>()) } returns
+                Ok(submittedResult())
+
+            tester
+                .post()
+                .uri(uri)
+                .assertThat()
+                .hasStatus(HttpStatus.OK)
+                .bodyJson()
+                .extractingPath("$.report_submitted_on")
+                .isEqualTo("2025-06-01")
+        }
+
+        @Test
+        fun `期限超過の提出は report_submitted_late が true で返ること`() {
+            every { submitReport(any<Command<SubmitBreedingReportCommand>>()) } returns
+                Ok(submittedResult())
+
+            tester
+                .post()
+                .uri(uri)
+                .assertThat()
+                .hasStatus(HttpStatus.OK)
+                .bodyJson()
+                .extractingPath("$.report_submitted_late")
+                .isEqualTo(true)
+        }
+
+        @Test
+        fun `BreedingResultNotFound で 404 と breeding_result_id 付きの problem+json が返ること`() {
+            val id = UUID.fromString(breedingResultId)
+            every { submitReport(any<Command<SubmitBreedingReportCommand>>()) } returns
+                Err(SubmitBreedingReportUseCaseError.BreedingResultNotFound(id))
+
+            tester
+                .post()
+                .uri(uri)
+                .assertThat()
+                .hasStatus(HttpStatus.NOT_FOUND)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.breeding_result_id")
+                .isEqualTo(id.toString())
+        }
+
+        @Test
+        fun `分娩結果未確定で 422 と problem+json が返ること`() {
+            every { submitReport(any<Command<SubmitBreedingReportCommand>>()) } returns
+                Err(
+                    SubmitBreedingReportUseCaseError.PreconditionViolated(
+                        SubmitBreedingReportError.OutcomeNotRecorded
+                    )
+                )
+
+            tester
+                .post()
+                .uri(uri)
+                .assertThat()
+                .hasStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.error_code")
+                .isEqualTo("breeding-report-outcome-not-recorded")
+        }
+
+        @Test
+        fun `提出済みで 409 と既存提出日付きの problem+json が返ること`() {
+            every { submitReport(any<Command<SubmitBreedingReportCommand>>()) } returns
+                Err(
+                    SubmitBreedingReportUseCaseError.PreconditionViolated(
+                        SubmitBreedingReportError.ReportAlreadySubmitted(LocalDate.of(2025, 5, 1))
+                    )
+                )
+
+            tester
+                .post()
+                .uri(uri)
+                .assertThat()
+                .hasStatus(HttpStatus.CONFLICT)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.error_code")
+                .isEqualTo("breeding-report-already-submitted")
+        }
+
+        @Test
+        fun `ConcurrentModification で 409 と problem+json が返ること`() {
+            val id = UUID.fromString(breedingResultId)
+            every { submitReport(any<Command<SubmitBreedingReportCommand>>()) } returns
+                Err(SubmitBreedingReportUseCaseError.ConcurrentModification(id))
+
+            tester
+                .post()
+                .uri(uri)
                 .assertThat()
                 .hasStatus(HttpStatus.CONFLICT)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)

--- a/src/test/kotlin/com/example/api/domain/studbook/model/breeding/BreedingReportDeadlineTest.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/model/breeding/BreedingReportDeadlineTest.kt
@@ -1,0 +1,43 @@
+package com.example.api.domain.studbook.model.breeding
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.Year
+import org.junit.jupiter.api.Test
+
+class BreedingReportDeadlineTest {
+
+    @Test
+    fun `繁殖年の翌年5月31日が提出期限になること`() {
+        val deadline = BreedingReportDeadline.of(Year.of(2024))
+
+        assert(deadline.date == LocalDate.of(2025, 5, 31))
+    }
+
+    @Test
+    fun `期限日当日の提出は期限内であること`() {
+        val deadline = BreedingReportDeadline.of(Year.of(2024))
+
+        assert(!deadline.isMissedBy(LocalDate.of(2025, 5, 31)))
+    }
+
+    @Test
+    fun `期限日翌日の提出は期限超過であること`() {
+        val deadline = BreedingReportDeadline.of(Year.of(2024))
+
+        assert(deadline.isMissedBy(LocalDate.of(2025, 6, 1)))
+    }
+
+    @Test
+    fun `提出日時は日本の暦日（JST）に写されること`() {
+        // UTC 14:59:59 = JST 23:59:59（同日 5/31）／ UTC 15:00:00 = JST 翌日 0:00:00（6/1）
+        assert(
+            BreedingReportDeadline.submissionDateOf(Instant.parse("2025-05-31T14:59:59Z")) ==
+                LocalDate.of(2025, 5, 31)
+        )
+        assert(
+            BreedingReportDeadline.submissionDateOf(Instant.parse("2025-05-31T15:00:00Z")) ==
+                LocalDate.of(2025, 6, 1)
+        )
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/studbook/model/breeding/BreedingResultSubmitReportTest.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/model/breeding/BreedingResultSubmitReportTest.kt
@@ -1,0 +1,66 @@
+package com.example.api.domain.studbook.model.breeding
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import java.time.LocalDate
+import org.junit.jupiter.api.Test
+
+class BreedingResultSubmitReportTest {
+
+    /** 分娩結果確定済み（提出可能）な繁殖成績。繁殖年 2024 → 提出期限は 2025-05-31。 */
+    private val reported =
+        BreedingFixture.breedingResult()
+            .recordFoaling(FoalingOutcome.LiveFoal(LocalDate.of(2025, 3, 20)))
+            .unwrap()
+
+    @Test
+    fun `分娩結果確定済みの成績は期限日当日に提出でき期限内と導出されること`() {
+        val submitted = reported.submitReport(LocalDate.of(2025, 5, 31)).unwrap()
+
+        assert(submitted.id == reported.id)
+        assert(submitted.reportSubmittedOn == LocalDate.of(2025, 5, 31))
+        assert(submitted.reportSubmittedLate == false)
+    }
+
+    @Test
+    fun `期限超過の提出も受理され期限超過と導出されること`() {
+        val submitted = reported.submitReport(LocalDate.of(2025, 6, 1)).unwrap()
+
+        assert(submitted.reportSubmittedOn == LocalDate.of(2025, 6, 1))
+        assert(submitted.reportSubmittedLate == true)
+    }
+
+    @Test
+    fun `種付せずの年次成績も提出できること`() {
+        val uncovered = BreedingFixture.uncoveredBreedingResult()
+
+        val submitted = uncovered.submitReport(LocalDate.of(2025, 4, 1)).unwrap()
+
+        assert(submitted.reportSubmittedOn == LocalDate.of(2025, 4, 1))
+        assert(submitted.reportSubmittedLate == false)
+    }
+
+    @Test
+    fun `分娩結果未確定の成績は提出できないこと`() {
+        val unreported = BreedingFixture.breedingResult()
+
+        val error = unreported.submitReport(LocalDate.of(2025, 5, 1)).getError()
+
+        assert(error == SubmitBreedingReportError.OutcomeNotRecorded)
+    }
+
+    @Test
+    fun `提出済みの成績への再提出は既存の提出日付きで拒まれ元は変わらないこと`() {
+        val submitted = reported.submitReport(LocalDate.of(2025, 5, 1)).unwrap()
+
+        val error = submitted.submitReport(LocalDate.of(2025, 5, 2)).getError()
+
+        assert(error == SubmitBreedingReportError.ReportAlreadySubmitted(LocalDate.of(2025, 5, 1)))
+        assert(submitted.reportSubmittedOn == LocalDate.of(2025, 5, 1))
+    }
+
+    @Test
+    fun `未提出の成績の期限超過導出はnullであること`() {
+        assert(reported.reportSubmittedLate == null)
+    }
+}

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepositoryContractTest.kt
@@ -214,4 +214,51 @@ class JdbcBreedingResultRepositoryContractTest(
 
         assert(conflicted.getError() == UpdateConflict)
     }
+
+    @Test
+    fun `提出済みの成績は提出日ごと往復できる`() {
+        val submitted =
+            BreedingFixture.breedingResult()
+                .recordFoaling(FoalingOutcome.LiveFoal(LocalDate.of(2025, 3, 1)))
+                .unwrap()
+                .submitReport(LocalDate.of(2025, 5, 30))
+                .unwrap()
+
+        repository.save(submitted).unwrap()
+        val found = repository.findById(submitted.id)
+
+        assert(found != null)
+        assert(found!!.reportSubmittedOn == LocalDate.of(2025, 5, 30))
+        assert(found.reportSubmittedLate == false)
+    }
+
+    @Test
+    fun `未提出の成績はreport_submitted_onがnullで往復する`() {
+        val unsubmitted = BreedingFixture.breedingResult()
+
+        repository.save(unsubmitted).unwrap()
+        val found = repository.findById(unsubmitted.id)
+
+        assert(found != null)
+        assert(found!!.reportSubmittedOn == null)
+        assert(found.reportSubmittedLate == null)
+    }
+
+    @Test
+    fun `分娩結果未確定なのに提出日を持つ行はCHECK制約で拒否される`() {
+        // 種付済み・分娩結果未報告（outcome_type IS NULL）なのに提出日がある不整合行
+        val row =
+            BreedingResultRow(
+                id = generateId(),
+                breedingRegistrationId = generateId(),
+                breedingYear = 2024,
+                coveringStallionId = generateId(),
+                coveringDate = LocalDate.of(2024, 4, 1),
+                coveringCertificateNumber = "C-2024-0001",
+                outcomeType = null,
+                reportSubmittedOn = LocalDate.of(2025, 5, 1),
+            )
+
+        assertThrows<DataIntegrityViolationException> { rows.save(row) }
+    }
 }


### PR DESCRIPTION
## 概要

繁殖成績報告書（様式第14号）の年次提出を `BreedingResult` のライフサイクルとしてモデル化し、提出期限（繁殖年の翌年5/31）を実装する。

Closes #455

## 設計判断（原典確認済み・詳細は #455 のコメント）

- **期限超過の提出は拒否せず受理し、期限超過をドメインの事実として記録する**（登録規程第25条ただし書き＝成績確定後の速やかな提出義務。報告自体を弾く規定は無い）
- **提出の前提は分娩結果の確定**（ただし書きの裏返し）。未確定は 422、二重提出は 409
- 期限算出（繁殖年→翌年5/31）と issuedAt→JST 暦日の写像は純粋 VO `BreedingReportDeadline`
- `Command.issuedAt` の初の実消費点（提出日時はサーバー時刻）

## 変更内容

- domain: `BreedingReportDeadline` VO / `BreedingResult.submitReport` 遷移・`reportSubmittedOn`・導出 `reportSubmittedLate`
- application: `SubmitBreedingReportUseCase`
- adapter: `POST /api/breedingResults/{id}:submitReport`（AIP-136）・レスポンス拡張（`report_submitted_on` / `report_submitted_late`）・problem マッピング（404/422/409）
- 永続化: V8 マイグレーション（`report_submitted_on` 列＋CHECK、NOT VALID→VALIDATE）・Row/マッパー・契約テスト
- docs: 用語集に提出期限を追記、dbdoc 再生成

## スコープ外（スペック参照）

- 種雄馬側の種付成績報告書（様式第13号・当年9/30 期限）／第29条の裁量サンクション／ドメインイベント発行（#433）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
