### PR TITLE
chore: VALIDATE CONSTRAINT を別マイグレーションへ分離する規約を導入する(#539)

### DIFF
--- a/.claude/rules/migrations.md
+++ b/.claude/rules/migrations.md
@@ -1,0 +1,36 @@
+---
+paths:
+  - "src/main/resources/db/migration/**"
+---
+
+# Flyway マイグレーション規約
+
+## VALIDATE CONSTRAINT は別マイグレーションへ分離する（ADR-0052）
+
+既存行のあるテーブルへ VALIDATE 対象制約（CHECK / FK）を追加するときは、**必ず 2 ファイルに分ける**:
+
+- `V<n>__add_xxx_check.sql` — `ADD CONSTRAINT ... NOT VALID` まで
+- `V<n+1>__validate_xxx_check.sql` — `VALIDATE CONSTRAINT` のみ（他の DDL を同居させない）
+
+Flyway は各マイグレーションを 1 トランザクションで適用するため、同一ファイルに同居させると
+`ADD CONSTRAINT` の ACCESS EXCLUSIVE ロックがコミットまで残り、`VALIDATE` の
+SHARE UPDATE EXCLUSIVE への格下げが効かない（無停止効果が出ない）。
+テーブル規模によらず常に分離する（閾値なし）。
+
+- 同居は `scripts/check-migration-validate-separation.sh` が検出し、
+  lefthook pre-commit / CI（`sql-check.yml`）で fail する。
+- **V6 / V8 / V9 は同居したままの既知例外**（規約制定前に本番適用済み。コメントのみの変更でも
+  Flyway チェックサムが変わるため編集禁止）。**新しいマイグレーションの手本にしないこと**。
+  V6/V8/V9 内の「書き込みを止めない」コメントは同一トランザクション内では事実誤認（ADR-0052）。
+- 新規テーブルの `CREATE TABLE` インライン CHECK はこの規約の対象外。
+
+## timeout は各ファイルに書く
+
+squawk（`require-timeout-settings`）に従い、既存テーブルを変更するマイグレーションの冒頭で
+`SET LOCAL lock_timeout = '5s';` / `SET LOCAL statement_timeout = '5min';` を設定する
+（SET LOCAL はそのマイグレーションのトランザクション内に閉じる）。
+
+## 適用済みマイグレーションは編集しない
+
+Flyway のチェックサムはコメントを含むファイル全体から計算される。適用済みファイルの変更は
+`validate-on-migrate` を落とすため、修正が要るときは新しいマイグレーションを足す。

--- a/.claude/rules/migrations.md
+++ b/.claude/rules/migrations.md
@@ -13,8 +13,8 @@ paths:
 - `V<n+1>__validate_xxx_check.sql` — `VALIDATE CONSTRAINT` のみ（他の DDL を同居させない）
 
 Flyway は各マイグレーションを 1 トランザクションで適用するため、同一ファイルに同居させると
-`ADD CONSTRAINT` の ACCESS EXCLUSIVE ロックがコミットまで残り、`VALIDATE` の
-SHARE UPDATE EXCLUSIVE への格下げが効かない（無停止効果が出ない）。
+`ADD CONSTRAINT` のロック（CHECK は ACCESS EXCLUSIVE、FK は SHARE ROW EXCLUSIVE）がコミットまで残り、
+`VALIDATE` の SHARE UPDATE EXCLUSIVE への格下げが効かない（無停止効果が出ない）。
 テーブル規模によらず常に分離する（閾値なし）。
 
 - 同居は `scripts/check-migration-validate-separation.sh` が検出し、

--- a/.github/workflows/sql-check.yml
+++ b/.github/workflows/sql-check.yml
@@ -13,12 +13,14 @@ on:
       - 'src/main/resources/db/migration/**'
       - '.sqlfluff'
       - '.squawk.toml'
+      - 'scripts/check-migration-validate-separation.sh'
   push:
     branches: [ main ]
     paths:
       - 'src/main/resources/db/migration/**'
       - '.sqlfluff'
       - '.squawk.toml'
+      - 'scripts/check-migration-validate-separation.sh'
   workflow_dispatch:
 
 jobs:
@@ -52,3 +54,6 @@ jobs:
 
     - name: squawk migration safety
       run: squawk src/main/resources/db/migration/*.sql
+
+    - name: VALIDATE CONSTRAINT separation check
+      run: scripts/check-migration-validate-separation.sh

--- a/docs/adr/0052-validate-constraint-in-separate-migration.md
+++ b/docs/adr/0052-validate-constraint-in-separate-migration.md
@@ -8,7 +8,7 @@
 
 既存行のあるテーブルへ CHECK 制約を遡及追加した V6（#522）・V8（#455）・V9（#531、version NOT NULL 遡及付与の中間 CHECK）は、`ADD CONSTRAINT ... NOT VALID` → `VALIDATE CONSTRAINT` の 2 段階を**同一マイグレーションファイル内**で実行し、コメントで「書き込みを止めない」と謳っていた。
 
-しかし PR #537 の最終レビューで指摘されたとおり、Flyway は各マイグレーションを 1 トランザクションで適用するため、`ADD CONSTRAINT` が取得した ACCESS EXCLUSIVE ロックはコミットまで保持される。同一トランザクション内の `VALIDATE CONSTRAINT` は SHARE UPDATE EXCLUSIVE へ「格下げ」されず、フルスキャン検証中もテーブルは排他ロックされたまま。つまり同一ファイル内の 2 段階は無停止効果を発揮していない（見かけ倒し）。V6/V8/V9 のコメント「VALIDATE CONSTRAINT で既存行を後追い検証する（SHARE UPDATE EXCLUSIVE・書き込みを止めない）」は**同一トランザクション内では事実誤認**だった。
+しかし PR #537 の最終レビューで指摘されたとおり、Flyway は各マイグレーションを 1 トランザクションで適用するため、`ADD CONSTRAINT` が取得したロック（CHECK は ACCESS EXCLUSIVE、FK は SHARE ROW EXCLUSIVE — いずれも書き込みをブロック）はコミットまで保持される。同一トランザクション内の `VALIDATE CONSTRAINT` は SHARE UPDATE EXCLUSIVE へ「格下げ」されず、フルスキャン検証中もテーブルは排他ロックされたまま。つまり同一ファイル内の 2 段階は無停止効果を発揮していない（見かけ倒し）。V6/V8/V9 のコメント「VALIDATE CONSTRAINT で既存行を後追い検証する（SHARE UPDATE EXCLUSIVE・書き込みを止めない）」は**同一トランザクション内では事実誤認**だった。
 
 現状は `SET LOCAL lock_timeout = '5s'` と行数の少なさで実害はほぼゼロだが、「安全パターンを踏んだ」という誤った安心がテーブル成長後の将来マイグレーションへ複製され続けるリスクがある（#539）。
 
@@ -19,7 +19,9 @@
 - `V<n>__add_xxx_check.sql` — `ADD CONSTRAINT ... NOT VALID` まで
 - `V<n+1>__validate_xxx_check.sql` — `VALIDATE CONSTRAINT` のみ
 
-分離すれば Flyway が連続適用しても別トランザクションになるため、`ADD ... NOT VALID` のコミットで排他ロックが解け、後続の `VALIDATE` は SHARE UPDATE EXCLUSIVE のみで走る（本来の無停止効果が出る）。
+分離すれば Flyway が連続適用しても別トランザクションになるため、`ADD ... NOT VALID` のコミットで排他ロックが解け、後続の `VALIDATE` は SHARE UPDATE EXCLUSIVE で走り、書き込みを止めない（FK の VALIDATE は参照先テーブルに ROW SHARE も取るが、これも書き込みと競合しない）。
+
+なお本規約は Flyway の既定（`group=false`、各マイグレーションを個別トランザクションで適用）を前提とする。`spring.flyway.group=true` は全 pending マイグレーションを 1 トランザクションへ束ね、分離してもロックが解放されなくなるため、有効化する場合は本 ADR を再訪すること。
 
 - **閾値は設けない**: テーブル規模による分岐は人の判断と allowlist 運用を呼び込み、誤った安心の複製リスクが残る。一律ルールなら機械チェック可能。
 - **VALIDATE 専用マイグレーションには他の DDL を同居させない**: そのトランザクションのロックを SHARE UPDATE EXCLUSIVE のみに保つため。

--- a/docs/adr/0052-validate-constraint-in-separate-migration.md
+++ b/docs/adr/0052-validate-constraint-in-separate-migration.md
@@ -1,0 +1,43 @@
+# 0052. VALIDATE CONSTRAINT は後続の別マイグレーションへ分離する
+
+- Status: Accepted
+- Date: 2026-07-04
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+既存行のあるテーブルへ CHECK 制約を遡及追加した V6（#522）・V8（#455）・V9（#531、version NOT NULL 遡及付与の中間 CHECK）は、`ADD CONSTRAINT ... NOT VALID` → `VALIDATE CONSTRAINT` の 2 段階を**同一マイグレーションファイル内**で実行し、コメントで「書き込みを止めない」と謳っていた。
+
+しかし PR #537 の最終レビューで指摘されたとおり、Flyway は各マイグレーションを 1 トランザクションで適用するため、`ADD CONSTRAINT` が取得した ACCESS EXCLUSIVE ロックはコミットまで保持される。同一トランザクション内の `VALIDATE CONSTRAINT` は SHARE UPDATE EXCLUSIVE へ「格下げ」されず、フルスキャン検証中もテーブルは排他ロックされたまま。つまり同一ファイル内の 2 段階は無停止効果を発揮していない（見かけ倒し）。V6/V8/V9 のコメント「VALIDATE CONSTRAINT で既存行を後追い検証する（SHARE UPDATE EXCLUSIVE・書き込みを止めない）」は**同一トランザクション内では事実誤認**だった。
+
+現状は `SET LOCAL lock_timeout = '5s'` と行数の少なさで実害はほぼゼロだが、「安全パターンを踏んだ」という誤った安心がテーブル成長後の将来マイグレーションへ複製され続けるリスクがある（#539）。
+
+## Decision（決定）
+
+**既存テーブルへの VALIDATE 対象制約（CHECK / FK）の追加は、常に 2 マイグレーションへ分離する（閾値なし）:**
+
+- `V<n>__add_xxx_check.sql` — `ADD CONSTRAINT ... NOT VALID` まで
+- `V<n+1>__validate_xxx_check.sql` — `VALIDATE CONSTRAINT` のみ
+
+分離すれば Flyway が連続適用しても別トランザクションになるため、`ADD ... NOT VALID` のコミットで排他ロックが解け、後続の `VALIDATE` は SHARE UPDATE EXCLUSIVE のみで走る（本来の無停止効果が出る）。
+
+- **閾値は設けない**: テーブル規模による分岐は人の判断と allowlist 運用を呼び込み、誤った安心の複製リスクが残る。一律ルールなら機械チェック可能。
+- **VALIDATE 専用マイグレーションには他の DDL を同居させない**: そのトランザクションのロックを SHARE UPDATE EXCLUSIVE のみに保つため。
+- **対象外**: 新規テーブルの `CREATE TABLE` インライン CHECK（既存行が無くロック問題が生じない）。
+- **機械チェック**: `scripts/check-migration-validate-separation.sh` が同一ファイル内の同名制約 `ADD CONSTRAINT` と `VALIDATE CONSTRAINT` の同居を検出し、lefthook pre-commit と CI（`sql-check.yml`）の両方で fail させる。squawk に該当ルールは無いため自前実装（`constraint-missing-not-valid` は NOT VALID の欠落を検出するのみで、同居は検出しない）。
+- **V6/V8/V9 は編集しない**: Flyway のチェックサムはコメントを含むファイル全体から計算されるため、コメントのみの更正でも適用済みの本番 DB（Prisma Postgres）で validate-on-migrate が落ちる。`flyway repair` の本番オペを払う価値はなく、ファイルは触らず本 ADR に事実誤認を記録して訴求先とする。機械チェックでは既知例外（baseline）として除外する。
+- `.squawk.toml` は変更不要（`VALIDATE` 単体のファイルは `constraint-missing-not-valid` に触れないことを確認済み）。
+- 作業時ガイダンスは `.claude/rules/migrations.md`（`src/main/resources/db/migration/**` に path-scope）に置く。
+
+## Alternatives（検討した代替案）
+
+- **閾値付き分離（現規模なら同一ファイル可）**: 機械チェックがテーブル行数を知れず allowlist 運用になる。「いつ閾値を越えたか」の判断も人任せで、#539 が懸念する誤った安心の複製が残る。不採用。
+- **分離しない（コメント更正のみ）**: `lock_timeout = '5s'` が実害を抑えるが、NOT VALID パターン自体が形骸化し、テーブル成長後に危ない前例として残る。不採用。
+- **V6/V8/V9 を編集して `flyway repair`**: ファイル単体で読んでも正しい状態になるが、コメント更正のためだけに本番オペを 1 回払うことになる。不採用。
+- **Bytebase の導入**: DB DevSecOps プラットフォーム。SQL Review（200+ ルール）を持つが常駐サーバー必須で solo sandbox には運用が不釣り合い、`ADD` と `VALIDATE` の同居を検出するルールも持たない。squawk との重複が大きく不採用（[0049](0049-decline-atlas-keep-flyway-toolchain.md) の Flyway ツールチェーン維持判断とも整合）。
+
+## Consequences（帰結）
+
+- 今後の遡及制約追加はマイグレーションファイルが 1 枚増えるが、規模判断なしの一律ルールとして機械的に強制される。
+- V6/V8/V9 は「同居したままの既知例外」として残る（実害は lock_timeout と少行数で抑制）。将来の読み手は本 ADR と機械チェックで正しいパターンへ誘導される。
+- CHECK 多層防御の原則（[0043](0043-aggregate-to-table-mapping-guidelines.md)）は変わらない。本 ADR はその適用手順（遡及追加時のファイル分割）を定めるもの。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,3 +60,4 @@
 | [0049](0049-decline-atlas-keep-flyway-toolchain.md) | Atlas（schema-as-code）を現時点では不採用とし Flyway 中心のスキーマツールチェーンを維持する | Accepted |
 | [0050](0050-domain-event-publication-after-commit.md) | ドメインイベントは ApplicationEventPublisher で発行し AFTER_COMMIT で購読する | Accepted |
 | [0051](0051-transactional-use-case-boundary.md) | トランザクション境界は application 層ユースケースの宣言的 @Transactional で置く | Accepted |
+| [0052](0052-validate-constraint-in-separate-migration.md) | VALIDATE CONSTRAINT は後続の別マイグレーションへ分離する | Accepted |

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -83,6 +83,14 @@ pre-commit:
       run: mise exec -- squawk {staged_files}
       tags: lint
 
+    # VALIDATE CONSTRAINT の別マイグレーション分離チェック（ADR-0052 / #539）。
+    # 同一ファイルに ADD CONSTRAINT と VALIDATE CONSTRAINT が同居すると、Flyway の
+    # 1 マイグレーション = 1 トランザクション適用下ではロック格下げが効かないため fail する。
+    validate-constraint-separation:
+      glob: "src/main/resources/db/migration/*.sql"
+      run: scripts/check-migration-validate-separation.sh {staged_files}
+      tags: lint
+
 pre-push:
   commands:
     # プッシュ前に全体のテストを実行

--- a/scripts/check-migration-validate-separation.sh
+++ b/scripts/check-migration-validate-separation.sh
@@ -42,8 +42,16 @@ for f in "$@"; do
     *" $base "*) continue ;;
   esac
 
-  # 改行・連続空白を単一スペースへ畳み、複数行に跨る DDL も一律に照合できるようにする
-  content=$(tr -s '[:space:]' ' ' <"$f")
+  # 存在しないパス（手動実行の typo 等）は NG 形式で報告して残りの検査を続行する
+  if [ ! -f "$f" ]; then
+    echo "NG: $f: ファイルが読めません（存在しないパス）" >&2
+    status=1
+    continue
+  fi
+
+  # 行コメント（-- 以降）を剥がしてから改行・連続空白を単一スペースへ畳み、
+  # コメント内の ADD/VALIDATE 言及を誤検出せず、複数行 DDL も一律に照合できるようにする
+  content=$(sed 's/--.*$//' "$f" | tr -s '[:space:]' ' ')
 
   # VALIDATE CONSTRAINT の対象制約名を抽出する（無ければこのファイルは合格）
   names=$(printf '%s' "$content" \

--- a/scripts/check-migration-validate-separation.sh
+++ b/scripts/check-migration-validate-separation.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# 同一マイグレーションファイル内に同名制約の ADD CONSTRAINT と VALIDATE CONSTRAINT が
+# 同居していないかを検査する（ADR-0052 / #539）。
+#
+# Flyway は各マイグレーションを 1 トランザクションで適用するため、ADD CONSTRAINT が取得した
+# ACCESS EXCLUSIVE ロックはコミットまで保持され、同一トランザクション内の VALIDATE CONSTRAINT は
+# SHARE UPDATE EXCLUSIVE へ格下げされない（無停止効果が出ない）。VALIDATE は必ず後続の
+# 別マイグレーションファイルへ分離する。
+#
+# 使い方:
+#   scripts/check-migration-validate-separation.sh [file...]
+#   - 引数あり: 指定ファイルのみ検査（lefthook の {staged_files} 用）。
+#     db/migration/ 配下の .sql 以外は黙ってスキップする。
+#   - 引数なし: src/main/resources/db/migration/V*.sql 全件を検査（CI 用）。
+#     リポジトリ root からの実行を前提とする。
+# 終了コード: 違反があれば 1、なければ 0。
+#
+# 互換: macOS 標準の bash 3.2 で動くよう連想配列/mapfile を使わない。
+set -euo pipefail
+
+# 既知例外（baseline）: 規約制定（ADR-0052）以前に本番へ適用済みのファイル。
+# コメントのみの変更でも Flyway チェックサムが変わり validate-on-migrate が落ちるため
+# 編集できず、同居したまま残す（実害は lock_timeout=5s と少行数で抑えられている）。
+BASELINE="V6__add_breeding_registration_retirement_check.sql V8__add_breeding_result_report_submission.sql V9__add_version_not_null.sql"
+
+if [ "$#" -eq 0 ]; then
+  set -- src/main/resources/db/migration/V*.sql
+fi
+
+status=0
+for f in "$@"; do
+  base=$(basename "$f")
+
+  # マイグレーション SQL 以外はスキップ（lefthook から他の .sql が渡られても無視する）
+  case "$f" in
+    *db/migration/*.sql) ;;
+    *) continue ;;
+  esac
+
+  # baseline は検査対象外
+  case " $BASELINE " in
+    *" $base "*) continue ;;
+  esac
+
+  # 改行・連続空白を単一スペースへ畳み、複数行に跨る DDL も一律に照合できるようにする
+  content=$(tr -s '[:space:]' ' ' <"$f")
+
+  # VALIDATE CONSTRAINT の対象制約名を抽出する（無ければこのファイルは合格）
+  names=$(printf '%s' "$content" \
+    | grep -oiE 'VALIDATE CONSTRAINT [a-z0-9_]+' \
+    | awk '{print tolower($3)}' | sort -u) || continue
+
+  for name in $names; do
+    # 同名制約の ADD CONSTRAINT が同一ファイルにあれば違反。
+    # 名前の後ろは識別子文字以外（または行末）を要求し、前方一致の誤検出を防ぐ。
+    if printf '%s' "$content" | grep -qiE "ADD CONSTRAINT ${name}([^a-z0-9_]|\$)"; then
+      echo "NG: $f: 制約 $name の ADD CONSTRAINT と VALIDATE CONSTRAINT が同一マイグレーションに同居しています。" >&2
+      echo "    VALIDATE CONSTRAINT を後続の別マイグレーションへ分離してください（ADR-0052 / .claude/rules/migrations.md）。" >&2
+      status=1
+    fi
+  done
+done
+exit "$status"


### PR DESCRIPTION
## 概要

既存テーブルへの CHECK/FK 追加時に `VALIDATE CONSTRAINT` を後続の別マイグレーションへ常に分離する規約を導入する（closes #539）。

Flyway は各マイグレーションを 1 トランザクションで適用するため、`ADD CONSTRAINT ... NOT VALID` と `VALIDATE CONSTRAINT` を同一ファイルに置くと ACCESS EXCLUSIVE ロックがコミットまで残り、ロック格下げによる無停止効果が出ない（PR #537 最終レビューの指摘）。

## 変更内容

- **ADR-0052**: 分離規約（閾値なし）と、V6/V8/V9 を編集しない判断（Flyway チェックサム制約）・代替案（閾値付き / Bytebase 等）を記録
- **`scripts/check-migration-validate-separation.sh`**: 同一ファイル内の同名制約 `ADD` + `VALIDATE` 同居を検出（V6/V8/V9 は baseline 除外）。ミューテーション検証済み（違反複製ファイルで fail / 全件走査で pass / VALIDATE 単体で pass）
- **lefthook / CI**: pre-commit と `sql-check.yml` へ配線
- **`.claude/rules/migrations.md`**: db/migration 編集時のみロードされる path-scoped 規約を新設

## 検証

- ShellCheck / actionlint 指摘ゼロ
- 既存マイグレーション全件走査で pass（V6/V8/V9 は既知例外として除外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaF581F5rTk4bA5z6kWwYz
