### PR TITLE
feat: 集約間参照に FK 制約を backstop として張る(#508)

### DIFF
--- a/.tbls.yml
+++ b/.tbls.yml
@@ -23,7 +23,7 @@ exclude:
 # lint ルールは可能な限り有効化する方針（crit レビュー: 基本的に全て true）。
 # ただし現スキーマに対して「違反ゼロで通せる」ものだけを true にする（CI の tbls lint ゲートを割らないため）。
 # 残りは該当機能（外部キー / ラベル / ビューポイント / index・制約コメント）を導入した時点で有効化する。
-# 外部キー・スキーマ名前空間の方針は別 Issue で検討中。
+# 外部キーは ADR-0052 で導入済み。スキーマ名前空間の方針は別 Issue（#509）で検討中。
 lint:
   # コメント必須（スキーマを一次情報とする）。
   requireTableComment:
@@ -36,7 +36,7 @@ lint:
   duplicateRelations:
     enabled: true # DB 外部キー未使用で関連ゼロ（対象ゼロ）
   requireForeignKeyIndex:
-    enabled: true # DB 外部キー未使用（対象ゼロ）。FK 導入後に実効化される
+    enabled: true # ADR-0052 で FK 導入済み。FK 列の index 有無を検査する
   labelStyleBigQuery:
     enabled: true # tbls ラベル未使用（対象ゼロ）
   columnCount:
@@ -44,7 +44,9 @@ lint:
     max: 50 # 現状の最大は blood_horse の 15 列。上限は緩めに設定
   # 以下は現スキーマだと違反が出て tbls lint が落ちるため、対応が済むまで無効（理由を明記）。
   unrelatedTable:
-    enabled: false # DB 外部キーが無く全テーブルが unrelated 判定になり落ちる（FK 導入で有効化）
+    enabled: true # 集約間 FK（ADR-0052）導入済み。関連を持たないテーブルの混入を検知する
+    exclude:
+      - jockey # racing コンテキストの単一集約でコンテキスト内に関連先が無く構造的に unrelated（意図的）
   requireIndexComment:
     enabled: false # PK 由来の暗黙 index にコメントが無く落ちる（index コメント追加で有効化）
   requireConstraintComment:

--- a/.tbls.yml
+++ b/.tbls.yml
@@ -34,7 +34,7 @@ lint:
   requireTriggerComment:
     enabled: true # トリガー未使用（対象ゼロ）
   duplicateRelations:
-    enabled: true # DB 外部キー未使用で関連ゼロ（対象ゼロ）
+    enabled: true # ADR-0052 で FK 導入済み。同一テーブル対の重複関連を検知する
   requireForeignKeyIndex:
     enabled: true # ADR-0052 で FK 導入済み。FK 列の index 有無を検査する
   labelStyleBigQuery:

--- a/dbdoc/README.md
+++ b/dbdoc/README.md
@@ -16,6 +16,13 @@
 ```mermaid
 erDiagram
 
+"public.breeding_registration" }o--|| "public.blood_horse" : "FOREIGN KEY (registered_horse_id) REFERENCES blood_horse(id)"
+"public.blood_horse" }o--o| "public.blood_horse" : "FOREIGN KEY (dam_id) REFERENCES blood_horse(id)"
+"public.blood_horse" }o--o| "public.blood_horse" : "FOREIGN KEY (sire_id) REFERENCES blood_horse(id)"
+"public.blood_horse" }o--|| "public.horse_inspection" : "FOREIGN KEY (inspection_id) REFERENCES horse_inspection(id)"
+"public.breeding_result" }o--|| "public.breeding_registration" : "FOREIGN KEY (breeding_registration_id) REFERENCES breeding_registration(id)"
+"public.breeding_result" }o--o| "public.blood_horse" : "FOREIGN KEY (covering_stallion_id) REFERENCES blood_horse(id)"
+"public.covering_report" }o--|| "public.breeding_registration" : "FOREIGN KEY (stallion_breeding_registration_id) REFERENCES breeding_registration(id)"
 
 "public.jockey" {
   uuid id
@@ -26,7 +33,7 @@ erDiagram
 "public.breeding_registration" {
   uuid id
   varchar_255_ registration_number
-  uuid registered_horse_id
+  uuid registered_horse_id FK
   varchar_32_ breeding_role
   varchar_32_ retirement_reason
   date retirement_occurred_on
@@ -40,20 +47,20 @@ erDiagram
   varchar_32_ breed_type
   date date_of_birth
   varchar_255_ breeder
-  uuid inspection_id
+  uuid inspection_id FK
   varchar_255_ name
   varchar_16_ origin_type
-  uuid sire_id
-  uuid dam_id
+  uuid sire_id FK
+  uuid dam_id FK
   varchar_255_ origin_country
   date landing_date
   bigint version
 }
 "public.breeding_result" {
   uuid id
-  uuid breeding_registration_id
+  uuid breeding_registration_id FK
   integer breeding_year
-  uuid covering_stallion_id
+  uuid covering_stallion_id FK
   date covering_date
   varchar_255_ covering_place
   varchar_255_ covering_certificate_number
@@ -74,7 +81,7 @@ erDiagram
 }
 "public.covering_report" {
   uuid id
-  uuid stallion_breeding_registration_id
+  uuid stallion_breeding_registration_id FK
   integer covering_year
   date submitted_on
   bigint version

--- a/dbdoc/public.blood_horse.md
+++ b/dbdoc/public.blood_horse.md
@@ -8,18 +8,18 @@
 
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
-| id | uuid |  | false |  |  | 識別子（外部採番の UUIDv7） |
+| id | uuid |  | false | [public.breeding_registration](public.breeding_registration.md) [public.blood_horse](public.blood_horse.md) [public.breeding_result](public.breeding_result.md) |  | 識別子（外部採番の UUIDv7） |
 | registration_number | varchar(255) |  | false |  |  | 登録番号 |
 | sex | varchar(16) |  | false |  |  | 性別（ドメイン enum 名） |
 | coat_color | varchar(32) |  | false |  |  | 毛色（ドメイン enum 名） |
 | breed_type | varchar(32) |  | false |  |  | 品種区分（ドメイン enum 名） |
 | date_of_birth | date |  | false |  |  | 生年月日 |
 | breeder | varchar(255) |  | false |  |  | 生産者 |
-| inspection_id | uuid |  | false |  |  | 個体識別審査（horse_inspection）の ID |
+| inspection_id | uuid |  | false |  | [public.horse_inspection](public.horse_inspection.md) | 個体識別審査（horse_inspection）の ID |
 | name | varchar(255) |  | true |  |  | 馬名（未命名なら NULL） |
 | origin_type | varchar(16) |  | false |  |  | 出自の判別子（DOMESTIC/IMPORTED） |
-| sire_id | uuid |  | true |  |  | 父馬 ID（内国産のみ） |
-| dam_id | uuid |  | true |  |  | 母馬 ID（内国産のみ） |
+| sire_id | uuid |  | true |  | [public.blood_horse](public.blood_horse.md) | 父馬 ID（内国産のみ） |
+| dam_id | uuid |  | true |  | [public.blood_horse](public.blood_horse.md) | 母馬 ID（内国産のみ） |
 | origin_country | varchar(255) |  | true |  |  | 原産国（輸入のみ） |
 | landing_date | date |  | true |  |  | 輸入上陸日（輸入のみ） |
 | version | bigint |  | false |  |  | 楽観ロック用バージョン（新規判定の NULL はエンティティ側のみ。保存済み行は常に非 NULL） |
@@ -30,18 +30,29 @@
 | ---- | ---- | ---------- |
 | chk_blood_horse_origin | CHECK | CHECK (((((origin_type)::text = 'DOMESTIC'::text) AND (sire_id IS NOT NULL) AND (dam_id IS NOT NULL) AND (origin_country IS NULL) AND (landing_date IS NULL)) OR (((origin_type)::text = 'IMPORTED'::text) AND (origin_country IS NOT NULL) AND (landing_date IS NOT NULL) AND (sire_id IS NULL) AND (dam_id IS NULL)))) |
 | blood_horse_pkey | PRIMARY KEY | PRIMARY KEY (id) |
+| fk_blood_horse_dam | FOREIGN KEY | FOREIGN KEY (dam_id) REFERENCES blood_horse(id) |
+| fk_blood_horse_sire | FOREIGN KEY | FOREIGN KEY (sire_id) REFERENCES blood_horse(id) |
+| fk_blood_horse_inspection | FOREIGN KEY | FOREIGN KEY (inspection_id) REFERENCES horse_inspection(id) |
 
 ## Indexes
 
 | Name | Definition |
 | ---- | ---------- |
 | blood_horse_pkey | CREATE UNIQUE INDEX blood_horse_pkey ON public.blood_horse USING btree (id) |
+| ix_blood_horse_inspection_id | CREATE INDEX ix_blood_horse_inspection_id ON public.blood_horse USING btree (inspection_id) |
+| ix_blood_horse_sire_id | CREATE INDEX ix_blood_horse_sire_id ON public.blood_horse USING btree (sire_id) |
+| ix_blood_horse_dam_id | CREATE INDEX ix_blood_horse_dam_id ON public.blood_horse USING btree (dam_id) |
 
 ## Relations
 
 ```mermaid
 erDiagram
 
+"public.breeding_registration" }o--|| "public.blood_horse" : "FOREIGN KEY (registered_horse_id) REFERENCES blood_horse(id)"
+"public.blood_horse" }o--o| "public.blood_horse" : "FOREIGN KEY (dam_id) REFERENCES blood_horse(id)"
+"public.blood_horse" }o--o| "public.blood_horse" : "FOREIGN KEY (sire_id) REFERENCES blood_horse(id)"
+"public.breeding_result" }o--o| "public.blood_horse" : "FOREIGN KEY (covering_stallion_id) REFERENCES blood_horse(id)"
+"public.blood_horse" }o--|| "public.horse_inspection" : "FOREIGN KEY (inspection_id) REFERENCES horse_inspection(id)"
 
 "public.blood_horse" {
   uuid id
@@ -51,13 +62,45 @@ erDiagram
   varchar_32_ breed_type
   date date_of_birth
   varchar_255_ breeder
-  uuid inspection_id
+  uuid inspection_id FK
   varchar_255_ name
   varchar_16_ origin_type
-  uuid sire_id
-  uuid dam_id
+  uuid sire_id FK
+  uuid dam_id FK
   varchar_255_ origin_country
   date landing_date
+  bigint version
+}
+"public.breeding_registration" {
+  uuid id
+  varchar_255_ registration_number
+  uuid registered_horse_id FK
+  varchar_32_ breeding_role
+  varchar_32_ retirement_reason
+  date retirement_occurred_on
+  bigint version
+}
+"public.breeding_result" {
+  uuid id
+  uuid breeding_registration_id FK
+  integer breeding_year
+  uuid covering_stallion_id FK
+  date covering_date
+  varchar_255_ covering_place
+  varchar_255_ covering_certificate_number
+  varchar_32_ outcome_type
+  date outcome_foaling_date
+  bigint version
+  date report_submitted_on
+}
+"public.horse_inspection" {
+  uuid id
+  varchar_64_ microchip_number
+  varchar_32_ parentage_type
+  varchar_16_ dna_parentage_result
+  varchar_255_ feature_hair_whorl
+  varchar_255_ feature_white_markings
+  varchar_255_ feature_nose_print
   bigint version
 }
 ```

--- a/dbdoc/public.breeding_registration.md
+++ b/dbdoc/public.breeding_registration.md
@@ -8,9 +8,9 @@
 
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
-| id | uuid |  | false |  |  | 識別子（外部採番の UUIDv7） |
+| id | uuid |  | false | [public.breeding_result](public.breeding_result.md) [public.covering_report](public.covering_report.md) |  | 識別子（外部採番の UUIDv7） |
 | registration_number | varchar(255) |  | false |  |  | 登録番号 |
-| registered_horse_id | uuid |  | false |  |  | 登録対象の血統馬 ID |
+| registered_horse_id | uuid |  | false |  | [public.blood_horse](public.blood_horse.md) | 登録対象の血統馬 ID |
 | breeding_role | varchar(32) |  | false |  |  | 繁殖の役割（STALLION/BROODMARE） |
 | retirement_reason | varchar(32) |  | true |  |  | 供用停止事由（供用中は NULL） |
 | retirement_occurred_on | date |  | true |  |  | 供用停止発生日（供用中は NULL） |
@@ -22,26 +22,68 @@
 | ---- | ---- | ---------- |
 | chk_breeding_registration_retirement_coexistence | CHECK | CHECK ((((retirement_reason IS NULL) AND (retirement_occurred_on IS NULL)) OR ((retirement_reason IS NOT NULL) AND (retirement_occurred_on IS NOT NULL)))) |
 | breeding_registration_pkey | PRIMARY KEY | PRIMARY KEY (id) |
+| fk_breeding_registration_registered_horse | FOREIGN KEY | FOREIGN KEY (registered_horse_id) REFERENCES blood_horse(id) |
 
 ## Indexes
 
 | Name | Definition |
 | ---- | ---------- |
 | breeding_registration_pkey | CREATE UNIQUE INDEX breeding_registration_pkey ON public.breeding_registration USING btree (id) |
+| ix_breeding_registration_registered_horse_id | CREATE INDEX ix_breeding_registration_registered_horse_id ON public.breeding_registration USING btree (registered_horse_id) |
 
 ## Relations
 
 ```mermaid
 erDiagram
 
+"public.breeding_result" }o--|| "public.breeding_registration" : "FOREIGN KEY (breeding_registration_id) REFERENCES breeding_registration(id)"
+"public.covering_report" }o--|| "public.breeding_registration" : "FOREIGN KEY (stallion_breeding_registration_id) REFERENCES breeding_registration(id)"
+"public.breeding_registration" }o--|| "public.blood_horse" : "FOREIGN KEY (registered_horse_id) REFERENCES blood_horse(id)"
 
 "public.breeding_registration" {
   uuid id
   varchar_255_ registration_number
-  uuid registered_horse_id
+  uuid registered_horse_id FK
   varchar_32_ breeding_role
   varchar_32_ retirement_reason
   date retirement_occurred_on
+  bigint version
+}
+"public.breeding_result" {
+  uuid id
+  uuid breeding_registration_id FK
+  integer breeding_year
+  uuid covering_stallion_id FK
+  date covering_date
+  varchar_255_ covering_place
+  varchar_255_ covering_certificate_number
+  varchar_32_ outcome_type
+  date outcome_foaling_date
+  bigint version
+  date report_submitted_on
+}
+"public.covering_report" {
+  uuid id
+  uuid stallion_breeding_registration_id FK
+  integer covering_year
+  date submitted_on
+  bigint version
+}
+"public.blood_horse" {
+  uuid id
+  varchar_255_ registration_number
+  varchar_16_ sex
+  varchar_32_ coat_color
+  varchar_32_ breed_type
+  date date_of_birth
+  varchar_255_ breeder
+  uuid inspection_id FK
+  varchar_255_ name
+  varchar_16_ origin_type
+  uuid sire_id FK
+  uuid dam_id FK
+  varchar_255_ origin_country
+  date landing_date
   bigint version
 }
 ```

--- a/dbdoc/public.breeding_result.md
+++ b/dbdoc/public.breeding_result.md
@@ -9,9 +9,9 @@
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
 | id | uuid |  | false |  |  | 識別子（外部採番の UUIDv7） |
-| breeding_registration_id | uuid |  | false |  |  | 対象の繁殖登録 ID |
+| breeding_registration_id | uuid |  | false |  | [public.breeding_registration](public.breeding_registration.md) | 対象の繁殖登録 ID |
 | breeding_year | integer |  | false |  |  | 繁殖年（java.time.Year の int 値） |
-| covering_stallion_id | uuid |  | true |  |  | 種付種牡馬 ID（種付なしは NULL） |
+| covering_stallion_id | uuid |  | true |  | [public.blood_horse](public.blood_horse.md) | 種付種牡馬 ID（種付なしは NULL） |
 | covering_date | date |  | true |  |  | 種付日（種付なしは NULL） |
 | covering_place | varchar(255) |  | true |  |  | 種付場所（任意） |
 | covering_certificate_number | varchar(255) |  | true |  |  | 種付証明書番号（種付なしは NULL） |
@@ -28,6 +28,8 @@
 | chk_breeding_result_foaling_date | CHECK | CHECK (((outcome_foaling_date IS NULL) OR ((outcome_type)::text = 'LIVE_FOAL'::text))) |
 | chk_breeding_result_outcome_covering | CHECK | CHECK ((((covering_date IS NULL) AND ((outcome_type)::text = 'NOT_COVERED'::text)) OR ((covering_date IS NOT NULL) AND ((outcome_type IS NULL) OR ((outcome_type)::text <> 'NOT_COVERED'::text))))) |
 | chk_breeding_result_report_needs_outcome | CHECK | CHECK (((report_submitted_on IS NULL) OR (outcome_type IS NOT NULL))) |
+| fk_breeding_result_breeding_registration | FOREIGN KEY | FOREIGN KEY (breeding_registration_id) REFERENCES breeding_registration(id) |
+| fk_breeding_result_covering_stallion | FOREIGN KEY | FOREIGN KEY (covering_stallion_id) REFERENCES blood_horse(id) |
 | breeding_result_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## Indexes
@@ -35,18 +37,22 @@
 | Name | Definition |
 | ---- | ---------- |
 | breeding_result_pkey | CREATE UNIQUE INDEX breeding_result_pkey ON public.breeding_result USING btree (id) |
+| ix_breeding_result_registration_year | CREATE INDEX ix_breeding_result_registration_year ON public.breeding_result USING btree (breeding_registration_id, breeding_year) |
+| ix_breeding_result_covering_stallion_id | CREATE INDEX ix_breeding_result_covering_stallion_id ON public.breeding_result USING btree (covering_stallion_id) |
 
 ## Relations
 
 ```mermaid
 erDiagram
 
+"public.breeding_result" }o--|| "public.breeding_registration" : "FOREIGN KEY (breeding_registration_id) REFERENCES breeding_registration(id)"
+"public.breeding_result" }o--o| "public.blood_horse" : "FOREIGN KEY (covering_stallion_id) REFERENCES blood_horse(id)"
 
 "public.breeding_result" {
   uuid id
-  uuid breeding_registration_id
+  uuid breeding_registration_id FK
   integer breeding_year
-  uuid covering_stallion_id
+  uuid covering_stallion_id FK
   date covering_date
   varchar_255_ covering_place
   varchar_255_ covering_certificate_number
@@ -54,6 +60,32 @@ erDiagram
   date outcome_foaling_date
   bigint version
   date report_submitted_on
+}
+"public.breeding_registration" {
+  uuid id
+  varchar_255_ registration_number
+  uuid registered_horse_id FK
+  varchar_32_ breeding_role
+  varchar_32_ retirement_reason
+  date retirement_occurred_on
+  bigint version
+}
+"public.blood_horse" {
+  uuid id
+  varchar_255_ registration_number
+  varchar_16_ sex
+  varchar_32_ coat_color
+  varchar_32_ breed_type
+  date date_of_birth
+  varchar_255_ breeder
+  uuid inspection_id FK
+  varchar_255_ name
+  varchar_16_ origin_type
+  uuid sire_id FK
+  uuid dam_id FK
+  varchar_255_ origin_country
+  date landing_date
+  bigint version
 }
 ```
 

--- a/dbdoc/public.covering_report.md
+++ b/dbdoc/public.covering_report.md
@@ -9,7 +9,7 @@
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
 | id | uuid |  | false |  |  | 種付成績報告ID（外部採番の UUIDv7） |
-| stallion_breeding_registration_id | uuid |  | false |  |  | 提出した種牡馬の繁殖登録ID |
+| stallion_breeding_registration_id | uuid |  | false |  | [public.breeding_registration](public.breeding_registration.md) | 提出した種牡馬の繁殖登録ID |
 | covering_year | integer |  | false |  |  | 種付年（java.time.Year の int 値。報告対象年） |
 | submitted_on | date |  | false |  |  | 提出日（日本の暦日）。期限（当年9/30）超過かは導出値のため保存しない |
 | version | bigint |  | false |  |  | 楽観ロック兼 insert 判定用の version |
@@ -18,6 +18,7 @@
 
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
+| fk_covering_report_stallion_registration | FOREIGN KEY | FOREIGN KEY (stallion_breeding_registration_id) REFERENCES breeding_registration(id) |
 | covering_report_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 | uq_covering_report_stallion_year | UNIQUE | UNIQUE (stallion_breeding_registration_id, covering_year) |
 
@@ -33,12 +34,22 @@
 ```mermaid
 erDiagram
 
+"public.covering_report" }o--|| "public.breeding_registration" : "FOREIGN KEY (stallion_breeding_registration_id) REFERENCES breeding_registration(id)"
 
 "public.covering_report" {
   uuid id
-  uuid stallion_breeding_registration_id
+  uuid stallion_breeding_registration_id FK
   integer covering_year
   date submitted_on
+  bigint version
+}
+"public.breeding_registration" {
+  uuid id
+  varchar_255_ registration_number
+  uuid registered_horse_id FK
+  varchar_32_ breeding_role
+  varchar_32_ retirement_reason
+  date retirement_occurred_on
   bigint version
 }
 ```

--- a/dbdoc/public.horse_inspection.md
+++ b/dbdoc/public.horse_inspection.md
@@ -8,7 +8,7 @@
 
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
-| id | uuid |  | false |  |  | 識別子（外部採番の UUIDv7） |
+| id | uuid |  | false | [public.blood_horse](public.blood_horse.md) |  | 識別子（外部採番の UUIDv7） |
 | microchip_number | varchar(64) |  | false |  |  | マイクロチップ番号 |
 | parentage_type | varchar(32) |  | false |  |  | 親子判定の判別子（BY_DNA/BY_BLOOD_TYPE/BY_OVERSEAS_INSTITUTION/NOT_APPLICABLE） |
 | dna_parentage_result | varchar(16) |  | true |  |  | DNA 親子判定結果（BY_DNA のときのみ） |
@@ -35,6 +35,7 @@
 ```mermaid
 erDiagram
 
+"public.blood_horse" }o--|| "public.horse_inspection" : "FOREIGN KEY (inspection_id) REFERENCES horse_inspection(id)"
 
 "public.horse_inspection" {
   uuid id
@@ -44,6 +45,23 @@ erDiagram
   varchar_255_ feature_hair_whorl
   varchar_255_ feature_white_markings
   varchar_255_ feature_nose_print
+  bigint version
+}
+"public.blood_horse" {
+  uuid id
+  varchar_255_ registration_number
+  varchar_16_ sex
+  varchar_32_ coat_color
+  varchar_32_ breed_type
+  date date_of_birth
+  varchar_255_ breeder
+  uuid inspection_id FK
+  varchar_255_ name
+  varchar_16_ origin_type
+  uuid sire_id FK
+  uuid dam_id FK
+  varchar_255_ origin_country
+  date landing_date
   bigint version
 }
 ```

--- a/docs/adr/0052-foreign-key-backstop-across-aggregates.md
+++ b/docs/adr/0052-foreign-key-backstop-across-aggregates.md
@@ -1,0 +1,39 @@
+# 0052. 集約間の ID 参照に外部キー制約を backstop として張る
+
+- Status: Accepted
+- Date: 2026-07-04
+- Deciders: ptiringo, Claude Code
+
+## Context（背景・課題）
+
+テーブル間の参照はすべてアプリ側の UUID 列（集約間の ID 参照）で表現しており、DB の外部キー制約を張っていなかった（#508。発端は #447 / [ADR-0045](0045-tbls-db-schema-docs.md) の tbls 導入時、ER 図に関連が一切描かれないという crit レビュー指摘）。
+
+FK を張らない立場には根拠があった。DDD では集約が整合性境界であり、集約間は ID 参照で疎結合に保つのが定石（[ADR-0027](0027-persistence-spring-data-jdbc.md) / [ADR-0030](0030-jdbc-only-persistence-retire-inmemory.md) の「集約 = 永続化境界」）。また V2〜V5 作成当時はランタイムが H2（PostgreSQL 互換モード）との両対応で、PostgreSQL 固有の段階的制約追加（`NOT VALID`）が使えなかった。
+
+一方でこのプロジェクトは「アプリのマッパーは常に整合した行を書くが、DB 単独でも不変条件が破られないようにする」という多層防御をすでに実践している。sealed 型・値オブジェクトの不変条件は CHECK 制約（[ADR-0043](0043-aggregate-to-table-mapping-guidelines.md)）、集合制約（種牡馬×種付年の一回性）は UNIQUE 制約（#532/#540）でスキーマ側にも強制しており、参照整合性だけ DB の関与から除外する積極的な理由がない。H2 全面脱却（#451 / [ADR-0044](0044-adopt-prisma-postgres-for-production-db.md)）で構文上の制約も消えた。
+
+検討した代替案:
+
+- **FK を張らず現状維持（＋ tbls の手動 `relations:` 定義で ER 図だけ得る）**: DDD の定石に忠実だが、主目的である参照整合性の担保を満たさない。手動 relations は実スキーマと乖離しうる二重管理になるため採らない。
+- **必須参照（NOT NULL 列）のみ FK を張る折衷**: nullable な参照（`sire_id` / `dam_id` / `covering_stallion_id`）でも「非 NULL なら実在する行を指す」は守りたい不変条件であり、除外する理由がない。中途半端に済ませると ER 図・lint も部分的になるため採らない。
+
+## Decision（決定）
+
+集約間の ID 参照列すべてに外部キー制約を **backstop** として張る。
+
+- **役割分担**: 参照整合性の一次担保はこれまで通りドメイン層が担う（親の引き当て検証は [ADR-0021](0021-parent-not-found-unprocessable-entity.md) / [ADR-0022](0022-domain-service-repository-for-set-invariants.md)）。FK はアプリ検証をすり抜けた壊れた参照を DB が最後に止める多層防御であり、業務フローの検証を FK 違反例外に頼らない。
+- **DDD との整理**: FK は O/R マッピングにも save 単位にも影響せず、集約間 ID 参照・集約単位の保存というアプリの姿はそのまま。「集約 = 永続化境界」（ADR-0027/0030）と矛盾しない。集約**内**の関係はフラット化（ADR-0043）のままで、FK の対象は集約**間**参照のみ。
+- **参照アクション**: `ON DELETE` / `ON UPDATE` は既定（NO ACTION）。削除ユースケースが存在しないため削除セマンティクスは設計せず、必要が生じたら再訪する。`DEFERRABLE` も使わない（ユースケースは親→子の順で保存する）。
+- **既存テーブルへの追加手順**: V6/V8 の前例に従い、`SET LOCAL` タイムアウト＋ `ADD CONSTRAINT ... NOT VALID` → `VALIDATE CONSTRAINT` の 2 段で行う（#539 の規約検討が確定したらそちらに従う）。
+- **FK 列の index**: PostgreSQL は FK 列に index を自動作成しないため、FK 追加とセットで参照列の index を張る（`.tbls.yml` の `requireForeignKeyIndex` lint で強制）。既存 index（UNIQUE 制約由来を含む）の先頭列が FK 列を担保する場合は追加しない。
+- **今後の規約**: 新しい集約間参照列を追加するときは FK と index を同時に張る。
+
+対象エッジ（初回導入時点）: `breeding_registration.registered_horse_id` → `blood_horse`、`blood_horse.inspection_id` → `horse_inspection`、`blood_horse.sire_id` / `dam_id` → `blood_horse`（自己参照）、`breeding_result.breeding_registration_id` → `breeding_registration`、`breeding_result.covering_stallion_id` → `blood_horse`、`covering_report.stallion_breeding_registration_id` → `breeding_registration`。
+
+## Consequences（結果・影響）
+
+- 壊れた参照（存在しない親を指す行）がどの経路からも DB に入らなくなり、集計・逆リンク系の機能（#456/#457 など）が参照整合を前提にできる。
+- tbls の ER 図に関連が描かれ、`unrelatedTable` / `duplicateRelations` / `requireForeignKeyIndex` lint が実効化される（`.tbls.yml` の無効化理由「FK が無いため」が解消）。
+- 契約テストは親行の seeding が必要になる（ランダム UUID の親 ID では insert できない）。テーブルを跨ぐクリーンアップは子→親の順序で行う。フィクスチャがやや重くなるのは backstop の対価として引き受ける。
+- FK 違反がアプリまで届いた場合は整合性バグの発見であり、`DataIntegrityViolationException`（500 相当）で表面化してよい（業務上の検証失敗はドメイン層が先に 4xx で返す）。
+- insert は親→子の順序制約を受ける。ユースケースが単一 Tx（[ADR-0051](0051-transactional-use-case-boundary.md)）で親→子の順に保存する現行構造では追加コストなし。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,3 +60,4 @@
 | [0049](0049-decline-atlas-keep-flyway-toolchain.md) | Atlas（schema-as-code）を現時点では不採用とし Flyway 中心のスキーマツールチェーンを維持する | Accepted |
 | [0050](0050-domain-event-publication-after-commit.md) | ドメインイベントは ApplicationEventPublisher で発行し AFTER_COMMIT で購読する | Accepted |
 | [0051](0051-transactional-use-case-boundary.md) | トランザクション境界は application 層ユースケースの宣言的 @Transactional で置く | Accepted |
+| [0052](0052-foreign-key-backstop-across-aggregates.md) | 集約間の ID 参照に外部キー制約を backstop として張る | Accepted |

--- a/src/main/resources/db/migration/V11__add_aggregate_reference_foreign_keys.sql
+++ b/src/main/resources/db/migration/V11__add_aggregate_reference_foreign_keys.sql
@@ -1,0 +1,86 @@
+-- 集約間の ID 参照列に FK を backstop として張る（#508 / ADR-0052）。
+-- 参照整合性の一次担保はドメイン層（ADR-0021/0022 の親引き当て検証）のまま、アプリ検証を
+-- すり抜けた壊れた参照を DB が最後に止める多層防御（CHECK = ADR-0043 / UNIQUE = #532 と同じ路線）。
+-- ON DELETE / ON UPDATE は既定（NO ACTION）。削除ユースケースが無いため削除セマンティクスは設計しない。
+-- 既存テーブルへの制約追加はフルスキャン検証で書き込みをブロックしうるため、NOT VALID で新規行への
+-- 強制を即時開始し、VALIDATE CONSTRAINT で既存行を後追い検証する 2 段で行う（V6/V8 と同様）。
+-- PostgreSQL は FK 列に index を自動作成しないため、参照列の index も併せて張る
+-- （covering_report.stallion_breeding_registration_id は既存 UNIQUE 制約の先頭列で担保済みのため張らない）。
+-- breeding_result は既存クエリ（繁殖牝馬×繁殖年の引き当て）があるため (breeding_registration_id,
+-- breeding_year) の複合 index とし、先頭列で FK を担保しつつクエリにも効かせる。
+-- timeout は squawk（require-timeout-settings）に従い設定する。Flyway は各マイグレーションを
+-- 1 トランザクションで適用するため、SET LOCAL でこのマイグレーション内に閉じる。
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+ALTER TABLE breeding_registration
+ADD CONSTRAINT fk_breeding_registration_registered_horse
+FOREIGN KEY (registered_horse_id) REFERENCES blood_horse (id) NOT VALID;
+
+ALTER TABLE breeding_registration
+VALIDATE CONSTRAINT fk_breeding_registration_registered_horse;
+
+ALTER TABLE blood_horse
+ADD CONSTRAINT fk_blood_horse_inspection
+FOREIGN KEY (inspection_id) REFERENCES horse_inspection (id) NOT VALID;
+
+ALTER TABLE blood_horse
+VALIDATE CONSTRAINT fk_blood_horse_inspection;
+
+ALTER TABLE blood_horse
+ADD CONSTRAINT fk_blood_horse_sire
+FOREIGN KEY (sire_id) REFERENCES blood_horse (id) NOT VALID;
+
+ALTER TABLE blood_horse
+VALIDATE CONSTRAINT fk_blood_horse_sire;
+
+ALTER TABLE blood_horse
+ADD CONSTRAINT fk_blood_horse_dam
+FOREIGN KEY (dam_id) REFERENCES blood_horse (id) NOT VALID;
+
+ALTER TABLE blood_horse
+VALIDATE CONSTRAINT fk_blood_horse_dam;
+
+ALTER TABLE breeding_result
+ADD CONSTRAINT fk_breeding_result_breeding_registration
+FOREIGN KEY (breeding_registration_id) REFERENCES breeding_registration (id) NOT VALID;
+
+ALTER TABLE breeding_result
+VALIDATE CONSTRAINT fk_breeding_result_breeding_registration;
+
+ALTER TABLE breeding_result
+ADD CONSTRAINT fk_breeding_result_covering_stallion
+FOREIGN KEY (covering_stallion_id) REFERENCES blood_horse (id) NOT VALID;
+
+ALTER TABLE breeding_result
+VALIDATE CONSTRAINT fk_breeding_result_covering_stallion;
+
+ALTER TABLE covering_report
+ADD CONSTRAINT fk_covering_report_stallion_registration
+FOREIGN KEY (stallion_breeding_registration_id) REFERENCES breeding_registration (id) NOT VALID;
+
+ALTER TABLE covering_report
+VALIDATE CONSTRAINT fk_covering_report_stallion_registration;
+
+-- CREATE INDEX CONCURRENTLY はトランザクション外でしか実行できず、Flyway は各マイグレーションを
+-- 1 トランザクションで適用するため通常の CREATE INDEX を使う（テーブルは小規模・SET LOCAL で保護済み）。
+-- squawk-ignore require-concurrent-index-creation
+CREATE INDEX ix_breeding_registration_registered_horse_id -- noqa: PG01
+ON breeding_registration (registered_horse_id);
+
+-- squawk-ignore require-concurrent-index-creation
+CREATE INDEX ix_blood_horse_inspection_id ON blood_horse (inspection_id); -- noqa: PG01
+
+-- squawk-ignore require-concurrent-index-creation
+CREATE INDEX ix_blood_horse_sire_id ON blood_horse (sire_id); -- noqa: PG01
+
+-- squawk-ignore require-concurrent-index-creation
+CREATE INDEX ix_blood_horse_dam_id ON blood_horse (dam_id); -- noqa: PG01
+
+-- squawk-ignore require-concurrent-index-creation
+CREATE INDEX ix_breeding_result_registration_year -- noqa: PG01
+ON breeding_result (breeding_registration_id, breeding_year);
+
+-- squawk-ignore require-concurrent-index-creation
+CREATE INDEX ix_breeding_result_covering_stallion_id -- noqa: PG01
+ON breeding_result (covering_stallion_id);

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterHorseTransactionRollbackTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterHorseTransactionRollbackTest.kt
@@ -11,10 +11,13 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
 import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
 import com.example.api.domain.studbook.model.inspection.DnaParentageResult
+import com.example.api.infrastructure.studbook.StudbookSeeder
+import com.example.api.infrastructure.studbook.breeding.BreedingRegistrationSpringDataRepository
 import com.example.api.infrastructure.studbook.horse.BloodHorseSpringDataRepository
 import com.example.api.infrastructure.studbook.horse.JdbcBloodHorseRepository
 import com.example.api.infrastructure.studbook.inspection.HorseInspectionSpringDataRepository
 import com.example.api.support.PostgresContainerSupport
+import com.example.api.support.deleteAllStudbookTables
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.unwrap
 import java.time.Instant
@@ -27,6 +30,7 @@ import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
 import org.springframework.dao.DataAccessResourceFailureException
+import org.springframework.jdbc.core.simple.JdbcClient
 import org.springframework.test.context.TestConstructor
 import org.springframework.test.context.TestConstructor.AutowireMode
 
@@ -45,7 +49,11 @@ class RegisterHorseTransactionRollbackTest(
     private val failingRepository: FailingBloodHorseRepository,
     private val inspectionRows: HorseInspectionSpringDataRepository,
     private val bloodHorseRows: BloodHorseSpringDataRepository,
+    private val registrationRows: BreedingRegistrationSpringDataRepository,
+    private val jdbcClient: JdbcClient,
 ) : PostgresContainerSupport() {
+
+    private val seeder = StudbookSeeder(inspectionRows, bloodHorseRows, registrationRows)
 
     @TestConfiguration
     class FailingSaveConfiguration {
@@ -59,8 +67,7 @@ class RegisterHorseTransactionRollbackTest(
     @BeforeEach
     fun cleanUp() {
         failingRepository.failOnSave = false
-        inspectionRows.deleteAll()
-        bloodHorseRows.deleteAll()
+        deleteAllStudbookTables(jdbcClient)
     }
 
     @Test
@@ -77,15 +84,20 @@ class RegisterHorseTransactionRollbackTest(
 
     @Test
     fun `内国産血統登録で軽種馬の保存がインフラ障害で失敗すると先行する審査の保存もロールバックされる`() {
-        val sire = failingRepository.save(BloodHorseFixture.bloodHorse(sex = Sex.MALE)).unwrap()
-        val dam = failingRepository.save(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)).unwrap()
+        val sireFixture = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
+        val damFixture = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        seeder.seedInspectionFor(sireFixture)
+        seeder.seedInspectionFor(damFixture)
+        val sire = failingRepository.save(sireFixture).unwrap()
+        val dam = failingRepository.save(damFixture).unwrap()
         failingRepository.failOnSave = true
 
         assertThrows<DataAccessResourceFailureException> {
             registerInStudBook(command(domesticCommand(sire, dam)))
         }
 
-        assert(inspectionRows.count() == 0L) { "審査が孤児として残っている" }
+        // 父・母の審査（seed 分の 2 行）は残り、ロールバックされた仔馬の審査は残らない
+        assert(inspectionRows.count() == 2L) { "仔馬の審査が孤児として残っている" }
         assert(bloodHorseRows.count() == 2L) { "父・母の 2 頭だけが残るはず" }
     }
 

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/StudbookSeeder.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/StudbookSeeder.kt
@@ -29,13 +29,7 @@ class StudbookSeeder(
 ) {
     /** [horse] が参照する審査行（inspection_id の親）を最小構成で永続化する。 */
     fun seedInspectionFor(horse: BloodHorse) {
-        inspectionRows.save(
-            HorseInspectionRow(
-                id = horse.inspectionId.value,
-                microchipNumber = "392140000000001",
-                parentageType = "NOT_APPLICABLE",
-            )
-        )
+        seedInspectionRow(horse.inspectionId.value)
     }
 
     /** 馬を審査行ごと永続化して返す（父・母・種牡馬・繁殖登録対象馬用）。 */

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/StudbookSeeder.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/StudbookSeeder.kt
@@ -1,0 +1,96 @@
+package com.example.api.infrastructure.studbook
+
+import com.example.api.domain.shared.generateId
+import com.example.api.domain.studbook.model.breeding.BreedingRegistration
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorse
+import com.example.api.infrastructure.studbook.breeding.BreedingRegistrationRow
+import com.example.api.infrastructure.studbook.breeding.BreedingRegistrationSpringDataRepository
+import com.example.api.infrastructure.studbook.breeding.JdbcBreedingRegistrationRepository
+import com.example.api.infrastructure.studbook.horse.BloodHorseRow
+import com.example.api.infrastructure.studbook.horse.BloodHorseSpringDataRepository
+import com.example.api.infrastructure.studbook.horse.JdbcBloodHorseRepository
+import com.example.api.infrastructure.studbook.inspection.HorseInspectionRow
+import com.example.api.infrastructure.studbook.inspection.HorseInspectionSpringDataRepository
+import com.github.michaelbull.result.unwrap
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * FK backstop（ADR-0052）を満たすように、テスト対象行が参照する親行を先に永続化するテスト用シーダ。
+ *
+ * 集約フィクスチャ（Object Mother）は親集約をメモリ上にしか組まないため、FK 導入後はテストが 参照先を先に DB へ入れる必要がある。集約用（seedHorse /
+ * seedRegistration）と、生 Row の フィクスチャ用に任意 ID の親行だけ作る row 系（seedInspectionRow / seedHorseRow /
+ * seedRegistrationRow）の 2 系統を提供する。
+ */
+class StudbookSeeder(
+    private val inspectionRows: HorseInspectionSpringDataRepository,
+    private val horseRows: BloodHorseSpringDataRepository,
+    private val registrationRows: BreedingRegistrationSpringDataRepository,
+) {
+    /** [horse] が参照する審査行（inspection_id の親）を最小構成で永続化する。 */
+    fun seedInspectionFor(horse: BloodHorse) {
+        inspectionRows.save(
+            HorseInspectionRow(
+                id = horse.inspectionId.value,
+                microchipNumber = "392140000000001",
+                parentageType = "NOT_APPLICABLE",
+            )
+        )
+    }
+
+    /** 馬を審査行ごと永続化して返す（父・母・種牡馬・繁殖登録対象馬用）。 */
+    fun seedHorse(horse: BloodHorse): BloodHorse {
+        seedInspectionFor(horse)
+        return JdbcBloodHorseRepository(horseRows).save(horse).unwrap()
+    }
+
+    /** 繁殖登録を永続化して返す。対象馬は事前に [seedHorse] しておくこと。 */
+    fun seedRegistration(registration: BreedingRegistration): BreedingRegistration =
+        JdbcBreedingRegistrationRepository(registrationRows).save(registration).unwrap()
+
+    /** 任意 ID の審査行を作り ID を返す（生 Row フィクスチャの inspection_id 用）。 */
+    fun seedInspectionRow(id: UUID = generateId()): UUID {
+        inspectionRows.save(
+            HorseInspectionRow(
+                id = id,
+                microchipNumber = "392140000000001",
+                parentageType = "NOT_APPLICABLE",
+            )
+        )
+        return id
+    }
+
+    /** 任意 ID の馬行（輸入馬の最小構成）を審査行ごと作り ID を返す（生 Row の sire/dam・種牡馬用）。 */
+    fun seedHorseRow(id: UUID = generateId(), sex: String = "MALE"): UUID {
+        horseRows.save(
+            BloodHorseRow(
+                id = id,
+                registrationNumber = "2020900001",
+                sex = sex,
+                coatColor = "BAY",
+                breedType = "THOROUGHBRED",
+                dateOfBirth = LocalDate.of(2020, 4, 10),
+                breeder = "Coolmore",
+                inspectionId = seedInspectionRow(),
+                originType = "IMPORTED",
+                originCountry = "アイルランド",
+                landingDate = LocalDate.of(2024, 9, 1),
+            )
+        )
+        return id
+    }
+
+    /** 任意 ID の繁殖登録行を対象馬・審査行ごと作り ID を返す（生 Row の breeding_registration_id 用）。 */
+    fun seedRegistrationRow(id: UUID = generateId(), role: String = "BROODMARE"): UUID {
+        registrationRows.save(
+            BreedingRegistrationRow(
+                id = id,
+                registrationNumber = "B-0001",
+                registeredHorseId =
+                    seedHorseRow(sex = if (role == "STALLION") "MALE" else "FEMALE"),
+                breedingRole = role,
+            )
+        )
+        return id
+    }
+}

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepositoryContractTest.kt
@@ -9,7 +9,11 @@ import com.example.api.domain.studbook.model.breeding.BreedingRole
 import com.example.api.domain.studbook.model.breeding.RetirementReason
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.example.api.infrastructure.studbook.StudbookSeeder
+import com.example.api.infrastructure.studbook.horse.BloodHorseSpringDataRepository
+import com.example.api.infrastructure.studbook.inspection.HorseInspectionSpringDataRepository
 import com.example.api.support.PostgresContainerSupport
+import com.example.api.support.deleteAllStudbookTables
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap
 import java.time.LocalDate
@@ -19,6 +23,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.jdbc.core.simple.JdbcClient
 import org.springframework.test.context.TestConstructor
 import org.springframework.test.context.TestConstructor.AutowireMode
 
@@ -44,14 +49,18 @@ import org.springframework.test.context.TestConstructor.AutowireMode
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class JdbcBreedingRegistrationRepositoryContractTest(
-    private val rows: BreedingRegistrationSpringDataRepository
+    private val rows: BreedingRegistrationSpringDataRepository,
+    private val inspectionRows: HorseInspectionSpringDataRepository,
+    private val horseRows: BloodHorseSpringDataRepository,
+    private val jdbcClient: JdbcClient,
 ) : PostgresContainerSupport() {
 
     private val repository = JdbcBreedingRegistrationRepository(rows)
+    private val seeder = StudbookSeeder(inspectionRows, horseRows, rows)
 
     @BeforeEach
     fun cleanUp() {
-        rows.deleteAll()
+        deleteAllStudbookTables(jdbcClient)
     }
 
     private fun row(
@@ -62,7 +71,7 @@ class JdbcBreedingRegistrationRepositoryContractTest(
         BreedingRegistrationRow(
             id = id,
             registrationNumber = "B-0001",
-            registeredHorseId = generateId(),
+            registeredHorseId = seeder.seedHorseRow(sex = "MALE"),
             breedingRole = BreedingRole.STALLION.name,
             retirementReason = retirementReason,
             retirementOccurredOn = retirementOccurredOn,
@@ -93,7 +102,7 @@ class JdbcBreedingRegistrationRepositoryContractTest(
 
     @Test
     fun `供用中のドメイン集約をsaveしfindByIdでID不変のまま再構成できる`() {
-        val mare = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        val mare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
         val registration =
             BreedingRegistration.create(BreedingRegistrationNumber.create("B-1234").unwrap(), mare)
 
@@ -115,7 +124,7 @@ class JdbcBreedingRegistrationRepositoryContractTest(
 
     @Test
     fun `供用停止済みのドメイン集約は事由と発生日が往復で保たれる`() {
-        val stallion = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
+        val stallion = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.MALE))
         val occurredOn = LocalDate.of(2026, 4, 1)
         val number = BreedingRegistrationNumber.create("B-5678").unwrap()
         val retired =
@@ -141,7 +150,7 @@ class JdbcBreedingRegistrationRepositoryContractTest(
 
     @Test
     fun `保存済み集約の再saveはupdateになりversionが進む`() {
-        val mare = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        val mare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
         val inserted =
             repository
                 .save(
@@ -163,7 +172,7 @@ class JdbcBreedingRegistrationRepositoryContractTest(
 
     @Test
     fun `古いversionでのsaveはUpdateConflictを返し先行の書き込みが保たれる`() {
-        val mare = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        val mare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
         val inserted =
             repository
                 .save(
@@ -188,7 +197,7 @@ class JdbcBreedingRegistrationRepositoryContractTest(
 
     @Test
     fun `並行削除された保存済み集約のsaveはUpdateConflictを返す`() {
-        val mare = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        val mare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
         val inserted =
             repository
                 .save(

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepositoryContractTest.kt
@@ -216,6 +216,13 @@ class JdbcBreedingResultRepositoryContractTest(
     }
 
     @Test
+    fun `存在しない繁殖登録を参照する行はFK制約で拒否される`() {
+        val orphan = uncoveredRow().copy(breedingRegistrationId = generateId())
+
+        assertThrows<DataIntegrityViolationException> { rows.save(orphan) }
+    }
+
+    @Test
     fun `存在しないIDのfindByIdはnullを返す`() {
         assert(repository.findById(BreedingResultId(generateId())) == null)
     }

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepositoryContractTest.kt
@@ -3,9 +3,16 @@ package com.example.api.infrastructure.studbook.breeding
 import com.example.api.domain.shared.UpdateConflict
 import com.example.api.domain.shared.generateId
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
+import com.example.api.domain.studbook.model.breeding.BreedingResult
 import com.example.api.domain.studbook.model.breeding.BreedingResultId
 import com.example.api.domain.studbook.model.breeding.FoalingOutcome
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
+import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.example.api.infrastructure.studbook.StudbookSeeder
+import com.example.api.infrastructure.studbook.horse.BloodHorseSpringDataRepository
+import com.example.api.infrastructure.studbook.inspection.HorseInspectionSpringDataRepository
 import com.example.api.support.PostgresContainerSupport
+import com.example.api.support.deleteAllStudbookTables
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap
 import java.time.LocalDate
@@ -16,6 +23,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.jdbc.core.simple.JdbcClient
 import org.springframework.test.context.TestConstructor
 import org.springframework.test.context.TestConstructor.AutowireMode
 
@@ -42,21 +50,56 @@ import org.springframework.test.context.TestConstructor.AutowireMode
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class JdbcBreedingResultRepositoryContractTest(
-    private val rows: BreedingResultSpringDataRepository
+    private val rows: BreedingResultSpringDataRepository,
+    private val inspectionRows: HorseInspectionSpringDataRepository,
+    private val horseRows: BloodHorseSpringDataRepository,
+    private val registrationRows: BreedingRegistrationSpringDataRepository,
+    private val jdbcClient: JdbcClient,
 ) : PostgresContainerSupport() {
 
     private val repository = JdbcBreedingResultRepository(rows)
+    private val seeder = StudbookSeeder(inspectionRows, horseRows, registrationRows)
 
     @BeforeEach
     fun cleanUp() {
-        rows.deleteAll()
+        deleteAllStudbookTables(jdbcClient)
+    }
+
+    /** 親（繁殖牝馬の登録と種牡馬）を seed 済みの、分娩結果未報告の成績を組む。 */
+    private fun seededBreedingResult(): BreedingResult {
+        val broodmareRegistration =
+            BreedingFixture.breedingRegistration(
+                broodmare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+            )
+        val stallionRegistration =
+            BreedingFixture.stallionRegistration(
+                stallion = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.MALE))
+            )
+        seeder.seedRegistration(broodmareRegistration)
+        seeder.seedRegistration(stallionRegistration)
+        return BreedingFixture.breedingResult(
+            broodmareRegistration = broodmareRegistration,
+            stallionRegistration = stallionRegistration,
+        )
+    }
+
+    /** 親（繁殖牝馬の登録）を seed 済みの、種付せず成績を組む。 */
+    private fun seededUncoveredResult(): BreedingResult {
+        val broodmareRegistration =
+            BreedingFixture.breedingRegistration(
+                broodmare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+            )
+        seeder.seedRegistration(broodmareRegistration)
+        return BreedingFixture.uncoveredBreedingResult(
+            broodmareRegistration = broodmareRegistration
+        )
     }
 
     /** 種付せず（covering 全 NULL・区分 NOT_COVERED）の整合した行。CHECK 制約を満たす最小行。 */
     private fun uncoveredRow(id: UUID = generateId()) =
         BreedingResultRow(
             id = id,
-            breedingRegistrationId = generateId(),
+            breedingRegistrationId = seeder.seedRegistrationRow(),
             breedingYear = 2024,
             outcomeType = "NOT_COVERED",
         )
@@ -86,7 +129,7 @@ class JdbcBreedingResultRepositoryContractTest(
 
     @Test
     fun `種付した未報告の成績は種付ごと往復し区分はnull`() {
-        val result = BreedingFixture.breedingResult()
+        val result = seededBreedingResult()
 
         val saved = repository.save(result).unwrap()
         val found = repository.findById(result.id)
@@ -106,9 +149,7 @@ class JdbcBreedingResultRepositoryContractTest(
     fun `生産を報告した成績は分娩日ごと往復できる`() {
         val foalingDate = LocalDate.of(2025, 3, 1)
         val reported =
-            BreedingFixture.breedingResult()
-                .recordFoaling(FoalingOutcome.LiveFoal(foalingDate))
-                .unwrap()
+            seededBreedingResult().recordFoaling(FoalingOutcome.LiveFoal(foalingDate)).unwrap()
 
         repository.save(reported).unwrap()
         val found = repository.findById(reported.id)
@@ -121,8 +162,7 @@ class JdbcBreedingResultRepositoryContractTest(
 
     @Test
     fun `産駒なし区分を報告した成績は区分が往復し分娩日を持たない`() {
-        val reported =
-            BreedingFixture.breedingResult().recordFoaling(FoalingOutcome.NotConceived).unwrap()
+        val reported = seededBreedingResult().recordFoaling(FoalingOutcome.NotConceived).unwrap()
 
         repository.save(reported).unwrap()
         val found = repository.findById(reported.id)
@@ -133,7 +173,7 @@ class JdbcBreedingResultRepositoryContractTest(
 
     @Test
     fun `種付せずの成績は種付なし区分NotCoveredのまま往復できる`() {
-        val uncovered = BreedingFixture.uncoveredBreedingResult()
+        val uncovered = seededUncoveredResult()
 
         repository.save(uncovered).unwrap()
         val found = repository.findById(uncovered.id)
@@ -146,7 +186,7 @@ class JdbcBreedingResultRepositoryContractTest(
 
     @Test
     fun `findByBreedingRegistrationIdAndBreedingYearで繁殖牝馬と年から引き当てられる`() {
-        val result = BreedingFixture.breedingResult() // breedingYear=2024
+        val result = seededBreedingResult() // breedingYear=2024
         repository.save(result).unwrap()
 
         val found =
@@ -182,7 +222,7 @@ class JdbcBreedingResultRepositoryContractTest(
 
     @Test
     fun `保存済み集約の再saveはupdateになりversionが進む`() {
-        val inserted = repository.save(BreedingFixture.breedingResult()).unwrap()
+        val inserted = repository.save(seededBreedingResult()).unwrap()
         assert(inserted.version != null)
 
         val reported = inserted.recordFoaling(FoalingOutcome.NotConceived).unwrap()
@@ -195,7 +235,7 @@ class JdbcBreedingResultRepositoryContractTest(
 
     @Test
     fun `古いversionでのsaveはUpdateConflictを返し先行の書き込みが保たれる`() {
-        val inserted = repository.save(BreedingFixture.breedingResult()).unwrap()
+        val inserted = repository.save(seededBreedingResult()).unwrap()
         repository.save(inserted.recordFoaling(FoalingOutcome.NotConceived).unwrap()).unwrap()
 
         val conflicted = repository.save(inserted.recordFoaling(FoalingOutcome.Abortion).unwrap())
@@ -206,7 +246,7 @@ class JdbcBreedingResultRepositoryContractTest(
 
     @Test
     fun `並行削除された保存済み集約のsaveはUpdateConflictを返す`() {
-        val inserted = repository.save(BreedingFixture.breedingResult()).unwrap()
+        val inserted = repository.save(seededBreedingResult()).unwrap()
         rows.deleteAll()
 
         val conflicted =
@@ -218,7 +258,7 @@ class JdbcBreedingResultRepositoryContractTest(
     @Test
     fun `提出済みの成績は提出日ごと往復できる`() {
         val submitted =
-            BreedingFixture.breedingResult()
+            seededBreedingResult()
                 .recordFoaling(FoalingOutcome.LiveFoal(LocalDate.of(2025, 3, 1)))
                 .unwrap()
                 .submitReport(LocalDate.of(2025, 5, 30))
@@ -234,7 +274,7 @@ class JdbcBreedingResultRepositoryContractTest(
 
     @Test
     fun `未提出の成績はreport_submitted_onがnullで往復する`() {
-        val unsubmitted = BreedingFixture.breedingResult()
+        val unsubmitted = seededBreedingResult()
 
         repository.save(unsubmitted).unwrap()
         val found = repository.findById(unsubmitted.id)
@@ -250,9 +290,9 @@ class JdbcBreedingResultRepositoryContractTest(
         val row =
             BreedingResultRow(
                 id = generateId(),
-                breedingRegistrationId = generateId(),
+                breedingRegistrationId = seeder.seedRegistrationRow(),
                 breedingYear = 2024,
-                coveringStallionId = generateId(),
+                coveringStallionId = seeder.seedHorseRow(sex = "MALE"),
                 coveringDate = LocalDate.of(2024, 4, 1),
                 coveringCertificateNumber = "C-2024-0001",
                 outcomeType = null,

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultSummaryQueriesContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultSummaryQueriesContractTest.kt
@@ -2,7 +2,11 @@ package com.example.api.infrastructure.studbook.breeding
 
 import com.example.api.domain.shared.generateId
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
+import com.example.api.infrastructure.studbook.StudbookSeeder
+import com.example.api.infrastructure.studbook.horse.BloodHorseSpringDataRepository
+import com.example.api.infrastructure.studbook.inspection.HorseInspectionSpringDataRepository
 import com.example.api.support.PostgresContainerSupport
+import com.example.api.support.deleteAllStudbookTables
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.UUID
@@ -26,16 +30,24 @@ import org.springframework.test.context.TestConstructor.AutowireMode
 class JdbcBreedingResultSummaryQueriesContractTest(
     private val jdbcClient: JdbcClient,
     private val rows: BreedingResultSpringDataRepository,
+    private val inspectionRows: HorseInspectionSpringDataRepository,
+    private val horseRows: BloodHorseSpringDataRepository,
+    private val registrationRows: BreedingRegistrationSpringDataRepository,
 ) : PostgresContainerSupport() {
 
     private val queries = JdbcBreedingResultSummaryQueries(jdbcClient)
+    private val seeder = StudbookSeeder(inspectionRows, horseRows, registrationRows)
 
     private val stallion = generateId()
     private val otherStallion = generateId()
+    private lateinit var registrationId: UUID
 
     @BeforeEach
     fun cleanUp() {
-        rows.deleteAll()
+        deleteAllStudbookTables(jdbcClient)
+        seeder.seedHorseRow(id = stallion, sex = "MALE")
+        seeder.seedHorseRow(id = otherStallion, sex = "MALE")
+        registrationId = seeder.seedRegistrationRow()
     }
 
     /** 種付あり行を作る。outcomeType=null は未報告。LIVE_FOAL のみ分娩日を持つ。 */
@@ -47,7 +59,7 @@ class JdbcBreedingResultSummaryQueriesContractTest(
     ) =
         BreedingResultRow(
             id = generateId(),
-            breedingRegistrationId = generateId(),
+            breedingRegistrationId = registrationId,
             breedingYear = year,
             coveringStallionId = stallionId,
             coveringDate = LocalDate.of(year, 4, 1),
@@ -61,7 +73,7 @@ class JdbcBreedingResultSummaryQueriesContractTest(
     private fun notCovered(year: Int) =
         BreedingResultRow(
             id = generateId(),
-            breedingRegistrationId = generateId(),
+            breedingRegistrationId = registrationId,
             breedingYear = year,
             outcomeType = "NOT_COVERED",
         )

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcCoveringReportRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcCoveringReportRepositoryContractTest.kt
@@ -135,6 +135,20 @@ class JdbcCoveringReportRepositoryContractTest(
     }
 
     @Test
+    fun `存在しない繁殖登録を参照する行はFK制約で拒否される`() {
+        val orphan =
+            CoveringReportRow(
+                id = generateId(),
+                stallionBreedingRegistrationId = generateId(),
+                coveringYear = 2024,
+                submittedOn = LocalDate.of(2024, 9, 30),
+                version = null,
+            )
+
+        assertThrows<DataIntegrityViolationException> { rows.save(orphan) }
+    }
+
+    @Test
     fun `存在しないIDのfindByIdはnullを返す`() {
         assert(repository.findById(CoveringReportId(generateId())) == null)
     }

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcCoveringReportRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcCoveringReportRepositoryContractTest.kt
@@ -3,8 +3,15 @@ package com.example.api.infrastructure.studbook.breeding
 import com.example.api.domain.shared.UpdateConflict
 import com.example.api.domain.shared.generateId
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
+import com.example.api.domain.studbook.model.breeding.BreedingRegistration
 import com.example.api.domain.studbook.model.breeding.CoveringReportId
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
+import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.example.api.infrastructure.studbook.StudbookSeeder
+import com.example.api.infrastructure.studbook.horse.BloodHorseSpringDataRepository
+import com.example.api.infrastructure.studbook.inspection.HorseInspectionSpringDataRepository
 import com.example.api.support.PostgresContainerSupport
+import com.example.api.support.deleteAllStudbookTables
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap
 import java.time.LocalDate
@@ -14,6 +21,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.jdbc.core.simple.JdbcClient
 import org.springframework.test.context.TestConstructor
 import org.springframework.test.context.TestConstructor.AutowireMode
 
@@ -33,19 +41,34 @@ import org.springframework.test.context.TestConstructor.AutowireMode
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class JdbcCoveringReportRepositoryContractTest(
-    private val rows: CoveringReportSpringDataRepository
+    private val rows: CoveringReportSpringDataRepository,
+    private val inspectionRows: HorseInspectionSpringDataRepository,
+    private val horseRows: BloodHorseSpringDataRepository,
+    private val registrationRows: BreedingRegistrationSpringDataRepository,
+    private val jdbcClient: JdbcClient,
 ) : PostgresContainerSupport() {
 
     private val repository = JdbcCoveringReportRepository(rows)
+    private val seeder = StudbookSeeder(inspectionRows, horseRows, registrationRows)
 
     @BeforeEach
     fun cleanUp() {
-        rows.deleteAll()
+        deleteAllStudbookTables(jdbcClient)
+    }
+
+    /** 親（種牡馬とその繁殖登録）を seed 済みの繁殖登録を返す。 */
+    private fun seededStallionRegistration(): BreedingRegistration {
+        val stallion = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.MALE))
+        return seeder.seedRegistration(BreedingFixture.stallionRegistration(stallion = stallion))
     }
 
     @Test
     fun `新規の種付成績報告はversionがnullなのでinsertされ属性ごと往復できる`() {
-        val report = BreedingFixture.coveringReport(submittedOn = LocalDate.of(2024, 10, 1))
+        val report =
+            BreedingFixture.coveringReport(
+                stallionRegistration = seededStallionRegistration(),
+                submittedOn = LocalDate.of(2024, 10, 1),
+            )
 
         val saved = repository.save(report).unwrap()
         val found = repository.findById(report.id)
@@ -62,7 +85,10 @@ class JdbcCoveringReportRepositoryContractTest(
 
     @Test
     fun `findByStallionRegistrationIdAndCoveringYearで種牡馬と年から引き当てられる`() {
-        val report = BreedingFixture.coveringReport() // coveringYear=2024
+        val report =
+            BreedingFixture.coveringReport(
+                stallionRegistration = seededStallionRegistration()
+            ) // coveringYear=2024
         repository.save(report).unwrap()
 
         val found =
@@ -84,7 +110,7 @@ class JdbcCoveringReportRepositoryContractTest(
     @Test
     fun `同一種牡馬×同一種付年の二重insertはUNIQUE制約で拒否される`() {
         // ドメインサービスの一意性検証をすり抜ける read-then-insert 並行競合（#532）の backstop。
-        val stallionRegistration = BreedingFixture.stallionRegistration()
+        val stallionRegistration = seededStallionRegistration()
         repository
             .save(BreedingFixture.coveringReport(stallionRegistration = stallionRegistration))
             .unwrap()
@@ -95,7 +121,11 @@ class JdbcCoveringReportRepositoryContractTest(
 
     @Test
     fun `並行削除された保存済み集約のsaveはUpdateConflictを返す`() {
-        val inserted = repository.save(BreedingFixture.coveringReport()).unwrap()
+        val stallionRegistration = seededStallionRegistration()
+        val inserted =
+            repository
+                .save(BreedingFixture.coveringReport(stallionRegistration = stallionRegistration))
+                .unwrap()
         rows.deleteAll()
 
         // version 非 null の集約の save は update 経路になり、対象行が無いので競合として検出される

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
@@ -9,7 +9,11 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
 import com.example.api.domain.studbook.model.horse.bloodhorse.Origin
 import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
+import com.example.api.infrastructure.studbook.StudbookSeeder
+import com.example.api.infrastructure.studbook.breeding.BreedingRegistrationSpringDataRepository
+import com.example.api.infrastructure.studbook.inspection.HorseInspectionSpringDataRepository
 import com.example.api.support.PostgresContainerSupport
+import com.example.api.support.deleteAllStudbookTables
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.unwrap
 import java.time.LocalDate
@@ -19,6 +23,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.jdbc.core.simple.JdbcClient
 import org.springframework.test.context.TestConstructor
 import org.springframework.test.context.TestConstructor.AutowireMode
 
@@ -43,14 +48,19 @@ import org.springframework.test.context.TestConstructor.AutowireMode
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)
-class JdbcBloodHorseRepositoryContractTest(private val rows: BloodHorseSpringDataRepository) :
-    PostgresContainerSupport() {
+class JdbcBloodHorseRepositoryContractTest(
+    private val rows: BloodHorseSpringDataRepository,
+    private val inspectionRows: HorseInspectionSpringDataRepository,
+    private val registrationRows: BreedingRegistrationSpringDataRepository,
+    private val jdbcClient: JdbcClient,
+) : PostgresContainerSupport() {
 
     private val repository = JdbcBloodHorseRepository(rows)
+    private val seeder = StudbookSeeder(inspectionRows, rows, registrationRows)
 
     @BeforeEach
     fun cleanUp() {
-        rows.deleteAll()
+        deleteAllStudbookTables(jdbcClient)
     }
 
     private fun domesticRow(id: UUID = generateId()) =
@@ -62,16 +72,16 @@ class JdbcBloodHorseRepositoryContractTest(private val rows: BloodHorseSpringDat
             breedType = "THOROUGHBRED",
             dateOfBirth = LocalDate.of(2023, 3, 15),
             breeder = "ノーザンファーム",
-            inspectionId = generateId(),
+            inspectionId = seeder.seedInspectionRow(),
             originType = "DOMESTIC",
-            sireId = generateId(),
-            damId = generateId(),
+            sireId = seeder.seedHorseRow(sex = "MALE"),
+            damId = seeder.seedHorseRow(sex = "FEMALE"),
         )
 
-    /** 内国産の父母を持つ命名済みの軽種馬を組み立てる（前提条件を満たす父=雄・母=雌・品種/ DNA 整合）。 */
+    /** 内国産の父母を持つ命名済みの軽種馬を組み立てる（前提条件を満たす父=雄・母=雌・品種/ DNA 整合）。父母・仔馬自身の審査行は seed 済み。 */
     private fun namedDomesticFoal(): BloodHorse {
-        val sire = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
-        val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        val sire = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.MALE))
+        val dam = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
         val foal =
             BloodHorse.create(
                     sire = sire,
@@ -81,6 +91,7 @@ class JdbcBloodHorseRepositoryContractTest(private val rows: BloodHorseSpringDat
                     registrationNumber = PedigreeRegistrationNumber.create("2023109999").unwrap(),
                 )
                 .unwrap()
+        seeder.seedInspectionFor(foal)
         return foal.assignName(HorseName.create("オグリキャップ").unwrap()).unwrap().aggregate
     }
 
@@ -91,7 +102,8 @@ class JdbcBloodHorseRepositoryContractTest(private val rows: BloodHorseSpringDat
 
         assert(saved.id == id)
         assert(saved.version != null)
-        assert(rows.count() == 1L)
+        // domesticRow() が FK 前提で seed する父・母の 2 行 + 対象行の 1 行 = 3 行
+        assert(rows.count() == 3L)
         assert(rows.findById(id).isPresent)
     }
 
@@ -103,13 +115,15 @@ class JdbcBloodHorseRepositoryContractTest(private val rows: BloodHorseSpringDat
 
         assert(updated.id == inserted.id)
         assert(updated.version!! > inserted.version!!)
-        assert(rows.count() == 1L)
+        // domesticRow() が FK 前提で seed する父・母の 2 行 + 対象行の 1 行 = 3 行（update なので増減なし）
+        assert(rows.count() == 3L)
         assert(rows.findById(inserted.id).orElseThrow().coatColor == "CHESTNUT")
     }
 
     @Test
     fun `輸入馬は出自Importedと未命名のまま往復できる`() {
         val imported = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        seeder.seedInspectionFor(imported)
         val expectedOrigin = imported.origin as Origin.Imported
 
         val saved = repository.save(imported).unwrap()
@@ -151,7 +165,9 @@ class JdbcBloodHorseRepositoryContractTest(private val rows: BloodHorseSpringDat
 
     @Test
     fun `findAllByIdはヒットしたIDだけをまとめて返す`() {
-        val imported = repository.save(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)).unwrap()
+        val importedFixture = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        seeder.seedInspectionFor(importedFixture)
+        val imported = repository.save(importedFixture).unwrap()
         val foal = repository.save(namedDomesticFoal()).unwrap()
         val missing = BloodHorseId(generateId())
 
@@ -195,7 +211,9 @@ class JdbcBloodHorseRepositoryContractTest(private val rows: BloodHorseSpringDat
 
     @Test
     fun `保存済み集約の再saveはupdateになりversionが進む`() {
-        val inserted = repository.save(BloodHorseFixture.bloodHorse()).unwrap()
+        val fixture = BloodHorseFixture.bloodHorse()
+        seeder.seedInspectionFor(fixture)
+        val inserted = repository.save(fixture).unwrap()
         assert(inserted.version != null)
 
         val named = inserted.assignName(HorseName.create("オグリキャップ").unwrap()).unwrap().aggregate
@@ -208,7 +226,9 @@ class JdbcBloodHorseRepositoryContractTest(private val rows: BloodHorseSpringDat
 
     @Test
     fun `古いversionでのsaveはUpdateConflictを返し先行の書き込みが保たれる`() {
-        val inserted = repository.save(BloodHorseFixture.bloodHorse()).unwrap()
+        val fixture = BloodHorseFixture.bloodHorse()
+        seeder.seedInspectionFor(fixture)
+        val inserted = repository.save(fixture).unwrap()
         repository
             .save(inserted.assignName(HorseName.create("オグリキャップ").unwrap()).unwrap().aggregate)
             .unwrap()
@@ -224,7 +244,9 @@ class JdbcBloodHorseRepositoryContractTest(private val rows: BloodHorseSpringDat
 
     @Test
     fun `並行削除された保存済み集約のsaveはUpdateConflictを返す`() {
-        val inserted = repository.save(BloodHorseFixture.bloodHorse()).unwrap()
+        val fixture = BloodHorseFixture.bloodHorse()
+        seeder.seedInspectionFor(fixture)
+        val inserted = repository.save(fixture).unwrap()
         rows.deleteAll()
 
         val conflicted =

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
@@ -191,6 +191,15 @@ class JdbcBloodHorseRepositoryContractTest(
     }
 
     @Test
+    fun `存在しない審査を参照する行はFK制約で拒否される`() {
+        // マッパー／ユースケースは常に親を先に保存するが、FK（ADR-0052）が DB 単独でも
+        // 壊れた参照の混入を拒否することを担保する。
+        val orphan = domesticRow().copy(inspectionId = generateId())
+
+        assertThrows<DataIntegrityViolationException> { rows.save(orphan) }
+    }
+
+    @Test
     fun `存在しないIDのfindByIdはnullを返す`() {
         assert(repository.findById(BloodHorseId(generateId())) == null)
     }

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionQueriesContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionQueriesContractTest.kt
@@ -6,6 +6,7 @@ import com.example.api.domain.studbook.model.inspection.HorseInspectionId
 import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
 import com.example.api.support.PostgresContainerSupport
+import com.example.api.support.deleteAllStudbookTables
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
@@ -38,7 +39,7 @@ class JdbcHorseInspectionQueriesContractTest(
 
     @BeforeEach
     fun cleanUp() {
-        rows.deleteAll()
+        deleteAllStudbookTables(jdbcClient)
     }
 
     @Test

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionRepositoryContractTest.kt
@@ -8,6 +8,7 @@ import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
 import com.example.api.support.PostgresContainerSupport
+import com.example.api.support.deleteAllStudbookTables
 import com.github.michaelbull.result.unwrap
 import java.util.UUID
 import org.junit.jupiter.api.BeforeEach
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.jdbc.core.simple.JdbcClient
 import org.springframework.test.context.TestConstructor
 import org.springframework.test.context.TestConstructor.AutowireMode
 
@@ -31,7 +33,8 @@ import org.springframework.test.context.TestConstructor.AutowireMode
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class JdbcHorseInspectionRepositoryContractTest(
-    private val rows: HorseInspectionSpringDataRepository
+    private val rows: HorseInspectionSpringDataRepository,
+    private val jdbcClient: JdbcClient,
 ) : PostgresContainerSupport() {
 
     private val repository = JdbcHorseInspectionRepository(rows)
@@ -39,7 +42,7 @@ class JdbcHorseInspectionRepositoryContractTest(
 
     @BeforeEach
     fun cleanUp() {
-        rows.deleteAll()
+        deleteAllStudbookTables(jdbcClient)
     }
 
     private fun byDnaRow(id: UUID = generateId()) =

--- a/src/test/kotlin/com/example/api/support/StudbookTables.kt
+++ b/src/test/kotlin/com/example/api/support/StudbookTables.kt
@@ -1,0 +1,21 @@
+package com.example.api.support
+
+import org.springframework.jdbc.core.simple.JdbcClient
+
+/**
+ * studbook コンテキストの全テーブルを FK の依存順（子→親）で空にするテストユーティリティ（ADR-0052）。
+ *
+ * 集約間 FK の導入後は、自テーブルだけの deleteAll() では他テーブルの残存行（共有コンテナを使い回す 他テストクラスの遺物）が FK
+ * 違反で削除を阻むため、契約テストのクリーンアップはこれで行う。 blood_horse の自己参照 FK（sire/dam）は NO ACTION（文末検査）のため単一 DELETE
+ * 文で全行消せる。
+ */
+fun deleteAllStudbookTables(jdbcClient: JdbcClient) {
+    listOf(
+            "covering_report",
+            "breeding_result",
+            "breeding_registration",
+            "blood_horse",
+            "horse_inspection",
+        )
+        .forEach { table -> jdbcClient.sql("DELETE FROM $table").update() }
+}


### PR DESCRIPTION
## 概要

集約間の ID 参照列 6 エッジ（7 制約）に外部キーを backstop として張る（ADR-0053）。

- **ADR-0053**: FK を張らない立場（DDD の集約間 ID 参照・旧 H2 両対応）からの転換を記録。一次担保はドメイン層のまま、FK は多層防御（CHECK = ADR-0043 / UNIQUE = #532 と同じ路線）
- **V11**: FK 7 本の `ADD CONSTRAINT ... NOT VALID` + 参照列 index 6 本（`breeding_result` は既存クエリに効く複合 index、`covering_report` は既存 UNIQUE 先頭列で担保済みのため追加なし）
- **V12**: `VALIDATE CONSTRAINT` 専用マイグレーション（先行マージされた #539 / ADR-0052 の分離規約に準拠。`check-migration-validate-separation.sh` 通過）
- **テスト**: 契約テストを親行 seeding（`StudbookSeeder`）と FK 順クリーンアップ（`deleteAllStudbookTables`）へ改修し、FK 違反を検証する契約テスト 3 件を TDD（RED→GREEN）で追加
- **tbls**: `unrelatedTable` lint を有効化（`jockey` は単独集約のため理由付き exclude）し、dbdoc を再生成（ER 図に関連線が出るようになった）

main コード（Kotlin）の変更は無し（ユースケースは既に親→子順で保存している）。`ON DELETE` は既定の NO ACTION、削除セマンティクスは削除ユースケースが生まれたら再訪。

### 途中経過のメモ

作業中に #539（PR #546）が main へ先行マージされたため、マージコミットで追随した: ADR 番号を 0052→0053 へ改番（0052 は VALIDATE 分離規約が取得）、当初 1 ファイルだった V11 を ADD / VALIDATE の 2 ファイルへ分割。

## 検証

- `./gradlew check` BUILD SUCCESSFUL（ktfmt / detekt / ArchUnit / test 410 件 / koverVerifyMature）
- `./gradlew e2eTest` BUILD SUCCESSFUL（実配線でユースケースの保存順序と FK の整合を確認）
- `./gradlew checkDbDoc` BUILD SUCCESSFUL（tbls diff 鮮度 + lint 違反ゼロ）
- `scripts/check-migration-validate-separation.sh` / sqlfluff / squawk 違反ゼロ（`CREATE INDEX` の CONCURRENTLY 不可は Flyway の Tx 内適用のため。理由コメント付き ignore）

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZdbeNfgRVBHFKBK55CXhN
