### PR TITLE
feat: シングルと選抜フォーメーションをモデル化する（Single/Senbatsu/Position）(#550)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -58,7 +58,7 @@ Kover 0.9 の検証ルールはパッケージ単位のフィルタを持てな�
 - **自動ラチェット機構は持たない**（YAGNI）。手動で引き上げる。
 
 探索除外パッケージ（`build.gradle.kts` の `variant("mature")` の `excludes` が唯一の出所。ここは要約）:
-`domain.racing.model.race` / `domain.racing.service` / `domain.sakamichi` / `domain.tennis` / `e2e`（Karate テスト基盤）。
+`domain.racing.model.race` / `domain.racing.service` / `domain.tennis` / `e2e`（Karate テスト基盤）/ `dbdoc`（tbls ドキュメント生成基盤）。
 
 集約ゲート（本見直し）は成熟領域全体の絶対水準を守り、patch coverage（[#437](https://github.com/ptiringo/toy-box/issues/437)）は新規・変更コードのカバレッジを別途課す補完関係にある。
 
@@ -78,6 +78,6 @@ CI（`api-tests.yml`）は test 後に `koverVerifyMature` でゲートを掛け
 
 - `infrastructure.*`（JDBC リポジトリ）: `Jockey` は Testcontainers 契約テスト済み。残り集約（`BloodHorse` / `BreedingRegistration` / `BreedingResult`）は JDBC 実装＋契約テストが未整備で、移行に伴い InMemory を廃止する（JDBC 一本化。[ADR-0030](../../docs/adr/0030-jdbc-only-persistence-retire-inmemory.md) / #435）。なお `infrastructure.*` は `excludes` に入れておらず**既にゲート母集団内**。未テスト分は集計に乗るが現状の LINE 90% / BRANCH 80% を満たしている（割り込んだらテストを添えること）。
 - `domain.racing.service`（`confirmRaceResult`）: サービスだがテスト無し。`excludes` 在籍。
-- `domain.racing.model`（`race`）・`sakamichi` / `tennis`: 探索段階のモデル。`excludes` 在籍。
+- `domain.racing.model`（`race`）・`tennis`: 探索段階のモデル。`excludes` 在籍（`sakamichi` は #367 でテストが揃いゲート対象へ昇格済み）。
 
-このうち `excludes` に在籍している探索領域（`racing.model.race` / `racing.service` / `sakamichi` / `tennis`）は、テストが揃った時点で `variant("mature")` の `excludes` から外してゲート対象へ昇格させる（`infrastructure.*` は既にゲート対象なので対象外）。
+このうち `excludes` に在籍している探索領域（`racing.model.race` / `racing.service` / `tennis`）は、テストが揃った時点で `variant("mature")` の `excludes` から外してゲート対象へ昇格させる（`infrastructure.*` は既にゲート対象なので対象外）。

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -122,8 +122,8 @@ JRA 管掌の騎手・競走を扱う。騎手免許は競馬法で JRA が管�
 
 ### sakamichi コンテキスト（エンターテイメント）
 
-坂道シリーズ（乃木坂46・櫻坂46・日向坂46）のグループとメンバーの在籍（加入・卒業・期生）を扱う。
-権威ソースの所在と用語の詳細は `.claude/skills/sakamichi-sources/` を参照。
+坂道シリーズ（乃木坂46・櫻坂46・日向坂46）のグループとメンバーの在籍（加入・卒業・期生）、シングルごとの
+選抜編成を扱う。権威ソースの所在と用語の詳細は `.claude/skills/sakamichi-sources/` を参照。
 
 | 用語 | 定義 | 補足 |
 | --- | --- | --- |
@@ -132,8 +132,15 @@ JRA 管掌の騎手・競走を扱う。騎手免許は競馬法で JRA が管�
 | 期生（`Generation`） | 加入時期で区切るコホート（1期生・2期生…） | 加入時に固定。**グループごとに独立採番**（横断で一意でない） |
 | 加入 / 卒業 | メンバーの参加 ／ 離脱の状態遷移（`Member.graduate`） | 卒業日は加入日以降。契約解除等の非円満離脱は「卒業」と区別しうるが未モデル化 |
 | 在籍状態（`Membership`） | 在籍中（`Active`）／卒業済み（`Graduated`）の相互排他 | sealed で型強制（ADR-0020 の流儀） |
+| シングル（`Single`） | グループが発表する作品。選抜を内包する集約ルート | 発表元グループは `GroupId` の ID 参照。発表後の編成変更等の状態遷移は未モデル化 |
+| 作品番号（`SingleNumber`） | n 枚目（1 以上の整数） | **グループごとに独立採番**（横断で一意でない）。グループ内の重複禁止は集合制約のため未モデル化（必要時に ADR-0022 の流儀でドメインサービスへ） |
+| 表題（`SingleTitle`） | シングルの表題曲の曲名 | カップリング曲は未モデル化 |
+| 選抜（`Senbatsu`） | シングル表題曲を歌う選ばれたメンバーの集合とフォーメーション | **シングル単位の一時的編成**（グループ・メンバーの恒久属性にしない）。不変条件: メンバー重複なし・立ち位置の定員 1 人・センター必須 |
+| 立ち位置（`Position`） | フォーメーション上の位置。センター（`Center`）とそれ以外（`Spot`＝列 × 列内番号）の相互排他 | シングルごとに変わる。1 列目が最前列。センターと `Spot` の空間的重なりは未検証（探索段階の割り切り） |
+| 選抜の枠（`SenbatsuSlot`） | 立ち位置 × メンバーの割り当て 1 件 | メンバーは `MemberId` の ID 参照 |
 
-**禁止語・注意**: 「選抜」はグループの恒久属性ではなくシングル単位の一時的編成（未モデル化・#364 段階 3）。
+**禁止語・注意**: 「選抜」をグループやメンバーの恒久属性として扱わない（シングル単位の一時的編成。⇔ アンダー＝非選抜、未モデル化）。
+「選抜対象メンバーが当該グループに在籍中であること」の検証は集約またぎのため `Senbatsu` では守らない（#551 のドメインサービスへ）。
 「桜坂46」は誤記（正しくは旧字の「櫻坂46」）。
 
 ### tennis コンテキスト（スポーツ）
@@ -182,6 +189,7 @@ graph LR
 | --- | --- | --- |
 | Group | 集約ルート | domain.sakamichi.model.group |
 | Member | 集約ルート | domain.sakamichi.model.member |
+| Single | 集約ルート | domain.sakamichi.model.single |
 | Generation | 値オブジェクト | domain.sakamichi.model.member |
 | GroupId | 値オブジェクト | domain.sakamichi.model.group |
 | GroupName | 値オブジェクト | domain.sakamichi.model.group |
@@ -190,6 +198,14 @@ graph LR
 | Membership | 値オブジェクト | domain.sakamichi.model.member |
 | Membership.Active | 値オブジェクト | domain.sakamichi.model.member |
 | Membership.Graduated | 値オブジェクト | domain.sakamichi.model.member |
+| Position | 値オブジェクト | domain.sakamichi.model.single |
+| Position.Center | 値オブジェクト | domain.sakamichi.model.single |
+| Position.Spot | 値オブジェクト | domain.sakamichi.model.single |
+| Senbatsu | 値オブジェクト | domain.sakamichi.model.single |
+| SenbatsuSlot | 値オブジェクト | domain.sakamichi.model.single |
+| SingleId | 値オブジェクト | domain.sakamichi.model.single |
+| SingleNumber | 値オブジェクト | domain.sakamichi.model.single |
+| SingleTitle | 値オブジェクト | domain.sakamichi.model.single |
 
 ### studbook
 

--- a/src/main/kotlin/com/example/api/domain/sakamichi/model/single/Position.kt
+++ b/src/main/kotlin/com/example/api/domain/sakamichi/model/single/Position.kt
@@ -1,0 +1,43 @@
+package com.example.api.domain.sakamichi.model.single
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import org.jmolecules.ddd.annotation.ValueObject
+
+/** 立ち位置が不変条件（列・列内番号とも 1 以上）を満たさない。 */
+data object InvalidPosition
+
+/**
+ * 選抜フォーメーション上の立ち位置。
+ *
+ * センター（[Center]）とそれ以外の立ち位置（[Spot]）は相互排他であり、sealed interface で型として 強制する（`Membership`
+ * と同じ流儀・ADR-0020）。立ち位置はシングルごとに変わる（グループやメンバーの 恒久属性ではない。sakamichi-sources §4）。
+ */
+@ValueObject
+sealed interface Position {
+    /** センター（フォーメーションの中心。選抜に必ず 1 人置く）。 */
+    @ValueObject data object Center : Position
+
+    /**
+     * センター以外の立ち位置（列 × 列内番号）。
+     *
+     * 1 列目が最前列。列内番号は同一列の中での位置を表す。センターとの空間的な重なり（1 列目中央等）は 検証しない（探索段階の割り切り）。
+     *
+     * @property row 列（1 以上。1 列目が最前列）
+     * @property numberInRow 列内番号（1 以上）
+     */
+    @ValueObject
+    @ConsistentCopyVisibility
+    data class Spot private constructor(val row: Int, val numberInRow: Int) : Position {
+        companion object {
+            /** 列・列内番号とも 1 以上であることを検証して [Spot] を生成する。 */
+            fun create(row: Int, numberInRow: Int): Result<Spot, InvalidPosition> =
+                if (row >= 1 && numberInRow >= 1) {
+                    Ok(Spot(row = row, numberInRow = numberInRow))
+                } else {
+                    Err(InvalidPosition)
+                }
+        }
+    }
+}

--- a/src/main/kotlin/com/example/api/domain/sakamichi/model/single/Senbatsu.kt
+++ b/src/main/kotlin/com/example/api/domain/sakamichi/model/single/Senbatsu.kt
@@ -1,0 +1,83 @@
+package com.example.api.domain.sakamichi.model.single
+
+import com.example.api.domain.sakamichi.model.member.MemberId
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import org.jmolecules.ddd.annotation.ValueObject
+
+/**
+ * 選抜の 1 枠。どの立ち位置（[position]）に誰（[memberId]）が立つか。
+ *
+ * @property position 立ち位置
+ * @property memberId 立つメンバーのID
+ */
+@ValueObject data class SenbatsuSlot(val position: Position, val memberId: MemberId)
+
+/**
+ * 選抜編成（[Senbatsu.create]）の不変条件違反。
+ *
+ * 失敗のしかたが複数あるため sealed interface とし、`when` の網羅性で漏れを防ぐ。
+ */
+sealed interface SenbatsuError {
+    /**
+     * 同一メンバーが複数の立ち位置に重複して選ばれている。
+     *
+     * @property memberIds 重複して選ばれているメンバーのIDの集合
+     */
+    data class DuplicateMember(val memberIds: Set<MemberId>) : SenbatsuError
+
+    /**
+     * 同一の立ち位置に複数のメンバーが割り当てられている（1 つの立ち位置に立てるのは 1 人）。
+     *
+     * @property positions 定員を超えて割り当てられた立ち位置の集合
+     */
+    data class PositionOverCapacity(val positions: Set<Position>) : SenbatsuError
+
+    /** センターが不在（選抜にはセンターを必ず 1 人置く）。 */
+    data object CenterMissing : SenbatsuError
+}
+
+/**
+ * 選抜。シングル表題曲を歌う選ばれたメンバーの集合と、そのフォーメーション（立ち位置の割り当て）。
+ *
+ * 選抜はグループの恒久属性ではなくシングル単位の一時的編成であり（sakamichi-sources §4）、[Single] 集約が VO として内包する。メンバーは別集約のため
+ * [MemberId] 経由の ID 参照で保持する。不変条件（同一メンバーの 重複なし・立ち位置の定員 1 人・センター必須）は生成ファクトリ [create] が検証する（ADR-0014）。
+ *
+ * 「選抜対象メンバーが当該グループに在籍中であること」は既存の Member 集約群をまたぐ前提条件のため 本 VO では守らない（ドメインサービスへ封じ込める。#551）。
+ *
+ * @property slots 選抜の枠（立ち位置 × メンバー）の並び
+ */
+@ValueObject
+@ConsistentCopyVisibility
+data class Senbatsu private constructor(val slots: List<SenbatsuSlot>) {
+    /** センターに立つメンバーのID。 */
+    val center: MemberId
+        get() = slots.first { it.position == Position.Center }.memberId
+
+    /** 選抜されたメンバーのIDの集合。 */
+    val memberIds: Set<MemberId>
+        get() = slots.map { it.memberId }.toSet()
+
+    companion object {
+        /**
+         * 不変条件（同一メンバーの重複なし・立ち位置の定員 1 人・センター必須）を検証して [Senbatsu] を生成する。
+         *
+         * @param slots 選抜の枠（立ち位置 × メンバー）の並び
+         * @return 編成された [Senbatsu]、または不変条件違反を表す [SenbatsuError]
+         */
+        fun create(slots: List<SenbatsuSlot>): Result<Senbatsu, SenbatsuError> {
+            val duplicateMembers = slots.groupBy { it.memberId }.filterValues { it.size > 1 }.keys
+            val overCapacityPositions =
+                slots.groupBy { it.position }.filterValues { it.size > 1 }.keys
+            return when {
+                duplicateMembers.isNotEmpty() ->
+                    Err(SenbatsuError.DuplicateMember(duplicateMembers))
+                overCapacityPositions.isNotEmpty() ->
+                    Err(SenbatsuError.PositionOverCapacity(overCapacityPositions))
+                slots.none { it.position == Position.Center } -> Err(SenbatsuError.CenterMissing)
+                else -> Ok(Senbatsu(slots))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/example/api/domain/sakamichi/model/single/Single.kt
+++ b/src/main/kotlin/com/example/api/domain/sakamichi/model/single/Single.kt
@@ -1,0 +1,64 @@
+package com.example.api.domain.sakamichi.model.single
+
+import com.example.api.domain.sakamichi.model.group.GroupId
+import com.example.api.domain.shared.Entity
+import com.example.api.domain.shared.generateId
+import java.util.UUID
+import org.jmolecules.ddd.annotation.AggregateRoot
+import org.jmolecules.ddd.annotation.Identity
+import org.jmolecules.ddd.annotation.ValueObject
+
+/** シングルID */
+@ValueObject @JvmInline value class SingleId(val value: UUID)
+
+/**
+ * シングル（グループが発表する作品）を表す集約ルート。
+ *
+ * 選抜（[Senbatsu]）はグループの恒久属性ではなくシングル単位の一時的編成のため、本集約が VO として 内包する（sakamichi-sources
+ * §4）。発表元のグループは別集約のため [GroupId] 経由の ID 参照で保持する。
+ *
+ * 状態はイミュータブルに扱う（ADR-0009）。コンストラクタは private とし、生成は [create] に限る。
+ * 選抜の入れ替え（発表後の編成変更）等の状態遷移は今回スコープ外（必要になった時点でモデリングする）。
+ *
+ * @property id シングルID（生成時に自動採番）
+ * @property groupId 発表元グループのID
+ * @property number 作品番号（n 枚目。グループ内での連番）
+ * @property title 表題（表題曲の曲名）
+ * @property senbatsu 選抜（表題曲を歌う編成）
+ */
+@AggregateRoot
+class Single
+private constructor(
+    @field:Identity override val id: SingleId,
+    val groupId: GroupId,
+    val number: SingleNumber,
+    val title: SingleTitle,
+    val senbatsu: Senbatsu,
+) : Entity<SingleId>() {
+    companion object {
+        /**
+         * シングルを生成する。
+         *
+         * 検証済みの VO を受け取るため失敗せず、[Single] をそのまま返す。選抜の構造的不変条件は [Senbatsu.create]
+         * が、選抜対象メンバーの在籍検証はドメインサービス（#551）が担う。
+         *
+         * @param groupId 発表元グループのID
+         * @param number 作品番号（n 枚目）
+         * @param title 表題
+         * @param senbatsu 選抜
+         */
+        fun create(
+            groupId: GroupId,
+            number: SingleNumber,
+            title: SingleTitle,
+            senbatsu: Senbatsu,
+        ): Single =
+            Single(
+                id = SingleId(generateId()),
+                groupId = groupId,
+                number = number,
+                title = title,
+                senbatsu = senbatsu,
+            )
+    }
+}

--- a/src/main/kotlin/com/example/api/domain/sakamichi/model/single/SingleNumber.kt
+++ b/src/main/kotlin/com/example/api/domain/sakamichi/model/single/SingleNumber.kt
@@ -1,0 +1,27 @@
+package com.example.api.domain.sakamichi.model.single
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import org.jmolecules.ddd.annotation.ValueObject
+
+/** 作品番号が不変条件（1 以上）を満たさない。 */
+data object InvalidSingleNumber
+
+/**
+ * 作品番号（n 枚目）。1 以上の整数を不変条件とする。
+ *
+ * グループ内での連番であり、グループ横断で一意ではない（期生番号と同じ独立採番の考え方）。 「同一グループ内で作品番号が重複しない」は既存シングル群をまたぐ集合制約のため、本 VO では守らない
+ * （必要になった時点でドメインサービスへ切り出す。ADR-0022）。
+ *
+ * @property value 作品番号（1 以上）
+ */
+@ValueObject
+@JvmInline
+value class SingleNumber private constructor(val value: Int) {
+    companion object {
+        /** 1 以上であることを検証して [SingleNumber] を生成する。 */
+        fun create(value: Int): Result<SingleNumber, InvalidSingleNumber> =
+            if (value >= 1) Ok(SingleNumber(value)) else Err(InvalidSingleNumber)
+    }
+}

--- a/src/main/kotlin/com/example/api/domain/sakamichi/model/single/SingleTitle.kt
+++ b/src/main/kotlin/com/example/api/domain/sakamichi/model/single/SingleTitle.kt
@@ -1,0 +1,32 @@
+package com.example.api.domain.sakamichi.model.single
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import org.jmolecules.ddd.annotation.ValueObject
+
+/** シングル表題が不変条件（非ブランク・100 文字以内）を満たさない。 */
+data object InvalidSingleTitle
+
+/**
+ * シングル表題（表題曲の曲名。例: ぐるぐるカーテン）。非ブランク・100 文字以内を不変条件とする。
+ *
+ * @property value シングル表題
+ */
+@ValueObject
+@JvmInline
+value class SingleTitle private constructor(val value: String) {
+    companion object {
+        private const val MAX_LENGTH = 100
+
+        /** 非ブランク・100 文字以内であることを検証して [SingleTitle] を生成する。 */
+        fun create(value: String): Result<SingleTitle, InvalidSingleTitle> {
+            val trimmed = value.trim()
+            return if (trimmed.isNotEmpty() && trimmed.length <= MAX_LENGTH) {
+                Ok(SingleTitle(trimmed))
+            } else {
+                Err(InvalidSingleTitle)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/sakamichi/model/single/PositionTest.kt
+++ b/src/test/kotlin/com/example/api/domain/sakamichi/model/single/PositionTest.kt
@@ -1,0 +1,34 @@
+package com.example.api.domain.sakamichi.model.single
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import org.junit.jupiter.api.Test
+
+/** Position 値オブジェクトの不変条件（列・列内番号とも 1 以上）のユニットテスト。 */
+class PositionTest {
+    @Test
+    fun `列・列内番号とも1以上なら立ち位置を生成できる`() {
+        val spot = Position.Spot.create(row = 1, numberInRow = 2).unwrap()
+
+        assert(spot.row == 1)
+        assert(spot.numberInRow == 2)
+    }
+
+    @Test
+    fun `列が1未満なら InvalidPosition を返す`() {
+        assert(Position.Spot.create(row = 0, numberInRow = 1).getError() == InvalidPosition)
+    }
+
+    @Test
+    fun `列内番号が1未満なら InvalidPosition を返す`() {
+        assert(Position.Spot.create(row = 1, numberInRow = 0).getError() == InvalidPosition)
+    }
+
+    @Test
+    fun `同じ列・列内番号の立ち位置は等価である`() {
+        val a = Position.Spot.create(row = 2, numberInRow = 3).unwrap()
+        val b = Position.Spot.create(row = 2, numberInRow = 3).unwrap()
+
+        assert(a == b)
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/sakamichi/model/single/SenbatsuTest.kt
+++ b/src/test/kotlin/com/example/api/domain/sakamichi/model/single/SenbatsuTest.kt
@@ -1,0 +1,85 @@
+package com.example.api.domain.sakamichi.model.single
+
+import com.example.api.domain.sakamichi.model.member.MemberId
+import com.example.api.domain.shared.generateId
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import org.junit.jupiter.api.Test
+
+/** Senbatsu 値オブジェクトの不変条件（メンバー重複なし・立ち位置の定員 1 人・センター必須）のユニットテスト。 */
+class SenbatsuTest {
+    private fun memberId(): MemberId = MemberId(generateId())
+
+    private fun spot(row: Int, numberInRow: Int): Position.Spot =
+        Position.Spot.create(row = row, numberInRow = numberInRow).unwrap()
+
+    @Test
+    fun `センターを含む選抜を編成できる`() {
+        val centerMember = memberId()
+        val otherMember = memberId()
+        val slots =
+            listOf(
+                SenbatsuSlot(Position.Center, centerMember),
+                SenbatsuSlot(spot(row = 1, numberInRow = 1), otherMember),
+            )
+
+        val senbatsu = Senbatsu.create(slots).unwrap()
+
+        assert(senbatsu.slots == slots)
+        assert(senbatsu.center == centerMember)
+        assert(senbatsu.memberIds == setOf(centerMember, otherMember))
+    }
+
+    @Test
+    fun `センター1人のみの選抜も編成できる`() {
+        val centerMember = memberId()
+
+        val senbatsu = Senbatsu.create(listOf(SenbatsuSlot(Position.Center, centerMember))).unwrap()
+
+        assert(senbatsu.center == centerMember)
+        assert(senbatsu.memberIds == setOf(centerMember))
+    }
+
+    @Test
+    fun `同一メンバーが複数の立ち位置に選ばれていると DuplicateMember を返す`() {
+        val duplicated = memberId()
+        val slots =
+            listOf(
+                SenbatsuSlot(Position.Center, duplicated),
+                SenbatsuSlot(spot(row = 1, numberInRow = 1), duplicated),
+                SenbatsuSlot(spot(row = 1, numberInRow = 2), memberId()),
+            )
+
+        val error = Senbatsu.create(slots).getError()
+
+        assert(error == SenbatsuError.DuplicateMember(setOf(duplicated)))
+    }
+
+    @Test
+    fun `同一の立ち位置に複数メンバーが割り当てられていると PositionOverCapacity を返す`() {
+        val crowded = spot(row = 2, numberInRow = 1)
+        val slots =
+            listOf(
+                SenbatsuSlot(Position.Center, memberId()),
+                SenbatsuSlot(crowded, memberId()),
+                SenbatsuSlot(crowded, memberId()),
+            )
+
+        val error = Senbatsu.create(slots).getError()
+
+        assert(error == SenbatsuError.PositionOverCapacity(setOf(crowded)))
+    }
+
+    @Test
+    fun `センターが不在なら CenterMissing を返す`() {
+        val slots =
+            listOf(
+                SenbatsuSlot(spot(row = 1, numberInRow = 1), memberId()),
+                SenbatsuSlot(spot(row = 1, numberInRow = 2), memberId()),
+            )
+
+        val error = Senbatsu.create(slots).getError()
+
+        assert(error == SenbatsuError.CenterMissing)
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/sakamichi/model/single/SingleNumberTest.kt
+++ b/src/test/kotlin/com/example/api/domain/sakamichi/model/single/SingleNumberTest.kt
@@ -1,0 +1,20 @@
+package com.example.api.domain.sakamichi.model.single
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import org.junit.jupiter.api.Test
+
+/** SingleNumber 値オブジェクトの不変条件（1 以上）のユニットテスト。 */
+class SingleNumberTest {
+    @Test
+    fun `1以上なら生成できる`() {
+        assert(SingleNumber.create(1).unwrap().value == 1)
+        assert(SingleNumber.create(31).unwrap().value == 31)
+    }
+
+    @Test
+    fun `0以下は InvalidSingleNumber を返す`() {
+        assert(SingleNumber.create(0).getError() == InvalidSingleNumber)
+        assert(SingleNumber.create(-1).getError() == InvalidSingleNumber)
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/sakamichi/model/single/SingleTest.kt
+++ b/src/test/kotlin/com/example/api/domain/sakamichi/model/single/SingleTest.kt
@@ -1,0 +1,35 @@
+package com.example.api.domain.sakamichi.model.single
+
+import com.example.api.domain.sakamichi.model.group.Group
+import com.example.api.domain.sakamichi.model.group.GroupName
+import com.example.api.domain.sakamichi.model.member.MemberId
+import com.example.api.domain.shared.generateId
+import com.github.michaelbull.result.unwrap
+import org.junit.jupiter.api.Test
+
+/** Single 集約の生成のユニットテスト。 */
+class SingleTest {
+    private val group = Group.create(GroupName.create("乃木坂46").unwrap())
+    private val number = SingleNumber.create(1).unwrap()
+    private val title = SingleTitle.create("ぐるぐるカーテン").unwrap()
+    private val senbatsu =
+        Senbatsu.create(listOf(SenbatsuSlot(Position.Center, MemberId(generateId())))).unwrap()
+
+    private fun createSingle(): Single =
+        Single.create(groupId = group.id, number = number, title = title, senbatsu = senbatsu)
+
+    @Test
+    fun `生成するとグループ・作品番号・表題・選抜を保持する`() {
+        val single = createSingle()
+
+        assert(single.groupId == group.id)
+        assert(single.number == number)
+        assert(single.title == title)
+        assert(single.senbatsu == senbatsu)
+    }
+
+    @Test
+    fun `生成のたびに異なるIDが採番される`() {
+        assert(createSingle().id != createSingle().id)
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/sakamichi/model/single/SingleTitleTest.kt
+++ b/src/test/kotlin/com/example/api/domain/sakamichi/model/single/SingleTitleTest.kt
@@ -1,0 +1,37 @@
+package com.example.api.domain.sakamichi.model.single
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import org.junit.jupiter.api.Test
+
+/** SingleTitle 値オブジェクトの不変条件（非ブランク・100 文字以内）のユニットテスト。 */
+class SingleTitleTest {
+    @Test
+    fun `非ブランクなら生成でき trim される`() {
+        val title = SingleTitle.create("  ぐるぐるカーテン  ").unwrap()
+
+        assert(title.value == "ぐるぐるカーテン")
+    }
+
+    @Test
+    fun `上限の100文字は許可される`() {
+        val title = SingleTitle.create("あ".repeat(100)).unwrap()
+
+        assert(title.value.length == 100)
+    }
+
+    @Test
+    fun `101文字は長すぎて InvalidSingleTitle を返す`() {
+        assert(SingleTitle.create("あ".repeat(101)).getError() == InvalidSingleTitle)
+    }
+
+    @Test
+    fun `空文字は InvalidSingleTitle を返す`() {
+        assert(SingleTitle.create("").getError() == InvalidSingleTitle)
+    }
+
+    @Test
+    fun `空白のみは InvalidSingleTitle を返す`() {
+        assert(SingleTitle.create("   ").getError() == InvalidSingleTitle)
+    }
+}


### PR DESCRIPTION
Closes #550

## 概要

#364（段階 3）のシングルと選抜フォーメーションをモデル化する。`Single` を集約ルートとし、`Senbatsu`（選抜）/ `Position`（立ち位置）を VO として内包する。

## 変更内容

### ドメインモデル（`domain/sakamichi/model/single/`）

| ビルディングブロック | 役割 | 不変条件 |
| --- | --- | --- |
| `Single`（集約ルート） | グループが発表する作品。選抜を内包 | 検証済み VO を受けるため create は失敗しない（`Member` と同型） |
| `SingleNumber`（VO） | 作品番号（n 枚目） | 1 以上。グループごとに独立採番 |
| `SingleTitle`（VO） | 表題曲の曲名 | 非ブランク・100 文字以内 |
| `Senbatsu`（VO） | 表題曲を歌うメンバー集合とフォーメーション | 同一メンバーの重複なし・立ち位置の定員 1 人・センター必須（自己検証ファクトリ、ADR-0014） |
| `Position`（VO, sealed） | 立ち位置。`Center` / `Spot`（列 × 列内番号）の相互排他 | `Spot` は列・列内番号とも 1 以上 |
| `SenbatsuSlot`（VO） | 立ち位置 × メンバーの割り当て 1 件 | メンバーは `MemberId` の ID 参照 |

### 設計上のポイント

- 選抜は**グループの恒久属性ではなくシングル単位の一時的編成**（sakamichi-sources §4）として `Single` 集約に内包
- 「選抜対象メンバーが当該グループに在籍中であること」は集約またぎの前提条件のため**本 PR のスコープ外**（#551 のドメインサービスへ封じ込め）
- 「同一グループ内で作品番号が重複しない」は集合制約のため未モデル化（必要時に ADR-0022 の流儀で）

### ドキュメント

- ユビキタス言語集（手書き用語集 + 型レベルカタログ再生成）にシングル・選抜の用語を整備
- testing.md の Kover 除外一覧を build.gradle.kts と同期（#367 で昇格済みの `domain.sakamichi` の記載残りを解消、`dbdoc` の記載漏れを追記）

## テスト

TDD（RED→GREEN）で実装。`domain.sakamichi` は Kover mature ゲート対象（LINE 90% / BRANCH 80%）。

- 各 VO の不変条件（境界値含む）・`Senbatsu` の 3 不変条件違反・`Single` の生成を純粋ユニットテストで網羅（18 ケース）
- `./gradlew check` 通過（ktfmt / detekt / ArchUnit / koverVerifyMature 含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
