### PR TITLE
feat: 選抜編成ドメインサービスで在籍チェックを封じ込める(#551)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -78,7 +78,13 @@ domain/
 │   │   └── race/                #   Race, RaceResult, ...
 │   └── service/                 # ドメインサービスリング
 │       └── race/                #   confirmRaceResult
-├── sakamichi/model/
+├── sakamichi/                   # エンターテイメントコンテキスト（坂道シリーズ）
+│   ├── model/                   # ドメインモデルリング
+│   │   ├── group/               #   Group, GroupId, GroupName
+│   │   ├── member/              #   Member, Generation, Membership, ...
+│   │   └── single/              #   Single, Senbatsu, Position, ...
+│   └── service/                 # ドメインサービスリング
+│       └── single/              #   releaseSingle
 └── tennis/model/
 ```
 

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -139,8 +139,14 @@ JRA 管掌の騎手・競走を扱う。騎手免許は競馬法で JRA が管�
 | 立ち位置（`Position`） | フォーメーション上の位置。センター（`Center`）とそれ以外（`Spot`＝列 × 列内番号）の相互排他 | シングルごとに変わる。1 列目が最前列。センターと `Spot` の空間的重なりは未検証（探索段階の割り切り） |
 | 選抜の枠（`SenbatsuSlot`） | 立ち位置 × メンバーの割り当て 1 件 | メンバーは `MemberId` の ID 参照 |
 
+#### ドメインサービス（複数集約をまたぐ操作）
+
+| 用語（関数） | 和名 | 定義 |
+| --- | --- | --- |
+| releaseSingle | シングルを発売する | 選抜を編成してシングルを成立させる入口。集約をまたぐ前提条件「選抜対象メンバーが当該グループに在籍中（`Active`・所属一致）であること」を検証してから `Senbatsu.create` → `Single.create` へ橋渡しする（studbook の `registerFoal` 型）。 |
+
 **禁止語・注意**: 「選抜」をグループやメンバーの恒久属性として扱わない（シングル単位の一時的編成。⇔ アンダー＝非選抜、未モデル化）。
-「選抜対象メンバーが当該グループに在籍中であること」の検証は集約またぎのため `Senbatsu` では守らない（#551 のドメインサービスへ）。
+「選抜対象メンバーが当該グループに在籍中であること」の検証は集約またぎのため `Senbatsu` では守らない（`releaseSingle` が封じ込める）。
 「桜坂46」は誤記（正しくは旧字の「櫻坂46」）。
 
 ### tennis コンテキスト（スポーツ）
@@ -206,6 +212,7 @@ graph LR
 | SingleId | 値オブジェクト | domain.sakamichi.model.single |
 | SingleNumber | 値オブジェクト | domain.sakamichi.model.single |
 | SingleTitle | 値オブジェクト | domain.sakamichi.model.single |
+| releaseSingle | ドメインサービス | domain.sakamichi.service.single |
 
 ### studbook
 

--- a/src/main/kotlin/com/example/api/domain/sakamichi/service/single/ReleaseSingle.kt
+++ b/src/main/kotlin/com/example/api/domain/sakamichi/service/single/ReleaseSingle.kt
@@ -1,0 +1,89 @@
+package com.example.api.domain.sakamichi.service.single
+
+import com.example.api.domain.sakamichi.model.group.Group
+import com.example.api.domain.sakamichi.model.member.Member
+import com.example.api.domain.sakamichi.model.member.MemberId
+import com.example.api.domain.sakamichi.model.member.Membership
+import com.example.api.domain.sakamichi.model.single.Position
+import com.example.api.domain.sakamichi.model.single.Senbatsu
+import com.example.api.domain.sakamichi.model.single.SenbatsuError
+import com.example.api.domain.sakamichi.model.single.SenbatsuSlot
+import com.example.api.domain.sakamichi.model.single.Single
+import com.example.api.domain.sakamichi.model.single.SingleNumber
+import com.example.api.domain.sakamichi.model.single.SingleTitle
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
+import com.github.michaelbull.result.mapError
+
+/**
+ * シングルを発売し、選抜を編成する（[Single] を成立させる入口）。
+ *
+ * **集約をまたぐ前提条件「選抜対象メンバーが当該グループに在籍中であること」を封じ込める**（studbook の registerFoal 型。#364 段階 4）。この前提は
+ * [Member] 単体でも [Senbatsu] 単体でも守れないため、協力集約 （[group] と選抜対象の [Member]
+ * 群）を引数で受け取って検証し、[Senbatsu.create] → [Single.create] へ
+ * 橋渡しする。既存レコード集合への問い合わせは不要なのでリポジトリポートは受け取らない（ADR-0022 の例外に 該当しない）。
+ *
+ * 検証は (1) 全員が在籍中（[Membership.Active]）であること、(2) 全員の所属が [group] と一致すること、 (3)
+ * 選抜の構造的不変条件（[Senbatsu.create] へ委譲）の順で行い、違反したメンバーが複数いる場合は まとめて返す。検証済みメンバーの ID を [SenbatsuSlot]
+ * へ写すため、成立した選抜のメンバー参照は 必ず本検証を通過している。
+ *
+ * @param group 発売元のグループ（選抜対象メンバーの在籍先であること）
+ * @param number 作品番号（n 枚目）
+ * @param title 表題
+ * @param lineup 選抜の編成（立ち位置 × メンバーの並び）
+ * @return 成立した [Single]、または前提条件違反を表す [ReleaseSingleError]
+ */
+fun releaseSingle(
+    group: Group,
+    number: SingleNumber,
+    title: SingleTitle,
+    lineup: List<Pair<Position, Member>>,
+): Result<Single, ReleaseSingleError> {
+    val members = lineup.map { (_, member) -> member }
+    val notActive = members.filter { it.membership != Membership.Active }.map { it.id }.toSet()
+    val notInGroup = members.filter { it.groupId != group.id }.map { it.id }.toSet()
+    return when {
+        notActive.isNotEmpty() -> Err(ReleaseSingleError.MembersNotActive(notActive))
+        notInGroup.isNotEmpty() -> Err(ReleaseSingleError.MembersNotInGroup(notInGroup))
+        else ->
+            Senbatsu.create(lineup.map { (position, member) -> SenbatsuSlot(position, member.id) })
+                .mapError { ReleaseSingleError.InvalidSenbatsu(it) }
+                .map { senbatsu ->
+                    Single.create(
+                        groupId = group.id,
+                        number = number,
+                        title = title,
+                        senbatsu = senbatsu,
+                    )
+                }
+    }
+}
+
+/**
+ * シングル発売（選抜編成）の前提条件違反。
+ *
+ * 失敗のしかたが複数あるため sealed interface とし、`when` の網羅性で漏れを防ぐ。
+ */
+sealed interface ReleaseSingleError {
+    /**
+     * 選抜対象メンバーに在籍中でない（卒業済みの）メンバーが含まれている。
+     *
+     * @property memberIds 在籍中でないメンバーのIDの集合
+     */
+    data class MembersNotActive(val memberIds: Set<MemberId>) : ReleaseSingleError
+
+    /**
+     * 選抜対象メンバーに当該グループへ所属していないメンバーが含まれている。
+     *
+     * @property memberIds 所属が一致しないメンバーのIDの集合
+     */
+    data class MembersNotInGroup(val memberIds: Set<MemberId>) : ReleaseSingleError
+
+    /**
+     * 委譲先の選抜編成（[Senbatsu.create]）の不変条件違反を wrap したもの。
+     *
+     * 個別バリアント（メンバー重複・立ち位置の定員超過・センター不在）は [SenbatsuError] を参照する。
+     */
+    data class InvalidSenbatsu(val cause: SenbatsuError) : ReleaseSingleError
+}

--- a/src/test/kotlin/com/example/api/domain/sakamichi/service/single/ReleaseSingleTest.kt
+++ b/src/test/kotlin/com/example/api/domain/sakamichi/service/single/ReleaseSingleTest.kt
@@ -1,0 +1,108 @@
+package com.example.api.domain.sakamichi.service.single
+
+import com.example.api.domain.sakamichi.model.group.Group
+import com.example.api.domain.sakamichi.model.group.GroupName
+import com.example.api.domain.sakamichi.model.member.Generation
+import com.example.api.domain.sakamichi.model.member.Member
+import com.example.api.domain.sakamichi.model.member.MemberName
+import com.example.api.domain.sakamichi.model.single.Position
+import com.example.api.domain.sakamichi.model.single.SenbatsuError
+import com.example.api.domain.sakamichi.model.single.SingleNumber
+import com.example.api.domain.sakamichi.model.single.SingleTitle
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import java.time.LocalDate
+import org.junit.jupiter.api.Test
+
+/** 選抜編成ドメインサービス releaseSingle の在籍チェック（集約またぎの前提条件）のユニットテスト。 */
+class ReleaseSingleTest {
+    private val group = Group.create(GroupName.create("乃木坂46").unwrap())
+    private val otherGroup = Group.create(GroupName.create("櫻坂46").unwrap())
+    private val number = SingleNumber.create(1).unwrap()
+    private val title = SingleTitle.create("ぐるぐるカーテン").unwrap()
+
+    private fun activeMember(group: Group, familyName: String = "齋藤"): Member =
+        Member.create(
+            name = MemberName.create(familyName, "飛鳥").unwrap(),
+            groupId = group.id,
+            generation = Generation.create(1).unwrap(),
+            joinedOn = LocalDate.of(2011, 8, 21),
+        )
+
+    private fun graduatedMember(group: Group, familyName: String = "西野"): Member =
+        activeMember(group, familyName).graduate(LocalDate.of(2023, 5, 18)).unwrap()
+
+    private fun spot(row: Int, numberInRow: Int): Position.Spot =
+        Position.Spot.create(row = row, numberInRow = numberInRow).unwrap()
+
+    @Test
+    fun `在籍中メンバーのみなら選抜が編成されシングルが成立する`() {
+        val centerMember = activeMember(group, "齋藤")
+        val otherMember = activeMember(group, "白石")
+        val lineup =
+            listOf(Position.Center to centerMember, spot(row = 1, numberInRow = 1) to otherMember)
+
+        val single = releaseSingle(group, number, title, lineup).unwrap()
+
+        assert(single.groupId == group.id)
+        assert(single.number == number)
+        assert(single.title == title)
+        assert(single.senbatsu.center == centerMember.id)
+        assert(single.senbatsu.memberIds == setOf(centerMember.id, otherMember.id))
+    }
+
+    @Test
+    fun `卒業済みメンバーが混じると MembersNotActive を返す`() {
+        val graduated1 = graduatedMember(group, "西野")
+        val graduated2 = graduatedMember(group, "生駒")
+        val lineup =
+            listOf(
+                Position.Center to activeMember(group),
+                spot(row = 1, numberInRow = 1) to graduated1,
+                spot(row = 1, numberInRow = 2) to graduated2,
+            )
+
+        val error = releaseSingle(group, number, title, lineup).getError()
+
+        assert(error == ReleaseSingleError.MembersNotActive(setOf(graduated1.id, graduated2.id)))
+    }
+
+    @Test
+    fun `他グループ在籍のメンバーが混じると MembersNotInGroup を返す`() {
+        val foreign = activeMember(otherGroup, "森田")
+        val lineup =
+            listOf(
+                Position.Center to activeMember(group),
+                spot(row = 1, numberInRow = 1) to foreign,
+            )
+
+        val error = releaseSingle(group, number, title, lineup).getError()
+
+        assert(error == ReleaseSingleError.MembersNotInGroup(setOf(foreign.id)))
+    }
+
+    @Test
+    fun `センター不在は InvalidSenbatsu に包んで返す`() {
+        val lineup = listOf(spot(row = 1, numberInRow = 1) to activeMember(group))
+
+        val error = releaseSingle(group, number, title, lineup).getError()
+
+        assert(error == ReleaseSingleError.InvalidSenbatsu(SenbatsuError.CenterMissing))
+    }
+
+    @Test
+    fun `同一メンバーの重複も InvalidSenbatsu に包んで返す`() {
+        val duplicated = activeMember(group)
+        val lineup =
+            listOf(Position.Center to duplicated, spot(row = 1, numberInRow = 1) to duplicated)
+
+        val error = releaseSingle(group, number, title, lineup).getError()
+
+        assert(
+            error ==
+                ReleaseSingleError.InvalidSenbatsu(
+                    SenbatsuError.DuplicateMember(setOf(duplicated.id))
+                )
+        )
+    }
+}


### PR DESCRIPTION
Closes #551

## 概要

#364（段階 4）の選抜編成ドメインサービスを実装し、**集約をまたぐ前提条件「選抜対象メンバーが当該グループに在籍中であること」を封じ込める**（studbook の registerFoal 型）。前段は #550（PR #553）の `Single`/`Senbatsu`/`Position`。

## 変更内容

### ドメインサービス（`domain/sakamichi/service/single/ReleaseSingle.kt`）

トップレベル関数 `releaseSingle(group, number, title, lineup)`:

- 協力集約（`Group` + 選抜対象の `Member` 群）を**引数で受け取って**検証する。既存レコード集合への問い合わせは不要なため、リポジトリポートは受け取らない（ADR-0022 の例外に該当しない）
- 検証順: (1) 全員が在籍中（`Membership.Active`）→ (2) 全員の所属が `group` と一致 → (3) 構造的不変条件（`Senbatsu.create` へ委譲）
- 違反メンバーが複数いる場合は `Set<MemberId>` でまとめて返す（`MembersNotActive` / `MembersNotInGroup`）
- 委譲先の `SenbatsuError` は cause を保持する `InvalidSenbatsu` に wrap（sealed 変換元の規約どおり）
- 検証済みメンバーの ID を `SenbatsuSlot` へ写すため、成立した選抜のメンバー参照は必ず本検証を通過している

### ドキュメント

- ユビキタス言語集: sakamichi にドメインサービス小節（`releaseSingle`＝シングルを発売する）を追加、型レベルカタログ再生成
- architecture.md: パッケージ構造図へ sakamichi の model/service 分割を反映

## テスト

TDD（RED→GREEN）。ドメインサービスリングの流儀（純粋ユニット・Fixture・モックなし）で 5 ケース:

- 在籍中メンバーのみ → `Single` 成立（groupId・選抜内容の検証）
- 卒業済み複数 → `MembersNotActive`（違反 ID の集合）
- 他グループ在籍 → `MembersNotInGroup`
- センター不在／同一メンバー重複 → `InvalidSenbatsu` への wrap

`./gradlew check` 通過（ktfmt / detekt / ArchUnit / koverVerifyMature 含む）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
