### PR TITLE
feat: OpenAPI 仕様を vacuum で lint して CI でドキュメント品質をゲートする(#327)

### DIFF
--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -1,0 +1,72 @@
+# OpenAPI lint ワークフロー（#327 / ADR-0054）
+#
+# 目的: springdoc が生成する OpenAPI 仕様（build/openapi.json）を vacuum で lint し、
+# API ドキュメント品質（記述漏れ・命名の一貫性）のドリフトを CI で防ぐ。
+# 生成はアプリの forked bootRun を伴い、datasource は spring-boot-docker-compose が
+# compose.yaml の PostgreSQL を供給する（Docker は ubuntu-latest に同梱）。
+# 重い（アプリ起動を伴う）ため check / pre-commit には載せず、この独立ワークフローが唯一のゲート。
+
+name: OpenAPI Lint
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/main/**'
+      - 'config/vacuum/**'
+      - 'build.gradle.kts'
+      - 'gradle/**'
+      - 'compose.yaml'
+      - 'mise.toml'
+      - 'mise.lock'
+      - '.github/workflows/openapi-lint.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/main/**'
+      - 'config/vacuum/**'
+      - 'build.gradle.kts'
+      - 'gradle/**'
+      - 'compose.yaml'
+      - 'mise.toml'
+      - 'mise.lock'
+      - '.github/workflows/openapi-lint.yml'
+  workflow_dispatch:
+
+jobs:
+  openapi-lint:
+    runs-on: ubuntu-latest
+    name: vacuum lint
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        with:
+          java-version-file: '.java-version'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-provider: basic
+
+      - name: Install mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        env:
+          # CI 用オーバーレイ mise.ci.toml を読み込み、http backend ツール（kotlin-lsp/tfctl）を
+          # インストール対象から外す（除外理由は mise.ci.toml を参照）。
+          MISE_ENV: ci
+
+      - name: Verify vacuum
+        run: vacuum version
+
+      - name: Generate and lint OpenAPI spec
+        run: ./gradlew lintOpenApiDocs --stacktrace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,10 @@ mise exec -- shellcheck .claude/hooks/*.sh .claude/hooks/lib/*.sh .devcontainer/
 # DB スキーマドキュメント（tbls）の生成・検査
 ./gradlew generateDbDoc   # dbdoc/ を再生成（手動）
 ./gradlew checkDbDoc      # tbls diff（鮮度）+ tbls lint（コメント必須）を検査
+
+# OpenAPI 仕様の生成・lint（vacuum。CI 専用ゲート、ローカル実行には Docker が必要）
+./gradlew generateOpenApiDocs   # build/openapi.json を書き出す（forked bootRun + docker-compose）
+./gradlew lintOpenApiDocs       # 生成 + vacuum lint（ルールは config/vacuum/ruleset.yaml）
 ```
 
 ktfmt はフォーマッタ、detekt は静的解析ツール。detekt 設定は `config/detekt/detekt.yml`（`buildUponDefaultConfig = true` でデフォルトに上書き、雛形再生成は `./gradlew detektGenerateConfig`）、レポートは `build/reports/detekt/`。プロジェクト固有のカスタムルール（例: ドメイン / アプリケーション層で `throw` しない）は `:detekt-rules` モジュールで定義し `detektPlugins` で組み込む（詳細は `.claude/rules/architecture.md`）。
@@ -177,7 +181,7 @@ Issue の優先度は **GitHub Projects（`toy-box` = Project #4）の `Priority
 
 ### mise
 
-セットアップは `mise install`、確認は `mise list`（未導入なら [mise インストール手順](https://mise.jdx.dev/getting-started.html)）。管理ツール（詳細は `mise.toml`）: ビルド用 JDK（`java` Temurin 21）、lint / 解析（`actionlint` / `editorconfig-checker` / `shellcheck` / `sqlfluff` / `squawk` / `zizmor` / `gitleaks`）、DB スキーマドキュメント生成（`tbls`。採否は [ADR-0045](docs/adr/0045-tbls-db-schema-docs.md)）、Git フック（`lefthook`）、シークレット（`fnox`）、インフラ（`terraform` と HCP Terraform 操作 CLI の `tfctl`。tfctl の採否は [ADR-0034](docs/adr/0034-adopt-tfctl-cli.md)）、コードインテリジェンス（`kotlin-lsp`＝Claude Code の Kotlin LSP プラグインが要求する JetBrains 公式 Language Server。採否と供給方法は [ADR-0046](docs/adr/0046-adopt-kotlin-lsp-plugin.md)）。
+セットアップは `mise install`、確認は `mise list`（未導入なら [mise インストール手順](https://mise.jdx.dev/getting-started.html)）。管理ツール（詳細は `mise.toml`）: ビルド用 JDK（`java` Temurin 21）、lint / 解析（`actionlint` / `editorconfig-checker` / `shellcheck` / `sqlfluff` / `squawk` / `vacuum`＝OpenAPI lint / `zizmor` / `gitleaks`）、DB スキーマドキュメント生成（`tbls`。採否は [ADR-0045](docs/adr/0045-tbls-db-schema-docs.md)）、Git フック（`lefthook`）、シークレット（`fnox`）、インフラ（`terraform` と HCP Terraform 操作 CLI の `tfctl`。tfctl の採否は [ADR-0034](docs/adr/0034-adopt-tfctl-cli.md)）、コードインテリジェンス（`kotlin-lsp`＝Claude Code の Kotlin LSP プラグインが要求する JetBrains 公式 Language Server。採否と供給方法は [ADR-0046](docs/adr/0046-adopt-kotlin-lsp-plugin.md)）。
 
 **Java バージョン管理について**: JDK のバージョン要件は `build.gradle.kts` の Gradle toolchain で宣言（`languageVersion = 21`）。実体の JDK は mise が提供し、Gradle の toolchain auto-detection が `JAVA_HOME` / `PATH` 経由で検出する。
 
@@ -209,6 +213,8 @@ LEFTHOOK_EXCLUDE=ktfmt-check git commit -m "メッセージ"   # 特定コマン
 ## OpenAPI/Swagger
 
 `springdoc-openapi` で API ドキュメントを自動生成する（Swagger UI: `/swagger-ui.html`、OpenAPI JSON: `/v3/api-docs`）。コントローラーのメソッドに `@Operation` / `@ApiResponse` / `@Content` 等を付与してドキュメント化し、全体定義 `@OpenAPIDefinition`（タイトル・タグ等）は `ApiApplication.kt` に置く。
+
+仕様の品質（summary 記述漏れ・operationId 命名等）は vacuum による lint で CI ゲートする（`openapi-lint.yml`、ルールは `config/vacuum/ruleset.yaml`、意図的な除外は `config/vacuum/ignore.yaml`。採否は [ADR-0054](docs/adr/0054-vacuum-openapi-lint.md)）。`OpenApiTest` は配線スモークとして残す。
 
 ## Spring Boot Actuator
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -324,6 +324,38 @@ openApi {
     }
 }
 
+// vacuum は mise(aqua backend) 管理で素の PATH に乗らないため、tbls（tblsBin）と同じ流儀で
+// `mise which vacuum` により絶対パスを解決する（タスク実現時に評価され、不要なタスクでは走らない）。
+val vacuumBin =
+    providers
+        .exec { commandLine("mise", "which", "vacuum") }
+        .standardOutput
+        .asText
+        .map(String::trim)
+
+// 生成済みの OpenAPI 仕様を vacuum で lint する。生成（アプリ起動・Docker 依存）が重いため
+// check / pre-push には載せず、CI の独立ワークフロー（openapi-lint.yml）専用とする
+// （checkDbDoc / e2eTest と同じ扱い。ADR-0054）。
+tasks.register<Exec>("lintOpenApiDocs") {
+    description = "OpenAPI 仕様を生成し vacuum で lint する（CI 専用。check には載せない）"
+    group = "verification"
+    dependsOn("generateOpenApiDocs")
+    workingDir = layout.projectDirectory.asFile
+    commandLine(
+        vacuumBin.get(),
+        "lint",
+        "--ruleset",
+        "config/vacuum/ruleset.yaml",
+        "--ignore-file",
+        "config/vacuum/ignore.yaml",
+        "--fail-severity",
+        "warn",
+        "--details",
+        "--no-banner",
+        "build/openapi.json",
+    )
+}
+
 // springdoc-openapi-gradle-plugin（gradle-execfork-plugin 経由）は Task を直接プロパティとして
 // 保持するため Configuration Cache と非互換（org.gradle.api.Task はシリアライズ不可）。
 // org.gradle.configuration-cache.problems=fail のもとでは通常のビルドが丸ごと失敗するため、

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -303,3 +303,35 @@ tasks.register<JavaExec>("checkDbDoc") {
     systemProperty("tbls.bin", tblsBin.get())
     args("check")
 }
+
+// --- OpenAPI 仕様の書き出しと lint（#327） ---
+// generateOpenApiDocs はアプリを forked bootRun でバックグラウンド起動し、/v3/api-docs を
+// build/openapi.json へ書き出す（出力先・ファイル名はプラグインのデフォルト）。datasource は
+// ローカル bootRun と同じく spring-boot-docker-compose が compose.yaml の PostgreSQL を
+// 自動供給する（Docker が必要）。生成物は build 成果物でありコミットしない（ADR-0054）。
+// ローカル開発中のアプリ（8080）と衝突しないよう forked 起動は専用ポート 8090 を使う。
+openApi {
+    apiDocsUrl.set("http://localhost:8090/v3/api-docs")
+    // CI のコールドスタート（PostgreSQL イメージ pull + Flyway 適用 + アプリ起動）を見込んで
+    // デフォルト 30 秒から延長する。
+    waitTimeInSeconds.set(120)
+    customBootRun {
+        args.set(listOf("--server.port=8090"))
+        // forked プロセスの既定 workingDir（build/tmp/forkedSpringBootRun）には compose.yaml が無く、
+        // spring-boot-docker-compose がそこを探して見つからず起動失敗する。プロジェクトルートを指定して
+        // ローカル bootRun と同じく compose.yaml を発見できるようにする。
+        workingDir.set(layout.projectDirectory)
+    }
+}
+
+// springdoc-openapi-gradle-plugin（gradle-execfork-plugin 経由）は Task を直接プロパティとして
+// 保持するため Configuration Cache と非互換（org.gradle.api.Task はシリアライズ不可）。
+// org.gradle.configuration-cache.problems=fail のもとでは通常のビルドが丸ごと失敗するため、
+// 関連タスクを個別に非対応と宣言し、これらのタスクだけ CC を使わず実行させる。
+listOf("forkedSpringBootRun", "generateOpenApiDocs", "forkedSpringBootStop").forEach { taskName ->
+    tasks.named(taskName) {
+        notCompatibleWithConfigurationCache(
+            "springdoc-openapi-gradle-plugin(gradle-execfork-plugin) が Task を直接保持し CC 非対応のため"
+        )
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -348,6 +348,7 @@ tasks.register<Exec>("lintOpenApiDocs") {
         "config/vacuum/ruleset.yaml",
         "--ignore-file",
         "config/vacuum/ignore.yaml",
+        "--ignore-polymorph-circle-ref",
         "--fail-severity",
         "warn",
         "--details",

--- a/config/vacuum/ignore.yaml
+++ b/config/vacuum/ignore.yaml
@@ -9,12 +9,7 @@ component-description:
   # springdoc.show-actuator による自動公開エンドポイント（/actuator）のレスポンススキーマで、
   # Spring Boot Actuator の Link 型から自動生成される。actuator 由来でありコードで直せない。
   - $.components.schemas['Link']
-circular-references:
-  # 相互排他な属性集合を discriminated union（oneOf + discriminatorProperty）で表す設計
-  # （ADR-0020）を springdoc が allOf でコード生成すると、親 interface がバリアントを oneOf
-  # で参照し、バリアントが allOf で親を参照し返すため $ref グラフ上は循環に見える。
-  # 実際には無限再帰ではなく discriminated union の定型パターンであり、oneOf 設計を
-  # 放棄しない限り解消できないため無視する（vacuum generate-ignorefile が出す
-  # 循環の実際の連鎖をそのまま使う）。
-  - RecordHorseInspectionRequest -> ParentageDeterminationDto -> ByDna -> ParentageDeterminationDto
-  - BloodHorseResponse -> OriginDto -> Domestic -> OriginDto
+# circular-references（discriminated union の oneOf + allOf に由来する polymorphic circular
+# reference。ADR-0020）は経路文字列のハードコードではなく、`lintOpenApiDocs` タスクの
+# `vacuum lint --ignore-polymorph-circle-ref` フラグでカテゴリごと無視する。
+# sealed バリアントの追加・変更で経路がずれても壊れない構造的な抑制のため、ここには置かない。

--- a/config/vacuum/ignore.yaml
+++ b/config/vacuum/ignore.yaml
@@ -1,0 +1,20 @@
+# 意図的に無視する lint 指摘の明示（#327 / ADR-0054）。
+component-description:
+  # springdoc-openapi は @Content の Schema(implementation = ProblemDetail::class) から
+  # org.springframework.http.ProblemDetail のフィールドを直接リフレクションしてコンポーネントを
+  # 生成する。Spring Framework 本体のクラスであり、@Schema(description = ...) を型定義に
+  # 付与できない（呼び出し側の @Schema に description を添えても生成される共有コンポーネントへは
+  # 反映されないことを実機で確認済み）。
+  - $.components.schemas['ProblemDetail']
+  # springdoc.show-actuator による自動公開エンドポイント（/actuator）のレスポンススキーマで、
+  # Spring Boot Actuator の Link 型から自動生成される。actuator 由来でありコードで直せない。
+  - $.components.schemas['Link']
+circular-references:
+  # 相互排他な属性集合を discriminated union（oneOf + discriminatorProperty）で表す設計
+  # （ADR-0020）を springdoc が allOf でコード生成すると、親 interface がバリアントを oneOf
+  # で参照し、バリアントが allOf で親を参照し返すため $ref グラフ上は循環に見える。
+  # 実際には無限再帰ではなく discriminated union の定型パターンであり、oneOf 設計を
+  # 放棄しない限り解消できないため無視する（vacuum generate-ignorefile が出す
+  # 循環の実際の連鎖をそのまま使う）。
+  - RecordHorseInspectionRequest -> ParentageDeterminationDto -> ByDna -> ParentageDeterminationDto
+  - BloodHorseResponse -> OriginDto -> Domestic -> OriginDto

--- a/config/vacuum/ruleset.yaml
+++ b/config/vacuum/ruleset.yaml
@@ -43,4 +43,6 @@ rules:
   # 上記と同じ oneOf + allOf のポリモーフィズム表現で、親 interface（例: OriginDto）が oneOf で
   # バリアント（例: Domestic）を参照し、バリアントが allOf で親を参照し返すため $ref グラフ上は
   # 循環に見える（無限再帰ではなく discriminated union の定型パターン。ADR-0020）。個別の循環経路
-  # を `config/vacuum/ignore.yaml` の circular-references で無視する。
+  # 文字列をハードコードすると sealed バリアントの追加・変更で経路がずれ壊れるため、`vacuum lint`
+  # の CLI フラグ `--ignore-polymorph-circle-ref`（`lintOpenApiDocs` タスクに設定済み）で
+  # polymorphic circular reference カテゴリごと無視する。

--- a/config/vacuum/ruleset.yaml
+++ b/config/vacuum/ruleset.yaml
@@ -1,0 +1,46 @@
+# OpenAPI 仕様の lint ルール（vacuum、Spectral 互換形式。#327 / ADR-0054）
+# ベースは vacuum 同梱の recommended ルールセット。固有ルールは実効の高いものだけを
+# 少数追加する（ProblemDetail スキーマ参照の強制など凝ったルールは後続 Issue へ）。
+extends: [[spectral:oas, recommended]]
+rules:
+  # @Operation の summary 付け忘れを検出する（組み込みルールは operation-description のみ）
+  operation-summary:
+    description: 全ての operation に summary を記述する
+    given: $.paths[*][get,put,post,delete,options,head,patch,trace]
+    severity: error
+    then:
+      field: summary
+      function: truthy
+  # operationId は camelCase（springdoc がハンドラメソッド名から生成するため通常は満たされる。
+  # @Operation(operationId = ...) の手動指定によるドリフトを検出する）
+  operation-operationId-camel-case:
+    description: operationId は camelCase で命名する
+    given: $.paths[*][get,put,post,delete,options,head,patch,trace].operationId
+    severity: error
+    then:
+      function: pattern
+      functionOptions:
+        match: "^[a-z][a-zA-Z0-9]*$"
+  # --- recommended ルールのうち、本プロジェクトに合わないため無効化するもの（#327 判断ルール 3） ---
+  # URL コレクション識別子の casing は AIP-122 に従い camelCase を正式採用している
+  # （.claude/rules/api-design.md、ADR-0012）。kebab-case を要求する recommended ルールは
+  # この設計判断と正面から矛盾し、全 11 件が /api/horseInspections 等の複数語コレクション名に
+  # 横断的にかかる。是正は実際の URL（@GetMapping/@PostMapping）変更＝API 契約の破壊的変更を
+  # 要し、OpenAPI ドキュメント注釈の補強という本 Issue のスコープを超えるため無効化する。
+  paths-kebab-case: false
+  # 生成される OpenAPI 仕様のほぼ全プロパティ・メディアタイプに example を要求するルール
+  # （73 件、違反の最大母数）。値の性質上 example は恣意的にならざるを得ず、探索的な
+  # sandbox API のドキュメントとして全フィールドに手作業で追加する投資対効果が低いため無効化する。
+  oas3-missing-example: false
+  # 相互排他な属性集合を discriminated union（oneOf + discriminatorProperty）で表す設計
+  # （ADR-0020）を springdoc が allOf でコード生成する際、追加フィールドを持たないバリアント
+  # （例: ParentageDeterminationDto.ByBloodType）は `allOf: [$ref]` という単一要素になる。
+  # これは springdoc のポリモーフィズム表現の副産物であり、oneOf 設計を放棄しない限り解消できない
+  # ため無効化する。
+  no-unnecessary-combinator: false
+  # circular-references は Spectral 互換の `rules:` では無効化できない vacuum 組み込みの構造
+  # チェックのため、ここでの `false` 指定は効かない（実行時のルール数に変化がないことで確認済み）。
+  # 上記と同じ oneOf + allOf のポリモーフィズム表現で、親 interface（例: OriginDto）が oneOf で
+  # バリアント（例: Domestic）を参照し、バリアントが allOf で親を参照し返すため $ref グラフ上は
+  # 循環に見える（無限再帰ではなく discriminated union の定型パターン。ADR-0020）。個別の循環経路
+  # を `config/vacuum/ignore.yaml` の circular-references で無視する。

--- a/docs/adr/0054-vacuum-openapi-lint.md
+++ b/docs/adr/0054-vacuum-openapi-lint.md
@@ -1,0 +1,73 @@
+# 0054. OpenAPI 仕様の lint に vacuum を採用し CI でドキュメント品質をゲートする
+
+- Status: Accepted
+- Date: 2026-07-06
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+Issue #327。OpenAPI ドキュメントは springdoc-openapi によるランタイム生成（`/v3/api-docs`）で、
+仕様の検証は `OpenApiTest`（@SpringBootTest）のスモーク（取得可否・バージョン・タイトル）に留まっていた。
+コントローラーには `@Operation` / `@ApiResponse` を付与する方針（CLAUDE.md「OpenAPI/Swagger」）だが、
+付け忘れ・記述の薄さを検出する仕組みがなく、仕様そのものの品質（記述漏れ・命名の一貫性）を
+機械的にゲートしたい。
+
+### 検討した要素
+
+- **linter の選定**: Spectral（Node、デファクト、JS/TS カスタム関数）/ vacuum（Go 単一バイナリ、
+  Spectral ルールセット完全互換、高速）/ Redocly CLI（Node、lint + bundle + docs preview 同梱）を比較した。
+  - ルールセットはいずれも実質 Spectral 形式の YAML で、`extends` + 個別ルール追加の構成も同じ。
+    vacuum は Spectral ルールセットを完全互換で読めるため、**採用後の乗り換えコストが低い**（ルール資産は持ち越し可能）。
+  - ツールバージョンの単一の出所を mise.toml とする方針（CLAUDE.md「ツール管理」）に対し、
+    vacuum は aqua backend の単一バイナリで最も素直に管理できる（tbls / shellcheck / trivy と同じ供給経路）。
+    Spectral も aqua 管理可能だが Node ベース、Redocly は npm backend が要る。
+  - 固有ルールの表現力: 初期スコープ（summary 必須化・operationId 命名）は YAML の組み込み関数
+    （truthy / pattern）で書ける。JS/TS カスタム関数が要る凝ったルール（例: error レスポンスに
+    ProblemDetail スキーマ参照を強制）は現時点で不要（YAGNI）。
+  - OpenAPI 3.1 対応（springdoc の生成は 3.1.0）は 3 候補とも満たす。2026-07 時点で 3 候補とも活発にメンテされている。
+- **仕様ファイルの生成方法**: alias 済みの springdoc-openapi-gradle-plugin（`generateOpenApiDocs` が
+  forked bootRun でアプリを起動し `/v3/api-docs` を書き出す）を使う。datasource はローカル bootRun と
+  同じく spring-boot-docker-compose が compose.yaml の PostgreSQL を自動供給する。
+  代替として dbdoc（tbls）型の「専用ソースセット + Testcontainers」自前ジェネレータも検討した。
+  前例と一貫するがコード量が増えるため、まずプラグインを使い、CI で不安定な場合のフォールバックとする
+  （lint 側は生成方法に依存しないため差し替え可能）。
+- **仕様ファイルの扱い**: リポジトリにコミットして dbdoc 型の鮮度検査（diff）を掛ける案もあるが、
+  生成・コミットの手間が毎回かかる。build 成果物のみ（コミットしない）とし、API 差分レビューは
+  コード差分で代替する。
+- **ゲートの場所**: 生成にアプリ起動（Docker + PostgreSQL）が要るため、check / pre-commit / pre-push には
+  載せない（checkDbDoc / e2eTest と同じ役割分担）。関心ごとに独立ワークフローを並べる既存の流儀に従い、
+  api-tests.yml への相乗りではなく独立ワークフローとする。
+
+## Decision（決定）
+
+### ツール採用
+
+**vacuum を採用し、springdoc が生成する OpenAPI 仕様を CI で lint する**（mise 管理）。
+
+- `./gradlew generateOpenApiDocs`: forked bootRun でアプリを起動し `build/openapi.json` を書き出す
+  （build 成果物。コミットしない）。
+- `./gradlew lintOpenApiDocs`: 生成に依存し、vacuum（`mise which` で解決）で lint する。
+  失敗閾値は `--fail-severity warn`。
+
+### ルールセット
+
+**`config/vacuum/ruleset.yaml`**（detekt の config/detekt/ と対称）に置き、vacuum 同梱の
+**recommended をベース**に固有ルールを少数追加する（operation の summary 必須化・operationId の
+camelCase 命名）。意図的に無視する指摘（/actuator/** 等のコードで直せないもの）は
+`config/vacuum/ignore.yaml` で明示する。
+
+### 実行タイミング
+
+**CI の独立ワークフロー `openapi-lint.yml` のみ**でゲートする（PR / main push、paths フィルタ付き）。
+check / lefthook には載せない。既存の `OpenApiTest` は配線スモークとして残し、仕様の品質ゲートは
+vacuum 側が担う役割分担とする。
+
+## Consequences（結果・影響）
+
+- `@Operation` の summary 付け忘れ等が CI で機械的に検出される。導入時に既存指摘は全て解消済みのため、
+  以降はドリフト検出として機能する。
+- ルール資産は Spectral 互換形式なので、JS/TS カスタム関数が必要になったら Spectral へ低コストで
+  乗り換えられる（ProblemDetail スキーマ参照の強制などの高度なルールは後続 Issue）。
+- ローカルで `lintOpenApiDocs` を実行するには Docker が必要（CI 専用ゲートのためローカル実行は任意）。
+- 開発用アプリと compose サービスを起動したまま `generateOpenApiDocs` を実行すると compose サービスを
+  共有し、生成完了時に停止されうる（既知の挙動。ポートは 8090 に分離済みでアプリ同士は衝突しない）。

--- a/docs/adr/0054-vacuum-openapi-lint.md
+++ b/docs/adr/0054-vacuum-openapi-lint.md
@@ -71,3 +71,11 @@ vacuum 側が担う役割分担とする。
 - ローカルで `lintOpenApiDocs` を実行するには Docker が必要（CI 専用ゲートのためローカル実行は任意）。
 - 開発用アプリと compose サービスを起動したまま `generateOpenApiDocs` を実行すると compose サービスを
   共有し、生成完了時に停止されうる（既知の挙動。ポートは 8090 に分離済みでアプリ同士は衝突しない）。
+- vacuum 組み込みの circular-references チェック（ポリモーフィック循環参照）は `ruleset.yaml` の `rules:`
+  では無効化できないため、`lintOpenApiDocs` に `--ignore-polymorph-circle-ref` フラグを設定してカテゴリ
+  ごと無視する。当初は `ignore.yaml` に参照チェーン文字列をハードコードしていたが、sealed バリアント
+  （判別共用体の追加）で連鎖がずれると壊れるためフラグ方式へ切り替えた。この循環参照は
+  sealed Origin + discriminated 部分オブジェクトの設計（[ADR-0020](0020-sealed-origin-and-discriminated-origin-subobject.md)）
+  に由来するもので、`config/vacuum/ruleset.yaml` / `config/vacuum/ignore.yaml` のコメントも同 ADR を参照している。
+- **関連 ADR**: [ADR-0020](0020-sealed-origin-and-discriminated-origin-subobject.md)（sealed Origin +
+  discriminated 部分オブジェクト。本 ADR の循環参照 ignore/ルール判断の起源）。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -62,3 +62,4 @@
 | [0051](0051-transactional-use-case-boundary.md) | トランザクション境界は application 層ユースケースの宣言的 @Transactional で置く | Accepted |
 | [0052](0052-validate-constraint-in-separate-migration.md) | VALIDATE CONSTRAINT は後続の別マイグレーションへ分離する | Accepted |
 | [0053](0053-foreign-key-backstop-across-aggregates.md) | 集約間の ID 参照に外部キー制約を backstop として張る | Accepted |
+| [0054](0054-vacuum-openapi-lint.md) | OpenAPI 仕様の lint に vacuum を採用し CI でドキュメント品質をゲートする | Accepted |

--- a/mise.lock
+++ b/mise.lock
@@ -491,6 +491,38 @@ checksum = "sha256:af9573a2e36f7020b18ec5fdde20117aae74bbad3f4acb3dc3fc03319f1aa
 url = "https://github.com/astral-sh/uv/releases/download/0.11.24/uv-x86_64-pc-windows-msvc.zip"
 provenance = "github-attestations"
 
+[[tools.vacuum]]
+version = "0.29.9"
+backend = "aqua:daveshanley/vacuum"
+
+[tools.vacuum."platforms.linux-arm64"]
+checksum = "sha256:058c377bb837faf24a940b41c15be8775f2c4770df910a71dc608fdd96c93c1b"
+url = "https://github.com/daveshanley/vacuum/releases/download/v0.29.9/vacuum_0.29.9_linux_arm64.tar.gz"
+
+[tools.vacuum."platforms.linux-arm64-musl"]
+checksum = "sha256:058c377bb837faf24a940b41c15be8775f2c4770df910a71dc608fdd96c93c1b"
+url = "https://github.com/daveshanley/vacuum/releases/download/v0.29.9/vacuum_0.29.9_linux_arm64.tar.gz"
+
+[tools.vacuum."platforms.linux-x64"]
+checksum = "sha256:d1b9618493a12a30390719b0af88bfc57a8c2074d900134983cd358c1f38b8b9"
+url = "https://github.com/daveshanley/vacuum/releases/download/v0.29.9/vacuum_0.29.9_linux_x86_64.tar.gz"
+
+[tools.vacuum."platforms.linux-x64-musl"]
+checksum = "sha256:d1b9618493a12a30390719b0af88bfc57a8c2074d900134983cd358c1f38b8b9"
+url = "https://github.com/daveshanley/vacuum/releases/download/v0.29.9/vacuum_0.29.9_linux_x86_64.tar.gz"
+
+[tools.vacuum."platforms.macos-arm64"]
+checksum = "sha256:0af9b2ead9a0e86254a9d232199825cd73e73599b837bf4e8832b1063168e6a0"
+url = "https://github.com/daveshanley/vacuum/releases/download/v0.29.9/vacuum_0.29.9_darwin_arm64.tar.gz"
+
+[tools.vacuum."platforms.macos-x64"]
+checksum = "sha256:6ce6908d5ed88b45c6afe51c11f2d17f457baf2974114969ce078a7e389f91e4"
+url = "https://github.com/daveshanley/vacuum/releases/download/v0.29.9/vacuum_0.29.9_darwin_x86_64.tar.gz"
+
+[tools.vacuum."platforms.windows-x64"]
+checksum = "sha256:dd3378bc97a6e2e9296765e8853695f04cc75b980969bbff16de0f80ec0b4a2b"
+url = "https://github.com/daveshanley/vacuum/releases/download/v0.29.9/vacuum_0.29.9_windows_x86_64.tar.gz"
+
 [[tools.zizmor]]
 version = "1.26.1"
 backend = "aqua:zizmorcore/zizmor"

--- a/mise.toml
+++ b/mise.toml
@@ -16,6 +16,7 @@ terraform = "1.15.6"
 tflint = "0.63.1"
 "aqua:aquasecurity/trivy" = "0.71.2"
 uv = "0.11.24"
+vacuum = "0.29.9"
 zizmor = "1.26.1"
 
 # tfctl: HCP Terraform / TFE 管理 CLI（run / variable / workspace 操作）。採否は ADR-0034 参照。

--- a/src/main/kotlin/com/example/api/ApiApplication.kt
+++ b/src/main/kotlin/com/example/api/ApiApplication.kt
@@ -8,8 +8,23 @@ import org.springframework.boot.runApplication
 
 @SpringBootApplication
 @OpenAPIDefinition(
-    info = Info(title = "toy-box", summary = "toy-box の API 定義です。"),
-    tags = [Tag(name = "Hello", description = "サンプル")],
+    info =
+        Info(
+            title = "toy-box",
+            summary = "toy-box の API 定義です。",
+            description = "複数のドメインモデル（軽種馬登録・競馬・エンターテイメント・テニス）を探索する sandbox API です。",
+            version = "1.0",
+        ),
+    tags =
+        [
+            Tag(name = "Hello", description = "サンプル"),
+            Tag(name = "Jockey", description = "騎手リソース（JRA: 騎手の登録・取得）"),
+            Tag(name = "BloodHorse", description = "軽種馬リソース（JAIRS: 血統登録・馬名登録）"),
+            Tag(name = "HorseInspection", description = "審査リソース（JAIRS: 個体識別・親子判定の記録・取得）"),
+            Tag(name = "BreedingRegistration", description = "繁殖登録リソース（JAIRS: 繁殖の用に供するための登録）"),
+            Tag(name = "BreedingResult", description = "繁殖成績リソース（JAIRS: 種付・分娩結果・成績報告・年次集計）"),
+            Tag(name = "CoveringReport", description = "種付成績報告リソース（JAIRS: 様式第13号の年次提出）"),
+        ],
 )
 class ApiApplication
 

--- a/src/main/kotlin/com/example/api/controller/HelloController.kt
+++ b/src/main/kotlin/com/example/api/controller/HelloController.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class HelloController {
-    data class HelloResponse(val message: String)
+    @Schema(description = "Hello World エンドポイントのレスポンス") data class HelloResponse(val message: String)
 
     @Operation(
         summary = "Hello World エンドポイント",

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationController.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationController.kt
@@ -10,6 +10,7 @@ import com.github.michaelbull.result.mapError
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody as OperationRequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Clock
 import org.springframework.http.HttpStatus
@@ -33,6 +34,7 @@ class BreedingRegistrationController(
     private val clock: Clock,
 ) {
     @Operation(
+        operationId = "registerBreedingRegistration",
         summary = "繁殖登録を成立させる",
         description =
             "血統登録済みの個体を繁殖の用に供するための繁殖登録を成立させ、成立した繁殖登録リソースを返す。" +
@@ -79,7 +81,9 @@ class BreedingRegistrationController(
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/breedingRegistrations")
     fun register(
-        @RequestBody request: RegisterBreedingRegistrationRequest
+        @OperationRequestBody(description = "成立させる繁殖登録（対象個体・繁殖登録番号）")
+        @RequestBody
+        request: RegisterBreedingRegistrationRequest
     ): BreedingRegistrationResponse =
         registerBreedingRegistration(Command.now(request.toCommand(), clock))
             .mapError { it.toProblemDetail() }

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationResponse.kt
@@ -2,6 +2,7 @@ package com.example.api.controller.breeding
 
 import com.example.api.domain.studbook.model.breeding.BreedingRegistration
 import com.example.api.domain.studbook.model.breeding.BreedingRetirement
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.util.UUID
 
@@ -19,6 +20,7 @@ import java.util.UUID
  * @property role 繁殖登録によって付与されたロール（種牡馬／繁殖牝馬）
  * @property retirement 供用停止。供用中なら null、供用停止済みなら事由と発生日を持つ
  */
+@Schema(description = "繁殖登録リソースの表現")
 data class BreedingRegistrationResponse(
     val id: UUID,
     val registrationNumber: String,
@@ -33,6 +35,7 @@ data class BreedingRegistrationResponse(
  * @property reason 供用停止の事由
  * @property occurredOn 事由が発生した日
  */
+@Schema(description = "繁殖供用停止の表現")
 data class BreedingRetirementResponse(val reason: RetirementReasonDto, val occurredOn: LocalDate)
 
 /** [BreedingRegistration] を繁殖登録リソースの表現へ変換する。各操作の成功レスポンスはこのリソース表現を一律で返す。 */

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultController.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultController.kt
@@ -16,8 +16,10 @@ import com.example.api.controller.orThrowProblem
 import com.example.api.domain.shared.Command
 import com.github.michaelbull.result.mapError
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody as OperationRequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Clock
 import java.util.UUID
@@ -47,6 +49,7 @@ class BreedingResultController(
     private val clock: Clock,
 ) {
     @Operation(
+        operationId = "recordBreedingResult",
         summary = "繁殖成績の年次レコードを起こす（種付記録／種付せず）",
         description =
             "繁殖登録済みの牝馬の年次成績を起こす。リクエストの covering が非 null なら種付を記録し（分娩結果は未報告）、" +
@@ -102,7 +105,11 @@ class BreedingResultController(
     )
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/breedingResults")
-    fun record(@RequestBody request: RecordBreedingResultRequest): BreedingResultResponse {
+    fun record(
+        @OperationRequestBody(description = "起票する繁殖成績の年次レコード（種付記録／種付せず）")
+        @RequestBody
+        request: RecordBreedingResultRequest
+    ): BreedingResultResponse {
         val covering = request.covering
         return if (covering != null) {
             recordCovering(Command.now(request.toCoveringCommand(covering), clock))
@@ -175,8 +182,8 @@ class BreedingResultController(
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/api/breedingResults/{breedingResultId}:reportFoaling")
     fun reportFoaling(
-        @PathVariable breedingResultId: UUID,
-        @RequestBody request: ReportFoalingRequest,
+        @Parameter(description = "分娩結果を報告する繁殖成績の生 UUID") @PathVariable breedingResultId: UUID,
+        @OperationRequestBody(description = "報告する分娩結果") @RequestBody request: ReportFoalingRequest,
     ): BreedingResultResponse {
         val outcome = request.toOutcome().orThrowProblem()
         return reportFoaling(Command.now(ReportFoalingCommand(breedingResultId, outcome), clock))
@@ -243,7 +250,9 @@ class BreedingResultController(
     )
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/api/breedingResults/{breedingResultId}:submitReport")
-    fun submitReport(@PathVariable breedingResultId: UUID): BreedingResultResponse =
+    fun submitReport(
+        @Parameter(description = "繁殖成績報告を提出する繁殖成績の生 UUID") @PathVariable breedingResultId: UUID
+    ): BreedingResultResponse =
         submitReport(Command.now(SubmitBreedingReportCommand(breedingResultId), clock))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultResponse.kt
@@ -1,6 +1,7 @@
 package com.example.api.controller.breeding
 
 import com.example.api.domain.studbook.model.breeding.BreedingResult
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.util.UUID
 
@@ -24,6 +25,7 @@ import java.util.UUID
  * @property reportSubmittedOn 繁殖成績報告書（様式第14号）の提出日。未提出は null
  * @property reportSubmittedLate 提出が期限（繁殖年の翌年5/31）超過だったか。未提出は null
  */
+@Schema(description = "繁殖成績リソースの表現")
 data class BreedingResultResponse(
     val id: UUID,
     val breedingRegistrationId: UUID,

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultSummaryController.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultSummaryController.kt
@@ -4,6 +4,7 @@ import com.example.api.application.studbook.breeding.FindBreedingResultSummaryQu
 import com.example.api.application.studbook.breeding.FindBreedingResultSummaryUseCase
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -55,7 +56,9 @@ class BreedingResultSummaryController(
             ],
     )
     @GetMapping("/api/breedingResultSummaries")
-    fun list(@RequestParam stallionId: UUID): List<BreedingResultSummaryResponse> =
+    fun list(
+        @Parameter(description = "集計対象の種牡馬の生 UUID") @RequestParam stallionId: UUID
+    ): List<BreedingResultSummaryResponse> =
         findBreedingResultSummary(FindBreedingResultSummaryQuery(BloodHorseId(stallionId))).map {
             it.toResponse()
         }

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultSummaryResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultSummaryResponse.kt
@@ -1,6 +1,7 @@
 package com.example.api.controller.breeding
 
 import com.example.api.application.studbook.breeding.BreedingResultSummaryView
+import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
 import java.util.UUID
 
@@ -12,6 +13,7 @@ import java.util.UUID
  *
  * @property conceptionRate 受胎率(%) 小数1桁、[productionRate] 生産率(%) 小数1桁
  */
+@Schema(description = "繁殖成績の年次集計リソースの表現")
 data class BreedingResultSummaryResponse(
     val stallionId: UUID,
     val breedingYear: Int,

--- a/src/main/kotlin/com/example/api/controller/breeding/CoveringReportController.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/CoveringReportController.kt
@@ -10,6 +10,7 @@ import com.github.michaelbull.result.mapError
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody as OperationRequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Clock
 import org.springframework.http.HttpStatus
@@ -80,7 +81,11 @@ class CoveringReportController(
     )
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/coveringReports")
-    fun submit(@RequestBody request: SubmitCoveringReportRequest): CoveringReportResponse =
+    fun submit(
+        @OperationRequestBody(description = "提出する種付成績報告（種牡馬の繁殖登録ID・種付年）")
+        @RequestBody
+        request: SubmitCoveringReportRequest
+    ): CoveringReportResponse =
         submitCoveringReport(Command.now(request.toCommand(), clock))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()

--- a/src/main/kotlin/com/example/api/controller/breeding/CoveringReportResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/CoveringReportResponse.kt
@@ -1,6 +1,7 @@
 package com.example.api.controller.breeding
 
 import com.example.api.domain.studbook.model.breeding.CoveringReport
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.util.UUID
 
@@ -16,6 +17,7 @@ import java.util.UUID
  * @property submittedOn 提出日（日本の暦日）
  * @property submittedLate 提出が期限（種付年の当年9/30）超過だったか
  */
+@Schema(description = "種付成績報告リソースの表現")
 data class CoveringReportResponse(
     val id: UUID,
     val stallionBreedingRegistrationId: UUID,

--- a/src/main/kotlin/com/example/api/controller/breeding/FoalingOutcomeWire.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/FoalingOutcomeWire.kt
@@ -1,6 +1,7 @@
 package com.example.api.controller.breeding
 
 import com.example.api.domain.studbook.model.breeding.FoalingOutcome
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
 /*
@@ -49,6 +50,7 @@ enum class FoalingOutcomeDto {
  * @property kind 分娩結果の区分
  * @property foalingDate 分娩日。生産（[FoalingOutcomeDto.LIVE_FOAL]）のときのみ非 null
  */
+@Schema(description = "分娩結果のリソース表現")
 data class FoalingOutcomeResponse(val kind: FoalingOutcomeDto, val foalingDate: LocalDate?)
 
 /** ドメインの分娩結果を HTTP 契約のリソース表現へ変換する。 */

--- a/src/main/kotlin/com/example/api/controller/breeding/request/RecordBreedingResultRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/request/RecordBreedingResultRequest.kt
@@ -7,6 +7,7 @@ import com.example.api.controller.problem
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.Year
 import java.util.UUID
@@ -26,6 +27,7 @@ import org.springframework.http.ProblemDetail
  * @property breedingYear 繁殖年。種付せず（[covering] が null）のとき必須。種付ありなら無視される
  * @property covering その年の種付。種付せずの年は null
  */
+@Schema(description = "繁殖成績の年次レコード起票リクエスト（種付記録／種付せず）")
 data class RecordBreedingResultRequest(
     val breedingRegistrationId: UUID,
     val breedingYear: Int?,
@@ -43,6 +45,7 @@ data class RecordBreedingResultRequest(
  * @property certificateNumber 種付証明書番号
  * @property studCertificate 種牡馬の種畜証明書（種付の有効性検証の与件）
  */
+@Schema(description = "種付の入力")
 data class CoveringRequest(
     val stallionRegistrationId: UUID,
     val coveringDate: LocalDate,
@@ -59,6 +62,7 @@ data class CoveringRequest(
  * @property validPeriodStart 有効期間の起点（当日を含む）
  * @property validPeriodEnd 有効期間の終点（当日を含む）
  */
+@Schema(description = "種畜証明書の入力")
 data class StudCertificateRequest(
     val number: String,
     val validRegions: List<String>,

--- a/src/main/kotlin/com/example/api/controller/breeding/request/RegisterBreedingRegistrationRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/request/RegisterBreedingRegistrationRequest.kt
@@ -1,6 +1,7 @@
 package com.example.api.controller.breeding.request
 
 import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationCommand
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
 /**
@@ -12,6 +13,7 @@ import java.util.UUID
  * @property bloodHorseId 繁殖登録する個体（血統登録済み）の軽種馬ID
  * @property registrationNumber 交付される繁殖登録番号
  */
+@Schema(description = "繁殖登録リクエスト")
 data class RegisterBreedingRegistrationRequest(
     val bloodHorseId: UUID,
     val registrationNumber: String,

--- a/src/main/kotlin/com/example/api/controller/breeding/request/ReportFoalingRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/request/ReportFoalingRequest.kt
@@ -6,6 +6,7 @@ import com.example.api.domain.studbook.model.breeding.FoalingOutcome
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
@@ -20,6 +21,7 @@ import org.springframework.http.ProblemDetail
  * @property outcome 分娩結果の区分
  * @property foalingDate 分娩日。生産のときは必須、それ以外は無視される
  */
+@Schema(description = "分娩結果報告リクエスト")
 data class ReportFoalingRequest(val outcome: FoalingOutcomeDto, val foalingDate: LocalDate?)
 
 /**

--- a/src/main/kotlin/com/example/api/controller/breeding/request/SubmitCoveringReportRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/request/SubmitCoveringReportRequest.kt
@@ -1,6 +1,7 @@
 package com.example.api.controller.breeding.request
 
 import com.example.api.application.studbook.breeding.SubmitCoveringReportCommand
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
 /**
@@ -11,6 +12,7 @@ import java.util.UUID
  * @property stallionBreedingRegistrationId 提出する種牡馬の繁殖登録ID
  * @property coveringYear 報告対象の種付年
  */
+@Schema(description = "種付成績報告提出リクエスト")
 data class SubmitCoveringReportRequest(
     val stallionBreedingRegistrationId: UUID,
     val coveringYear: Int,

--- a/src/main/kotlin/com/example/api/controller/horse/BloodHorseController.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/BloodHorseController.kt
@@ -12,8 +12,10 @@ import com.example.api.controller.orThrowProblem
 import com.example.api.domain.shared.Command
 import com.github.michaelbull.result.mapError
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody as OperationRequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Clock
 import java.util.UUID
@@ -42,6 +44,7 @@ class BloodHorseController(
     private val clock: Clock,
 ) {
     @Operation(
+        operationId = "registerBloodHorse",
         summary = "軽種馬を血統登録する",
         description = "父母を指定して血統登録を行い、誕生した軽種馬を返す。業務ルール違反時は RFC 9457 形式の problem+json を返す。",
         tags = ["BloodHorse"],
@@ -84,7 +87,11 @@ class BloodHorseController(
     )
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/bloodHorses")
-    fun register(@RequestBody request: RegisterBloodHorseRequest): BloodHorseResponse =
+    fun register(
+        @OperationRequestBody(description = "血統登録する軽種馬の登録申請フォーム")
+        @RequestBody
+        request: RegisterBloodHorseRequest
+    ): BloodHorseResponse =
         registerInStudBook(Command.now(request.toCommand(), clock))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()
@@ -124,7 +131,11 @@ class BloodHorseController(
     )
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/bloodHorses:registerImported")
-    fun registerImported(@RequestBody request: RegisterImportedHorseRequest): BloodHorseResponse =
+    fun registerImported(
+        @OperationRequestBody(description = "血統登録する輸入馬・基礎輸入馬の登録申請フォーム")
+        @RequestBody
+        request: RegisterImportedHorseRequest
+    ): BloodHorseResponse =
         registerImportedHorse(Command.now(request.toCommand(), clock))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()
@@ -185,8 +196,8 @@ class BloodHorseController(
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/api/bloodHorses/{bloodHorseId}:registerName")
     fun registerName(
-        @PathVariable bloodHorseId: UUID,
-        @RequestBody request: RegisterHorseNameRequest,
+        @Parameter(description = "馬名を登録する軽種馬の生 UUID") @PathVariable bloodHorseId: UUID,
+        @OperationRequestBody(description = "馬名") @RequestBody request: RegisterHorseNameRequest,
     ): BloodHorseResponse =
         nameHorse(Command.now(request.toCommand(bloodHorseId), clock))
             .mapError { it.toProblemDetail() }

--- a/src/main/kotlin/com/example/api/controller/horse/BloodHorseResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/BloodHorseResponse.kt
@@ -1,6 +1,7 @@
 package com.example.api.controller.horse
 
 import com.example.api.application.studbook.horse.RegisteredBloodHorse
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.util.UUID
 
@@ -26,6 +27,7 @@ import java.util.UUID
  * @property name 馬名。未命名なら null
  */
 @Suppress("LongParameterList") // resource 全体を返すため項目数が多いのは必然
+@Schema(description = "軽種馬リソースの表現")
 data class BloodHorseResponse(
     val id: UUID,
     val registrationNumber: String,

--- a/src/main/kotlin/com/example/api/controller/horse/OriginDto.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/OriginDto.kt
@@ -35,6 +35,7 @@ sealed interface OriginDto {
      * @property sireId 父（雄）の生 UUID
      * @property damId 母（雌）の生 UUID
      */
+    @Schema(description = "内国産馬の出自")
     data class Domestic(val sireId: UUID, val damId: UUID) : OriginDto
 
     /**
@@ -43,6 +44,7 @@ sealed interface OriginDto {
      * @property country 原産国名
      * @property landingDate 揚陸日
      */
+    @Schema(description = "輸入馬・基礎輸入馬の出自")
     data class Imported(val country: String, val landingDate: LocalDate) : OriginDto
 }
 

--- a/src/main/kotlin/com/example/api/controller/horse/request/RegisterBloodHorseRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/request/RegisterBloodHorseRequest.kt
@@ -6,6 +6,7 @@ import com.example.api.controller.horse.CoatColorDto
 import com.example.api.controller.horse.DnaParentageResultDto
 import com.example.api.controller.horse.SexDto
 import com.example.api.controller.horse.toDomain
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.util.UUID
 
@@ -29,6 +30,7 @@ import java.util.UUID
  * @property registrationNumber 交付される血統登録番号
  */
 @Suppress("LongParameterList") // 登録申請フォーム相当の境界入力であり、項目の分割はかえって意味を損なう
+@Schema(description = "軽種馬血統登録リクエスト")
 data class RegisterBloodHorseRequest(
     val sireId: UUID,
     val damId: UUID,

--- a/src/main/kotlin/com/example/api/controller/horse/request/RegisterHorseNameRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/request/RegisterHorseNameRequest.kt
@@ -1,6 +1,7 @@
 package com.example.api.controller.horse.request
 
 import com.example.api.application.studbook.horse.NameHorseCommand
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
 /**
@@ -11,7 +12,7 @@ import java.util.UUID
  *
  * @property name 付与する馬名
  */
-data class RegisterHorseNameRequest(val name: String)
+@Schema(description = "馬名登録リクエスト") data class RegisterHorseNameRequest(val name: String)
 
 /** リクエストボディと URL パスの軽種馬IDを馬名登録ユースケースの入力コマンドへ変換する。 */
 fun RegisterHorseNameRequest.toCommand(bloodHorseId: UUID): NameHorseCommand =

--- a/src/main/kotlin/com/example/api/controller/horse/request/RegisterImportedHorseRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/request/RegisterImportedHorseRequest.kt
@@ -5,6 +5,7 @@ import com.example.api.controller.horse.BreedTypeDto
 import com.example.api.controller.horse.CoatColorDto
 import com.example.api.controller.horse.SexDto
 import com.example.api.controller.horse.toDomain
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
 /**
@@ -25,6 +26,7 @@ import java.time.LocalDate
  * @property registrationNumber 交付される血統登録番号
  */
 @Suppress("LongParameterList") // 登録申請フォーム相当の境界入力であり、項目の分割はかえって意味を損なう
+@Schema(description = "輸入馬・基礎輸入馬血統登録リクエスト")
 data class RegisterImportedHorseRequest(
     val sex: SexDto,
     val coatColor: CoatColorDto,

--- a/src/main/kotlin/com/example/api/controller/inspection/HorseInspectionController.kt
+++ b/src/main/kotlin/com/example/api/controller/inspection/HorseInspectionController.kt
@@ -10,8 +10,10 @@ import com.example.api.controller.orThrowProblem
 import com.example.api.domain.shared.Command
 import com.github.michaelbull.result.mapError
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody as OperationRequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Clock
 import java.util.UUID
@@ -39,6 +41,7 @@ class HorseInspectionController(
     private val clock: Clock,
 ) {
     @Operation(
+        operationId = "recordHorseInspection",
         summary = "審査を記録する",
         description = "確定済みの審査（個体識別・親子判定）を記録する。業務ルール違反時は RFC 9457 形式の problem+json を返す。",
         tags = ["HorseInspection"],
@@ -70,13 +73,18 @@ class HorseInspectionController(
     )
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/horseInspections")
-    fun record(@RequestBody request: RecordHorseInspectionRequest): HorseInspectionResponse =
+    fun record(
+        @OperationRequestBody(description = "記録する審査（個体識別・親子判定）")
+        @RequestBody
+        request: RecordHorseInspectionRequest
+    ): HorseInspectionResponse =
         recordHorseInspection(Command.now(request.toCommand(), clock))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()
             .toResponse()
 
     @Operation(
+        operationId = "getHorseInspection",
         summary = "審査を取得する",
         description = "ID で審査を取得する。対象が存在しなければ RFC 9457 形式の problem+json を返す。",
         tags = ["HorseInspection"],
@@ -107,7 +115,9 @@ class HorseInspectionController(
             ],
     )
     @GetMapping("/api/horseInspections/{id}")
-    fun get(@PathVariable id: UUID): HorseInspectionResponse =
+    fun get(
+        @Parameter(description = "取得する審査の生 UUID") @PathVariable id: UUID
+    ): HorseInspectionResponse =
         findHorseInspection(FindHorseInspectionQuery(id))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()

--- a/src/main/kotlin/com/example/api/controller/inspection/HorseInspectionResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/inspection/HorseInspectionResponse.kt
@@ -2,6 +2,7 @@ package com.example.api.controller.inspection
 
 import com.example.api.application.studbook.inspection.HorseInspectionView
 import com.example.api.domain.studbook.model.inspection.HorseInspection
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
 /**
@@ -15,6 +16,7 @@ import java.util.UUID
  * @property parentage 親子判定
  * @property features 特徴記述子。未記録なら null
  */
+@Schema(description = "審査リソースの表現")
 data class HorseInspectionResponse(
     val id: UUID,
     val microchipNumber: String,

--- a/src/main/kotlin/com/example/api/controller/inspection/IdentificationFeaturesDto.kt
+++ b/src/main/kotlin/com/example/api/controller/inspection/IdentificationFeaturesDto.kt
@@ -1,6 +1,7 @@
 package com.example.api.controller.inspection
 
 import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
+import io.swagger.v3.oas.annotations.media.Schema
 
 /**
  * 審査リソースの「特徴記述子」の表現（HTTP 契約）。
@@ -12,6 +13,7 @@ import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
  * @property whiteMarkings 白斑（四肢別）の記述
  * @property nosePrint 鼻紋の記述
  */
+@Schema(description = "審査リソースの特徴記述子（旋毛・白斑・鼻紋。いずれも任意）")
 data class IdentificationFeaturesDto(
     val hairWhorl: String?,
     val whiteMarkings: String?,

--- a/src/main/kotlin/com/example/api/controller/inspection/ParentageDeterminationDto.kt
+++ b/src/main/kotlin/com/example/api/controller/inspection/ParentageDeterminationDto.kt
@@ -51,15 +51,19 @@ sealed interface ParentageDeterminationDto {
      *
      * @property dnaParentageResult DNA 型による判定結果
      */
+    @Schema(description = "DNA 型による親子判定")
     data class ByDna(val dnaParentageResult: DnaParentageResultDto) : ParentageDeterminationDto
 
     /** 血液型検査によるフォールバック。追加フィールドなし（詳細は #267）。 */
+    @Schema(description = "血液型検査によるフォールバック判定。追加フィールドなし（詳細は #267）")
     data object ByBloodType : ParentageDeterminationDto
 
     /** 承認海外機関の判定によるフォールバック。追加フィールドなし（詳細は #267）。 */
+    @Schema(description = "承認海外機関の判定によるフォールバック判定。追加フィールドなし（詳細は #267）")
     data object ByOverseasInstitution : ParentageDeterminationDto
 
     /** 親子判定の対象外（父母不明等）。追加フィールドなし。 */
+    @Schema(description = "親子判定の対象外（父母不明等）。追加フィールドなし")
     data object NotApplicable : ParentageDeterminationDto
 }
 

--- a/src/main/kotlin/com/example/api/controller/inspection/request/RecordHorseInspectionRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/inspection/request/RecordHorseInspectionRequest.kt
@@ -4,6 +4,7 @@ import com.example.api.application.studbook.inspection.RecordHorseInspectionComm
 import com.example.api.controller.inspection.IdentificationFeaturesDto
 import com.example.api.controller.inspection.ParentageDeterminationDto
 import com.example.api.controller.inspection.toDomain
+import io.swagger.v3.oas.annotations.media.Schema
 
 /**
  * `POST /api/horseInspections` のリクエストボディ。
@@ -15,6 +16,7 @@ import com.example.api.controller.inspection.toDomain
  * @property parentage 親子判定
  * @property features 特徴記述子（任意）
  */
+@Schema(description = "審査記録リクエスト")
 data class RecordHorseInspectionRequest(
     val microchipNumber: String,
     val parentage: ParentageDeterminationDto,

--- a/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
@@ -10,8 +10,10 @@ import com.example.api.controller.orThrowProblem
 import com.example.api.domain.shared.Command
 import com.github.michaelbull.result.mapError
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody as OperationRequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Clock
 import java.util.UUID
@@ -38,6 +40,7 @@ class JockeyController(
     private val clock: Clock,
 ) {
     @Operation(
+        operationId = "registerJockey",
         summary = "ジョッキーを登録する",
         description = "ジョッキーを新規登録する。業務ルール違反時は RFC 9457 形式の problem+json を返す。",
         tags = ["Jockey"],
@@ -80,13 +83,18 @@ class JockeyController(
     )
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/jockeys")
-    fun register(@RequestBody request: RegisterJockeyRequest): JockeyResponse {
+    fun register(
+        @OperationRequestBody(description = "登録するジョッキーの氏名")
+        @RequestBody
+        request: RegisterJockeyRequest
+    ): JockeyResponse {
         val command = Command.now(RegisterJockeyCommand(request.firstName, request.lastName), clock)
         val jockey = registerJockey(command).mapError { it.toProblemDetail() }.orThrowProblem()
         return jockey.toResponse()
     }
 
     @Operation(
+        operationId = "getJockey",
         summary = "ジョッキーを取得する",
         description = "ID でジョッキーを取得する。対象が存在しなければ RFC 9457 形式の problem+json を返す。",
         tags = ["Jockey"],
@@ -117,7 +125,7 @@ class JockeyController(
             ],
     )
     @GetMapping("/api/jockeys/{id}")
-    fun get(@PathVariable id: UUID): JockeyResponse {
+    fun get(@Parameter(description = "取得するジョッキーの生 UUID") @PathVariable id: UUID): JockeyResponse {
         val view =
             findJockey(FindJockeyQuery(id)).mapError { it.toProblemDetail() }.orThrowProblem()
         return view.toResponse()

--- a/src/main/kotlin/com/example/api/controller/jockey/JockeyResponse.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/JockeyResponse.kt
@@ -2,6 +2,7 @@ package com.example.api.controller.jockey
 
 import com.example.api.application.racing.jockey.JockeyView
 import com.example.api.domain.racing.model.jockey.Jockey
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
 /**
@@ -14,6 +15,7 @@ import java.util.UUID
  * @property firstName 名
  * @property lastName 姓
  */
+@Schema(description = "ジョッキーリソースの表現")
 data class JockeyResponse(val id: UUID, val firstName: String, val lastName: String)
 
 /** [Jockey] をジョッキーリソースの表現へ変換する。各操作の成功レスポンスはこのリソース表現を一律で返す。 */

--- a/src/main/kotlin/com/example/api/controller/jockey/request/RegisterJockeyRequest.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/request/RegisterJockeyRequest.kt
@@ -1,9 +1,12 @@
 package com.example.api.controller.jockey.request
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 /**
  * `POST /api/jockeys` のリクエストボディ。
  *
  * @property firstName 名
  * @property lastName 姓
  */
+@Schema(description = "ジョッキー登録リクエスト")
 data class RegisterJockeyRequest(val firstName: String, val lastName: String)


### PR DESCRIPTION
## 概要

Issue #327: springdoc が生成する OpenAPI 仕様を build 成果物として書き出し、[vacuum](https://github.com/daveshanley/vacuum) で lint して CI（独立ワークフロー）でドキュメント品質をゲートする。既存の `OpenApiTest`（@SpringBootTest スモーク）は配線確認として残し、仕様の品質ゲートは vacuum 側が担う役割分担とする。

決定記録は [ADR-0054](docs/adr/0054-vacuum-openapi-lint.md) 。

## 実装内容

- **linter に vacuum を採用**（mise aqua backend、0.29.9）。Spectral 互換ルールセットで乗り換え退路あり・Go 単一バイナリで mise 管理が素直・OpenAPI 3.1 対応。比較（Spectral / Redocly 見送り）は ADR 参照。
- **仕様の書き出し**: `generateOpenApiDocs`（springdoc-openapi-gradle-plugin）で `build/openapi.json` を forked bootRun（専用ポート 8090・docker-compose が PostgreSQL 供給）から書き出す。build 成果物でありコミットしない。
- **lint タスク**: `lintOpenApiDocs`（`mise which vacuum` で解決する Exec タスク）が生成に依存し `config/vacuum/ruleset.yaml` で lint（`--fail-severity warn`）。ルールは recommended ベース + 固有ルール（operation の summary 必須化・operationId の camelCase 命名）。意図的な除外は `config/vacuum/ignore.yaml`（ProblemDetail / Link の component-description）。判別共用体由来の循環参照は `--ignore-polymorph-circle-ref` フラグでカテゴリごと無視（脆い参照チェーン文字列のハードコードを回避）。
- **CI 独立ワークフロー** `.github/workflows/openapi-lint.yml`（db-doc-check.yml をひな型に、paths フィルタ付き）。`check` / lefthook には載せない（生成にアプリ起動が要るため。checkDbDoc / e2eTest と同じ役割分担）。
- **初回 lint 指摘の解消**: 既存コントローラー / DTO / `@OpenAPIDefinition` に @Operation / @Schema 等を補強（HTTP 契約のドメイン enum 非依存規約は維持）。
- **ドキュメント**: ADR-0054 追加・CLAUDE.md 3 節（コード品質チェック・OpenAPI/Swagger・ツール管理）を更新。

## 検証

- `./gradlew lintOpenApiDocs` が exit 0（残存は info レベル 5 件のみで非ブロッキング）
- `./gradlew check` BUILD SUCCESSFUL（ktfmt / detekt / test / ArchUnit / koverVerifyMature。OpenAPI 系タスクは check のタスクグラフに非搭載）
- `actionlint` / `zizmor` 指摘ゼロ
- mise.lock に vacuum の全プラットフォーム checksum（Linux CI の `--locked` を満たす）

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)
