### PR TITLE
build: e2eTest タスクを非推奨の registering から register へ移行する

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -245,14 +245,13 @@ configurations["e2eTestRuntimeOnly"].extendsFrom(configurations["testRuntimeOnly
 dependencies { "e2eTestImplementation"(libs.karate.core) }
 
 // CI 独立ジョブ専用のタスク。check / pre-push には意図的に載せない（速い内側ループを保つ）。
-val e2eTest by
-    tasks.registering(Test::class) {
-        description = "Karate によるブラックボックス API E2E テスト（CI 独立ジョブ専用。check/pre-push には載せない）"
-        group = "verification"
-        testClassesDirs = sourceSets["e2eTest"].output.classesDirs
-        classpath = sourceSets["e2eTest"].runtimeClasspath
-        shouldRunAfter(tasks.named("test"))
-    }
+tasks.register<Test>("e2eTest") {
+    description = "Karate によるブラックボックス API E2E テスト（CI 独立ジョブ専用。check/pre-push には載せない）"
+    group = "verification"
+    testClassesDirs = sourceSets["e2eTest"].output.classesDirs
+    classpath = sourceSets["e2eTest"].runtimeClasspath
+    shouldRunAfter(tasks.named("test"))
+}
 
 // --- DB スキーマドキュメント生成（tbls, #447） ---
 // 専用ソースセットに隔離する（ArchUnit は src/test のみ走査、Kover は test タスク紐付けのため、


### PR DESCRIPTION
## 背景

CI（API Tests）の Gradle 実行で、build script 由来の deprecation 警告が出ていた:

```
w: build.gradle.kts:249: 'registering(...)' is deprecated.
   Use 'val task = tasks.register<Type>(name) { }' instead. See the Gradle 9.6 upgrading guide.
Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.
```

`e2eTest` タスクだけが古い `val e2eTest by tasks.registering(Test::class) { }`（プロパティ委譲による遅延登録）で書かれており、これが Gradle 9.6 で deprecated、Gradle 10 で非互換となる。

## 変更

`e2eTest` を、同ファイルの他タスク（`generateDbDoc` / `checkDbDoc` / `lintOpenApiDocs`）が既に使っている新 API `tasks.register<Type>("name") { }` へ揃えた。`e2eTest` はローカル変数として他所から参照していないため委譲を外しても影響はない。

## 検証

- `./gradlew help --warning-mode all` で `build.gradle.kts:249` の deprecation が消えたことを確認
- `ktfmtCheck` パス、pre-push の full-test パス

## 補足（このPRの対象外）

構成時にはもう 1 件、`Using a Project object as a dependency notation` の deprecation が残るが、これは **Kover プラグイン内部**（`kotlinx.kover.gradle.plugin.appliers.PrepareKoverKt.prepare(PrepareKover.kt:29)`）が発生源で、当リポジトリの build script からは制御できない。Kover は現状最新の 0.9.8 でも該当し、上流の修正リリース待ち。

将来 Kover がこれを解消したら、`org.gradle.warning.mode=fail` を `gradle.properties` に入れて deprecation を自動でゲート化する予定（本PRでは入れない。今入れると Kover の上記1件で全ビルドが即失敗するため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
