### PR TITLE
chore: Dependabot のグルーピングを棚卸しして PR ノイズを削減する(#381)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,8 @@
 version: 2
+# グルーピング方針（#381）:
+# - minor / patch の低リスク更新はエコシステムごとに 1 グループへ束ね、PR ノイズを削減する。
+# - major 更新はグループから外し個別 PR に残す（破壊的変更をまとめてレビューを難しくしない）。
+# - 例外的に高リスク・手作業を伴う依存（Spring Boot / Kotlin プラグイン）は個別・専用グループに分離する。
 updates:
   # Enable updates for Gradle dependencies
   - package-ecosystem: "gradle"
@@ -7,10 +11,23 @@ updates:
       interval: "weekly"
     # Keep PRs manageable by limiting the number of open PRs
     open-pull-requests-limit: 5
-    # Group Kotlin plugins together (Spring manages other Kotlin dependencies)
     groups:
+      # Kotlin プラグインは KGP 互換（Spring / detekt / ktfmt）で手作業が要りがちなので分離し、
+      # 一般グループ（gradle-minor-patch）を軽く緑に保つ。2 プラグインは常に同一版で足並みを揃える。
       kotlin:
         patterns:
+          - "org.jetbrains.kotlin.jvm"
+          - "org.jetbrains.kotlin.plugin.spring"
+      # 残りの minor / patch を集約。Spring Boot は Spring 管理 BOM を巻き込むため個別（除外）、
+      # Kotlin プラグインは上の専用グループへ回す（除外）。major も個別 PR に残る。
+      gradle-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "org.springframework.boot"
           - "org.jetbrains.kotlin.jvm"
           - "org.jetbrains.kotlin.plugin.spring"
 
@@ -21,6 +38,21 @@ updates:
       interval: "weekly"
     # Keep PRs manageable by limiting the number of open PRs
     open-pull-requests-limit: 5
+    groups:
+      # codeql-action の init / analyze / upload-sarif はバージョン完全一致が必須。
+      # 分割更新すると "Loaded a configuration file for version X, but running version Y" で
+      # CI が壊れる（#560）。major も含め全 update-type で常に束ね、齟齬を構造的に防ぐ。
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
+      # 残りの Actions の minor / patch を集約。major は個別 PR に残る。
+      # codeql-action はグループ定義順で先勝ちのため、このグループには入らない。
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
 
   # Enable updates for Terraform providers
   - package-ecosystem: "terraform"
@@ -28,3 +60,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      # /infra は実質 hashicorp/google 単一プロバイダ。minor / patch を集約、major は個別 PR に残る。
+      terraform:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"


### PR DESCRIPTION
## 概要

`.github/dependabot.yml` のグルーピング設定を棚卸しし、更新 PR のノイズを削減する（#381）。あわせて、PR #560 で顕在化した **codeql-action の init/analyze バージョン齟齬による CI 失敗**を構造的に防ぐ。

## 背景

PR #560（`github/codeql-action/analyze` 4.36.2 → 4.36.3）の CodeQL ジョブが以下で失敗した：

```
Loaded a configuration file for version '4.36.2', but running version '4.36.3'
```

Dependabot が `analyze` だけを個別 PR で更新し、`init`（4.36.2 のまま）と齟齬が生じたのが原因。codeql-action は init/analyze/upload-sarif のバージョン完全一致が必須のため、サブアクションは常に同時に更新される必要がある。

## 方針（全エコシステム共通）

- **minor / patch の低リスク更新はエコシステムごとに 1 グループへ束ねる**（PR ノイズ削減）
- **major 更新はグループから外し個別 PR に残す**（破壊的変更をまとめない）
- 高リスク・手作業を伴う依存は個別/専用グループへ分離

## 変更内容

| エコシステム | グループ | 対象 | update-types |
|---|---|---|---|
| github-actions | `codeql-action` | `github/codeql-action*` | 制限なし（全 update-type で束ねる） |
| github-actions | `github-actions` | `*`（codeql は先勝ちで除外） | minor, patch |
| terraform | `terraform` | `*`（実質 hashicorp/google） | minor, patch |
| gradle | `kotlin`（既存維持） | kotlin プラグイン 2 つ | 制限なし |
| gradle | `gradle-minor-patch` | `*`（spring-boot / kotlin を除外） | minor, patch |

### 個別 PR に残すもの（意図的）

- 全エコシステムの **メジャー更新**
- **`org.springframework.boot`**: Spring 管理 BOM を巻き込むため個別（既存方針を維持）

### 補足

- `codeql-action` 専用グループは update-types 制限を付けず、**major（v4→v5）でも init/analyze/upload-sarif を必ず束ねる**ことで齟齬の再発を防ぐ。
- 判断根拠は `.github/dependabot.yml` のコメントに記録した。

## PR #560 の扱い

本 PR マージ後に **#560 はクローズ**する。次回スケジュールで Dependabot が init/analyze/upload-sarif をまとめた正しい PR を作り直す。

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)
