### PR TITLE
ci: copilot-setup-steps に MISE_ENV=ci を付与し http backend ツール除外を揃える

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -22,6 +22,11 @@ jobs:
 
       - name: Set up mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        env:
+          # CI 用オーバーレイ mise.ci.toml を読み込み、http backend ツール（kotlin-lsp/tfctl）を
+          # インストール対象から外す（mise が per-platform SHA を mise.lock に永続化せず
+          # `mise install --locked` を満たせない。#510 回帰。どちらも Copilot 環境では不要）。
+          MISE_ENV: ci
 
       - name: Set up lefthook
         run: lefthook install


### PR DESCRIPTION
## 概要

`copilot-setup-steps` ワークフローの `Set up mise` ステップに `MISE_ENV: ci` が漏れていたのを補い、他 7 ワークフローと http backend ツールの除外挙動を揃える。Closes #584。

## 背景・原因

- 2026-07-07 以降、`copilot-setup-steps` が全ブランチで一斉に失敗していた（`http:kotlin-lsp@... is not in the lockfile` で exit 1）。
- 根本原因は #510 で既知: mise は http backend の per-platform SHA を `mise.lock` に永続化しないため、Linux CI の `mise install --locked` を満たせない。mise 2026.7.2（07-07 リリース）で http backend の `--locked` 解決が変わり、これが再顕在化した。
- 緩和策として `mise.ci.toml`（`disable_tools = ["http:kotlin-lsp", "http:tfctl"]`）が既に存在し、他 7 ワークフローは `MISE_ENV: ci` でこれを読み込んで http ツールを除外している。**`copilot-setup-steps.yml` だけこの env が漏れていた。**

## 変更

- `.github/workflows/copilot-setup-steps.yml`: `Set up mise` ステップに `env.MISE_ENV: ci` を追加（除外理由をコメントで明記）。

kotlin-lsp / tfctl はいずれも Copilot 環境では不要（LSP はローカル編集用 ADR-0046 / tfctl は HCP 対話操作 ADR-0034）。mise 版のピン留め（Issue 候補1）は行わず、既存の緩和パターンに揃える方針。

## 検証

- ローカルで `actionlint` / `dprint check` パス。
- 編集対象が `copilot-setup-steps.yml` 自身のため、本 PR で当該ワークフローが `pull_request` トリガで実走し、修正を実証できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
