### PR TITLE
chore: architecture.md の sakamichi パッケージ構成例を現状へ更新する

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -80,10 +80,13 @@ domain/
 │       └── race/                #   confirmRaceResult
 ├── sakamichi/                   # エンターテイメントコンテキスト（坂道シリーズ）
 │   ├── model/                   # ドメインモデルリング
+│   │   ├── album/               #   Album, AlbumTitle
 │   │   ├── group/               #   Group, GroupId, GroupName
 │   │   ├── member/              #   Member, Generation, Membership, ...
-│   │   └── single/              #   Single, Senbatsu, Position, ...
+│   │   ├── release/             #   Formation, FormationSlot, Position, ReleaseNumber（作品共通の編成語彙）
+│   │   └── single/              #   Single, SingleTitle
 │   └── service/                 # ドメインサービスリング
+│       ├── album/               #   releaseAlbum
 │       └── single/              #   releaseSingle
 └── tennis/model/
 ```


### PR DESCRIPTION
## 概要

`.claude/rules/architecture.md` の sakamichi パッケージ構成の例示が二重に陳腐化していたのを現状へ更新する（#587）。

- **旧名 `Senbatsu` を除去**: #556（PR #585）で選抜 VO `Senbatsu` を中立の `Formation` へ汎用化済み。`single/` の例示 `Single, Senbatsu, Position, ...` を `Single, SingleTitle` に修正。
- **`release/` パッケージを追加**: #555（アルバム対応）で作品共通の編成語彙（`Formation` / `FormationSlot` / `Position` / `ReleaseNumber`）を `release/` へ抽出済み。例示に欠落していたので追加。
- **`album/` を model・service 両リングに追加**: #555 のアルバム対応（`Album` / `AlbumTitle`、`releaseAlbum`）が例示に無かったので追加。

## 完了の目安

- [x] 例示行が現行のパッケージ・型名（`release/`・`Formation`・`Album` 等）を正しく反映している
- [x] `Senbatsu` / `SenbatsuSlot` など旧名の残存が `.claude/rules/architecture.md` に無い（grep 確認済み）
- [x] 他の stale な sakamichi 例示が無いか一巡確認済み（該当は 85 行のみ）

説明用の例示行の陳腐化解消で、実装コードへの影響はない。

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)
