### PR TITLE
feat: #582 非選抜活動体の呼称を Group 属性としてモデル化する

### DIFF
--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -138,7 +138,8 @@ JRA 管掌の騎手・競走を扱う。騎手免許は競馬法で JRA が管�
 | アルバム（`Album`） | グループが発表する作品。リード曲の選抜を内包する集約ルート | 発表元グループは `GroupId` の ID 参照。シングルとは独立採番。収録曲（トラックリスト）は未モデル化（別 Issue） |
 | リード曲名（`AlbumTitle`） | アルバムのリード曲（代表曲）の曲名 | シングルの表題曲（`SingleTitle`）と呼称が異なる別概念 |
 | 選抜（`Formation` の `senbatsu` ロール） | シングル表題曲/アルバムリード曲を歌う編成 | シングル・アルバム共通の作品編成語彙（`domain.sakamichi.model.release`）。**作品単位の一時的編成**（グループ・メンバーの恒久属性にしない）。不変条件: メンバー重複なし・`Center` 以外の立ち位置の定員 1 人・センター 1〜2 人（W センター許容） |
-| 非選抜（`Formation` の `nonSenbatsu` ロール） | 表題曲を歌わないメンバーの編成（アンダー曲等）。`Single` が任意で内包（不在＝全員選抜） | グループ別の呼称（乃木坂=アンダー / 櫻坂=BACKS / 日向坂=ひなた坂46）は別 Issue で `Group` 属性として扱う。センターを持つ（アンダーセンター等）。排他（選抜と同一メンバー不可）は `releaseSingle` が検証 |
+| 非選抜（`Formation` の `nonSenbatsu` ロール） | 表題曲を歌わないメンバーの編成（アンダー曲等）。`Single` が任意で内包（不在＝全員選抜） | グループ別の呼称（乃木坂=アンダー / 櫻坂=BACKS / 日向坂=ひなた坂46）は `Group.nonSenbatsuAppellation`（`非選抜活動体の呼称`）としてモデル化済み（#582）。センターを持つ（アンダーセンター等）。排他（選抜と同一メンバー不可）は `releaseSingle` が検証 |
+| 非選抜活動体の呼称（`Group.nonSenbatsuAppellation`） | グループ別の非選抜編成の呼び名（乃木坂46=アンダー／櫻坂46=BACKS／日向坂46=ひなた坂46） | `Group` の**任意属性**（`domain.sakamichi.model.group`）。呼称を持たないグループ/時期は null。**時間軸を持たない**（いつから適用かは作品側の関心・#583）。作品・編成・ライブとの結び付けは持たない。典拠は `.claude/skills/sakamichi-sources`（参照日 2026-07-08） |
 | 立ち位置（`Position`） | フォーメーション上の位置。センター（`Center`）とそれ以外（`Spot`＝列 × 列内番号）の相互排他 | 作品ごとに変わる（シングル表題曲・アルバムリード曲共通）。1 列目が最前列。センターは 1〜2 人（W センター）・`Center` 以外は定員 1 人。センターと `Spot` の空間的重なりは未検証（探索段階の割り切り） |
 | 編成の枠（`FormationSlot`） | 立ち位置 × メンバーの割り当て 1 件 | メンバーは `MemberId` の ID 参照。選抜・非選抜共通、シングル/アルバム共通で使う値オブジェクト |
 
@@ -149,7 +150,7 @@ JRA 管掌の騎手・競走を扱う。騎手免許は競馬法で JRA が管�
 | releaseSingle | シングルを発売する | 選抜を編成してシングルを成立させる入口。非選抜編成（`nonSenbatsuLineup`）を任意で受け取り、選抜との排他・両編成の在籍を検証する。集約をまたぐ前提条件「選抜対象メンバーが当該グループに在籍中（`Active`・所属一致）であること」を検証してから `Formation.create` → `Single.create` へ橋渡しする（studbook の `registerFoal` 型）。 |
 | releaseAlbum | アルバムを発売する | 選抜（リード曲フォーメーション）を編成してアルバムを成立させる入口。集約をまたぐ前提条件「選抜対象メンバーが当該グループに在籍中（`Active`・所属一致）であること」を検証してから `Formation.create` → `Album.create` へ橋渡しする（`releaseSingle` と対称）。 |
 
-**禁止語・注意**: 「選抜」をグループやメンバーの恒久属性として扱わない（作品単位（シングル/アルバム共通）の一時的編成。⇔ 非選抜（アンダー）＝`Formation` の `nonSenbatsu` ロールとしてモデル化済み（#556）。呼称は別 Issue）。
+**禁止語・注意**: 「選抜」をグループやメンバーの恒久属性として扱わない（作品単位（シングル/アルバム共通）の一時的編成。⇔ 非選抜（アンダー）＝`Formation` の `nonSenbatsu` ロールとしてモデル化済み（#556）。呼称は `Group.nonSenbatsuAppellation` としてモデル化済み（#582））。
 「選抜対象メンバーが当該グループに在籍中であること」の検証は集約またぎのため `Formation` では守らない（`releaseSingle` / `releaseAlbum` が封じ込める）。
 「桜坂46」は誤記（正しくは旧字の「櫻坂46」）。
 
@@ -213,6 +214,7 @@ graph LR
 | Membership | 値オブジェクト | domain.sakamichi.model.member |
 | Membership.Active | 値オブジェクト | domain.sakamichi.model.member |
 | Membership.Graduated | 値オブジェクト | domain.sakamichi.model.member |
+| NonSenbatsuAppellation | 値オブジェクト | domain.sakamichi.model.group |
 | Position | 値オブジェクト | domain.sakamichi.model.release |
 | Position.Center | 値オブジェクト | domain.sakamichi.model.release |
 | Position.Spot | 値オブジェクト | domain.sakamichi.model.release |

--- a/src/main/kotlin/com/example/api/domain/sakamichi/model/group/Group.kt
+++ b/src/main/kotlin/com/example/api/domain/sakamichi/model/group/Group.kt
@@ -17,20 +17,36 @@ import org.jmolecules.ddd.annotation.ValueObject
  * 参照で持つ（方向の判断はスペック `docs/superpowers/specs/2026-07-04-sakamichi-member-group-design.md`
  * を参照）。「グループの在籍者一覧」の ような読み取りは軽量 CQRS（ADR-0031）の Read Model で解決する。
  *
+ * 非選抜活動体の呼称（[NonSenbatsuAppellation]）は任意属性で、呼称を持たないグループ/時期は null で許容する。
+ * 呼称の有効期間や作品との結び付けは持たない（時間軸・結び付けは #583 の関心）。
+ *
  * 改名（欅坂46→櫻坂46 等）の状態遷移は今回スコープ外。コンストラクタは private とし、生成は [create] に限る。
  *
  * @property id グループID（生成時に自動採番）
  * @property name グループ名
+ * @property nonSenbatsuAppellation 非選抜活動体の呼称。持たない場合は null
  */
 @AggregateRoot
-class Group private constructor(@field:Identity override val id: GroupId, val name: GroupName) :
-    Entity<GroupId>() {
+class Group
+private constructor(
+    @field:Identity override val id: GroupId,
+    val name: GroupName,
+    val nonSenbatsuAppellation: NonSenbatsuAppellation?,
+) : Entity<GroupId>() {
     companion object {
         /**
          * グループを生成する。
          *
-         * 検証済みの [GroupName] を受け取るため失敗せず、[Group] をそのまま返す。
+         * 検証済みの [GroupName] / [NonSenbatsuAppellation] を受け取るため失敗せず、[Group] をそのまま返す。
+         *
+         * @param name グループ名
+         * @param nonSenbatsuAppellation 非選抜活動体の呼称（任意）。持たない場合は指定しない（null）
          */
-        fun create(name: GroupName): Group = Group(id = GroupId(generateId()), name = name)
+        fun create(name: GroupName, nonSenbatsuAppellation: NonSenbatsuAppellation? = null): Group =
+            Group(
+                id = GroupId(generateId()),
+                name = name,
+                nonSenbatsuAppellation = nonSenbatsuAppellation,
+            )
     }
 }

--- a/src/main/kotlin/com/example/api/domain/sakamichi/model/group/NonSenbatsuAppellation.kt
+++ b/src/main/kotlin/com/example/api/domain/sakamichi/model/group/NonSenbatsuAppellation.kt
@@ -1,0 +1,35 @@
+package com.example.api.domain.sakamichi.model.group
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import org.jmolecules.ddd.annotation.ValueObject
+
+/** 非選抜活動体の呼称が不変条件（非ブランク・100 文字以内）を満たさない。 */
+data object InvalidNonSenbatsuAppellation
+
+/**
+ * 非選抜活動体の呼称。
+ *
+ * グループ別の非選抜編成の呼び名（乃木坂46=アンダー／櫻坂46=BACKS／日向坂46=ひなた坂46）。非ブランク・100 文字以内を 不変条件とする（[GroupName]
+ * と同一方針）。どの作品から適用されたか等の時間軸は持たない（作品側の関心・#583）。
+ *
+ * @property value 呼称
+ */
+@ValueObject
+@JvmInline
+value class NonSenbatsuAppellation private constructor(val value: String) {
+    companion object {
+        private const val MAX_LENGTH = 100
+
+        /** 非ブランク・100 文字以内であることを検証して [NonSenbatsuAppellation] を生成する。 */
+        fun create(value: String): Result<NonSenbatsuAppellation, InvalidNonSenbatsuAppellation> {
+            val trimmed = value.trim()
+            return if (trimmed.isNotEmpty() && trimmed.length <= MAX_LENGTH) {
+                Ok(NonSenbatsuAppellation(trimmed))
+            } else {
+                Err(InvalidNonSenbatsuAppellation)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/sakamichi/model/group/GroupTest.kt
+++ b/src/test/kotlin/com/example/api/domain/sakamichi/model/group/GroupTest.kt
@@ -21,4 +21,20 @@ class GroupTest {
 
         assert(first.id != second.id)
     }
+
+    @Test
+    fun `非選抜活動体の呼称ありで生成すると属性に反映される`() {
+        val appellation = NonSenbatsuAppellation.create("アンダー").unwrap()
+
+        val group = Group.create(name, appellation)
+
+        assert(group.nonSenbatsuAppellation == appellation)
+    }
+
+    @Test
+    fun `呼称を省略すると null になる`() {
+        val group = Group.create(name)
+
+        assert(group.nonSenbatsuAppellation == null)
+    }
 }

--- a/src/test/kotlin/com/example/api/domain/sakamichi/model/group/NonSenbatsuAppellationTest.kt
+++ b/src/test/kotlin/com/example/api/domain/sakamichi/model/group/NonSenbatsuAppellationTest.kt
@@ -1,0 +1,40 @@
+package com.example.api.domain.sakamichi.model.group
+
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import org.junit.jupiter.api.Test
+
+/** NonSenbatsuAppellation 値オブジェクトの不変条件（非ブランク・100 文字以内）のユニットテスト。 */
+class NonSenbatsuAppellationTest {
+    @Test
+    fun `非ブランクなら生成でき trim される`() {
+        val appellation = NonSenbatsuAppellation.create("  アンダー  ").unwrap()
+
+        assert(appellation.value == "アンダー")
+    }
+
+    @Test
+    fun `上限の100文字は許可される`() {
+        val appellation = NonSenbatsuAppellation.create("あ".repeat(100)).unwrap()
+
+        assert(appellation.value.length == 100)
+    }
+
+    @Test
+    fun `101文字は長すぎて InvalidNonSenbatsuAppellation を返す`() {
+        assert(
+            NonSenbatsuAppellation.create("あ".repeat(101)).getError() ==
+                InvalidNonSenbatsuAppellation
+        )
+    }
+
+    @Test
+    fun `空文字は InvalidNonSenbatsuAppellation を返す`() {
+        assert(NonSenbatsuAppellation.create("").getError() == InvalidNonSenbatsuAppellation)
+    }
+
+    @Test
+    fun `空白のみは InvalidNonSenbatsuAppellation を返す`() {
+        assert(NonSenbatsuAppellation.create("   ").getError() == InvalidNonSenbatsuAppellation)
+    }
+}


### PR DESCRIPTION
## 概要

#582。坂道シリーズの非選抜活動体の呼称（乃木坂46=アンダー／櫻坂46=BACKS／日向坂46=ひなた坂46）を `Group` 集約の任意属性 `nonSenbatsuAppellation` としてモデル化する。#556（非選抜編成を `Formation` の `nonSenbatsu` ロールとして導入・ADR-0058）で先送りしたグループ別呼称の追随。

## 変更点

- 新規 VO `NonSenbatsuAppellation`（非ブランク・100 文字以内・自己検証ファクトリ。`GroupName` と同一方針）
- `Group` に任意属性 `nonSenbatsuAppellation`（nullable・既定 null）を追加。呼称を持たないグループ/時期を型で許容
- ユビキタス言語ドキュメント同期（自動生成ブロック再生成＋手書き用語表に追録、#556 由来の「別 Issue」前方参照を実装済みへ更新）

## スコープ外（設計判断）

- 呼称と作品・編成・ライブの結び付け（#583）
- 呼称の有効期間・時間軸（日向坂の 11th 以降など）
- 「櫻エイト」等の選抜内下位区分
- 呼称を後から変更する状態遷移（改名同様スコープ外・イミュータブル集約）

## 検証

`./gradlew check`（ktfmt / detekt / test / koverVerifyMature / ArchUnit）を単独実行で BUILD SUCCESSFUL。

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)
