### PR TITLE
feat: DB スキーマをコンテキスト別に分割する（ADR-0048 の実装）

### DIFF
--- a/.tbls.yml
+++ b/.tbls.yml
@@ -23,7 +23,7 @@ exclude:
 # lint ルールは可能な限り有効化する方針（crit レビュー: 基本的に全て true）。
 # ただし現スキーマに対して「違反ゼロで通せる」ものだけを true にする（CI の tbls lint ゲートを割らないため）。
 # 残りは該当機能（外部キー / ラベル / ビューポイント / index・制約コメント）を導入した時点で有効化する。
-# 外部キーは ADR-0053 で導入済み。スキーマ名前空間の方針は別 Issue（#509）で検討中。
+# 外部キーは ADR-0053 で導入済み。DB スキーマはコンテキスト別に分割済み（#569 / ADR-0048。studbook / racing）。
 lint:
   # コメント必須（スキーマを一次情報とする）。
   requireTableComment:
@@ -46,7 +46,9 @@ lint:
   unrelatedTable:
     enabled: true # 集約間 FK（ADR-0053）導入済み。関連を持たないテーブルの混入を検知する
     exclude:
-      - jockey # racing コンテキストの単一集約でコンテキスト内に関連先が無く構造的に unrelated（意図的）
+      # スキーマ分割（#569 / ADR-0048）後、tbls はテーブルをスキーマ修飾名で扱うため
+      # racing.jockey と完全修飾する（旧 public 単一スキーマ時代の bare 名 `jockey` は非マッチになる）。
+      - racing.jockey # racing コンテキストの単一集約でコンテキスト内に関連先が無く構造的に unrelated（意図的）
   requireIndexComment:
     enabled: false # PK 由来の暗黙 index にコメントが無く落ちる（index コメント追加で有効化）
   requireConstraintComment:

--- a/dbdoc/README.md
+++ b/dbdoc/README.md
@@ -4,33 +4,33 @@
 
 | Name | Columns | Comment | Type |
 | ---- | ------- | ------- | ---- |
-| [public.jockey](public.jockey.md) | 4 | 騎手（JRA 競馬コンテキスト） | BASE TABLE |
-| [public.breeding_registration](public.breeding_registration.md) | 7 | 繁殖登録（軽種馬登録コンテキスト） | BASE TABLE |
-| [public.blood_horse](public.blood_horse.md) | 15 | 血統馬（軽種馬登録コンテキスト） | BASE TABLE |
-| [public.breeding_result](public.breeding_result.md) | 11 | 繁殖成績（軽種馬登録コンテキスト） | BASE TABLE |
-| [public.horse_inspection](public.horse_inspection.md) | 8 | 個体識別審査・親子判定（軽種馬登録コンテキスト） | BASE TABLE |
-| [public.covering_report](public.covering_report.md) | 5 | 種付成績報告書（様式第13号）の年次提出記録（種牡馬×種付年） | BASE TABLE |
+| [racing.jockey](racing.jockey.md) | 4 | 騎手（JRA 競馬コンテキスト） | BASE TABLE |
+| [studbook.breeding_registration](studbook.breeding_registration.md) | 7 | 繁殖登録（軽種馬登録コンテキスト） | BASE TABLE |
+| [studbook.blood_horse](studbook.blood_horse.md) | 15 | 血統馬（軽種馬登録コンテキスト） | BASE TABLE |
+| [studbook.breeding_result](studbook.breeding_result.md) | 11 | 繁殖成績（軽種馬登録コンテキスト） | BASE TABLE |
+| [studbook.horse_inspection](studbook.horse_inspection.md) | 8 | 個体識別審査・親子判定（軽種馬登録コンテキスト） | BASE TABLE |
+| [studbook.covering_report](studbook.covering_report.md) | 5 | 種付成績報告書（様式第13号）の年次提出記録（種牡馬×種付年） | BASE TABLE |
 
 ## Relations
 
 ```mermaid
 erDiagram
 
-"public.breeding_registration" }o--|| "public.blood_horse" : "FOREIGN KEY (registered_horse_id) REFERENCES blood_horse(id)"
-"public.blood_horse" }o--o| "public.blood_horse" : "FOREIGN KEY (dam_id) REFERENCES blood_horse(id)"
-"public.blood_horse" }o--o| "public.blood_horse" : "FOREIGN KEY (sire_id) REFERENCES blood_horse(id)"
-"public.blood_horse" }o--|| "public.horse_inspection" : "FOREIGN KEY (inspection_id) REFERENCES horse_inspection(id)"
-"public.breeding_result" }o--|| "public.breeding_registration" : "FOREIGN KEY (breeding_registration_id) REFERENCES breeding_registration(id)"
-"public.breeding_result" }o--o| "public.blood_horse" : "FOREIGN KEY (covering_stallion_id) REFERENCES blood_horse(id)"
-"public.covering_report" }o--|| "public.breeding_registration" : "FOREIGN KEY (stallion_breeding_registration_id) REFERENCES breeding_registration(id)"
+"studbook.breeding_registration" }o--|| "studbook.blood_horse" : "FOREIGN KEY (registered_horse_id) REFERENCES studbook.blood_horse(id)"
+"studbook.blood_horse" }o--o| "studbook.blood_horse" : "FOREIGN KEY (dam_id) REFERENCES studbook.blood_horse(id)"
+"studbook.blood_horse" }o--o| "studbook.blood_horse" : "FOREIGN KEY (sire_id) REFERENCES studbook.blood_horse(id)"
+"studbook.blood_horse" }o--|| "studbook.horse_inspection" : "FOREIGN KEY (inspection_id) REFERENCES studbook.horse_inspection(id)"
+"studbook.breeding_result" }o--|| "studbook.breeding_registration" : "FOREIGN KEY (breeding_registration_id) REFERENCES studbook.breeding_registration(id)"
+"studbook.breeding_result" }o--o| "studbook.blood_horse" : "FOREIGN KEY (covering_stallion_id) REFERENCES studbook.blood_horse(id)"
+"studbook.covering_report" }o--|| "studbook.breeding_registration" : "FOREIGN KEY (stallion_breeding_registration_id) REFERENCES studbook.breeding_registration(id)"
 
-"public.jockey" {
+"racing.jockey" {
   uuid id
   varchar_255_ first_name
   varchar_255_ last_name
   bigint version
 }
-"public.breeding_registration" {
+"studbook.breeding_registration" {
   uuid id
   varchar_255_ registration_number
   uuid registered_horse_id FK
@@ -39,7 +39,7 @@ erDiagram
   date retirement_occurred_on
   bigint version
 }
-"public.blood_horse" {
+"studbook.blood_horse" {
   uuid id
   varchar_255_ registration_number
   varchar_16_ sex
@@ -56,7 +56,7 @@ erDiagram
   date landing_date
   bigint version
 }
-"public.breeding_result" {
+"studbook.breeding_result" {
   uuid id
   uuid breeding_registration_id FK
   integer breeding_year
@@ -69,7 +69,7 @@ erDiagram
   bigint version
   date report_submitted_on
 }
-"public.horse_inspection" {
+"studbook.horse_inspection" {
   uuid id
   varchar_64_ microchip_number
   varchar_32_ parentage_type
@@ -79,7 +79,7 @@ erDiagram
   varchar_255_ feature_nose_print
   bigint version
 }
-"public.covering_report" {
+"studbook.covering_report" {
   uuid id
   uuid stallion_breeding_registration_id FK
   integer covering_year

--- a/dbdoc/racing.jockey.md
+++ b/dbdoc/racing.jockey.md
@@ -1,4 +1,4 @@
-# public.jockey
+# racing.jockey
 
 ## Description
 
@@ -23,7 +23,7 @@
 
 | Name | Definition |
 | ---- | ---------- |
-| jockey_pkey | CREATE UNIQUE INDEX jockey_pkey ON public.jockey USING btree (id) |
+| jockey_pkey | CREATE UNIQUE INDEX jockey_pkey ON racing.jockey USING btree (id) |
 
 ## Relations
 
@@ -31,7 +31,7 @@
 erDiagram
 
 
-"public.jockey" {
+"racing.jockey" {
   uuid id
   varchar_255_ first_name
   varchar_255_ last_name

--- a/dbdoc/studbook.blood_horse.md
+++ b/dbdoc/studbook.blood_horse.md
@@ -1,4 +1,4 @@
-# public.blood_horse
+# studbook.blood_horse
 
 ## Description
 
@@ -8,18 +8,18 @@
 
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
-| id | uuid |  | false | [public.breeding_registration](public.breeding_registration.md) [public.blood_horse](public.blood_horse.md) [public.breeding_result](public.breeding_result.md) |  | 識別子（外部採番の UUIDv7） |
+| id | uuid |  | false | [studbook.breeding_registration](studbook.breeding_registration.md) [studbook.blood_horse](studbook.blood_horse.md) [studbook.breeding_result](studbook.breeding_result.md) |  | 識別子（外部採番の UUIDv7） |
 | registration_number | varchar(255) |  | false |  |  | 登録番号 |
 | sex | varchar(16) |  | false |  |  | 性別（ドメイン enum 名） |
 | coat_color | varchar(32) |  | false |  |  | 毛色（ドメイン enum 名） |
 | breed_type | varchar(32) |  | false |  |  | 品種区分（ドメイン enum 名） |
 | date_of_birth | date |  | false |  |  | 生年月日 |
 | breeder | varchar(255) |  | false |  |  | 生産者 |
-| inspection_id | uuid |  | false |  | [public.horse_inspection](public.horse_inspection.md) | 個体識別審査（horse_inspection）の ID |
+| inspection_id | uuid |  | false |  | [studbook.horse_inspection](studbook.horse_inspection.md) | 個体識別審査（horse_inspection）の ID |
 | name | varchar(255) |  | true |  |  | 馬名（未命名なら NULL） |
 | origin_type | varchar(16) |  | false |  |  | 出自の判別子（DOMESTIC/IMPORTED） |
-| sire_id | uuid |  | true |  | [public.blood_horse](public.blood_horse.md) | 父馬 ID（内国産のみ） |
-| dam_id | uuid |  | true |  | [public.blood_horse](public.blood_horse.md) | 母馬 ID（内国産のみ） |
+| sire_id | uuid |  | true |  | [studbook.blood_horse](studbook.blood_horse.md) | 父馬 ID（内国産のみ） |
+| dam_id | uuid |  | true |  | [studbook.blood_horse](studbook.blood_horse.md) | 母馬 ID（内国産のみ） |
 | origin_country | varchar(255) |  | true |  |  | 原産国（輸入のみ） |
 | landing_date | date |  | true |  |  | 輸入上陸日（輸入のみ） |
 | version | bigint |  | false |  |  | 楽観ロック用バージョン（新規判定の NULL はエンティティ側のみ。保存済み行は常に非 NULL） |
@@ -30,31 +30,31 @@
 | ---- | ---- | ---------- |
 | chk_blood_horse_origin | CHECK | CHECK (((((origin_type)::text = 'DOMESTIC'::text) AND (sire_id IS NOT NULL) AND (dam_id IS NOT NULL) AND (origin_country IS NULL) AND (landing_date IS NULL)) OR (((origin_type)::text = 'IMPORTED'::text) AND (origin_country IS NOT NULL) AND (landing_date IS NOT NULL) AND (sire_id IS NULL) AND (dam_id IS NULL)))) |
 | blood_horse_pkey | PRIMARY KEY | PRIMARY KEY (id) |
-| fk_blood_horse_dam | FOREIGN KEY | FOREIGN KEY (dam_id) REFERENCES blood_horse(id) |
-| fk_blood_horse_sire | FOREIGN KEY | FOREIGN KEY (sire_id) REFERENCES blood_horse(id) |
-| fk_blood_horse_inspection | FOREIGN KEY | FOREIGN KEY (inspection_id) REFERENCES horse_inspection(id) |
+| fk_blood_horse_dam | FOREIGN KEY | FOREIGN KEY (dam_id) REFERENCES studbook.blood_horse(id) |
+| fk_blood_horse_sire | FOREIGN KEY | FOREIGN KEY (sire_id) REFERENCES studbook.blood_horse(id) |
+| fk_blood_horse_inspection | FOREIGN KEY | FOREIGN KEY (inspection_id) REFERENCES studbook.horse_inspection(id) |
 
 ## Indexes
 
 | Name | Definition |
 | ---- | ---------- |
-| blood_horse_pkey | CREATE UNIQUE INDEX blood_horse_pkey ON public.blood_horse USING btree (id) |
-| ix_blood_horse_inspection_id | CREATE INDEX ix_blood_horse_inspection_id ON public.blood_horse USING btree (inspection_id) |
-| ix_blood_horse_sire_id | CREATE INDEX ix_blood_horse_sire_id ON public.blood_horse USING btree (sire_id) |
-| ix_blood_horse_dam_id | CREATE INDEX ix_blood_horse_dam_id ON public.blood_horse USING btree (dam_id) |
+| blood_horse_pkey | CREATE UNIQUE INDEX blood_horse_pkey ON studbook.blood_horse USING btree (id) |
+| ix_blood_horse_inspection_id | CREATE INDEX ix_blood_horse_inspection_id ON studbook.blood_horse USING btree (inspection_id) |
+| ix_blood_horse_sire_id | CREATE INDEX ix_blood_horse_sire_id ON studbook.blood_horse USING btree (sire_id) |
+| ix_blood_horse_dam_id | CREATE INDEX ix_blood_horse_dam_id ON studbook.blood_horse USING btree (dam_id) |
 
 ## Relations
 
 ```mermaid
 erDiagram
 
-"public.breeding_registration" }o--|| "public.blood_horse" : "FOREIGN KEY (registered_horse_id) REFERENCES blood_horse(id)"
-"public.blood_horse" }o--o| "public.blood_horse" : "FOREIGN KEY (dam_id) REFERENCES blood_horse(id)"
-"public.blood_horse" }o--o| "public.blood_horse" : "FOREIGN KEY (sire_id) REFERENCES blood_horse(id)"
-"public.breeding_result" }o--o| "public.blood_horse" : "FOREIGN KEY (covering_stallion_id) REFERENCES blood_horse(id)"
-"public.blood_horse" }o--|| "public.horse_inspection" : "FOREIGN KEY (inspection_id) REFERENCES horse_inspection(id)"
+"studbook.breeding_registration" }o--|| "studbook.blood_horse" : "FOREIGN KEY (registered_horse_id) REFERENCES studbook.blood_horse(id)"
+"studbook.blood_horse" }o--o| "studbook.blood_horse" : "FOREIGN KEY (dam_id) REFERENCES studbook.blood_horse(id)"
+"studbook.blood_horse" }o--o| "studbook.blood_horse" : "FOREIGN KEY (sire_id) REFERENCES studbook.blood_horse(id)"
+"studbook.breeding_result" }o--o| "studbook.blood_horse" : "FOREIGN KEY (covering_stallion_id) REFERENCES studbook.blood_horse(id)"
+"studbook.blood_horse" }o--|| "studbook.horse_inspection" : "FOREIGN KEY (inspection_id) REFERENCES studbook.horse_inspection(id)"
 
-"public.blood_horse" {
+"studbook.blood_horse" {
   uuid id
   varchar_255_ registration_number
   varchar_16_ sex
@@ -71,7 +71,7 @@ erDiagram
   date landing_date
   bigint version
 }
-"public.breeding_registration" {
+"studbook.breeding_registration" {
   uuid id
   varchar_255_ registration_number
   uuid registered_horse_id FK
@@ -80,7 +80,7 @@ erDiagram
   date retirement_occurred_on
   bigint version
 }
-"public.breeding_result" {
+"studbook.breeding_result" {
   uuid id
   uuid breeding_registration_id FK
   integer breeding_year
@@ -93,7 +93,7 @@ erDiagram
   bigint version
   date report_submitted_on
 }
-"public.horse_inspection" {
+"studbook.horse_inspection" {
   uuid id
   varchar_64_ microchip_number
   varchar_32_ parentage_type

--- a/dbdoc/studbook.breeding_registration.md
+++ b/dbdoc/studbook.breeding_registration.md
@@ -1,4 +1,4 @@
-# public.breeding_registration
+# studbook.breeding_registration
 
 ## Description
 
@@ -8,9 +8,9 @@
 
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
-| id | uuid |  | false | [public.breeding_result](public.breeding_result.md) [public.covering_report](public.covering_report.md) |  | 識別子（外部採番の UUIDv7） |
+| id | uuid |  | false | [studbook.breeding_result](studbook.breeding_result.md) [studbook.covering_report](studbook.covering_report.md) |  | 識別子（外部採番の UUIDv7） |
 | registration_number | varchar(255) |  | false |  |  | 登録番号 |
-| registered_horse_id | uuid |  | false |  | [public.blood_horse](public.blood_horse.md) | 登録対象の血統馬 ID |
+| registered_horse_id | uuid |  | false |  | [studbook.blood_horse](studbook.blood_horse.md) | 登録対象の血統馬 ID |
 | breeding_role | varchar(32) |  | false |  |  | 繁殖の役割（STALLION/BROODMARE） |
 | retirement_reason | varchar(32) |  | true |  |  | 供用停止事由（供用中は NULL） |
 | retirement_occurred_on | date |  | true |  |  | 供用停止発生日（供用中は NULL） |
@@ -22,25 +22,25 @@
 | ---- | ---- | ---------- |
 | chk_breeding_registration_retirement_coexistence | CHECK | CHECK ((((retirement_reason IS NULL) AND (retirement_occurred_on IS NULL)) OR ((retirement_reason IS NOT NULL) AND (retirement_occurred_on IS NOT NULL)))) |
 | breeding_registration_pkey | PRIMARY KEY | PRIMARY KEY (id) |
-| fk_breeding_registration_registered_horse | FOREIGN KEY | FOREIGN KEY (registered_horse_id) REFERENCES blood_horse(id) |
+| fk_breeding_registration_registered_horse | FOREIGN KEY | FOREIGN KEY (registered_horse_id) REFERENCES studbook.blood_horse(id) |
 
 ## Indexes
 
 | Name | Definition |
 | ---- | ---------- |
-| breeding_registration_pkey | CREATE UNIQUE INDEX breeding_registration_pkey ON public.breeding_registration USING btree (id) |
-| ix_breeding_registration_registered_horse_id | CREATE INDEX ix_breeding_registration_registered_horse_id ON public.breeding_registration USING btree (registered_horse_id) |
+| breeding_registration_pkey | CREATE UNIQUE INDEX breeding_registration_pkey ON studbook.breeding_registration USING btree (id) |
+| ix_breeding_registration_registered_horse_id | CREATE INDEX ix_breeding_registration_registered_horse_id ON studbook.breeding_registration USING btree (registered_horse_id) |
 
 ## Relations
 
 ```mermaid
 erDiagram
 
-"public.breeding_result" }o--|| "public.breeding_registration" : "FOREIGN KEY (breeding_registration_id) REFERENCES breeding_registration(id)"
-"public.covering_report" }o--|| "public.breeding_registration" : "FOREIGN KEY (stallion_breeding_registration_id) REFERENCES breeding_registration(id)"
-"public.breeding_registration" }o--|| "public.blood_horse" : "FOREIGN KEY (registered_horse_id) REFERENCES blood_horse(id)"
+"studbook.breeding_result" }o--|| "studbook.breeding_registration" : "FOREIGN KEY (breeding_registration_id) REFERENCES studbook.breeding_registration(id)"
+"studbook.covering_report" }o--|| "studbook.breeding_registration" : "FOREIGN KEY (stallion_breeding_registration_id) REFERENCES studbook.breeding_registration(id)"
+"studbook.breeding_registration" }o--|| "studbook.blood_horse" : "FOREIGN KEY (registered_horse_id) REFERENCES studbook.blood_horse(id)"
 
-"public.breeding_registration" {
+"studbook.breeding_registration" {
   uuid id
   varchar_255_ registration_number
   uuid registered_horse_id FK
@@ -49,7 +49,7 @@ erDiagram
   date retirement_occurred_on
   bigint version
 }
-"public.breeding_result" {
+"studbook.breeding_result" {
   uuid id
   uuid breeding_registration_id FK
   integer breeding_year
@@ -62,14 +62,14 @@ erDiagram
   bigint version
   date report_submitted_on
 }
-"public.covering_report" {
+"studbook.covering_report" {
   uuid id
   uuid stallion_breeding_registration_id FK
   integer covering_year
   date submitted_on
   bigint version
 }
-"public.blood_horse" {
+"studbook.blood_horse" {
   uuid id
   varchar_255_ registration_number
   varchar_16_ sex

--- a/dbdoc/studbook.breeding_result.md
+++ b/dbdoc/studbook.breeding_result.md
@@ -1,4 +1,4 @@
-# public.breeding_result
+# studbook.breeding_result
 
 ## Description
 
@@ -9,9 +9,9 @@
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
 | id | uuid |  | false |  |  | 識別子（外部採番の UUIDv7） |
-| breeding_registration_id | uuid |  | false |  | [public.breeding_registration](public.breeding_registration.md) | 対象の繁殖登録 ID |
+| breeding_registration_id | uuid |  | false |  | [studbook.breeding_registration](studbook.breeding_registration.md) | 対象の繁殖登録 ID |
 | breeding_year | integer |  | false |  |  | 繁殖年（java.time.Year の int 値） |
-| covering_stallion_id | uuid |  | true |  | [public.blood_horse](public.blood_horse.md) | 種付種牡馬 ID（種付なしは NULL） |
+| covering_stallion_id | uuid |  | true |  | [studbook.blood_horse](studbook.blood_horse.md) | 種付種牡馬 ID（種付なしは NULL） |
 | covering_date | date |  | true |  |  | 種付日（種付なしは NULL） |
 | covering_place | varchar(255) |  | true |  |  | 種付場所（任意） |
 | covering_certificate_number | varchar(255) |  | true |  |  | 種付証明書番号（種付なしは NULL） |
@@ -28,27 +28,27 @@
 | chk_breeding_result_foaling_date | CHECK | CHECK (((outcome_foaling_date IS NULL) OR ((outcome_type)::text = 'LIVE_FOAL'::text))) |
 | chk_breeding_result_outcome_covering | CHECK | CHECK ((((covering_date IS NULL) AND ((outcome_type)::text = 'NOT_COVERED'::text)) OR ((covering_date IS NOT NULL) AND ((outcome_type IS NULL) OR ((outcome_type)::text <> 'NOT_COVERED'::text))))) |
 | chk_breeding_result_report_needs_outcome | CHECK | CHECK (((report_submitted_on IS NULL) OR (outcome_type IS NOT NULL))) |
-| fk_breeding_result_breeding_registration | FOREIGN KEY | FOREIGN KEY (breeding_registration_id) REFERENCES breeding_registration(id) |
-| fk_breeding_result_covering_stallion | FOREIGN KEY | FOREIGN KEY (covering_stallion_id) REFERENCES blood_horse(id) |
+| fk_breeding_result_breeding_registration | FOREIGN KEY | FOREIGN KEY (breeding_registration_id) REFERENCES studbook.breeding_registration(id) |
+| fk_breeding_result_covering_stallion | FOREIGN KEY | FOREIGN KEY (covering_stallion_id) REFERENCES studbook.blood_horse(id) |
 | breeding_result_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## Indexes
 
 | Name | Definition |
 | ---- | ---------- |
-| breeding_result_pkey | CREATE UNIQUE INDEX breeding_result_pkey ON public.breeding_result USING btree (id) |
-| ix_breeding_result_registration_year | CREATE INDEX ix_breeding_result_registration_year ON public.breeding_result USING btree (breeding_registration_id, breeding_year) |
-| ix_breeding_result_covering_stallion_id | CREATE INDEX ix_breeding_result_covering_stallion_id ON public.breeding_result USING btree (covering_stallion_id) |
+| breeding_result_pkey | CREATE UNIQUE INDEX breeding_result_pkey ON studbook.breeding_result USING btree (id) |
+| ix_breeding_result_registration_year | CREATE INDEX ix_breeding_result_registration_year ON studbook.breeding_result USING btree (breeding_registration_id, breeding_year) |
+| ix_breeding_result_covering_stallion_id | CREATE INDEX ix_breeding_result_covering_stallion_id ON studbook.breeding_result USING btree (covering_stallion_id) |
 
 ## Relations
 
 ```mermaid
 erDiagram
 
-"public.breeding_result" }o--|| "public.breeding_registration" : "FOREIGN KEY (breeding_registration_id) REFERENCES breeding_registration(id)"
-"public.breeding_result" }o--o| "public.blood_horse" : "FOREIGN KEY (covering_stallion_id) REFERENCES blood_horse(id)"
+"studbook.breeding_result" }o--|| "studbook.breeding_registration" : "FOREIGN KEY (breeding_registration_id) REFERENCES studbook.breeding_registration(id)"
+"studbook.breeding_result" }o--o| "studbook.blood_horse" : "FOREIGN KEY (covering_stallion_id) REFERENCES studbook.blood_horse(id)"
 
-"public.breeding_result" {
+"studbook.breeding_result" {
   uuid id
   uuid breeding_registration_id FK
   integer breeding_year
@@ -61,7 +61,7 @@ erDiagram
   bigint version
   date report_submitted_on
 }
-"public.breeding_registration" {
+"studbook.breeding_registration" {
   uuid id
   varchar_255_ registration_number
   uuid registered_horse_id FK
@@ -70,7 +70,7 @@ erDiagram
   date retirement_occurred_on
   bigint version
 }
-"public.blood_horse" {
+"studbook.blood_horse" {
   uuid id
   varchar_255_ registration_number
   varchar_16_ sex

--- a/dbdoc/studbook.covering_report.md
+++ b/dbdoc/studbook.covering_report.md
@@ -1,4 +1,4 @@
-# public.covering_report
+# studbook.covering_report
 
 ## Description
 
@@ -9,7 +9,7 @@
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
 | id | uuid |  | false |  |  | 種付成績報告ID（外部採番の UUIDv7） |
-| stallion_breeding_registration_id | uuid |  | false |  | [public.breeding_registration](public.breeding_registration.md) | 提出した種牡馬の繁殖登録ID |
+| stallion_breeding_registration_id | uuid |  | false |  | [studbook.breeding_registration](studbook.breeding_registration.md) | 提出した種牡馬の繁殖登録ID |
 | covering_year | integer |  | false |  |  | 種付年（java.time.Year の int 値。報告対象年） |
 | submitted_on | date |  | false |  |  | 提出日（日本の暦日）。期限（当年9/30）超過かは導出値のため保存しない |
 | version | bigint |  | false |  |  | 楽観ロック兼 insert 判定用の version |
@@ -18,7 +18,7 @@
 
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
-| fk_covering_report_stallion_registration | FOREIGN KEY | FOREIGN KEY (stallion_breeding_registration_id) REFERENCES breeding_registration(id) |
+| fk_covering_report_stallion_registration | FOREIGN KEY | FOREIGN KEY (stallion_breeding_registration_id) REFERENCES studbook.breeding_registration(id) |
 | covering_report_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 | uq_covering_report_stallion_year | UNIQUE | UNIQUE (stallion_breeding_registration_id, covering_year) |
 
@@ -26,24 +26,24 @@
 
 | Name | Definition |
 | ---- | ---------- |
-| covering_report_pkey | CREATE UNIQUE INDEX covering_report_pkey ON public.covering_report USING btree (id) |
-| uq_covering_report_stallion_year | CREATE UNIQUE INDEX uq_covering_report_stallion_year ON public.covering_report USING btree (stallion_breeding_registration_id, covering_year) |
+| covering_report_pkey | CREATE UNIQUE INDEX covering_report_pkey ON studbook.covering_report USING btree (id) |
+| uq_covering_report_stallion_year | CREATE UNIQUE INDEX uq_covering_report_stallion_year ON studbook.covering_report USING btree (stallion_breeding_registration_id, covering_year) |
 
 ## Relations
 
 ```mermaid
 erDiagram
 
-"public.covering_report" }o--|| "public.breeding_registration" : "FOREIGN KEY (stallion_breeding_registration_id) REFERENCES breeding_registration(id)"
+"studbook.covering_report" }o--|| "studbook.breeding_registration" : "FOREIGN KEY (stallion_breeding_registration_id) REFERENCES studbook.breeding_registration(id)"
 
-"public.covering_report" {
+"studbook.covering_report" {
   uuid id
   uuid stallion_breeding_registration_id FK
   integer covering_year
   date submitted_on
   bigint version
 }
-"public.breeding_registration" {
+"studbook.breeding_registration" {
   uuid id
   varchar_255_ registration_number
   uuid registered_horse_id FK

--- a/dbdoc/studbook.horse_inspection.md
+++ b/dbdoc/studbook.horse_inspection.md
@@ -1,4 +1,4 @@
-# public.horse_inspection
+# studbook.horse_inspection
 
 ## Description
 
@@ -8,7 +8,7 @@
 
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
-| id | uuid |  | false | [public.blood_horse](public.blood_horse.md) |  | 識別子（外部採番の UUIDv7） |
+| id | uuid |  | false | [studbook.blood_horse](studbook.blood_horse.md) |  | 識別子（外部採番の UUIDv7） |
 | microchip_number | varchar(64) |  | false |  |  | マイクロチップ番号 |
 | parentage_type | varchar(32) |  | false |  |  | 親子判定の判別子（BY_DNA/BY_BLOOD_TYPE/BY_OVERSEAS_INSTITUTION/NOT_APPLICABLE） |
 | dna_parentage_result | varchar(16) |  | true |  |  | DNA 親子判定結果（BY_DNA のときのみ） |
@@ -28,16 +28,16 @@
 
 | Name | Definition |
 | ---- | ---------- |
-| horse_inspection_pkey | CREATE UNIQUE INDEX horse_inspection_pkey ON public.horse_inspection USING btree (id) |
+| horse_inspection_pkey | CREATE UNIQUE INDEX horse_inspection_pkey ON studbook.horse_inspection USING btree (id) |
 
 ## Relations
 
 ```mermaid
 erDiagram
 
-"public.blood_horse" }o--|| "public.horse_inspection" : "FOREIGN KEY (inspection_id) REFERENCES horse_inspection(id)"
+"studbook.blood_horse" }o--|| "studbook.horse_inspection" : "FOREIGN KEY (inspection_id) REFERENCES studbook.horse_inspection(id)"
 
-"public.horse_inspection" {
+"studbook.horse_inspection" {
   uuid id
   varchar_64_ microchip_number
   varchar_32_ parentage_type
@@ -47,7 +47,7 @@ erDiagram
   varchar_255_ feature_nose_print
   bigint version
 }
-"public.blood_horse" {
+"studbook.blood_horse" {
   uuid id
   varchar_255_ registration_number
   varchar_16_ sex

--- a/src/main/kotlin/com/example/api/infrastructure/racing/jockey/JdbcJockeyQueries.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/racing/jockey/JdbcJockeyQueries.kt
@@ -22,7 +22,7 @@ class JdbcJockeyQueries(private val jdbcClient: JdbcClient) : JockeyQueries {
 
     override fun findById(id: JockeyId): JockeyView? =
         jdbcClient
-            .sql("SELECT id, first_name, last_name FROM jockey WHERE id = :id")
+            .sql("SELECT id, first_name, last_name FROM racing.jockey WHERE id = :id")
             .param("id", id.value)
             .query { rs, _ ->
                 JockeyView(

--- a/src/main/kotlin/com/example/api/infrastructure/racing/jockey/JockeyRow.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/racing/jockey/JockeyRow.kt
@@ -17,7 +17,7 @@ import org.springframework.data.relational.core.mapping.Table
  * - [version] は楽観ロック用の `@Version` 列。null のとき Spring Data JDBC は「新規」とみなして insert する （ID が常に非 null
  *   な外部採番でも insert/update を正しく判別できる。ADR-0027 の落とし穴②③）。
  */
-@Table("jockey")
+@Table(schema = "racing", name = "jockey")
 data class JockeyRow(
     @Id @Column("id") val id: UUID,
     @Column("first_name") val firstName: String,

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/BreedingRegistrationRow.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/BreedingRegistrationRow.kt
@@ -22,7 +22,7 @@ import org.springframework.data.relational.core.mapping.Table
  * - [version] は楽観ロック用の `@Version` 列。null のとき Spring Data JDBC は「新規」とみなして insert する （外部採番で `@Id`
  *   が常に非 null でも insert/update を正しく判別できる。ADR-0027 の落とし穴②③）。
  */
-@Table("breeding_registration")
+@Table(schema = "studbook", name = "breeding_registration")
 data class BreedingRegistrationRow(
     @Id @Column("id") val id: UUID,
     @Column("registration_number") val registrationNumber: String,

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/BreedingResultRow.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/BreedingResultRow.kt
@@ -27,7 +27,7 @@ import org.springframework.data.relational.core.mapping.Table
  * - covering の有無と区分（NotCovered）・分娩日の整合は CHECK 制約でスキーマ側にも強制する（V4 参照）。
  * - [version] は楽観ロック用の `@Version` 列。null のとき Spring Data JDBC は「新規」とみなして insert する。
  */
-@Table("breeding_result")
+@Table(schema = "studbook", name = "breeding_result")
 data class BreedingResultRow(
     @Id @Column("id") val id: UUID,
     @Column("breeding_registration_id") val breedingRegistrationId: UUID,

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/CoveringReportRow.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/CoveringReportRow.kt
@@ -19,7 +19,7 @@ import org.springframework.data.relational.core.mapping.Table
  * - 「種牡馬×種付年」の一意性は UNIQUE 制約でスキーマ側にも強制する（V10 参照）。
  * - [version] は楽観ロック用の `@Version` 列。null のとき Spring Data JDBC は「新規」とみなして insert する。
  */
-@Table("covering_report")
+@Table(schema = "studbook", name = "covering_report")
 data class CoveringReportRow(
     @Id @Column("id") val id: UUID,
     @Column("stallion_breeding_registration_id") val stallionBreedingRegistrationId: UUID,

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultSummaryQueries.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultSummaryQueries.kt
@@ -42,7 +42,7 @@ class JdbcBreedingResultSummaryQueries(private val jdbcClient: JdbcClient) :
                         AND outcome_type <> 'NOT_COVERED'
                     ) AS conceived,
                     COUNT(*) FILTER (WHERE outcome_type = 'LIVE_FOAL') AS live_foals
-                FROM breeding_result
+                FROM studbook.breeding_result
                 WHERE covering_stallion_id = :stallionId
                 GROUP BY covering_stallion_id, breeding_year
                 ORDER BY breeding_year

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/horse/BloodHorseRow.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/horse/BloodHorseRow.kt
@@ -22,7 +22,7 @@ import org.springframework.data.relational.core.mapping.Table
  * - [version] は楽観ロック用の `@Version` 列。null のとき Spring Data JDBC は「新規」とみなして insert する （外部採番で `@Id`
  *   が常に非 null でも insert/update を正しく判別できる。ADR-0027 の落とし穴②③）。
  */
-@Table("blood_horse")
+@Table(schema = "studbook", name = "blood_horse")
 data class BloodHorseRow(
     @Id @Column("id") val id: UUID,
     @Column("registration_number") val registrationNumber: String,

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/HorseInspectionRow.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/HorseInspectionRow.kt
@@ -18,7 +18,7 @@ import org.springframework.data.relational.core.mapping.Table
  *   フラット化する。特徴記述子（nullable `IdentificationFeatures`）は feature_* 列に nullable でフラット化する。
  * - [version] は楽観ロック用の `@Version` 列。null のとき Spring Data JDBC は「新規」とみなして insert する。
  */
-@Table("horse_inspection")
+@Table(schema = "studbook", name = "horse_inspection")
 data class HorseInspectionRow(
     @Id @Column("id") val id: UUID,
     @Column("microchip_number") val microchipNumber: String,

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionQueries.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/inspection/JdbcHorseInspectionQueries.kt
@@ -25,7 +25,7 @@ class JdbcHorseInspectionQueries(private val jdbcClient: JdbcClient) : HorseInsp
                 """
                 SELECT id, microchip_number, parentage_type, dna_parentage_result,
                     feature_hair_whorl, feature_white_markings, feature_nose_print
-                FROM horse_inspection
+                FROM studbook.horse_inspection
                 WHERE id = :id
                 """
                     .trimIndent()

--- a/src/main/resources/db/migration/V13__split_schema_per_context.sql
+++ b/src/main/resources/db/migration/V13__split_schema_per_context.sql
@@ -1,0 +1,33 @@
+-- 境界づけられたコンテキスト別に DB スキーマを分割する（#569 / ADR-0048）。
+-- 現状は全テーブルが public。テーブルを持つのは studbook と racing の 2 コンテキストのみ
+-- （sakamichi / tennis は永続化を持たないため、永続化を持ったとき初めてスキーマを作る）。
+-- コンテキスト分離はコード層で ArchUnit が既に強制しており（ADR-0048）、それを DB 層にも反映する。
+--
+-- 方針:
+--   - スキーマ名は小文字（PostgreSQL の識別子慣習）。
+--   - CREATE SCHEMA IF NOT EXISTS で冪等に作成し、既存 5 + covering_report の 6 テーブルを
+--     ALTER TABLE ... SET SCHEMA で移設する（search_path 依存を避け完全修飾で操作）。
+--   - flyway_schema_history は Flyway の内部管理テーブルなので既定スキーマに残す
+--     （spring.flyway.schemas は設定しない）。
+--   - FK 6 本はすべて studbook 内で閉じるためクロススキーマ FK は発生しない（ADR-0053）。
+--     FK 制約・index はテーブルに従って移設先スキーマへ追随する。
+--
+-- 安全性: 本番 Prisma Postgres 稼働中。ALTER TABLE ... SET SCHEMA はメタデータのみの操作で
+-- テーブル書き換えを伴わないが ACCESS EXCLUSIVE ロックを取るため、squawk（require-timeout-settings）
+-- に従い lock_timeout / statement_timeout を SET LOCAL でこのマイグレーション内に閉じる
+-- （Flyway は各マイグレーションを 1 トランザクションで適用する）。
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+CREATE SCHEMA IF NOT EXISTS studbook;
+CREATE SCHEMA IF NOT EXISTS racing;
+
+-- studbook コンテキスト（軽種馬登録）
+ALTER TABLE blood_horse SET SCHEMA studbook;
+ALTER TABLE breeding_registration SET SCHEMA studbook;
+ALTER TABLE breeding_result SET SCHEMA studbook;
+ALTER TABLE horse_inspection SET SCHEMA studbook;
+ALTER TABLE covering_report SET SCHEMA studbook;
+
+-- racing コンテキスト（競馬）
+ALTER TABLE jockey SET SCHEMA racing;

--- a/src/test/kotlin/com/example/api/support/StudbookTables.kt
+++ b/src/test/kotlin/com/example/api/support/StudbookTables.kt
@@ -11,11 +11,11 @@ import org.springframework.jdbc.core.simple.JdbcClient
  */
 fun deleteAllStudbookTables(jdbcClient: JdbcClient) {
     listOf(
-            "covering_report",
-            "breeding_result",
-            "breeding_registration",
-            "blood_horse",
-            "horse_inspection",
+            "studbook.covering_report",
+            "studbook.breeding_result",
+            "studbook.breeding_registration",
+            "studbook.blood_horse",
+            "studbook.horse_inspection",
         )
         .forEach { table -> jdbcClient.sql("DELETE FROM $table").update() }
 }


### PR DESCRIPTION
## 概要

[ADR-0048](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0048-per-context-db-schema-namespaces.md)（#509）で決定した「DB スキーマを境界づけられたコンテキスト別に分割する（案B）」の**実装**（Closes #569）。現状全テーブルが `public` にあるのを、`studbook` / `racing` スキーマへ分割する。

## 変更内容

- **Flyway `V13__split_schema_per_context.sql`**（新規）: `CREATE SCHEMA IF NOT EXISTS studbook/racing;` ＋ 既存 6 テーブルを `ALTER TABLE ... SET SCHEMA` で移設。`flyway_schema_history` は既定スキーマに残す（`spring.flyway.schemas` は設定しない）。本番 Prisma Postgres 稼働中のため `SET LOCAL` で `lock_timeout`/`statement_timeout` を設定（squawk `require-timeout-settings`）。sqlfluff / squawk 通過。
  - `studbook`: `blood_horse` / `breeding_registration` / `breeding_result` / `horse_inspection` / `covering_report`
  - `racing`: `jockey`
- **Row `@Table`**: studbook 5 本＋`jockey` に `schema` 属性を付与。
- **CQRS 生 SQL**: `JdbcBreedingResultSummaryQueries` / `JdbcHorseInspectionQueries` / `JdbcJockeyQueries` の `FROM` をスキーマ修飾。
- **テスト掃除ヘルパー**: `support/StudbookTables.kt` の `DELETE FROM` をスキーマ修飾。
- **tbls**: dbdoc を `studbook.*` / `racing.jockey` で再生成、`.tbls.yml` の `unrelatedTable.exclude` を `racing.jockey` へ修飾（多スキーマ化で完全修飾名が要るため）。#509 検討中コメントを ADR-0048 決定済みへ更新。

## Issue チェックリスト外で対処した論点

1. **`covering_report` の移設漏れ**: Issue 本文は studbook 4 テーブルだが、その後 V10 で追加された `covering_report` も studbook へ含めた（現状 6 テーブル）。
2. **`@Table` 経由でない生 SQL / テスト掃除ヘルパー**: Spring Data JDBC（`@Table`）はスキーマに追随するが、手書き SELECT と `DELETE FROM` は追随せず `search_path` 非設定方針では壊れる（当初 61 テスト失敗 → 修正で解消）。
3. **tbls exclude のマッチ挙動**: 単一 `public` 時代は bare 名でマッチしていた `unrelatedTable.exclude` が、多スキーマ化で完全修飾名（`racing.jockey`）を要求するようになった。

## FK

FK 6 本はすべて `studbook` 内で閉じるため**クロススキーマ FK は発生しない**（ADR-0053 と整合）。制約・index はテーブルに従って移設先スキーマへ追随する。

## 確認

- `./gradlew check`（ktfmt / detekt / ArchUnit / リポジトリ結合 / koverVerifyMature）green
- `./gradlew checkDbDoc`（tbls diff + lint）green
- sqlfluff / squawk 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
