### PR TITLE
build(ci): setup-gradle に configuration-cache 持ち越しとキャッシュ剪定を追加

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -38,6 +38,14 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
+          # configuration-cache データ（gradle.properties の org.gradle.configuration-cache=true の成果）も
+          # runner 間で持ち越す。CC は秘密を含みうるため setup-gradle は encryption-key 指定時のみ
+          # 暗号化して保存・復元する（未指定だとエフェメラル CI で設定フェーズのスキップが効かない）。
+          # 全ジョブで同一キーを使う必要があるため repo secret GRADLE_ENCRYPTION_KEY を出所にする。
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          # 保存前に Gradle User Home の未使用ファイルを剪定してキャッシュエントリを軽量化する
+          # （main での保存時のみ作用。10GB のキャッシュ枠の消費と復元時間を抑える）。
+          cache-cleanup: on-success
 
       - name: Install mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,6 +38,9 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
+          # configuration-cache を runner 間で持ち越す（詳細は api-tests.yml のコメント参照）。
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          cache-cleanup: on-success
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3

--- a/.github/workflows/container-smoke-test.yml
+++ b/.github/workflows/container-smoke-test.yml
@@ -45,6 +45,9 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
+          # configuration-cache を runner 間で持ち越す（詳細は api-tests.yml のコメント参照）。
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          cache-cleanup: on-success
 
       - name: Build Docker image with bootBuildImage
         run: ./gradlew bootBuildImage --imageName=api-smoke:test

--- a/.github/workflows/db-doc-check.yml
+++ b/.github/workflows/db-doc-check.yml
@@ -53,6 +53,9 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
+          # configuration-cache を runner 間で持ち越す（詳細は api-tests.yml のコメント参照）。
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          cache-cleanup: on-success
 
       - name: Install mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,6 +34,9 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
+          # configuration-cache を runner 間で持ち越す（詳細は api-tests.yml のコメント参照）。
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          cache-cleanup: on-success
 
       - name: Run E2E tests
         run: ./gradlew e2eTest --stacktrace

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -57,6 +57,9 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
+          # configuration-cache を runner 間で持ち越す（詳細は api-tests.yml のコメント参照）。
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          cache-cleanup: on-success
 
       - name: Install mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0


### PR DESCRIPTION
## 概要

[Gradle on Ephemeral CI（Part 2）](https://blog.gradle.org/gradle-on-ephemeral-ci-2 )を踏まえ、既に導入済みの `setup-gradle` から取りこぼしていた効果を取り込む。ビルド系 6 ワークフローの `setup-gradle` に 2 オプションを追加する。

## 変更内容

- **`cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}`**
  - `gradle.properties` の `org.gradle.configuration-cache=true` は入っているが、`setup-gradle` は **encryption-key 指定時のみ** configuration-cache データを暗号化して runner 間で保存・復元する。未指定のためエフェメラル CI では毎回まっさらから設定フェーズが走り、CC の効果がローカル（デーモン常駐）でしか得られていなかった。
  - repo secret `GRADLE_ENCRYPTION_KEY` を出所にする（全ジョブで同一キーが必要。登録済み）。
- **`cache-cleanup: on-success`**
  - 保存前に Gradle User Home の未使用ファイルを剪定し、キャッシュ枠（10GB）の消費と復元時間を抑える（main 保存時のみ作用）。

対象: `api-tests` / `codeql` / `db-doc-check` / `e2e-tests` / `openapi-lint` / `container-smoke-test`。
`deploy.yml`（`cache-disabled`）・`copilot-setup-steps.yml`（キャッシュ warm が役目）は対象外。

## 見送った項目

- **書き込み集約（`cache-read-only`）**: `setup-gradle` の既定が「default ブランチ（main）でのみ保存・他は復元のみ」で既に達成済みのため変更なし（[docs](https://docs.gradle.org/current/userguide/github-actions.html )で確認）。

## 前提

- secret `GRADLE_ENCRYPTION_KEY` を登録済み（未登録なら空文字＝未指定扱いで無害。効果は出ないだけ）。
- マージ後、初回の main 実行で CC データが seed され、以降の PR/main で設定フェーズが復元される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
