### PR TITLE
chore: #506 commit-msg フックで通常のマージコミットを CC 検査から除外する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,7 @@ Git フックは **Lefthook** で管理（`lefthook.yml`）。セットアップ
 
 - **pre-commit**（並列）: gitleaks、EditorConfig チェック、ktfmt チェック、detekt、actionlint、zizmor、Terraform fmt / validate、sqlfluff / squawk による SQL チェック、ShellCheck によるシェルスクリプトチェック
 - **pre-push**: 全テスト
-- **commit-msg**: Conventional Commits 形式チェック
+- **commit-msg**: Conventional Commits 形式チェック（マージ進行中は検査せず通すため、main 取り込みマージに `--no-verify` は不要）
 
 ```bash
 lefthook run pre-commit                                # フック全体を手動実行

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -128,8 +128,21 @@ pre-push:
 commit-msg:
   commands:
     # コミットメッセージのフォーマットチェック（オプション）
+    #
+    # マージ進行中（MERGE_HEAD が存在する）なら検査せず通す（#506）。`git merge` が生成する
+    # 既定のメッセージ（`Merge branch 'origin/main' ...` / `Merge pull request #NNN ...`）は
+    # Conventional Commits 形式ではないため、main 取り込みのたびに弾かれ `--no-verify` での
+    # 回避（gitleaks 等の他フックまで一緒にスキップする）を誘発していた。
+    # 個々のコミット履歴を main に残す merge commit 方針（CLAUDE.md）と整合させ、マージ
+    # コミットだけを緩める。メッセージ本文ではなく MERGE_HEAD の有無で判定するので、
+    # `Merge ` で始まる通常のコミットは従来どおり CC 形式を強制される。
+    # `--git-path` を使うのは、リンクされた作業ツリー（git worktree）でも MERGE_HEAD の
+    # 実パスを正しく解決するため。
     commitizen-check:
       run: |
+        if [ -f "$(git rev-parse --git-path MERGE_HEAD)" ]; then
+          exit 0
+        fi
         if ! echo "$(head -n1 {1})" | grep -E "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .{1,50}" > /dev/null; then
           echo "コミットメッセージは conventional commit 形式で記述してください"
           echo "例: feat: 新機能を追加"


### PR DESCRIPTION
## 概要

`git merge` が生成する既定のメッセージ（`Merge branch 'origin/main' ...` / `Merge pull request #NNN ...`）が commit-msg フック（Lefthook の `commitizen-check`）の Conventional Commits 検査に弾かれ、main 取り込みのたびに `--no-verify` での回避を誘発していた papercut を解消する。`--no-verify` は commit-msg だけでなく gitleaks 等の他フックまで一緒にスキップするため安全側でなかった。

Closes #506

## 変更内容

### `lefthook.yml`

- `commitizen-check` の先頭に、**マージ進行中（`MERGE_HEAD` が存在する）なら検査せず通す**ガードを追加。
- 判定はコミットメッセージ本文の前方一致（`^Merge `）ではなく `MERGE_HEAD` の有無で行う。これにより `Merge ` で始まる**通常の**コミットは従来どおり CC 形式を強制される。
- `git rev-parse --git-path MERGE_HEAD` 経由で参照し、リンクされた作業ツリー（git worktree）でも実パスを解決できるようにする。
- `[ ... ] && exit 0` ではなく `if` 文で書き、実行シェルが `set -e` でも意図せず失敗扱いにならないようにする。

個々のコミット履歴を main に残す merge commit 方針（CLAUDE.md「PR のマージ方式」）と整合させ、**マージコミットだけ**を緩めている。feature コミットは引き続き CC 強制。

### `CLAUDE.md`

- commit-msg フックの説明に、マージ進行中は検査を通すこと（main 取り込みマージに `--no-verify` が不要になったこと）を追記。

## 検証

実物の `lefthook` バイナリと、この PR の `commit-msg` セクションをそのまま移植した一時リポジトリで、修正前は 2 ケースが落ち（red）、修正後は全ケース通ること（green）を確認した。

| シナリオ | 期待 | 結果 |
| --- | --- | --- |
| 非マージ・非 CC 形式（`とりあえず修正`） | 弾かれる | OK |
| 非マージ・CC 形式（`feat: 機能を追加`） | 通る | OK |
| 非マージだが `Merge ` 始まり（`Merge something by hand`） | 弾かれる | OK |
| マージコミット（コンフリクトなし、既定メッセージ） | 通る | OK |
| マージコミット（コンフリクト解決後、既定メッセージ） | 通る | OK |

3 番目のケースが弾かれることで、メッセージ前方一致ではなく `MERGE_HEAD` 判定になっていることを担保している。

受け入れ条件（Issue #506）はいずれも満たしている:

- [x] `git merge origin/main`（コンフリクトあり / なし）後の既定メッセージのマージコミットがフックを通る
- [x] 通常の feature コミット（非マージ）は従来どおり CC 形式を強制される
- [x] `--no-verify` に頼らずに main 取り込みマージが完了できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)
