### PR TITLE
build(ci): setup-gradle を既定の enhanced キャッシュプロバイダへ切り替える

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -31,14 +31,15 @@ jobs:
           distribution: "temurin"
 
       - name: Set up Gradle
-        # cache-provider: basic は Gradle User Home（依存・wrapper・ローカル build cache の
-        # ~/.gradle/caches/build-cache-1 を含む）を actions/cache で runner 間に持ち越す。
+        # cache-provider は既定（enhanced）。Gradle User Home（依存・wrapper・ローカル build cache の
+        # ~/.gradle/caches/build-cache-1 を含む）に加え configuration-cache データも runner 間に持ち越す。
         # gradle.properties の org.gradle.caching=true と組み合わせ、PR では読み取り・main では
         # 書き込み（setup-gradle 既定）で compile/test 出力を再利用する（#349）。
+        # basic は actions/cache の薄ラッパで CC キャッシュも cache-cleanup も非対応、かつ restore key を
+        # 使わずキー完全一致時は保存をスキップするため採用しない（ADR-0060）。
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
-          cache-provider: basic
-          # configuration-cache データ（gradle.properties の org.gradle.configuration-cache=true の成果）も
+          # configuration-cache データ（gradle.properties の org.gradle.configuration-cache=true の成果）を
           # runner 間で持ち越す。CC は秘密を含みうるため setup-gradle は encryption-key 指定時のみ
           # 暗号化して保存・復元する（未指定だとエフェメラル CI で設定フェーズのスキップが効かない）。
           # 全ジョブで同一キーを使う必要があるため repo secret GRADLE_ENCRYPTION_KEY を出所にする。

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
-          cache-provider: basic
           # configuration-cache を runner 間で持ち越す（詳細は api-tests.yml のコメント参照）。
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache-cleanup: on-success

--- a/.github/workflows/container-smoke-test.yml
+++ b/.github/workflows/container-smoke-test.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
-          cache-provider: basic
           # configuration-cache を runner 間で持ち越す（詳細は api-tests.yml のコメント参照）。
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache-cleanup: on-success

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -37,7 +37,7 @@ jobs:
           java-version-file: ".java-version"
           distribution: "temurin"
 
+      # cache-provider は既定（enhanced）。ここはエージェント環境のキャッシュ warm が役目なので
+      # 書き込みを止めず、CC 用の cache-encryption-key も渡さない（Copilot 環境での secret 可用性に依存しないため）。
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          cache-provider: basic

--- a/.github/workflows/db-doc-check.yml
+++ b/.github/workflows/db-doc-check.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
-          cache-provider: basic
           # configuration-cache を runner 間で持ち越す（詳細は api-tests.yml のコメント参照）。
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache-cleanup: on-success

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
-          cache-provider: basic
           # configuration-cache を runner 間で持ち越す（詳細は api-tests.yml のコメント参照）。
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache-cleanup: on-success

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
-          cache-provider: basic
           # configuration-cache を runner 間で持ち越す（詳細は api-tests.yml のコメント参照）。
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache-cleanup: on-success

--- a/docs/adr/0015-gradle-build-performance-tuning.md
+++ b/docs/adr/0015-gradle-build-performance-tuning.md
@@ -43,6 +43,8 @@ JVM 内スレッド並列（JUnit 5 `junit.jupiter.execution.parallel`、単一�
 
 CI（`api-tests.yml`）は `gradle/actions/setup-gradle`（`cache-provider: basic`）が Gradle User Home（ローカル build cache の `~/.gradle/caches/build-cache-1` を含む）を runner 間で持ち越すため、`org.gradle.caching=true` の有効化だけで build cache が CI でも効く。ワークフロー自体の変更は根拠コメントの追記に留める。
 
+> **注記（2026-07-09）**: この `cache-provider: basic` に関する記述は [ADR-0060](0060-gradle-enhanced-cache-provider-and-cc-persistence.md) で置き換えられた。basic は configuration cache を保存しないため、CI で CC の効果が得られていなかった。本 ADR のその他の決定（CC / build cache / jvmargs / parallel の採否）は有効。
+
 ## Consequences（結果・影響）
 
 - ローカル（非サンドボックス）・CI のクリーン／インクリメンタルビルドが、キャッシュヒット時に大幅に短縮される。`koverVerifyMature` のカバレッジゲートは test が FROM-CACHE でも正常に通過することを確認済み。

--- a/docs/adr/0060-gradle-enhanced-cache-provider-and-cc-persistence.md
+++ b/docs/adr/0060-gradle-enhanced-cache-provider-and-cc-persistence.md
@@ -1,0 +1,40 @@
+# 0060. setup-gradle は既定の enhanced キャッシュプロバイダを使い configuration cache を CI で持ち越す
+
+- Status: Accepted
+- Date: 2026-07-09
+- Deciders: ptiringo
+
+## Context（背景・課題）
+
+[ADR-0015](0015-gradle-build-performance-tuning.md) で `org.gradle.configuration-cache=true`（設定フェーズのキャッシュ、以下 CC）と `org.gradle.caching=true`（build cache）を採用した。しかし CI はエフェメラル（使い捨て runner）であり、runner 間でキャッシュを持ち越さない限り効果が出ない。
+
+CI の `gradle/actions/setup-gradle` には `cache-provider: basic` が指定されていた。これは v6 系で既定が enhanced になった際に依存更新コミット（`f2561d8`、Copilot agent 生成）で理由の記述なく追加されたもので、ADR-0015 も事実として言及するのみで basic を選んだ根拠は残っていない。
+
+`gradle-on-ephemeral-ci` の記事を契機に実測・原文確認したところ、以下が判明した。
+
+- `basic` は `@actions/cache` の薄いラッパで、Gradle User Home の **`~/.gradle/caches` と `~/.gradle/wrapper` の 2 つだけ**を保存・復元する。CC のデータはプロジェクト配下 `.gradle/configuration-cache` にあるため**保存対象外**であり、CC は runner 間で持ち越されない。
+- `basic` は公式ドキュメントの制限に **`cache-cleanup` 非対応**と明記されている。
+- `basic` は restore key を使わず、キャッシュキー（Gradle ビルドファイルのハッシュ）が完全一致すると保存をスキップする。実際に main の実行ログで `Save was skipped` を確認した。すなわち **ビルドファイルが変わるまで Gradle User Home のキャッシュ（ローカル build cache 含む）は更新されない**。
+- `cache-encryption-key` は「GitHub Actions cache に保存する CC データを暗号化する」ための入力であり、CC を保存する enhanced と組み合わせて初めて機能する。`basic` の下では `GRADLE_ENCRYPTION_KEY` を env に出すだけで、跨ランの再利用は起きない。
+
+検討した代替案:
+
+- **`basic` を維持する**: MIT ライセンスの `actions/cache` のみに依存でき、供給網が単純。しかし ADR-0015 で採用した CC の効果が CI で得られず、build cache も上記のとおり更新が滞る。basic を積極的に選んだ経緯も存在しない。
+- **`GRADLE_RO_DEP_CACHE`（共有 read-only 依存キャッシュ）**: setup-gradle を使わない構成向けの手法で、本プロジェクトには不要。
+- **キャッシュ書き込みの集約（`cache-read-only`）**: setup-gradle の既定が「default ブランチでのみ保存し、他は復元のみ」であるため既に達成済み。追加設定は no-op。
+
+## Decision（決定）
+
+- `gradle/actions/setup-gradle` の `cache-provider` 指定を**削除し、既定の enhanced を使う**。enhanced は proprietary 技術だが、GitHub Actions cache を保存先とし、**public リポジトリでは無料**である（本リポジトリは public）。
+- CC データを runner 間で持ち越すため、キャッシュ有効な全ワークフローに `cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}` を指定する。鍵は repo secret を唯一の出所とし（全ジョブで同一鍵が必要）、`openssl rand -base64 16` で生成する。
+- キャッシュエントリを軽量に保つため `cache-cleanup: on-success` を指定する。
+- 対象は `api-tests` / `codeql` / `db-doc-check` / `e2e-tests` / `openapi-lint` / `container-smoke-test`。`deploy.yml` はサプライチェーン保護のため `cache-disabled: true` を維持し対象外。`copilot-setup-steps.yml` はエージェント環境のキャッシュ warm が役目のため provider の既定化のみ行い、`cache-encryption-key` は渡さない（Copilot 環境での secret 可用性に依存させない）。
+- `cache-read-only` は設定しない（既定で達成済みのため）。
+
+## Consequences（結果・影響）
+
+- CI で設定フェーズ（タスクグラフ構築）がスキップされ、エフェメラル runner でも CC の効果が得られる。enhanced は restore key と重複排除を持つため、build cache のヒット率も basic より改善する見込み。
+- **proprietary な gradle-actions-caching に依存する**。public リポジトリでは無料だが、private 化する場合は Free Preview の条件を確認する必要がある。ライセンス純度（MIT）を優先するなら basic へ戻す判断もありうる。
+- **repo secret `GRADLE_ENCRYPTION_KEY` が前提**になる。未登録・空文字の場合は CC が持ち越されないだけで、ビルドは壊れない（graceful degradation）。鍵をローテーションすると既存の CC エントリは復号できず捨てられる（再構築されるだけで無害）。
+- ADR-0015 の「CI は `cache-provider: basic` が Gradle User Home を持ち越す」という記述は本 ADR で置き換わる（ADR-0015 の他の決定は有効）。
+- 効果の実測（設定フェーズ時間の before/after）は、本決定のマージ後に main でキャッシュが seed され、次の実行で `Reusing configuration cache.` が出ることを確認して行う。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -69,3 +69,4 @@
 | [0057](0057-gradle-build-health-tooling-not-adopted.md) | Gradle build 健全性チェックの常設ツールは現時点で採用しない | Accepted |
 | [0058](0058-non-senbatsu-formation-role.md) | 非選抜（アンダー）を作品単位の Formation ロールとしてモデル化する | Accepted |
 | [0059](0059-sakamichi-tracklist-and-headline-track.md) | 収録曲をトラックリストで持ち見出し曲をトラックの一種として表現する | Accepted |
+| [0060](0060-gradle-enhanced-cache-provider-and-cc-persistence.md) | setup-gradle は既定の enhanced キャッシュプロバイダを使い configuration cache を CI で持ち越す | Accepted |


### PR DESCRIPTION
## 概要

#594 で追加した `cache-encryption-key` / `cache-cleanup` は、**`cache-provider: basic` の下では無効**だったことが実測と公式ドキュメントで判明した。provider を既定（enhanced）へ戻し、configuration cache（CC）の runner 間持ち越しを実効化する。

決定は [ADR-0060](https://github.com/ptiringo/toy-box/blob/chore/gradle-enhanced-cache-provider/docs/adr/0060-gradle-enhanced-cache-provider-and-cc-persistence.md ) に記録した。

## 根拠（実測 + 原文）

- `basic` が保存するのは **`~/.gradle/caches` と `~/.gradle/wrapper` のみ**。CC はプロジェクト配下 `.gradle/configuration-cache` にあるため**保存対象外**。
- 公式ドキュメントの basic 制限に **"Cache cleanup (`cache-cleanup`): Stale entries are not automatically removed."** と明記＝非対応。
- `basic` は restore key を使わず、キー完全一致で保存をスキップする。マージ後の main 実行ログで **`Save was skipped`** を確認（＝Gradle User Home のキャッシュはビルドファイルが変わるまで更新されない）。
- `cache-encryption-key` は「GitHub Actions cache に保存する CC データを暗号化する」入力であり、CC を保存する enhanced と組み合わせて初めて機能する。

`cache-provider: basic` は依存更新コミット `f2561d8`（Copilot agent 生成）で理由の記述なく入ったもので、積極的な採用経緯は存在しない（ADR-0015 も事実の言及のみ）。

## 変更内容

- 7 ワークフローから `cache-provider: basic` を削除（＝v6.1.0 以降の既定 enhanced）。
- `copilot-setup-steps.yml` は provider の既定化のみ。キャッシュ warm が役目なので `cache-encryption-key` は渡さない（Copilot 環境での secret 可用性に依存させない）。
- `deploy.yml` は `cache-disabled: true` を維持し対象外。
- ADR-0060 を追加。ADR-0015 には該当記述が置き換わった旨を注記（決定本文は書き換えず）。

## トレードオフ

- enhanced は **proprietary**（basic は MIT の `actions/cache` 薄ラッパ）。ただし保存先は GitHub Actions cache で、**public リポジトリは無料**（本リポジトリは public）。private 化する場合は Free Preview の条件確認が要る。

## 確認方法

マージ後、初回 main 実行で CC が seed され、次の実行で Gradle 出力に `Reusing configuration cache.` が出れば有効。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
