### PR TITLE
build(ci): 効果のない cache-encryption-key / cache-cleanup を削除し ADR-0060 を訂正

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -31,22 +31,16 @@ jobs:
           distribution: "temurin"
 
       - name: Set up Gradle
-        # cache-provider は既定（enhanced）。Gradle User Home（依存・wrapper・ローカル build cache の
-        # ~/.gradle/caches/build-cache-1 を含む）に加え configuration-cache データも runner 間に持ち越す。
+        # cache-provider は既定（enhanced）。Gradle User Home（依存の modules-2、スクリプトコンパイル結果の
+        # kotlin-dsl、ローカル build cache の build-cache-1 等）を runner 間に持ち越す。
         # gradle.properties の org.gradle.caching=true と組み合わせ、PR では読み取り・main では
         # 書き込み（setup-gradle 既定）で compile/test 出力を再利用する（#349）。
-        # basic は actions/cache の薄ラッパで CC キャッシュも cache-cleanup も非対応、かつ restore key を
-        # 使わずキー完全一致時は保存をスキップするため採用しない（ADR-0060）。
+        # basic は restore key を使わずキー完全一致時は保存をスキップするため採用しない（ADR-0060）。
+        # configuration cache（org.gradle.configuration-cache=true）は runner 間で持ち越せない。
+        # setup-gradle の project-state キャッシュは Develocity 資格情報を要する beta 機能のため
+        # cache-encryption-key だけでは有効にならない（ADR-0060 で実測・不採用）。
+        # cache-cleanup は既定が on-success なので明示しない。
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          # configuration-cache データ（gradle.properties の org.gradle.configuration-cache=true の成果）を
-          # runner 間で持ち越す。CC は秘密を含みうるため setup-gradle は encryption-key 指定時のみ
-          # 暗号化して保存・復元する（未指定だとエフェメラル CI で設定フェーズのスキップが効かない）。
-          # 全ジョブで同一キーを使う必要があるため repo secret GRADLE_ENCRYPTION_KEY を出所にする。
-          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          # 保存前に Gradle User Home の未使用ファイルを剪定してキャッシュエントリを軽量化する
-          # （main での保存時のみ作用。10GB のキャッシュ枠の消費と復元時間を抑える）。
-          cache-cleanup: on-success
 
       - name: Install mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,10 +36,6 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          # configuration-cache を runner 間で持ち越す（詳細は api-tests.yml のコメント参照）。
-          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-cleanup: on-success
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,8 +45,13 @@ jobs:
       # CodeQL は解析用に production コードがコンパイルできれば十分。
       # assemble は check 配下（test / ktfmt / detekt / koverVerify）を一切呼ばないため、
       # 検証タスクの個別除外が不要で、check に検証が増えてもメンテ不要。
+      #
+      # --no-build-cache は必須。CodeQL の extractor は Kotlin/Java コンパイラの実行をトレースして
+      # ソースを取り込むため、compileKotlin が build cache から FROM-CACHE で復元されると
+      # 「CodeQL could not process any code written in Java/Kotlin」で失敗する（ADR-0060）。
+      # 依存キャッシュは setup-gradle 側で効かせたままにし、このビルドの build cache だけを切る。
       - name: Build with Gradle
-        run: ./gradlew assemble --stacktrace
+        run: ./gradlew assemble --no-build-cache --stacktrace
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3

--- a/.github/workflows/container-smoke-test.yml
+++ b/.github/workflows/container-smoke-test.yml
@@ -43,10 +43,6 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          # configuration-cache を runner 間で持ち越す（詳細は api-tests.yml のコメント参照）。
-          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-cleanup: on-success
 
       - name: Build Docker image with bootBuildImage
         run: ./gradlew bootBuildImage --imageName=api-smoke:test

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -38,6 +38,6 @@ jobs:
           distribution: "temurin"
 
       # cache-provider は既定（enhanced）。ここはエージェント環境のキャッシュ warm が役目なので
-      # 書き込みを止めず、CC 用の cache-encryption-key も渡さない（Copilot 環境での secret 可用性に依存しないため）。
+      # 書き込みを止めない（ADR-0060）。
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0

--- a/.github/workflows/db-doc-check.yml
+++ b/.github/workflows/db-doc-check.yml
@@ -51,10 +51,6 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          # configuration-cache を runner 間で持ち越す（詳細は api-tests.yml のコメント参照）。
-          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-cleanup: on-success
 
       - name: Install mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,10 +32,6 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          # configuration-cache を runner 間で持ち越す（詳細は api-tests.yml のコメント参照）。
-          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-cleanup: on-success
 
       - name: Run E2E tests
         run: ./gradlew e2eTest --stacktrace

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -55,10 +55,6 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          # configuration-cache を runner 間で持ち越す（詳細は api-tests.yml のコメント参照）。
-          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-cleanup: on-success
 
       - name: Install mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/docs/adr/0015-gradle-build-performance-tuning.md
+++ b/docs/adr/0015-gradle-build-performance-tuning.md
@@ -43,7 +43,7 @@ JVM 内スレッド並列（JUnit 5 `junit.jupiter.execution.parallel`、単一�
 
 CI（`api-tests.yml`）は `gradle/actions/setup-gradle`（`cache-provider: basic`）が Gradle User Home（ローカル build cache の `~/.gradle/caches/build-cache-1` を含む）を runner 間で持ち越すため、`org.gradle.caching=true` の有効化だけで build cache が CI でも効く。ワークフロー自体の変更は根拠コメントの追記に留める。
 
-> **注記（2026-07-09）**: この `cache-provider: basic` に関する記述は [ADR-0060](0060-gradle-enhanced-cache-provider-and-cc-persistence.md) で置き換えられた。basic は configuration cache を保存しないため、CI で CC の効果が得られていなかった。本 ADR のその他の決定（CC / build cache / jvmargs / parallel の採否）は有効。
+> **注記（2026-07-09）**: この `cache-provider: basic` に関する記述は [ADR-0060](0060-gradle-enhanced-cache-provider-and-cc-persistence.md) で置き換えられた（既定の enhanced を使う）。あわせて、**configuration cache は CI では効かない**ことが実測で判明している（`setup-gradle` は CC をキャッシュせず、持ち越しには Develocity が要る）。CC の恩恵はローカルに限られる。本 ADR のその他の決定（build cache / jvmargs / parallel の採否）は有効。
 
 ## Consequences（結果・影響）
 

--- a/docs/adr/0060-gradle-enhanced-cache-provider-and-cc-persistence.md
+++ b/docs/adr/0060-gradle-enhanced-cache-provider-and-cc-persistence.md
@@ -1,4 +1,4 @@
-# 0060. setup-gradle は既定の enhanced キャッシュプロバイダを使い configuration cache を CI で持ち越す
+# 0060. setup-gradle は既定の enhanced キャッシュプロバイダを使う（configuration cache の CI 持ち越しは断念）
 
 - Status: Accepted
 - Date: 2026-07-09
@@ -10,31 +10,47 @@
 
 CI の `gradle/actions/setup-gradle` には `cache-provider: basic` が指定されていた。これは v6 系で既定が enhanced になった際に依存更新コミット（`f2561d8`、Copilot agent 生成）で理由の記述なく追加されたもので、ADR-0015 も事実として言及するのみで basic を選んだ根拠は残っていない。
 
-`gradle-on-ephemeral-ci` の記事を契機に実測・原文確認したところ、以下が判明した。
+`gradle-on-ephemeral-ci` の記事を契機に、実際の CI ログと `gradle/actions` の原文・ソースを突き合わせて次を確認した。
 
-- `basic` は `@actions/cache` の薄いラッパで、Gradle User Home の **`~/.gradle/caches` と `~/.gradle/wrapper` の 2 つだけ**を保存・復元する。CC のデータはプロジェクト配下 `.gradle/configuration-cache` にあるため**保存対象外**であり、CC は runner 間で持ち越されない。
-- `basic` は公式ドキュメントの制限に **`cache-cleanup` 非対応**と明記されている。
-- `basic` は restore key を使わず、キャッシュキー（Gradle ビルドファイルのハッシュ）が完全一致すると保存をスキップする。実際に main の実行ログで `Save was skipped` を確認した。すなわち **ビルドファイルが変わるまで Gradle User Home のキャッシュ（ローカル build cache 含む）は更新されない**。
-- `cache-encryption-key` は「GitHub Actions cache に保存する CC データを暗号化する」ための入力であり、CC を保存する enhanced と組み合わせて初めて機能する。`basic` の下では `GRADLE_ENCRYPTION_KEY` を env に出すだけで、跨ランの再利用は起きない。
+**basic プロバイダの問題**
+
+- `basic` は `@actions/cache` の薄いラッパで、Gradle User Home の **`~/.gradle/caches` と `~/.gradle/wrapper` だけ**を保存・復元する。
+- **restore key を使わず、キャッシュキー（Gradle ビルドファイルのハッシュ）が完全一致すると保存をスキップする**。実際に main の実行ログで `Save was skipped` を確認した。すなわちビルドファイルが変わるまで Gradle User Home のキャッシュ（ローカル build cache 含む）は更新されない。
+- 公式ドキュメントの制限に `cache-cleanup` 非対応と明記されている。
+
+**CC の持ち越しは setup-gradle 単体では実現できない**
+
+当初は `cache-encryption-key` を与えれば CC が runner 間で持ち越せると考えたが、これは誤りだった。実測と一次資料で次を確認した。
+
+- `setup-gradle` がキャッシュするのは Gradle User Home のみで、その内訳は `generated-gradle-jars` / `kotlin-dsl` / `scripts` / `modules-2` / `transforms-3` / `jars-9` / `build-cache-1`。CC の実体はプロジェクト配下 `.gradle/configuration-cache` にあり、この一覧に含まれない。
+- `cache-encryption-key` は **必要条件だが十分条件ではない**（`setup-gradle/action.yml`: "Configuration-cache data will not be saved/restored without an encryption key being provided."）。
+- CC を含む project-state キャッシュ（`ProjectCacheStatus`）は **two-tier gate（opt-in ＋ Develocity trial、次いで encryption key ＋ Gradle version）に守られた beta 機能**であり、`develocity-access-key` と `develocity-server-url` を要する（`sources/vendor/gradle-actions-caching/index.d.ts`、`sources/src/caching-report.ts` の `trial-not-licensed` 文言）。
+- 実測: enhanced ＋ `cache-encryption-key` を設定した main 実行でも、保存されたエントリに `configuration-cache` パスは 1 件も無く、次の main 実行は 5 回の Gradle 起動すべてが `Calculating task graph as no cached configuration is available` だった（`Reusing configuration cache` は 0 件）。
 
 検討した代替案:
 
-- **`basic` を維持する**: MIT ライセンスの `actions/cache` のみに依存でき、供給網が単純。しかし ADR-0015 で採用した CC の効果が CI で得られず、build cache も上記のとおり更新が滞る。basic を積極的に選んだ経緯も存在しない。
-- **`GRADLE_RO_DEP_CACHE`（共有 read-only 依存キャッシュ）**: setup-gradle を使わない構成向けの手法で、本プロジェクトには不要。
-- **キャッシュ書き込みの集約（`cache-read-only`）**: setup-gradle の既定が「default ブランチでのみ保存し、他は復元のみ」であるため既に達成済み。追加設定は no-op。
+- **`basic` を維持する**: MIT ライセンスの `actions/cache` のみに依存でき、供給網が単純。しかし上記のとおりキャッシュがほとんど更新されない。basic を積極的に選んだ経緯も存在しない。
+- **Develocity を導入して CC 持ち越しを取りに行く**: 効果は大きいが、beta 機能かつ外部サービス（access key / server URL）への依存を伴う。本プロジェクトの規模に対して割に合わないため、現時点では採らない。
+- **`GRADLE_RO_DEP_CACHE`（共有 read-only 依存キャッシュ）**: setup-gradle を使わない構成向けの手法で不要。
+- **キャッシュ書き込みの集約（`cache-read-only`）**: setup-gradle の既定が「default ブランチでのみ保存し、他は復元のみ」であるため既に達成済み。PR 実行のログでも `cache-read-only: true` が自動設定されることを確認した。追加設定は no-op。
 
 ## Decision（決定）
 
 - `gradle/actions/setup-gradle` の `cache-provider` 指定を**削除し、既定の enhanced を使う**。enhanced は proprietary 技術だが、GitHub Actions cache を保存先とし、**public リポジトリでは無料**である（本リポジトリは public）。
-- CC データを runner 間で持ち越すため、キャッシュ有効な全ワークフローに `cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}` を指定する。鍵は repo secret を唯一の出所とし（全ジョブで同一鍵が必要）、`openssl rand -base64 16` で生成する。
-- キャッシュエントリを軽量に保つため `cache-cleanup: on-success` を指定する。
-- 対象は `api-tests` / `codeql` / `db-doc-check` / `e2e-tests` / `openapi-lint` / `container-smoke-test`。`deploy.yml` はサプライチェーン保護のため `cache-disabled: true` を維持し対象外。`copilot-setup-steps.yml` はエージェント環境のキャッシュ warm が役目のため provider の既定化のみ行い、`cache-encryption-key` は渡さない（Copilot 環境での secret 可用性に依存させない）。
-- `cache-read-only` は設定しない（既定で達成済みのため）。
+- **CC の runner 間持ち越しは行わない**。Develocity を導入しない限り不可能であり、Develocity は導入しない。`cache-encryption-key` は単体では無効なので指定しない。
+- `cache-cleanup` は指定しない（enhanced の既定が `on-success` のため）。
+- `cache-read-only` は指定しない（既定で達成済みのため）。
+- `deploy.yml` はサプライチェーン保護のため `cache-disabled: true` を維持する。
 
 ## Consequences（結果・影響）
 
-- CI で設定フェーズ（タスクグラフ構築）がスキップされ、エフェメラル runner でも CC の効果が得られる。enhanced は restore key と重複排除を持つため、build cache のヒット率も basic より改善する見込み。
-- **proprietary な gradle-actions-caching に依存する**。public リポジトリでは無料だが、private 化する場合は Free Preview の条件を確認する必要がある。ライセンス純度（MIT）を優先するなら basic へ戻す判断もありうる。
-- **repo secret `GRADLE_ENCRYPTION_KEY` が前提**になる。未登録・空文字の場合は CC が持ち越されないだけで、ビルドは壊れない（graceful degradation）。鍵をローテーションすると既存の CC エントリは復号できず捨てられる（再構築されるだけで無害）。
+- CI の Gradle User Home キャッシュが毎回更新・復元されるようになる。実測（`api-tests.yml`、main）で `modules-2`（依存）・`build-cache-1`・`kotlin-dsl`（ビルドスクリプトのコンパイル結果）・`transforms` などがすべてキャッシュヒットした。basic 時代の「キー完全一致で保存スキップ」という停滞は解消した。
+  - 参考値: basic の main 実行 195s に対し、enhanced の warm 実行は 136s。ただし後者は同一 SHA の再実行で build cache が全ヒットする条件のため、厳密な等価比較ではない（方向性の証拠として扱う）。
+- **CC は CI では効かない**。`org.gradle.configuration-cache=true` の恩恵はローカル（デーモン常駐）に限られる。設定フェーズの時間は CI では毎回発生する。ADR-0015 が想定していた「CI でも CC が効く」は成り立たない。
+- **proprietary な gradle-actions-caching に依存する**。public リポジトリでは無料だが、private 化する場合は Free Preview の条件を確認する必要がある。ライセンス純度（MIT）を優先するなら basic へ戻す判断もありうるが、その場合はキャッシュ更新の停滞を受け入れることになる。
+- 将来 Develocity を導入する場合は、`develocity-access-key` / `develocity-server-url` と `cache-encryption-key` を揃えれば project-state キャッシュ（build-logic ＋ CC）が有効化しうる。beta 機能である点に注意。
 - ADR-0015 の「CI は `cache-provider: basic` が Gradle User Home を持ち越す」という記述は本 ADR で置き換わる（ADR-0015 の他の決定は有効）。
-- 効果の実測（設定フェーズ時間の before/after）は、本決定のマージ後に main でキャッシュが seed され、次の実行で `Reusing configuration cache.` が出ることを確認して行う。
+
+## 補足: 本 ADR 内での訂正（2026-07-09）
+
+初版では「`cache-encryption-key` を指定すれば CC が runner 間で持ち越される」と記述し、その前提で 6 ワークフローに `cache-encryption-key` と `cache-cleanup` を追加した（PR #594・#598）。その後の実測で CC が一切キャッシュされていないことが判明し、原因が Develocity ゲートであることを一次資料で確認したため、当該 2 オプションを削除し本 ADR を訂正した。決定（enhanced プロバイダの採用）自体は変わっていない。

--- a/docs/adr/0060-gradle-enhanced-cache-provider-and-cc-persistence.md
+++ b/docs/adr/0060-gradle-enhanced-cache-provider-and-cc-persistence.md
@@ -47,6 +47,7 @@ CI の `gradle/actions/setup-gradle` には `cache-provider: basic` が指定さ
 - CI の Gradle User Home キャッシュが毎回更新・復元されるようになる。実測（`api-tests.yml`、main）で `modules-2`（依存）・`build-cache-1`・`kotlin-dsl`（ビルドスクリプトのコンパイル結果）・`transforms` などがすべてキャッシュヒットした。basic 時代の「キー完全一致で保存スキップ」という停滞は解消した。
   - 参考値: basic の main 実行 195s に対し、enhanced の warm 実行は 136s。ただし後者は同一 SHA の再実行で build cache が全ヒットする条件のため、厳密な等価比較ではない（方向性の証拠として扱う）。
 - **CC は CI では効かない**。`org.gradle.configuration-cache=true` の恩恵はローカル（デーモン常駐）に限られる。設定フェーズの時間は CI では毎回発生する。ADR-0015 が想定していた「CI でも CC が効く」は成り立たない。
+- **build cache が実際に効くようになった副作用として、CodeQL が壊れた**。CodeQL の extractor は Kotlin/Java コンパイラの実行をトレースしてソースを取り込むため、`compileKotlin` が `FROM-CACHE` で復元されると `CodeQL could not process any code written in Java/Kotlin` で失敗する。basic 時代はキャッシュが更新されず実コンパイルが走っていたため顕在化しなかった。対策として `codeql.yml` のビルドは `./gradlew assemble --no-build-cache` とし、依存キャッシュは維持したままこのビルドの build cache だけを切る。
 - **proprietary な gradle-actions-caching に依存する**。public リポジトリでは無料だが、private 化する場合は Free Preview の条件を確認する必要がある。ライセンス純度（MIT）を優先するなら basic へ戻す判断もありうるが、その場合はキャッシュ更新の停滞を受け入れることになる。
 - 将来 Develocity を導入する場合は、`develocity-access-key` / `develocity-server-url` と `cache-encryption-key` を揃えれば project-state キャッシュ（build-logic ＋ CC）が有効化しうる。beta 機能である点に注意。
 - ADR-0015 の「CI は `cache-provider: basic` が Gradle User Home を持ち越す」という記述は本 ADR で置き換わる（ADR-0015 の他の決定は有効）。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -69,4 +69,4 @@
 | [0057](0057-gradle-build-health-tooling-not-adopted.md) | Gradle build 健全性チェックの常設ツールは現時点で採用しない | Accepted |
 | [0058](0058-non-senbatsu-formation-role.md) | 非選抜（アンダー）を作品単位の Formation ロールとしてモデル化する | Accepted |
 | [0059](0059-sakamichi-tracklist-and-headline-track.md) | 収録曲をトラックリストで持ち見出し曲をトラックの一種として表現する | Accepted |
-| [0060](0060-gradle-enhanced-cache-provider-and-cc-persistence.md) | setup-gradle は既定の enhanced キャッシュプロバイダを使い configuration cache を CI で持ち越す | Accepted |
+| [0060](0060-gradle-enhanced-cache-provider-and-cc-persistence.md) | setup-gradle は既定の enhanced キャッシュプロバイダを使う（configuration cache の CI 持ち越しは断念） | Accepted |


### PR DESCRIPTION
## 概要

#594 で追加した `cache-encryption-key` は **configuration cache（CC）を runner 間で持ち越さない**ことが実測と一次資料で判明した。当初の前提が誤っていたため、当該オプションと（既定値と同じ）`cache-cleanup` を削除し、ADR-0060 を事実に合わせて訂正する。

**enhanced プロバイダの採用（#598）は実測で有効なので維持する。**

## 根拠

**一次資料**

- `setup-gradle` がキャッシュするのは Gradle User Home のみ（`generated-gradle-jars` / `kotlin-dsl` / `scripts` / `modules-2` / `transforms-3` / `jars-9` / `build-cache-1`）。CC の実体は**プロジェクト配下 `.gradle/configuration-cache`** で、この一覧に含まれない。
- `setup-gradle/action.yml`: *"Configuration-cache data will not be saved/restored without an encryption key being provided."* → **必要条件だが十分条件ではない**。
- `sources/vendor/gradle-actions-caching/index.d.ts` の `ProjectCacheStatus`: *"Status of project-entry caching (build-logic artifacts + configuration-cache data)… reflect the **two-tier gate (opt-in + Develocity trial, then encryption key + Gradle version). Still beta.**"*
- `sources/src/caching-report.ts`: `trial-not-licensed` = *"Project state (build-logic and configuration cache) was not cached - a **develocity-access-key and develocity-server-url is required**."*
- docs L319: `cache-cleanup: on-success` は **enhanced の既定値** → 明示指定は冗長。

**実測（main）**

- enhanced + encryption key の seed 実行で、保存されたエントリに `configuration-cache` パスは **0 件**。
- 次の main 実行で `Reusing configuration cache` **0 件** / `Calculating task graph as no cached configuration is available` **5 件**。

## enhanced 化の効果（維持する理由）

- basic 時代は post で **`Save was skipped`**（キー完全一致で保存されない）＝キャッシュが更新されない状態だった。
- enhanced では `modules-2`（依存）・`build-cache-1`・`kotlin-dsl`（スクリプトコンパイル）・`transforms` 等が**全てキャッシュヒット**。
- 参考値: basic の main 実行 195s → enhanced の warm 実行 136s。ただし後者は同一 SHA の再実行で build cache が全ヒットする条件のため**厳密な等価比較ではない**（方向性の証拠）。

## 変更内容

- 6 ワークフローから `cache-encryption-key` / `cache-cleanup` を削除。
- `api-tests.yml` に「CC は CI では効かない（Develocity 必須）」ことを明記。
- ADR-0060 のタイトル・決定・影響を訂正し、訂正の経緯を補足節に記録（決定＝enhanced 採用は不変）。
- ADR-0015 の注記に「CC は CI では効かない」を追記。

## 後片付け

repo secret `GRADLE_ENCRYPTION_KEY` は不要になる（残しても無害）。削除する場合:

```
gh secret delete GRADLE_ENCRYPTION_KEY -R ptiringo/toy-box
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 追加: CodeQL のリグレッション修正

この PR の CI で `Analyze Kotlin/Java` が **`CodeQL could not process any code written in Java/Kotlin`** で落ちた。#598 で build cache が実際に効くようになった副作用で、`codeql.yml` の `assemble` が `compileKotlin` を `FROM-CACHE` で復元し、CodeQL の extractor がコンパイラ実行をトレースできなくなったため。basic 時代はキャッシュが更新されず実コンパイルが走っていたので顕在化していなかった。

対策として `./gradlew assemble --no-build-cache` に変更（依存キャッシュは維持）。ADR-0060 の Consequences にも記録した。
