### PR TITLE
feat: #544 馬名・繁殖年の一意性に DB UNIQUE 制約の backstop を追加する

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -157,7 +157,7 @@ class Command<T>(val payload: T, val issuedAt: Instant)
 - **単一の sealed 型・nullable 埋め込み VO はフラット化**する。sealed は判別子列 `<名詞>_type`（値は enum 名の文字列）＋各バリアント固有列、共在 VO は構成列をまとめて「全 NULL／全 NOT NULL」で在不在を表す。
 - **相互排他・共在の不変条件は CHECK 制約で必須強制**する（多層防御。マッパーが整合行を書いても DB 単独で破れないように）。命名は `chk_<table>_<rule>`。
 - **子テーブル化は多重度（コレクション `List`）かイベント性（[ADR-0041](../../docs/adr/0041-immutable-data-model-as-modeling-discipline.md) の INSERT-only イベント）のときだけ**。リソースの現在状態は親行へフラット化して UPDATE、イベントは INSERT-only 子テーブル。
-- マッピング SQL は H2(PostgreSQL 互換モード) と PostgreSQL 双方で適用可能な構文に保つ。
+- マッピング SQL は PostgreSQL 専用構文でよい（H2 は #451 で全面脱却済み。ADR-0062）。
 
 ### 機械強制しない規約（レビューで担保）
 

--- a/.claude/rules/migrations.md
+++ b/.claude/rules/migrations.md
@@ -24,6 +24,33 @@ Flyway は各マイグレーションを 1 トランザクションで適用す�
   V6/V8/V9 内の「書き込みを止めない」コメントは同一トランザクション内では事実誤認（ADR-0052）。
 - 新規テーブルの `CREATE TABLE` インライン CHECK はこの規約の対象外。
 
+## 既存テーブルへの UNIQUE 追加（ADR-0062）
+
+既存テーブルへ UNIQUE backstop を張るときは、素の `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE` を使う
+（索引構築のあいだ ACCESS EXCLUSIVE を取るが、現行のデータ量では一瞬）。`CREATE INDEX CONCURRENTLY` は
+非トランザクション実行となり、失敗時に INVALID index を残して起動時 migrate を詰まらせるため採らない。
+
+- **`NOT VALID` は使えない**。PostgreSQL は CHECK と FOREIGN KEY にしか許さないため、ADR-0052 の
+  VALIDATE 分離規約はこのケースの対象外。
+- squawk の `disallowed-unique-constraint` / `constraint-missing-not-valid` は、**警告が紐づく
+  `ADD CONSTRAINT` 行の直前**に抑止コメントを置いて黙らせる。ルールは**カンマ区切り・空白なし**で並べる。
+
+  ```sql
+  ALTER TABLE studbook.blood_horse
+  -- squawk-ignore disallowed-unique-constraint,constraint-missing-not-valid
+  ADD CONSTRAINT uq_blood_horse_name UNIQUE (name);
+  ```
+
+  `ALTER TABLE` 行の上に置いても効かない。空白区切り・コロン付き（`-- squawk-ignore: a, b`）も効かない。
+- **`-- squawk-ignore-file` は使わない**（そのファイルの全ルールを無効化し、将来の警告まで見えなくする）。
+- nullable 列は素の `UNIQUE (col)` でよい（PostgreSQL は NULL 同士を衝突とみなさない）。partial index は不要。
+- 命名は `uq_<table>_<columns>`。
+
+## DDL は PostgreSQL 専用構文でよい
+
+H2 は #451 で全面脱却済み。ローカル・CI・テスト・本番のすべてが PostgreSQL であり、DDL を H2 互換に
+保つ必要はない（`SET LOCAL` / `ALTER TABLE ... SET SCHEMA` 等を自由に使ってよい）。
+
 ## timeout は各ファイルに書く
 
 squawk（`require-timeout-settings`）に従い、既存テーブルを変更するマイグレーションの冒頭で

--- a/dbdoc/studbook.blood_horse.md
+++ b/dbdoc/studbook.blood_horse.md
@@ -33,6 +33,7 @@
 | fk_blood_horse_dam | FOREIGN KEY | FOREIGN KEY (dam_id) REFERENCES studbook.blood_horse(id) |
 | fk_blood_horse_sire | FOREIGN KEY | FOREIGN KEY (sire_id) REFERENCES studbook.blood_horse(id) |
 | fk_blood_horse_inspection | FOREIGN KEY | FOREIGN KEY (inspection_id) REFERENCES studbook.horse_inspection(id) |
+| uq_blood_horse_name | UNIQUE | UNIQUE (name) |
 
 ## Indexes
 
@@ -42,6 +43,7 @@
 | ix_blood_horse_inspection_id | CREATE INDEX ix_blood_horse_inspection_id ON studbook.blood_horse USING btree (inspection_id) |
 | ix_blood_horse_sire_id | CREATE INDEX ix_blood_horse_sire_id ON studbook.blood_horse USING btree (sire_id) |
 | ix_blood_horse_dam_id | CREATE INDEX ix_blood_horse_dam_id ON studbook.blood_horse USING btree (dam_id) |
+| uq_blood_horse_name | CREATE UNIQUE INDEX uq_blood_horse_name ON studbook.blood_horse USING btree (name) |
 
 ## Relations
 

--- a/dbdoc/studbook.breeding_result.md
+++ b/dbdoc/studbook.breeding_result.md
@@ -31,6 +31,7 @@
 | fk_breeding_result_breeding_registration | FOREIGN KEY | FOREIGN KEY (breeding_registration_id) REFERENCES studbook.breeding_registration(id) |
 | fk_breeding_result_covering_stallion | FOREIGN KEY | FOREIGN KEY (covering_stallion_id) REFERENCES studbook.blood_horse(id) |
 | breeding_result_pkey | PRIMARY KEY | PRIMARY KEY (id) |
+| uq_breeding_result_registration_year | UNIQUE | UNIQUE (breeding_registration_id, breeding_year) |
 
 ## Indexes
 
@@ -39,6 +40,7 @@
 | breeding_result_pkey | CREATE UNIQUE INDEX breeding_result_pkey ON studbook.breeding_result USING btree (id) |
 | ix_breeding_result_registration_year | CREATE INDEX ix_breeding_result_registration_year ON studbook.breeding_result USING btree (breeding_registration_id, breeding_year) |
 | ix_breeding_result_covering_stallion_id | CREATE INDEX ix_breeding_result_covering_stallion_id ON studbook.breeding_result USING btree (covering_stallion_id) |
+| uq_breeding_result_registration_year | CREATE UNIQUE INDEX uq_breeding_result_registration_year ON studbook.breeding_result USING btree (breeding_registration_id, breeding_year) |
 
 ## Relations
 

--- a/docs/adr/0062-unique-backstop-plain-add-constraint.md
+++ b/docs/adr/0062-unique-backstop-plain-add-constraint.md
@@ -1,0 +1,42 @@
+# 0062. 既存テーブルへの UNIQUE backstop は素の ADD CONSTRAINT で行う
+
+- Status: Accepted
+- Date: 2026-07-09
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+ドメインサービスは既存レコード集合を読み取って一意性を検証する（ADR-0022）。しかし READ COMMITTED 下の read-then-insert には並行競合の窓があり（#532）、検証をすり抜けた敗者の insert が重複データを永続化しうる。これを DB の UNIQUE 制約で塞ぐ（#540 の `covering_report`、#544 の `blood_horse.name` と `breeding_result`）。
+
+`covering_report` は新規テーブルだったため `CREATE TABLE` にインラインで UNIQUE を書けた。既存テーブルへ後から追加する #544 では、そうはいかない。
+
+- PostgreSQL の `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE` は索引を構築するあいだ ACCESS EXCLUSIVE ロックを取り、読み書きを止める。
+- squawk（ADR-0032）は `disallowed-unique-constraint` でこれを警告し、`CREATE INDEX CONCURRENTLY` ＋ `ADD CONSTRAINT ... USING INDEX` を勧める。
+- 同時に `constraint-missing-not-valid` も発火するが、**PostgreSQL は `NOT VALID` を CHECK と FOREIGN KEY にしか許さず UNIQUE には使えない**ため、この助言はそもそも従えない。
+
+## Decision（決定）
+
+既存テーブルへの UNIQUE backstop は、トランザクション内の**素の `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE`** で追加する。squawk の上記 2 ルールは、**当該文に限って**抑止する。
+
+- 抑止は `-- squawk-ignore disallowed-unique-constraint,constraint-missing-not-valid` を警告が紐づく `ADD CONSTRAINT` 行の直前に置いて行う（カンマ区切り・空白なし）。
+- **`-- squawk-ignore-file` は使わない**。ファイル全体の全ルールを無効化し、将来の警告まで見えなくするため。
+- ADR-0052 の「VALIDATE CONSTRAINT を別マイグレーションへ分離する」規約は、UNIQUE に `NOT VALID` が存在しない以上、対象外である。
+- nullable 列への UNIQUE は素の `UNIQUE (col)` でよい。PostgreSQL は UNIQUE 制約において NULL 同士を衝突とみなさないため、partial index は不要（`blood_horse.name` は未命名の馬で NULL）。
+
+**再評価トリガ**: 対象テーブルが「索引構築のあいだ書き込みを止めても許容できる」規模を超えたとき。そのときは `CREATE UNIQUE INDEX CONCURRENTLY` ＋ `ADD CONSTRAINT ... USING INDEX` へ移し、非トランザクション実行に伴う失敗時の復旧手順（INVALID index の `DROP INDEX` と Flyway の repair）を用意する。
+
+なお ADR-0043 が前提としていた「DDL は H2(PostgreSQL 互換モード) と PostgreSQL の双方で適用可能な構文に保つ」という制約は、**#451（H2 全面脱却）で失効した**。以後の DDL は PostgreSQL 専用構文でよい。ADR-0043 は決定時点の文脈を残す記録として改訂しない。
+
+## Alternatives（検討した代替案）
+
+- **`CREATE UNIQUE INDEX CONCURRENTLY` のみ**: lint を完全に通り、真に無停止。だが Flyway の PostgreSQL パーサーが `CREATE INDEX CONCURRENTLY` を非トランザクションと判定するため、失敗すると INVALID index が残りマイグレーションが failed 状態のまま残る。本番は Cloud Run の**起動時に Flyway が migrate する**構成なので、この状態はデプロイを詰まらせ、手動の SQL 実行による復旧を要する。named constraint ではなく index になるため `covering_report` と非対称にもなる。
+- **`CREATE UNIQUE INDEX CONCURRENTLY` ＋ `ADD CONSTRAINT ... USING INDEX`（2 ファイル）**: 上に加えて named constraint の対称性は保てるが、非トランザクションの復旧リスクはそのまま残り、マイグレーションが 2 枚に増える。
+- **`.squawk.toml` の `excluded_rules` へ追加**: プロジェクト全体でルールが無効になり、将来の本当に危険な UNIQUE 追加を見逃す。
+
+ADR-0052 は「lint を黙らせず実際に無停止にする」と定めたが、あれは VALIDATE の分離コストがゼロだったからである。今回の CONCURRENTLY は実運用リスクを伴うため、同じ結論にはならない。現行のデータ量（数十行規模）では ACCESS EXCLUSIVE は一瞬で終わり、回復可能性（トランザクション内・失敗時に自動 rollback）を優先する価値のほうが大きい。
+
+## Consequences（帰結）
+
+- **得るもの**: ドメインサービスの一意性検証をすり抜けた並行 insert を DB が最後に止める多層防御。マイグレーションは原子的で、失敗しても自動 rollback される。squawk の抑止は文単位・2 ルール限定に留まり、他の警告は生きたまま。
+- **引き受けるもの**: 索引構築のあいだ ACCESS EXCLUSIVE ロックを取る（現行規模では一瞬）。squawk の警告を意図的に抑止した箇所が 2 つ増え、テーブル成長時に CONCURRENTLY へ移す宿題を負う。
+- UNIQUE 違反（`DuplicateKeyException`）は 409 へ写像せず 500 のままとする（#532 の決定を継承）。通常経路ではドメインサービスが 409 を返す。再評価トリガは「実クライアントで競合時の 500 が問題になったとき」。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -69,3 +69,4 @@
 | [0057](0057-gradle-build-health-tooling-not-adopted.md) | Gradle build 健全性チェックの常設ツールは現時点で採用しない | Accepted |
 | [0058](0058-non-senbatsu-formation-role.md) | 非選抜（アンダー）を作品単位の Formation ロールとしてモデル化する | Accepted |
 | [0059](0059-sakamichi-tracklist-and-headline-track.md) | 収録曲をトラックリストで持ち見出し曲をトラックの一種として表現する | Accepted |
+| [0062](0062-unique-backstop-plain-add-constraint.md) | 既存テーブルへの UNIQUE backstop は素の ADD CONSTRAINT で行う | Accepted |

--- a/src/main/resources/db/migration/V14__add_unique_backstop.sql
+++ b/src/main/resources/db/migration/V14__add_unique_backstop.sql
@@ -5,12 +5,12 @@
 --
 -- ロック: 既存テーブルへの UNIQUE 追加は索引構築のあいだ ACCESS EXCLUSIVE を取り、読み書きを止める。
 -- 「書き込みを止めない」ものではない（ADR-0052 が V6/V8/V9 のコメントを事実誤認と断じた点）。現行の
--- データ量では一瞬で終わるため受け入れる。テーブルが育ったら CONCURRENTLY へ移す（ADR-0060）。
+-- データ量では一瞬で終わるため受け入れる。テーブルが育ったら CONCURRENTLY へ移す（ADR-0062）。
 --
 -- PostgreSQL は NOT VALID を CHECK と FOREIGN KEY にしか許さず UNIQUE には使えないため、ADR-0052 の
 -- 「VALIDATE を別マイグレーションへ分離する」規約は本ファイルの対象外。squawk の
 -- constraint-missing-not-valid / disallowed-unique-constraint はこの文脈では従えない助言なので、
--- 当該文に限って抑止する（-- squawk-ignore-file でファイル全体を黙らせない。ADR-0060）。
+-- 当該文に限って抑止する（-- squawk-ignore-file でファイル全体を黙らせない。ADR-0062）。
 --
 -- blood_horse.name は未命名の馬で NULL になるが、PostgreSQL は UNIQUE 制約で NULL 同士を衝突とみなさ
 -- ないため素の UNIQUE (name) で足りる（partial index は不要）。

--- a/src/main/resources/db/migration/V14__add_unique_backstop.sql
+++ b/src/main/resources/db/migration/V14__add_unique_backstop.sql
@@ -1,0 +1,27 @@
+-- 馬名・繁殖年の一意性に対する DB UNIQUE 制約の backstop（#544）。
+-- ドメインサービス（nameHorse / recordCovering / recordUncovered）は既存レコードを読み取って一意性を
+-- 検証するが、READ COMMITTED 下の read-then-insert には並行競合の窓がある（#532）。検証をすり抜けた
+-- 敗者の insert を DB 側で拒否する多層防御。covering_report は #540 で対応済みで、残り 2 箇所を揃える。
+--
+-- ロック: 既存テーブルへの UNIQUE 追加は索引構築のあいだ ACCESS EXCLUSIVE を取り、読み書きを止める。
+-- 「書き込みを止めない」ものではない（ADR-0052 が V6/V8/V9 のコメントを事実誤認と断じた点）。現行の
+-- データ量では一瞬で終わるため受け入れる。テーブルが育ったら CONCURRENTLY へ移す（ADR-0060）。
+--
+-- PostgreSQL は NOT VALID を CHECK と FOREIGN KEY にしか許さず UNIQUE には使えないため、ADR-0052 の
+-- 「VALIDATE を別マイグレーションへ分離する」規約は本ファイルの対象外。squawk の
+-- constraint-missing-not-valid / disallowed-unique-constraint はこの文脈では従えない助言なので、
+-- 当該文に限って抑止する（-- squawk-ignore-file でファイル全体を黙らせない。ADR-0060）。
+--
+-- blood_horse.name は未命名の馬で NULL になるが、PostgreSQL は UNIQUE 制約で NULL 同士を衝突とみなさ
+-- ないため素の UNIQUE (name) で足りる（partial index は不要）。
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+ALTER TABLE studbook.blood_horse
+-- squawk-ignore disallowed-unique-constraint,constraint-missing-not-valid
+ADD CONSTRAINT uq_blood_horse_name UNIQUE (name);
+
+ALTER TABLE studbook.breeding_result
+-- squawk-ignore disallowed-unique-constraint,constraint-missing-not-valid
+ADD CONSTRAINT uq_breeding_result_registration_year
+UNIQUE (breeding_registration_id, breeding_year);

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepositoryContractTest.kt
@@ -46,6 +46,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode
  * 9. save は集約の version（null なら insert、非 null なら楽観ロック付き update）で判別すること
  * 10. 古い version での save が UpdateConflict を返し先行の書き込みを保つこと（楽観ロック）
  * 11. 並行削除された集約への save が UpdateConflict を返すこと
+ * 12. 「繁殖登録×繁殖年」の一意性が UNIQUE 制約でスキーマ側にも強制されること（read-then-insert 競合の backstop）
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)
@@ -220,6 +221,17 @@ class JdbcBreedingResultRepositoryContractTest(
         val orphan = uncoveredRow().copy(breedingRegistrationId = generateId())
 
         assertThrows<DataIntegrityViolationException> { rows.save(orphan) }
+    }
+
+    @Test
+    fun `同一繁殖登録×同一繁殖年の二重insertはUNIQUE制約で拒否される`() {
+        // ドメインサービス recordCovering / recordUncovered の一意性検証をすり抜ける
+        // read-then-insert 並行競合（#532）の backstop。
+        val registrationId = seeder.seedRegistrationRow()
+        rows.save(uncoveredRow().copy(breedingRegistrationId = registrationId))
+        val duplicate = uncoveredRow().copy(breedingRegistrationId = registrationId)
+
+        assertThrows<DataIntegrityViolationException> { rows.save(duplicate) }
     }
 
     @Test

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultSummaryQueriesContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultSummaryQueriesContractTest.kt
@@ -40,22 +40,25 @@ class JdbcBreedingResultSummaryQueriesContractTest(
 
     private val stallion = generateId()
     private val otherStallion = generateId()
-    private lateinit var registrationId: UUID
 
     @BeforeEach
     fun cleanUp() {
         deleteAllStudbookTables(jdbcClient)
         seeder.seedHorseRow(id = stallion, sex = "MALE")
         seeder.seedHorseRow(id = otherStallion, sex = "MALE")
-        registrationId = seeder.seedRegistrationRow()
     }
 
-    /** 種付あり行を作る。outcomeType=null は未報告。LIVE_FOAL のみ分娩日を持つ。 */
+    /**
+     * 種付あり行を作る。outcomeType=null は未報告。LIVE_FOAL のみ分娩日を持つ。
+     *
+     * 繁殖登録は行ごとに新しく seed する（`breeding_result` は「繁殖登録×繁殖年で一度」の UNIQUE 制約を 持つため。集計上も 1 行 = 1 頭の繁殖牝馬）。
+     */
     private fun covered(
         stallionId: UUID,
         year: Int,
         outcomeType: String?,
         foalingDate: LocalDate? = null,
+        registrationId: UUID = seeder.seedRegistrationRow(),
     ) =
         BreedingResultRow(
             id = generateId(),
@@ -70,7 +73,7 @@ class JdbcBreedingResultSummaryQueriesContractTest(
         )
 
     /** 種付せず行（covering 列は全 null、outcomeType は NOT_COVERED 固定）。 */
-    private fun notCovered(year: Int) =
+    private fun notCovered(year: Int, registrationId: UUID = seeder.seedRegistrationRow()) =
         BreedingResultRow(
             id = generateId(),
             breedingRegistrationId = registrationId,

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultSummaryQueriesContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultSummaryQueriesContractTest.kt
@@ -51,7 +51,7 @@ class JdbcBreedingResultSummaryQueriesContractTest(
     /**
      * 種付あり行を作る。outcomeType=null は未報告。LIVE_FOAL のみ分娩日を持つ。
      *
-     * 繁殖登録は行ごとに新しく seed する（`breeding_result` は「繁殖登録×繁殖年で一度」の UNIQUE 制約を 持つため。集計上も 1 行 = 1 頭の繁殖牝馬）。
+     * 繁殖登録は行ごとに新しく seed する（`breeding_result` は「繁殖登録×繁殖年で一度」の UNIQUE 制約を持つため。集計上も 1 行 = 1 頭の繁殖牝馬）。
      */
     private fun covered(
         stallionId: UUID,

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
@@ -45,6 +45,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode
  * 8. save は集約の version（null なら insert、非 null なら楽観ロック付き update）で判別すること
  * 9. 古い version での save が UpdateConflict を返し先行の書き込みを保つこと（楽観ロック）
  * 10. 並行削除された集約への save が UpdateConflict を返すこと
+ * 11. 馬名の一意性が UNIQUE 制約でスキーマ側にも強制されること（read-then-insert 競合の backstop）
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)
@@ -216,6 +217,16 @@ class JdbcBloodHorseRepositoryContractTest(
         repository.save(namedDomesticFoal()).unwrap() // "オグリキャップ"
 
         assert(!repository.existsByName(HorseName.create("トウカイテイオー").unwrap()))
+    }
+
+    @Test
+    fun `同一馬名の二重insertはUNIQUE制約で拒否される`() {
+        // ドメインサービス nameHorse の existsByName 検証をすり抜ける
+        // read-then-insert 並行競合（#532）の backstop。
+        repository.save(namedDomesticFoal()).unwrap() // "オグリキャップ" で命名済み
+        val duplicate = namedDomesticFoal() // 別個体・同じ馬名
+
+        assertThrows<DataIntegrityViolationException> { repository.save(duplicate) }
     }
 
     @Test


### PR DESCRIPTION
## 概要

read-then-insert 並行競合（#532）の backstop として、`blood_horse.name` と
`breeding_result (breeding_registration_id, breeding_year)` に UNIQUE 制約を追加します。
`covering_report` は #540 / PR #542 で対応済みで、残り 2 箇所を対称に揃えるものです。

これでドメインサービスが読み取り検証している一意性 4 箇所（`nameHorse` / `recordCovering` /
`recordUncovered` / 種付成績報告）すべてに DB 制約が揃い、多層防御が完成します。

Closes #544

## 方式

既存テーブルへの UNIQUE 追加は、トランザクション内の素の `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE`
で行います。`CREATE UNIQUE INDEX CONCURRENTLY` は真に無停止ですが、Flyway が非トランザクション実行する
ため失敗時に INVALID index を残し、Cloud Run の起動時 migrate を詰まらせます。現行のデータ量では
ACCESS EXCLUSIVE は一瞬なので、回復可能性（失敗時の自動 rollback）を優先しました。決定と再評価トリガは
ADR-0062 に記録しています。

squawk の `disallowed-unique-constraint` / `constraint-missing-not-valid` は、**当該文に限って**抑止
しました（`-- squawk-ignore-file` でファイル全体を黙らせてはいません）。なお PostgreSQL は UNIQUE に
`NOT VALID` を許さないため、後者の助言はそもそも従えず、ADR-0052 の VALIDATE 分離規約も対象外です。

`blood_horse.name` は未命名の馬で NULL になりますが、PostgreSQL は UNIQUE で NULL 同士を衝突と
みなさないため、素の `UNIQUE (name)` で足ります（partial index は不要）。

## 既存テストの是正

`JdbcBreedingResultSummaryQueriesContractTest` が単一の繁殖登録に同一年の成績を 9 行ぶら下げており、
制約に違反していました。これはドメイン不変条件「繁殖登録×繁殖年で一度」に反するデータの作り方で、
DB 制約が無かったために通っていたものです（同一の繁殖牝馬を 7 頭として数えていた）。行ごとに別の繁殖
登録を seed する形へ直しました。集計は `COUNT(*)` で行数を数えるだけなので期待値は変わりません。

## 確認したこと

- `./gradlew check` / `./gradlew checkDbDoc` — いずれも BUILD SUCCESSFUL
- `squawk` は 14 マイグレーション全体で 0 issues、`sqlfluff` と `scripts/check-migration-validate-separation.sh` も通過
- 契約テストは Testcontainers の PostgreSQL に実際に V14 を適用して制約の実効を確認
- 追加した 2 つのテストが、他の制約（FK・CHECK・登録番号）の巻き添えではなく、意図した UNIQUE で
  落ちていることをレビューで検証

## デプロイ前の確認（推奨）

本番には既存データがあります。万一すでに重複があると起動時 migrate が失敗し `flyway repair` が要るため、
適用前に重複ゼロを確認しておくと安全です。

```sql
SELECT name, COUNT(*) FROM studbook.blood_horse WHERE name IS NOT NULL GROUP BY name HAVING COUNT(*) > 1;
SELECT breeding_registration_id, breeding_year, COUNT(*) FROM studbook.breeding_result GROUP BY 1, 2 HAVING COUNT(*) > 1;
```

## 補足

- UNIQUE 違反（`DuplicateKeyException`）は 409 へ写像せず 500 のままです（#532 の決定を継承）。通常経路では
  ドメインサービスが 409 を返します。
- ADR は 0060 を予定していましたが、作業中に main で 0060 / 0061 が埋まったため 0062 を採番しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
