### PR TITLE
docs(adr): ADR-0058 の二重採番を解消し dprint 側を 0063 へリナンバリングする

### DIFF
--- a/.github/workflows/dprint-check.yml
+++ b/.github/workflows/dprint-check.yml
@@ -1,7 +1,7 @@
 # dprint による設定ファイル（TOML/JSON/YAML）整形チェックワークフロー
 #
 # 目的: 設定ファイルの変更時に dprint check を実行し、ローカルの pre-commit と同じ
-# 整形ゲートを CI でも担保する（ADR-0058 / #328）。
+# 整形ゲートを CI でも担保する（ADR-0063 / #328）。
 
 name: dprint Check
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ mise exec -- shellcheck .claude/hooks/*.sh .claude/hooks/lib/*.sh .devcontainer/
 
 ktfmt はフォーマッタ、detekt は静的解析ツール。detekt 設定は `config/detekt/detekt.yml`（`buildUponDefaultConfig = true` でデフォルトに上書き、雛形再生成は `./gradlew detektGenerateConfig`）、レポートは `build/reports/detekt/`。プロジェクト固有のカスタムルール（例: ドメイン / アプリケーション層で `throw` しない）は `:detekt-rules` モジュールで定義し `detektPlugins` で組み込む（詳細は `.claude/rules/architecture.md`）。detekt はソースコードの静的解析を担い、依存の更新追従は Dependabot が担う。ビルド構成の健全性（未使用依存の棚卸し等）を機械強制する常設ツール（nebula.lint / dependency-analysis 等）は現時点では不採用（実機評価の結果、Kotlin DSL 非対応や Spring Boot での偽陽性で費用対効果が合わず。[ADR-0057](docs/adr/0057-gradle-build-health-tooling-not-adopted.md)）。
 
-設定ファイル（TOML/JSON/YAML）の整形は dprint が担う（`json`/`toml`/`pretty_yaml` プラグイン、コメント保持、Node 非依存）。採否は [ADR-0058](docs/adr/0058-dprint-config-file-formatting.md)。
+設定ファイル（TOML/JSON/YAML）の整形は dprint が担う（`json`/`toml`/`pretty_yaml` プラグイン、コメント保持、Node 非依存）。採否は [ADR-0063](docs/adr/0063-dprint-config-file-formatting.md)。
 
 ### 単一テストの実行
 

--- a/docs/adr/0063-dprint-config-file-formatting.md
+++ b/docs/adr/0063-dprint-config-file-formatting.md
@@ -1,4 +1,4 @@
-# 0058. 設定ファイル（TOML/JSON/YAML）の整形に dprint を採用し lefthook / CI でゲートする
+# 0063. 設定ファイル（TOML/JSON/YAML）の整形に dprint を採用し lefthook / CI でゲートする
 
 - Status: Accepted
 - Date: 2026-07-08

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -72,3 +72,4 @@
 | [0060](0060-gradle-enhanced-cache-provider-and-cc-persistence.md) | setup-gradle は既定の enhanced キャッシュプロバイダを使う（configuration cache の CI 持ち越しは断念） | Accepted |
 | [0061](0061-sakamichi-non-senbatsu-tracks.md) | 非選抜曲をトラック × 編成の 0..\* コレクションとしてモデル化する | Accepted |
 | [0062](0062-unique-backstop-plain-add-constraint.md) | 既存テーブルへの UNIQUE backstop は素の ADD CONSTRAINT で行う | Accepted |
+| [0063](0063-dprint-config-file-formatting.md) | 設定ファイル（TOML/JSON/YAML）の整形に dprint を採用し lefthook / CI でゲートする | Accepted |

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -71,7 +71,7 @@ pre-commit:
       run: cd infra && mise exec -- trivy config . --exit-code 1 --quiet
       tags: security
 
-    # dprint による設定ファイル（TOML/JSON/YAML）の整形チェック（ADR-0058 / #328）
+    # dprint による設定ファイル（TOML/JSON/YAML）の整形チェック（ADR-0063 / #328）
     # glob の `{,**/}` はルート直下と入れ子の両方に一致させるため（lefthook の `**/` は 1 階層以上を要求する）。
     # スコープの正は dprint.json の includes/excludes 側。ここでの exclude は devcontainer-lock.json のみ明示し、
     # 他の除外（build/**・.gradle/**・worktrees・settings.local.json）は gitignore と dprint.json が backstop する


### PR DESCRIPTION
## 概要

`docs/adr/` で ADR 番号 **0058 が二重採番**されていた（#597）。連番の一意性を回復し、索引・本文リンクを実ファイルと整合させる。

- `docs/adr/0058-dprint-config-file-formatting.md`
- `docs/adr/0058-non-senbatsu-formation-role.md`

## リナンバリングの方針

**dprint 側を 0063 へ**リネームした。

- non-senbatsu 側は README 索引に載っており、ADR-0061 から `Superseded by` として複数箇所で参照されているため、動かすと影響が広い。
- dprint 側は索引に載っておらず、参照は 3 箇所（CLAUDE.md / lefthook.yml / dprint-check.yml）のみで影響が小さい。
- Issue 本文は「空き番号は 0061」としていたが、その後 `0061` / `0062` が埋まったため、実際の空き番号 **0063** を採った。

ADR 本文の決定内容は書き換えていない（ファイル名＝番号のリネームとリンク修正のみ）。これは supersede ではなく採番ミスの是正なので、新 ADR は起こさない。

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `docs/adr/0058-dprint-config-file-formatting.md` | `0063-dprint-config-file-formatting.md` へリネーム。見出しの番号を `0063.` に更新 |
| `docs/adr/README.md` | 索引から欠落していた dprint 側 ADR の行を `0063` として追加 |
| `CLAUDE.md` | dprint の採否リンクを `ADR-0063` の実ファイルへ更新 |
| `lefthook.yml` | pre-commit の dprint コマンドのコメント参照を `ADR-0063` へ更新 |
| `.github/workflows/dprint-check.yml` | ヘッダコメントの参照を `ADR-0063` へ更新 |

## 検証

- 重複番号なし: `ls docs/adr/ | cut -c1-4 | sort | uniq -d` が空
- 参照の残存なし: `git grep '0058-dprint'` が空。残る `ADR-0058` 参照は `0061-sakamichi-non-senbatsu-tracks.md` のみで、正しく non-senbatsu 側を指す
- 索引の全リンク先が実在し、索引に載っていない ADR ファイルもなし（双方向チェック）
- `dprint check` / `actionlint` / `editorconfig-checker` / `zizmor` / `gitleaks`（lefthook pre-commit 全体）が緑

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)
