### PR TITLE
chore: #601 H2 前提の陳腐化したソースコメントを棚卸しする

### DIFF
--- a/src/main/kotlin/com/example/api/infrastructure/racing/jockey/JdbcJockeyRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/racing/jockey/JdbcJockeyRepository.kt
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Repository
  * へ委譲する。value class の `JockeyId` ↔ DB `uuid` 列の変換も、別途の Spring Data カスタムコンバータではなく本マッパーが
  * `JockeyId(uuid)` / `id.value` で担う（永続化モデルを分離した帰結。ADR-0027）。
  *
- * 永続化実装は JDBC 一本に統一し、起動 datasource を H2(dev / Cloud Run) ↔ PostgreSQL(本番) で差し替える方針のため、 InMemory
- * 実装・プロファイル切替は持たない（ADR-0030）。デフォルト（H2・PostgreSQL 互換）でも本クラスが配線される。
+ * 永続化実装は JDBC 一本に統一し、datasource は実行環境が外部供給する（本番 = Prisma Postgres の env 注入、ローカル = docker-compose の
+ * PostgreSQL。H2 全面脱却・#451）ため、InMemory 実装・プロファイル切替は持たない（ADR-0030）。
  */
 @Repository
 class JdbcJockeyRepository(private val rows: JockeySpringDataRepository) : JockeyRepository {

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepository.kt
@@ -24,8 +24,8 @@ import org.springframework.stereotype.Repository
  * `BloodHorseId`）↔ DB `uuid` 列、enum（`BreedingRole` / `RetirementReason`）↔ 文字列列、nullable な供用停止
  * （`BreedingRetirement`）↔ 2 列のフラット化も本マッパーが担う（永続化モデルを分離した帰結。ADR-0027）。
  *
- * 永続化実装は JDBC 一本に統一し、起動 datasource を H2(dev / Cloud Run) ↔ PostgreSQL(本番) で差し替える方針のため、 InMemory
- * 実装・プロファイル切替は持たない（ADR-0030）。デフォルト（H2・PostgreSQL 互換）でも本クラスが配線される。
+ * 永続化実装は JDBC 一本に統一し、datasource は実行環境が外部供給する（本番 = Prisma Postgres の env 注入、ローカル = docker-compose の
+ * PostgreSQL。H2 全面脱却・#451）ため、InMemory 実装・プロファイル切替は持たない（ADR-0030）。
  */
 @Repository
 class JdbcBreedingRegistrationRepository(

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultSummaryQueries.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultSummaryQueries.kt
@@ -21,8 +21,8 @@ import org.springframework.stereotype.Repository
  * - 受胎数 = 報告済みかつ `NOT_CONCEIVED` でない件数（流産・死産・生後直死は受胎に含む）
  * - 生産数 = `LIVE_FOAL` のみ（生後直死は「産駒がない母」に分類され生産に含めない）
  *
- * 受胎率・生産率は SQL で割らず [BreedingResultSummaryView.of] が件数から算出する（H2/PostgreSQL の 浮動小数・丸めの差を避ける）。 `GROUP
- * BY` 後の行は種付雌馬数が常に 1 以上のため 0 除算は起きない。 `COUNT(*) FILTER (WHERE ...)` は PostgreSQL / H2 双方が対応する。
+ * 受胎率・生産率は SQL で割らず [BreedingResultSummaryView.of] が件数から算出する（DB の除算・丸めに依存させず、BigDecimal の HALF_UP
+ * で決定的に丸めるため）。 `GROUP BY` 後の行は種付雌馬数が常に 1 以上のため 0 除算は起きない。
  */
 @Repository
 class JdbcBreedingResultSummaryQueries(private val jdbcClient: JdbcClient) :

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepository.kt
@@ -37,8 +37,8 @@ private fun <V, E> Result<V, E>.orThrow(): V = getOrThrow {
  * [BloodHorseSpringDataRepository] へ委譲する。value class ID・各種 VO（生成口が `create`＝`Result` のもの）・enum・
  * sealed な出自 [Origin] の判別子フラット化も本マッパーが担う（永続化モデルを分離した帰結。ADR-0027）。
  *
- * 永続化実装は JDBC 一本に統一し、起動 datasource を H2(dev / Cloud Run) ↔ PostgreSQL(本番) で差し替える方針のため、 InMemory
- * 実装・プロファイル切替は持たない（ADR-0030）。デフォルト（H2・PostgreSQL 互換）でも本クラスが配線される。
+ * 永続化実装は JDBC 一本に統一し、datasource は実行環境が外部供給する（本番 = Prisma Postgres の env 注入、ローカル = docker-compose の
+ * PostgreSQL。H2 全面脱却・#451）ため、InMemory 実装・プロファイル切替は持たない（ADR-0030）。
  */
 @Repository
 class JdbcBloodHorseRepository(private val rows: BloodHorseSpringDataRepository) :


### PR DESCRIPTION
Closes #601

## 背景

#451（ADR-0044）で H2 は全面脱却済みで、ローカル bootRun・CI・テスト・本番のすべてが PostgreSQL。
にもかかわらず「起動 datasource を H2 ↔ PostgreSQL で差し替える」「デフォルト（H2）でも配線される」といった
正面から矛盾するソースコメントが残っており、読者を誤らせる（PR #600 / ADR-0062 の最終レビューで判明）。

## 変更内容

- **`JdbcJockeyRepository.kt` / `JdbcBreedingRegistrationRepository.kt` / `JdbcBloodHorseRepository.kt`**
  datasource 差し替え方針とデフォルト配線の記述を削り、既に正しく書かれていた
  `JdbcBreedingResultRepository` の文言（datasource は実行環境が外部供給する）へ揃えた。
- **`JdbcBreedingResultSummaryQueries.kt`**
  受胎率・生産率を SQL で割らない理由を「H2/PostgreSQL の浮動小数・丸めの差を避ける」から、
  実際の理由（`BreedingResultSummaryView.of` が `BigDecimal` の HALF_UP で決定的に丸める）へ書き換えた。
  あわせて、PostgreSQL 専用構文でよくなった `COUNT(*) FILTER (WHERE ...)` の互換性注記を削除した。

## やっていないこと

適用済みマイグレーションのヘッダに残る H2 記述は**編集しない**。Flyway のチェックサムはコメントを含む
ファイル全体から計算されるため（`.claude/rules/migrations.md`「適用済みマイグレーションは編集しない」）、
凍結された史料として扱う。

なお Issue は V1〜V5 を挙げていたが、実際には `V6__add_breeding_registration_retirement_check.sql` と
`V10__create_covering_report.sql` にも H2 への言及がある。V6 は「#451 の H2 全面脱却で前提が消えた」という
正しい経緯の記述。V10 の「H2 と PostgreSQL の双方で適用可能な構文に保つ」は陳腐化しているが、同じ理由で
編集対象外とした。

## 検証

- `./gradlew check` → BUILD SUCCESSFUL
- `grep -rn -iE '\bH2\b' src/main/kotlin/` の残存はすべて「H2 全面脱却・#451」という正しい経緯の記述のみ

コメントのみの変更で、挙動・バイトコードのセマンティクスに影響はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
