### PR TITLE
feat: #605 OAuth2 リソースサーバとして Identity Platform の ID トークンを検証する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,12 @@ jobs:
       # secrets_update_strategy=overwrite: 本ワークフローをサービスの secret 配線の唯一の出所とし、
       # ここに列挙しない secret 配線はデプロイ時に取り除く（宣言的・削除追従）。
       #
+      # env_vars: GCP_PROJECT_ID は OAuth2 リソースサーバの issuer / audience を組み立てるために要る
+      # （ADR-0064）。プロジェクト ID は秘密ではないが、値はコードに直書きせず production 環境の
+      # リポジトリ変数（vars.GCP_PROJECT_ID）から供給する（IMAGE / WIF_PROJECT_NUMBER と同じ流儀）。
+      # 注入されないと application.yml の既定値（実在しないプロジェクト ID）に落ち、全トークンが 401 になる。
+      # env_vars_update_strategy も secrets と同じく overwrite で、本ワークフローを唯一の出所とする。
+      #
       # --execution-environment=gen2: 実行環境を第2世代（フル Linux 互換）に明示固定する。
       # 未指定（Cloud Run の自動選択）だと gen1（gVisor）が選ばれることがあり、外部 DB
       # （Prisma Postgres）への接続時に JVM の DNS 解決が UnknownHostException で失敗した
@@ -90,4 +96,7 @@ jobs:
             SPRING_DATASOURCE_USERNAME=spring-datasource-username:latest
             SPRING_DATASOURCE_PASSWORD=spring-datasource-password:latest
           secrets_update_strategy: overwrite
+          env_vars: |-
+            GCP_PROJECT_ID=${{ vars.GCP_PROJECT_ID }}
+          env_vars_update_strategy: overwrite
           flags: "--service-account=api-runner@ptiringo-toy-box.iam.gserviceaccount.com --no-allow-unauthenticated --port=8080 --memory=1Gi --cpu=1 --cpu-boost --min-instances=0 --max-instances=3 --execution-environment=gen2"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,15 @@ LEFTHOOK_EXCLUDE=ktfmt-check git commit -m "メッセージ"   # 特定コマン
 
 ヘルスチェックは `/actuator/health` で公開（公開設定は `application.yml`、詳細表示は認可時のみ、動作確認は `HealthEndpointTest.kt`）。アプリ起動後に `curl http://localhost:8080/actuator/health` で `{"status":"UP"}` が返る。公開しているのはヘルスエンドポイントのみで、`info` / `metrics` 等は非公開。
 
+## 認証（OAuth2 リソースサーバ）
+
+認証は GCP Identity Platform に委譲し、この API は **OAuth2 リソースサーバとして ID トークン（JWT）を検証するだけ**とする（資格情報を保持しない）。設定は `SecurityConfig`（**`controller` パッケージ**に置く。RFC 9457 の `problem()` ビルダが adapter リングにあり、内側から参照するとオニオン規約に反するため）と `application.yml` の `spring.security.oauth2.resourceserver.jwt.issuer-uri` / `.audiences`。issuer が OIDC discovery を公開しているため `JwtDecoder` は自前で書かない。決定経緯は [ADR-0064](docs/adr/0064-authn-via-identity-platform-authz-in-app.md)。
+
+- **`permitAll` は運用・CI が壊れるエンドポイントに限る**: `/actuator/health`（Cloud Run のヘルスチェック）、`/v3/api-docs` 配下と Swagger UI（`generateOpenApiDocs` が forked bootRun 経由で取得するため、認証を掛けると OpenAPI lint のゲートが壊れる）、MCP エンドポイント（クライアントがトークンを持てない）。それ以外は `authenticated`。
+- **認可（何をしてよいか）はフィルタ層で判断しない**。ロール・権限の出所は自前 DB で、認可は application 層が担う。
+- **`@WebMvcTest` の slice は `@AutoConfigureMockMvc(addFilters = false)` で認証フィルタを無効化する**（slice は HTTP 契約の検証に集中させる）。認証そのものは `SecurityConfigTest` と E2E が担保し、テストは実 JWKS を引かず HS256 の `JwtDecoder` Bean（`support/TestJwtSupport.kt`）へ差し替える。
+- 本番（Cloud Run）は `GCP_PROJECT_ID` を環境変数で受け取る（`deploy.yml`）。注入されないと issuer が既定値に落ち全トークンが 401 になる。
+
 ## Google Cloud 操作のガードレール
 
 Claude Code から GCP を触るときは、変更・削除・課金を伴う操作を deny（CI/HCP 専用）/ ask（確認強制）で抑え、ローカルは最小権限 viewer SA の impersonation で読み取りに限定する。語彙・手順は `.claude/rules/gcp-guardrails.md`、決定経緯は [ADR-0036](docs/adr/0036-gcp-operation-guardrails.md) を参照。

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,10 @@ dependencies {
     // トランスポートで配線する。@McpTool 注釈付き Bean を annotation scanner が自動登録する。採否は ADR-0035。
     implementation(libs.spring.ai.starter.mcp.server.webmvc)
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    // 認証は GCP Identity Platform に委譲し、本 API は OAuth2 リソースサーバとして ID トークン（JWT）を
+    // 検証するだけとする（ADR-0064）。issuer-uri から OIDC discovery で JWKS まで解決するため、
+    // JwtDecoder は自前で組まない。ロール・権限は JWT の claim に載せず自前 DB を出所とする。
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
     // 永続化アクセス（Spring Data JDBC + Flyway）。集約 write は Spring Data JDBC（集約 = 永続化境界）。
     // 本番ランタイムの datasource は Prisma Postgres（実 PostgreSQL v17）へ配線する（#451 / ADR-0044）。
     // ローカル/CI/smoke/テストは全て PostgreSQL（組み込み H2 は cutover で全面脱却済み）。永続化の契約
@@ -59,6 +63,11 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     testImplementation("org.springframework.boot:spring-boot-resttestclient")
+    // @WebMvcTest スライスに SecurityAutoConfiguration（＝HttpSecurity の供給元）を登録する。Boot 4 では
+    // spring-boot-security-oauth2-resource-server が自分の autoconfig だけをスライスへ持ち込むため、
+    // これが無いと OAuth2ResourceServerWebSecurityAutoConfiguration が HttpSecurity を解決できず
+    // 全 slice のコンテキストが起動しない。spring-security-test（MockMvc の認証ヘルパ）も推移で入る。
+    testImplementation("org.springframework.boot:spring-boot-security-test")
     testImplementation(libs.mockk)
     testImplementation(libs.springmockk)
     testImplementation(libs.archunit.junit5)

--- a/src/e2eTest/kotlin/com/example/api/e2e/JockeyApiE2eTest.kt
+++ b/src/e2eTest/kotlin/com/example/api/e2e/JockeyApiE2eTest.kt
@@ -1,10 +1,14 @@
 package com.example.api.e2e
 
 import com.example.api.support.PostgresContainerSupport
+import com.example.api.support.TestJwt
+import com.example.api.support.TestJwtDecoderConfiguration
 import com.jayway.jsonpath.JsonPath
 import org.junit.jupiter.api.Test
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.context.TestConstructor
 import org.springframework.test.context.TestConstructor.AutowireMode
@@ -17,10 +21,14 @@ import org.springframework.test.web.servlet.client.RestTestClient
  * [PostgresContainerSupport] 経由で実配線したまま、[RestTestClient] で HTTP 越しに叩く。 controller → application →
  * infrastructure → 実 DB の結線を本物で検証する。
  *
+ * `/api` 配下は認証必須（ADR-0064）なので、各リクエストに Bearer トークンを載せる。`JwtDecoder` は [TestJwtDecoderConfiguration]
+ * の HS256 実装に差し替え、実 JWKS を引かずに認証フィルタを本物のまま通す。
+ *
  * Karate（`.feature` ＋ Runner）から素の Spring ネイティブ（RestTestClient）へ載せ替えた（ADR-0056）。
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureRestTestClient
+@Import(TestJwtDecoderConfiguration::class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class JockeyApiE2eTest(val restTestClient: RestTestClient) : PostgresContainerSupport() {
 
@@ -30,6 +38,7 @@ class JockeyApiE2eTest(val restTestClient: RestTestClient) : PostgresContainerSu
         restTestClient
             .get()
             .uri("/api/jockeys/{id}", missingId)
+            .header(HttpHeaders.AUTHORIZATION, TestJwt.bearerToken())
             .exchange()
             .expectStatus()
             .isNotFound
@@ -55,6 +64,7 @@ class JockeyApiE2eTest(val restTestClient: RestTestClient) : PostgresContainerSu
             restTestClient
                 .post()
                 .uri("/api/jockeys")
+                .header(HttpHeaders.AUTHORIZATION, TestJwt.bearerToken())
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(mapOf("first_name" to "Yutaka", "last_name" to "Take"))
                 .exchange()
@@ -75,6 +85,7 @@ class JockeyApiE2eTest(val restTestClient: RestTestClient) : PostgresContainerSu
         restTestClient
             .get()
             .uri("/api/jockeys/{id}", jockeyId)
+            .header(HttpHeaders.AUTHORIZATION, TestJwt.bearerToken())
             .exchange()
             .expectStatus()
             .isOk

--- a/src/main/kotlin/com/example/api/controller/ProblemAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/example/api/controller/ProblemAuthenticationEntryPoint.kt
@@ -1,0 +1,51 @@
+package com.example.api.controller
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.web.ErrorResponseException
+import org.springframework.web.servlet.HandlerExceptionResolver
+
+/**
+ * 認証されていないリクエスト（トークン無し・不正なトークン）を 401 + `application/problem+json` で返す入口。
+ *
+ * セキュリティフィルタは DispatcherServlet の外側で走るため、そのままでは Spring MVC の中央エラー funnel
+ * （[GlobalExceptionHandler]）を通らず、Servlet コンテナ既定の空ボディ 401 になってしまう。ここで [problem] を組み立てた
+ * [ErrorResponseException] を `handlerExceptionResolver` へ手渡すことで、業務エラーと同じ funnel・同じ RFC 9457
+ * の形に揃える（problem の描画点を 1 つに保つ）。
+ *
+ * WWW-Authenticate ヘッダは RFC 6750 が 401 に求める challenge であり、resolver へ渡す前に自分で載せる （funnel
+ * は認証スキームを知らないため）。
+ */
+internal class ProblemAuthenticationEntryPoint(private val resolver: HandlerExceptionResolver) :
+    AuthenticationEntryPoint {
+
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException,
+    ) {
+        response.setHeader(HttpHeaders.WWW_AUTHENTICATE, BEARER_CHALLENGE)
+        val problem =
+            problem(
+                status = HttpStatus.UNAUTHORIZED,
+                code = "unauthenticated",
+                title = "Unauthenticated",
+                detail = "この API の呼び出しには有効な ID トークンが必要です。",
+            )
+        resolver.resolveException(
+            request,
+            response,
+            null,
+            ErrorResponseException(HttpStatusCode.valueOf(problem.status), problem, authException),
+        )
+    }
+
+    private companion object {
+        const val BEARER_CHALLENGE = "Bearer"
+    }
+}

--- a/src/main/kotlin/com/example/api/controller/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/api/controller/SecurityConfig.kt
@@ -1,0 +1,90 @@
+package com.example.api.controller
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.web.servlet.HandlerExceptionResolver
+
+/**
+ * OAuth2 リソースサーバとしての認証設定（ADR-0064）。
+ *
+ * 認証は GCP Identity Platform に委譲し、本 API は Bearer トークン（ID トークン = JWT）の検証だけを担う。 検証パラメータ（issuer /
+ * audience）は `application.yml` の `spring.security.oauth2.resourceserver.jwt.*` が供給し、`JwtDecoder` は
+ * Spring Boot の自動構成が issuer の OIDC discovery から組み立てる（`@ConditionalOnMissingBean` のため、テストは自前の
+ * `JwtDecoder` Bean で差し替えられる）。
+ *
+ * **認可（何をしてよいか）はフィルタ層で判断しない。** ロール・権限の出所は自前 DB であり、認可は application
+ * 層が担う。したがってここでの規則は「[PUBLIC_ENDPOINTS] は誰でも / それ以外は認証済みなら通す」の 2 種類だけで、認証済みユーザーが 403
+ * になる経路は存在しない（`AccessDeniedHandler` を置いていないのはこのため）。
+ *
+ * 本クラスが `config` ではなく adapter リング（`controller`）に居るのは、401 の RFC 9457 応答を組み立てる [problem] ビルダが adapter
+ * リングにあるため。内側のリングから参照すると ArchUnit の `onionLayers` に違反する。 HTTP セキュリティは adapter の関心事でもあり、配置としても正しい。
+ *
+ * `@ConditionalOnWebApplication` は必須。`HttpSecurity` は servlet Web コンテキストでしか Bean 化されないため、 これが無いと
+ * `webEnvironment = NONE` の `@SpringBootTest`（永続化の契約テスト等）が軒並みコンテキスト起動に失敗する。 Boot 自身の Web
+ * セキュリティ設定も同じ条件で守られている。
+ */
+@Configuration
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+class SecurityConfig {
+
+    @Bean
+    fun securityFilterChain(
+        http: HttpSecurity,
+        problemEntryPoint: AuthenticationEntryPoint,
+    ): SecurityFilterChain {
+        http {
+            // Bearer トークンによるステートレス認証。セッション（Cookie）を発行しないため CSRF 対策は不要。
+            csrf { disable() }
+            sessionManagement { sessionCreationPolicy = SessionCreationPolicy.STATELESS }
+            authorizeHttpRequests {
+                PUBLIC_ENDPOINTS.forEach { authorize(it, permitAll) }
+                authorize(anyRequest, authenticated)
+            }
+            oauth2ResourceServer {
+                jwt {}
+                authenticationEntryPoint = problemEntryPoint
+            }
+            // トークンを一切持たないリクエストは認可判定で弾かれ ExceptionTranslationFilter を通るため、
+            // そちらの入口にも同じ entry point を据えて 401 の描画を 1 つに揃える。
+            exceptionHandling { authenticationEntryPoint = problemEntryPoint }
+        }
+        return http.build()
+    }
+
+    /**
+     * 認証失敗（401）を RFC 9457 の `application/problem+json` で描画する入口。
+     *
+     * 描画そのものは [GlobalExceptionHandler]（中央 funnel）へ委譲するため `handlerExceptionResolver` を注入する。
+     * セキュリティフィルタは DispatcherServlet の外側で走るので、resolver を明示的に呼んで funnel に載せる。
+     */
+    @Bean
+    fun problemAuthenticationEntryPoint(
+        @Qualifier("handlerExceptionResolver") resolver: HandlerExceptionResolver
+    ): AuthenticationEntryPoint = ProblemAuthenticationEntryPoint(resolver)
+
+    companion object {
+        /**
+         * 認証を要求しないエンドポイント。運用・CI が壊れるものだけに絞る（ADR-0064）。
+         * - actuator の health: Cloud Run のヘルスチェックがトークンを持てない
+         * - OpenAPI ドキュメントと Swagger UI: `generateOpenApiDocs` が forked bootRun 経由で取得するため、 認証を掛けると
+         *   OpenAPI lint の CI ゲート（`lintOpenApiDocs`）が壊れる
+         * - MCP エンドポイント: MCP クライアントにトークンを載せる術がまだない（ADR-0035 の adapter に認証を 載せる設計は未決）
+         */
+        private val PUBLIC_ENDPOINTS =
+            listOf(
+                "/actuator/health",
+                "/v3/api-docs",
+                "/v3/api-docs/**",
+                "/swagger-ui.html",
+                "/swagger-ui/**",
+                "/mcp/**",
+            )
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,18 @@ spring:
     problemdetails:
       # Spring MVC 標準例外（リクエストボディ不正・媒体型不一致等）を RFC 9457 形式に変換する
       enabled: true
+  # OAuth2 リソースサーバとしての ID トークン（JWT）検証（ADR-0064）。認証は GCP Identity Platform に委譲する。
+  # issuer は OIDC discovery（.well-known/openid-configuration）を公開しているため、issuer-uri 1 本で JWKS まで
+  # 解決できる（jwk-set-uri の明示は不要）。audiences と併せて指定すると issuer 検証・audience 検証が自動で入る。
+  # GCP_PROJECT_ID は秘密ではないため Secret Manager ではなく素の環境変数で供給する（本番は deploy.yml が注入）。
+  # 既定値は意図的に実在しないプロジェクト ID にしてある。注入を忘れた環境では issuer が一致せず全トークンが
+  # 401 になる（fail closed）。テストは HS256 の JwtDecoder Bean を定義して差し替えるため、この値を引かない。
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: https://securetoken.google.com/${GCP_PROJECT_ID:gcp-project-id-not-injected}
+          audiences: ${GCP_PROJECT_ID:gcp-project-id-not-injected}
 
 springdoc:
   show-actuator: true

--- a/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
@@ -13,6 +13,7 @@ import com.github.michaelbull.result.Err
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.junit.jupiter.api.Test
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
@@ -28,6 +29,7 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester
  * 業務ルール違反ではない例外（リクエストボディ不正・想定外例外）が RFC 9457 形式で返ることを、 [JockeyController] を踏み台にして確認する。
  */
 @WebMvcTest(JockeyController::class)
+@AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class GlobalExceptionHandlerTest(val mockMvc: MockMvc) {

--- a/src/test/kotlin/com/example/api/controller/HelloControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/HelloControllerTest.kt
@@ -1,6 +1,7 @@
 package com.example.api.controller
 
 import org.junit.jupiter.api.Test
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.test.context.TestConstructor
 import org.springframework.test.context.TestConstructor.AutowireMode
@@ -8,6 +9,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 
 @WebMvcTest(HelloController::class)
+@AutoConfigureMockMvc(addFilters = false)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class HelloControllerTest(val mockMvc: MockMvc) {
     private val tester = MockMvcTester.create(mockMvc)

--- a/src/test/kotlin/com/example/api/controller/SecurityConfigTest.kt
+++ b/src/test/kotlin/com/example/api/controller/SecurityConfigTest.kt
@@ -1,0 +1,95 @@
+package com.example.api.controller
+
+import com.example.api.support.PostgresContainerSupport
+import com.example.api.support.TestJwt
+import com.example.api.support.TestJwtDecoderConfiguration
+import org.junit.jupiter.api.Test
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.context.TestConstructor.AutowireMode
+import org.springframework.test.web.servlet.client.RestTestClient
+
+/**
+ * OAuth2 リソースサーバとしての認証フィルタチェーン（[SecurityConfig]）の検証。
+ *
+ * `@WebMvcTest` の slice は認証フィルタを無効化してあるため（ADR-0064）、フィルタ層の振る舞いはここと E2E だけが担保する。 `JwtDecoder` は
+ * [TestJwtDecoderConfiguration] の HS256 実装に差し替え、実 JWKS を引かずに本物のフィルタチェーンを走らせる。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureRestTestClient
+@Import(TestJwtDecoderConfiguration::class)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class SecurityConfigTest(val restTestClient: RestTestClient) : PostgresContainerSupport() {
+
+    private val anyJockeyUri = "/api/jockeys/00000000-0000-0000-0000-000000000000"
+
+    @Test
+    fun `トークン無しの保護エンドポイントは 401 と RFC9457 problem+json を返す`() {
+        restTestClient
+            .get()
+            .uri(anyJockeyUri)
+            .exchange()
+            .expectStatus()
+            .isUnauthorized
+            .expectHeader()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON)
+            .expectHeader()
+            .valueEquals(HttpHeaders.WWW_AUTHENTICATE, "Bearer")
+            .expectBody()
+            .jsonPath("$.type")
+            .isEqualTo("urn:problem-type:unauthenticated")
+            .jsonPath("$.title")
+            .isEqualTo("Unauthenticated")
+            .jsonPath("$.status")
+            .isEqualTo(401)
+            .jsonPath("$.error_code")
+            .isEqualTo("unauthenticated")
+    }
+
+    @Test
+    fun `署名が検証できないトークンは 401 になる`() {
+        restTestClient
+            .get()
+            .uri(anyJockeyUri)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer not-a-valid-jwt")
+            .exchange()
+            .expectStatus()
+            .isUnauthorized
+            .expectHeader()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON)
+            .expectBody()
+            .jsonPath("$.error_code")
+            .isEqualTo("unauthenticated")
+    }
+
+    @Test
+    fun `有効なトークンは認証を通過しアプリケーションまで届く（不在の馬なので 404）`() {
+        // 401（認証で弾かれた）ではなく 404（アプリのユースケースが応答した）であることが、
+        // フィルタチェーンを通過した唯一の観測可能な証拠になる。
+        restTestClient
+            .get()
+            .uri(anyJockeyUri)
+            .header(HttpHeaders.AUTHORIZATION, TestJwt.bearerToken())
+            .exchange()
+            .expectStatus()
+            .isNotFound
+            .expectBody()
+            .jsonPath("$.type")
+            .isEqualTo("urn:problem-type:jockey-not-found")
+    }
+
+    @Test
+    fun `ヘルスチェックは認証なしで 200 を返す`() {
+        restTestClient.get().uri("/actuator/health").exchange().expectStatus().isOk
+    }
+
+    @Test
+    fun `OpenAPI ドキュメントは認証なしで 200 を返す`() {
+        // 認証を掛けると generateOpenApiDocs（forked bootRun 経由）が失敗し OpenAPI lint の CI ゲートが壊れる。
+        restTestClient.get().uri("/v3/api-docs").exchange().expectStatus().isOk
+    }
+}

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
@@ -12,6 +12,7 @@ import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import java.util.UUID
 import org.junit.jupiter.api.Test
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
@@ -22,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 
 @WebMvcTest(BreedingRegistrationController::class)
+@AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class BreedingRegistrationControllerTest(val mockMvc: MockMvc) {

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
@@ -32,6 +32,7 @@ import java.time.Year
 import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
@@ -42,6 +43,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 
 @WebMvcTest(BreedingResultController::class)
+@AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class BreedingResultControllerTest(val mockMvc: MockMvc) {

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultSummaryControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultSummaryControllerTest.kt
@@ -7,6 +7,7 @@ import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import java.util.UUID
 import org.junit.jupiter.api.Test
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.TestConstructor
@@ -15,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 
 @WebMvcTest(BreedingResultSummaryController::class)
+@AutoConfigureMockMvc(addFilters = false)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class BreedingResultSummaryControllerTest(val mockMvc: MockMvc) {
     @MockkBean private lateinit var findBreedingResultSummary: FindBreedingResultSummaryUseCase

--- a/src/test/kotlin/com/example/api/controller/breeding/CoveringReportControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/CoveringReportControllerTest.kt
@@ -15,6 +15,7 @@ import java.time.LocalDate
 import java.time.Year
 import java.util.UUID
 import org.junit.jupiter.api.Test
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
@@ -25,6 +26,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 
 @WebMvcTest(CoveringReportController::class)
+@AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class CoveringReportControllerTest(val mockMvc: MockMvc) {

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -27,6 +27,7 @@ import java.util.UUID
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
@@ -38,6 +39,7 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester
 import tools.jackson.databind.json.JsonMapper
 
 @WebMvcTest(BloodHorseController::class)
+@AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper) {

--- a/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
@@ -27,6 +27,7 @@ import java.util.UUID
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
@@ -38,6 +39,7 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester
 import tools.jackson.databind.json.JsonMapper
 
 @WebMvcTest(HorseInspectionController::class)
+@AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class HorseInspectionControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper) {

--- a/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
@@ -19,6 +19,7 @@ import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
@@ -29,6 +30,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 
 @WebMvcTest(JockeyController::class)
+@AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class JockeyControllerTest(val mockMvc: MockMvc) {

--- a/src/test/kotlin/com/example/api/support/TestJwtSupport.kt
+++ b/src/test/kotlin/com/example/api/support/TestJwtSupport.kt
@@ -1,0 +1,61 @@
+package com.example.api.support
+
+import com.nimbusds.jose.jwk.source.ImmutableSecret
+import com.nimbusds.jose.proc.SecurityContext
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm
+import org.springframework.security.oauth2.jwt.JwsHeader
+import org.springframework.security.oauth2.jwt.JwtClaimsSet
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder
+
+/**
+ * 認証（OAuth2 リソースサーバ・ADR-0064）を要するテストのための、対称鍵（HS256）で自己完結する JWT 発行・検証ハーネス。
+ *
+ * 本番の `JwtDecoder` は `issuer-uri` から OIDC discovery で GCP Identity Platform の JWKS を引くが、テスト環境は GCP
+ * へ到達できない（到達できてもトークンを発行できない）。Spring Boot の `JwtDecoder` 自動構成は `@ConditionalOnMissingBean`
+ * のため、[TestJwtDecoderConfiguration] を `@Import` すれば HS256 の decoder が
+ * 勝ち、ネットワークに出ずに署名検証だけを本物のフィルタチェーンで走らせられる。
+ *
+ * 裏返すと issuer / audience の検証（本番で Boot が組み立てる validator）はテストの射程外であり、`application.yml`
+ * のプロパティが効いているかは検証していない。
+ */
+object TestJwt {
+    /** HS256 の鍵長要件（256bit 以上）を満たす、テスト専用の固定シークレット。 */
+    private const val SECRET = "toy-box-test-only-hmac-secret-key-for-hs256!!"
+
+    private val key: SecretKey = SecretKeySpec(SECRET.toByteArray(), "HmacSHA256")
+
+    private val encoder = NimbusJwtEncoder(ImmutableSecret<SecurityContext>(key))
+
+    fun decoder(): JwtDecoder =
+        NimbusJwtDecoder.withSecretKey(key).macAlgorithm(MacAlgorithm.HS256).build()
+
+    /** `Authorization` ヘッダにそのまま載せられる、有効な Bearer トークン。 */
+    fun bearerToken(subject: String = "test-user"): String = "Bearer ${token(subject)}"
+
+    private fun token(subject: String): String {
+        val issuedAt = Instant.now()
+        val claims =
+            JwtClaimsSet.builder()
+                .subject(subject)
+                .issuedAt(issuedAt)
+                .expiresAt(issuedAt.plus(10, ChronoUnit.MINUTES))
+                .build()
+        val header = JwsHeader.with(MacAlgorithm.HS256).build()
+        return encoder.encode(JwtEncoderParameters.from(header, claims)).tokenValue
+    }
+}
+
+/** [TestJwt] の HS256 decoder を `JwtDecoder` Bean として差し込む。 */
+@TestConfiguration(proxyBeanMethods = false)
+class TestJwtDecoderConfiguration {
+    @Bean fun jwtDecoder(): JwtDecoder = TestJwt.decoder()
+}


### PR DESCRIPTION
Closes #605

## 概要

認証を GCP Identity Platform に委譲し、この API を **OAuth2 リソースサーバ**にする。Bearer トークン（ID トークン = JWT）の検証だけを担い、資格情報は保持しない。ロール・権限は本 PR では扱わない（認証済みなら全操作可）。決定と経緯は [ADR-0064](docs/adr/0064-authn-via-identity-platform-authz-in-app.md)。

`issuer-uri` と `.audiences` の 2 プロパティで構成し、issuer が OIDC discovery を公開しているため `JwtDecoder` は自前で書かない。

## 変更点

- `SecurityConfig`（`controller` パッケージ）: Bearer ステートレス認証・CSRF 無効・`anyRequest` は `authenticated`
- `ProblemAuthenticationEntryPoint`: 401 を RFC 9457（`application/problem+json`）で返す
- `permitAll` は運用・CI が壊れるエンドポイントに限定（actuator health / OpenAPI ドキュメント / Swagger UI / MCP）
- 既存 9 本の `@WebMvcTest` slice に `@AutoConfigureMockMvc(addFilters = false)`
- `SecurityConfigTest`（新規）と `JockeyApiE2eTest`（Bearer 追加）が認証を担保。テストは実 JWKS を引かず HS256 の `JwtDecoder` へ差し替える
- `deploy.yml` が Cloud Run へ `GCP_PROJECT_ID` を注入

## 設計上の判断

**401 の描画を既存の中央 funnel に合流させた。** セキュリティフィルタは DispatcherServlet の外側で走るため、素の実装だと Servlet コンテナ既定の空ボディ 401 になる。`problem()` を載せた `ErrorResponseException` を `handlerExceptionResolver` へ手渡すことで、業務エラーと同じ `GlobalExceptionHandler` を通り、problem+json の形が 1 箇所で決まる。RFC 6750 の `WWW-Authenticate: Bearer` challenge も付与する。

## Issue に書かれていなかった実装上の発見

**1. `SecurityConfig` には `@ConditionalOnWebApplication(SERVLET)` が必須。** `HttpSecurity` は servlet Web コンテキストでしか Bean 化されないため、これが無いと `webEnvironment = NONE` の `@SpringBootTest`（永続化の契約テスト・Tx ロールバックテスト）が 72 件コンテキスト起動に失敗する。Boot 自身の Web セキュリティ設定も同じ条件で守られている。

**2. Boot 4.1 では `spring-security-test` ではなく `spring-boot-security-test` を足す。** slice が壊れる真因は 401 ではなく **コンテキスト起動失敗** だった。`spring-boot-security-oauth2-resource-server` は `OAuth2ResourceServerWebSecurityAutoConfiguration` を `@WebMvcTest` スライスへ登録するのに、その `jwtSecurityFilterChain(HttpSecurity)` が要求する `HttpSecurity` を供給する `SecurityAutoConfiguration` はスライスに入らない。`addFilters = false` だけでは直らない。`spring-boot-security-test` がスライス用 imports で `SecurityAutoConfiguration` を足し、`spring-security-test:7.1.0` も推移で入る。

**3. Kotlin のブロックコメントはネストする。** KDoc に `` `/v3/api-docs/**` `` と書くと `/*` がネストコメントを開き `Unclosed comment` でコンパイルが落ちる。

## 検証（ローカル実測）

| 検証 | 結果 |
|---|---|
| `./gradlew check`（ktfmt + detekt + test + `koverVerifyMature`） | BUILD SUCCESSFUL |
| `./gradlew e2eTest` | BUILD SUCCESSFUL |
| `SecurityConfigTest` | 5/5 通過 |
| 差分カバレッジ（diff-cover, `--fail-under 90`） | 100%（33 行中 0 行未カバー） |

`SecurityConfigTest` が実配線で確認したこと: トークン無し / 不正トークンで 401 + `application/problem+json` + `WWW-Authenticate: Bearer`、有効トークンでアプリまで到達（不在の馬なので 404）、`/actuator/health` と `/v3/api-docs` は認証なしで 200。

「Cloud Run に `GCP_PROJECT_ID` が注入されている」だけは実デプロイ後にしか確認できない。

## 後続

- 認可（RBAC）: #606
- リソース単位の認可: #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)
