### PR TITLE
chore: #611 Claude Code on the web でクラウドセッションを整備する（最小構成）

### DIFF
--- a/docs/adr/0065-claude-code-on-the-web-support.md
+++ b/docs/adr/0065-claude-code-on-the-web-support.md
@@ -1,0 +1,36 @@
+# 0065. Claude Code on the web を軽量変更ワークフローとして最小サポートする
+
+- Status: Accepted
+- Date: 2026-07-11
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+[Claude Code on the web](https://code.claude.com/docs/ja/claude-code-on-the-web) は Anthropic 管理のクラウド VM でセッションを実行し、モバイルからも監視できる。本リポジトリでもクラウド／モバイルから軽い変更や PR 起票を回せるようにしたい。
+
+ただしクラウドセッションは「リポジトリのクローンにあるものだけ」で起動し、ローカルの mise 管理ツール・環境変数は引き継がれない。素の環境（プリインストール: OpenJDK 21・Maven・Gradle・Docker/compose・PostgreSQL 16・Node、リソース 4 vCPU / 16 GB RAM / 30 GB disk）と本リポジトリの要求（Gradle toolchain `languageVersion = 25`）にギャップがある。素の JDK 21 では toolchain auto-detection を満たせない。
+
+さらに Claude Code on the web では、**セットアップスクリプトの登録・環境変数・Custom 許可ドメインがクラウド環境 UI 側に保存され、リポジトリにコミットできない**。これは「Claude への指示ファイルはリポジトリ管理・ポータブルに保つ」という本リポジトリの方針（CLAUDE.md）と衝突する。
+
+スコープとして次の 2 案を検討した。
+
+- **フル同等化**: kotlin-lsp のクラウド有効化・gh + Projects/PR マージ運用・terraform MCP の動作確認までローカルと揃える。学習・利便性は高いが、UI 側非ポータブル設定が増え、取得先ドメインと失敗点も膨らむ。
+- **最小構成**: まず `./gradlew check`（ビルド + テスト + Testcontainers + カバレッジゲート）がクラウドで緑になることだけをゴールにする。
+
+まず足場として動くこと（check が緑）を優先し、**最小構成**を採る。
+
+## Decision（決定）
+
+Claude Code on the web を軽量変更ワークフローとして**最小構成でサポートする**。
+
+- 素の JDK 21 と toolchain 25 のギャップは **mise で JDK 25 を供給**して埋める。ヘルパー `scripts/web-setup.sh` は mise 導入 → `mise install java` → mise activate 仕込みを担い、**`mise install java`（JDK 25 のみ）に限定**する（全ツール導入はしない）。`./gradlew check` に必要なのは JDK 25 と Docker（プリインストール）のみで、kotlin-lsp（JetBrains ホスト）や pipx 系ツールの取得失敗で `mise install` 全体を止めない・不要な Custom 許可ドメインを増やさないため。
+- PATH 注入は既存の `.claude/hooks/session-start-mise.sh`（SessionStart フック。毎セッション `mise hook-env` を実行）に委ね、web 専用の新規フックは追加しない。
+- UI 側にしか置けない非ポータブル設定（セットアップスクリプト登録・env・Custom 許可ドメイン）は、コミットできる**再現手順ドキュメント `docs/claude-code-on-the-web.md`** に残す。Custom 許可ドメインの出所は `.devcontainer/allowed-domains.txt`（コミット共有）にリンクで指し、値を二重管理しない。
+- kotlin-lsp のクラウド有効化・gh + `GH_TOKEN` 運用・terraform MCP のクラウド確認は**スコープ外**とし、必要になったら別 Issue で扱う。
+
+## Consequences（結果・影響）
+
+- クラウド／モバイルから軽い変更・PR 起票を回せる足場が整う。`./gradlew check` が緑になる最小構成に絞ったことで、導入コストと失敗点を小さく保てる。
+- UI 側設定（スクリプト登録・env・Custom ドメイン）は共有できないため、各自が `docs/claude-code-on-the-web.md` の手順を見て再現する必要がある。この非ポータブル性はドキュメントによる再現手順で補償する（リポジトリ管理・ポータブル方針との折り合い）。
+- 全ツールを入れないため、クラウドでは lint 系ゲート（ktfmt 以外の shellcheck / sqlfluff / dprint / actionlint / zizmor など）の一部が動かない。ただしそれらは CI / pre-commit が担うため `./gradlew check` の緑には影響しない。
+- 実クラウドセッションでの `./gradlew check` 緑・Custom 許可ドメインの過不足確定・16 GB RAM での Testcontainers 挙動は、初回セッションで実測して `docs/claude-code-on-the-web.md` に反映する運用とする。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -74,3 +74,4 @@
 | [0062](0062-unique-backstop-plain-add-constraint.md) | 既存テーブルへの UNIQUE backstop は素の ADD CONSTRAINT で行う | Accepted |
 | [0063](0063-dprint-config-file-formatting.md) | 設定ファイル（TOML/JSON/YAML）の整形に dprint を採用し lefthook / CI でゲートする | Accepted |
 | [0064](0064-authn-via-identity-platform-authz-in-app.md) | 認証は GCP Identity Platform に委譲し、認可の権限は自前 DB に持つ | Accepted |
+| [0065](0065-claude-code-on-the-web-support.md) | Claude Code on the web を軽量変更ワークフローとして最小サポートする | Accepted |

--- a/docs/claude-code-on-the-web.md
+++ b/docs/claude-code-on-the-web.md
@@ -1,0 +1,61 @@
+# Claude Code on the web セットアップ手順
+
+[Claude Code on the web](https://code.claude.com/docs/ja/claude-code-on-the-web) は Anthropic 管理のクラウド VM でセッションを実行する。本リポジトリをクラウド／モバイルから回すための設定手順を記録する。
+
+> **これは Dev Container（`.devcontainer/`）とは別の実行環境**である。web 環境は containers.dev の devcontainer ではなく Anthropic 管理 VM で、`devcontainer.json` / features / firewall は使わない。共通するのは「ツールの出所は `mise.toml`」という一点のみ。
+
+## ゴール
+
+クラウドセッションで `./gradlew check`（ビルド + テスト + Testcontainers + カバレッジゲート）が緑になること。kotlin-lsp / gh + Projects 運用 / terraform MCP のフル同等化はスコープ外（本ドキュメント末尾「スコープ外」参照）。
+
+## 前提（クラウド VM のプリインストール）
+
+公式ドキュメント（2026-07 時点）で確認済み: OpenJDK 21・Maven・Gradle・Docker / docker compose・PostgreSQL 16・Node。リソースは 4 vCPU / 16 GB RAM / 30 GB disk。
+
+本リポジトリの Gradle toolchain は `languageVersion = 25`（`build.gradle.kts`）。素の JDK 21 では toolchain auto-detection が満たせないため、**mise で Temurin 25 を供給する**。
+
+## UI 側に設定する内容
+
+Claude Code on the web では、セットアップスクリプトの登録・環境変数・Custom 許可ドメインは**クラウド環境 UI 側に保存され、リポジトリにコミットできない**。そのため以下を「UI に貼る内容」として手動で設定する（この非ポータブル性の記録は [ADR-0065](adr/0065-claude-code-on-the-web-support.md)）。
+
+### 1. セットアップスクリプト
+
+UI の「セットアップスクリプト」欄に次を貼る（本体はリポジトリ管理の `scripts/web-setup.sh`）:
+
+```bash
+bash scripts/web-setup.sh
+```
+
+`scripts/web-setup.sh` は mise を導入し、`mise install java`（JDK 25 のみ）を実行して toolchain を検証する。全ツールは入れない（`./gradlew check` に不要なため）。
+
+### 2. Custom 許可ドメイン
+
+クラウド環境のデフォルト Trusted には Maven Central・`plugins.gradle.org`・`services.gradle.org`・`spring.io`・`repo.spring.io`・`kotlinlang.org`・Docker Hub（`registry-1.docker.io` / `auth.docker.io` / `production.cloudflare.docker.com`）が含まれる。したがって Gradle 依存解決と Testcontainers の image pull は追加設定なしで通る見込み。
+
+デフォルト Trusted に**無く、Custom に足す必要がある**のは mise 本体・ツール取得系:
+
+- `mise.jdx.dev`
+- `mise-versions.jdx.dev`
+
+加えて mise の java（Temurin）取得先が Trusted に無ければ足す（実セッションで確認。候補は Adoptium API / GitHub Releases 系）。
+
+> Custom ドメインの**出所は [`.devcontainer/allowed-domains.txt`](../.devcontainer/allowed-domains.txt)**（コミット共有の許可リスト）。web の Custom 欄はデフォルト Trusted との**差分だけ**を足す。値をこのドキュメントに転記して二重管理しない。過不足は下記「検証」で確定する。
+
+### 3. 環境変数
+
+現状、`./gradlew check` に必要な環境変数は無い。将来 GH_TOKEN 等が要るようになったらここに追記する。
+
+## 検証（初回セッションで実施）
+
+初回のクラウドセッションで次を確認し、結果を本ドキュメントに反映する:
+
+1. セッション開始後、`./gradlew check` が緑になること。
+   - PATH は既存の `.claude/hooks/session-start-mise.sh`（SessionStart フック）が `mise hook-env` で注入するので、`mise exec --` プレフィックス無しで `./gradlew` が動く。
+2. 16 GB RAM で Testcontainers Postgres（`postgres:17-alpine` + Ryuk）が起動し JDBC 契約テストが通ること。
+3. ドメイン不足で pull / 依存解決が落ちたら、落ちたホストを Custom 許可ドメインに足して再実行する。確定したら上記「2. Custom 許可ドメイン」を実測値に更新する。
+
+## スコープ外（別 Issue で扱う）
+
+- kotlin-lsp のクラウド有効化（JetBrains ホスト・編集時診断は補助操舵で check ゲートではない）。
+- gh + `GH_TOKEN` による Projects・PR マージ運用。
+- terraform MCP（`docker run`）のクラウド動作確認。

--- a/docs/claude-code-on-the-web.md
+++ b/docs/claude-code-on-the-web.md
@@ -30,7 +30,7 @@ bash scripts/web-setup.sh
 
 ### 2. Custom 許可ドメイン
 
-クラウド環境のデフォルト Trusted には Maven Central・`plugins.gradle.org`・`services.gradle.org`・`spring.io`・`repo.spring.io`・`kotlinlang.org`・Docker Hub（`registry-1.docker.io` / `auth.docker.io` / `production.cloudflare.docker.com`）が含まれる。したがって Gradle 依存解決と Testcontainers の image pull は追加設定なしで通る見込み。
+クラウド環境のデフォルト Trusted には Maven Central・`plugins.gradle.org`・`services.gradle.org`・`spring.io`・`repo.spring.io`・`kotlinlang.org`・Docker Hub（`registry-1.docker.io` / `auth.docker.io` / `production.cloudfront.docker.com`）が含まれる。したがって Gradle 依存解決と Testcontainers の image pull は追加設定なしで通る見込み。
 
 デフォルト Trusted に**無く、Custom に足す必要がある**のは mise 本体・ツール取得系:
 

--- a/scripts/web-setup.sh
+++ b/scripts/web-setup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Claude Code on the web のクラウドセッション用セットアップ。
+#
+# クラウド環境 UI の「セットアップスクリプト」欄から `bash scripts/web-setup.sh` として呼ぶ本体。
+# クラウド VM は素の JDK 21 だが本リポジトリの Gradle toolchain は 25 を要求するため、
+# mise で Temurin 25 を供給してギャップを埋める。PATH 注入は既存の
+# .claude/hooks/session-start-mise.sh（SessionStart フック）が毎セッション担うので、
+# ここでは「mise 導入 → mise install java → mise activate 仕込み」までを一度だけ行う。
+#
+# スコープは `./gradlew check` を緑にすることに限定し、`mise install`（全ツール）ではなく
+# `mise install java`（JDK 25 のみ）だけを入れる。kotlin-lsp（JetBrains ホスト・スコープ外）や
+# pipx 系ツールの取得失敗で全体を止めない・不要な Custom 許可ドメインを増やさないため。
+#
+# 冪等: 再実行しても mise 再導入や .bashrc への重複追記は行わない。
+set -euo pipefail
+
+# mise 本体が無ければ導入し、このスクリプト内でも使えるよう PATH に載せる。
+if ! command -v mise >/dev/null 2>&1; then
+  echo "installing mise ..."
+  curl -fsSL https://mise.run | sh
+fi
+export PATH="${HOME}/.local/bin:${PATH}"
+
+if ! command -v mise >/dev/null 2>&1; then
+  echo "error: mise の導入に失敗しました（PATH に mise が見つかりません）。" >&2
+  exit 1
+fi
+
+# 対話 bash 起動時に mise を有効化する（重複追記を避ける。post-create.sh と同方式）。
+if ! grep -qs 'mise activate bash' "${HOME}/.bashrc"; then
+  # `$(mise activate bash)` は .bashrc にリテラルとして書き込むのが意図（ここで展開しない）。
+  # shellcheck disable=SC2016
+  echo 'eval "$(mise activate bash)"' >> "${HOME}/.bashrc"
+fi
+
+# このリポジトリの mise.toml を信頼してから JDK 25 のみ導入する。
+mise trust
+echo "installing JDK 25 via mise (java only) ..."
+mise install java
+
+# 検証: JDK 25 が解決でき、Gradle が toolchain を満たせること。
+echo "verifying toolchain ..."
+mise exec -- java -version
+mise exec -- ./gradlew --version
+
+echo "web-setup done. Run './gradlew check' to validate the session."


### PR DESCRIPTION
## 概要

Claude Code on the web（Anthropic 管理クラウド VM）のセッションで `./gradlew check` が緑になる最小構成を整える。素の JDK 21 とリポジトリの Gradle toolchain 25 のギャップを mise（JDK 25）で埋め、PATH 注入は既存の SessionStart フックに委ねる。採否と非ポータブル性のトレードオフは ADR-0065 に記録。

Closes #611

## 変更内容

- `scripts/web-setup.sh`: クラウド UI のセットアップスクリプト欄から呼ぶヘルパー。mise 導入 → `mise install java`（JDK 25 のみ）→ `~/.bashrc` に mise activate 仕込み。冪等・`set -euo pipefail`・ShellCheck 準拠。`./gradlew check` に必要なのは JDK 25 と Docker（プリインストール）のみなので全ツールは入れない（kotlin-lsp/pipx の取得失敗で止めない・不要な Custom 許可ドメインを増やさない）。
- `docs/claude-code-on-the-web.md`: クラウド UI に貼る内容（セットアップスクリプト・Custom 許可ドメイン差分・env）と検証手順の再現ドキュメント。Custom ドメインの出所は `.devcontainer/allowed-domains.txt` にリンクで指し二重管理しない。Dev Container とは別環境である旨とスコープ外を明記。
- `docs/adr/0065-claude-code-on-the-web-support.md`（+ README 一覧）: 最小サポートの採用と、UI 側設定が非ポータブル（コミット不可）というトレードオフ・補償策を記録。

## ローカル検証

- `./gradlew check` → BUILD SUCCESSFUL（回帰なし）
- `shellcheck .claude/hooks/*.sh .claude/hooks/lib/*.sh .devcontainer/*.sh scripts/*.sh` → クリーン
- `web-setup.sh` の ShellCheck / `bash -n` / `.bashrc` 冪等性、実ツールチェーン（JDK 25.0.3 / Gradle）解決を確認

## 未完（ユーザーの web 実操作待ち）

以下はローカルセッションからは実行できないため、初回のクラウドセッションで確認し `docs/claude-code-on-the-web.md` に反映する:

- 実際にクラウドセッションを立てて `./gradlew check` が緑になること
- Custom 許可ドメインの過不足の実測確定
- 16 GB RAM での Testcontainers Postgres 挙動

## スコープ外（必要なら別 Issue）

- kotlin-lsp のクラウド有効化
- gh + `GH_TOKEN` による Projects・PR マージ運用
- terraform MCP（`docker run`）のクラウド動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
