### PR TITLE
fix: #611 Claude Code on the web の setup スクリプトを CWD 非依存にする

### DIFF
--- a/docs/claude-code-on-the-web.md
+++ b/docs/claude-code-on-the-web.md
@@ -23,10 +23,14 @@ Claude Code on the web では、セットアップスクリプトの登録・環
 UI の「セットアップスクリプト」欄に次を貼る（本体はリポジトリ管理の `scripts/web-setup.sh`）:
 
 ```bash
-bash scripts/web-setup.sh
+bash "$(find / -type f -name web-setup.sh -path '*/scripts/web-setup.sh' 2>/dev/null | head -n1)"
 ```
 
 `scripts/web-setup.sh` は mise を導入し、`mise install java`（JDK 25 のみ）を実行して toolchain を検証する。全ツールは入れない（`./gradlew check` に不要なため）。
+
+> **なぜ `bash scripts/web-setup.sh` ではなく `find` で絶対パス解決するか**: セットアップスクリプトの実行時 CWD は公式ドキュメントに記載がなく、リポジトリルートである保証がない。repo 相対パスで呼ぶと `exit 127: No such file or directory` になる（実測）。リポジトリのクローン自体は setup 実行時点で存在する（"Cloud sessions start from a fresh clone ... Everything committed is available"）が、クローン先パスも未文書化のため、コミット済みヘルパーを `find` で引いて絶対パスで実行する。ヘルパー側は自分の位置からリポジトリルートへ `cd` するので、以降の `mise trust` / `mise install`（`mise.toml` を読む）は正しく走る。
+
+> **なぜ SessionStart フックでなく setup スクリプトか**: 公式は「ランタイム/CLI の導入は setup スクリプト、両環境で要るプロジェクト設定は SessionStart フック」を推奨している。mise + JDK の導入は前者にあたる。加えて SessionStart フックに寄せると、初回セッションで mise 未導入のまま既存の `session-start-mise.sh`（`mise hook-env`）が空振りし PATH が注入されない順序問題が起きる。setup スクリプトは Claude Code 起動前に完走するのでこれを避けられる。
 
 ### 2. Custom 許可ドメイン
 

--- a/scripts/web-setup.sh
+++ b/scripts/web-setup.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Claude Code on the web のクラウドセッション用セットアップ。
 #
-# クラウド環境 UI の「セットアップスクリプト」欄から `bash scripts/web-setup.sh` として呼ぶ本体。
-# クラウド VM は素の JDK 21 だが本リポジトリの Gradle toolchain は 25 を要求するため、
-# mise で Temurin 25 を供給してギャップを埋める。PATH 注入は既存の
+# クラウド環境 UI の「セットアップスクリプト」欄から呼ぶ本体。呼び出し方は
+# docs/claude-code-on-the-web.md 参照（クローン位置は setup 実行時の CWD からは不定なので
+# 絶対パスで呼ぶ）。クラウド VM は素の JDK 21 だが本リポジトリの Gradle toolchain は 25 を
+# 要求するため、mise で Temurin 25 を供給してギャップを埋める。PATH 注入は既存の
 # .claude/hooks/session-start-mise.sh（SessionStart フック）が毎セッション担うので、
 # ここでは「mise 導入 → mise install java → mise activate 仕込み」までを一度だけ行う。
 #
@@ -13,6 +14,12 @@
 #
 # 冪等: 再実行しても mise 再導入や .bashrc への重複追記は行わない。
 set -euo pipefail
+
+# 呼び出し時の CWD に依存せずリポジトリルートで動くよう、スクリプト自身の位置から移動する。
+# Claude Code on the web の setup スクリプトは CWD がリポジトリルートである保証がなく（公式未記載）、
+# repo 相対パスで呼ぶと 127（No such file or directory）になる。後続の `mise trust` /
+# `mise install`（mise.toml を読む）はリポジトリルートで実行する必要がある。
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # mise 本体が無ければ導入し、このスクリプト内でも使えるよう PATH に載せる。
 if ! command -v mise >/dev/null 2>&1; then


### PR DESCRIPTION
## 概要

#611（PR #613 でマージ済み）の follow-up。Claude Code on the web の実クラウドセッションで、UI のセットアップスクリプトに設定した `bash scripts/web-setup.sh` が次のエラーで失敗した:

```
exit code 127: bash: scripts/web-setup.sh: No such file or directory
```

原因は、**セットアップスクリプトの実行時 CWD がリポジトリルートである保証がない**（公式ドキュメントに CWD の記載がない）こと。リポジトリのクローン自体は setup 実行時点で存在する（"Cloud sessions start from a fresh clone ... Everything committed is available"）が、repo 相対パスでは解決できない。

## 変更内容

- **`scripts/web-setup.sh`**: スクリプト自身の位置からリポジトリルートへ `cd` し、呼び出し時 CWD に依存しないようにする（後続の `mise trust` / `mise install java` は `mise.toml` を読むため repo root で走る必要がある）。
- **`docs/claude-code-on-the-web.md`**: UI セットアップスクリプトを `find` による絶対パス解決に変更（クローン先パスも未文書化のため）。CWD 未記載という原因・根拠と、SessionStart フックでなく setup スクリプトを使う理由（初回セッションの PATH 注入順序問題）を明記。

## 検証

- `shellcheck scripts/web-setup.sh` → クリーン
- `bash -n scripts/web-setup.sh` → OK
- `ec scripts/web-setup.sh docs/claude-code-on-the-web.md` → クリーン
- 自己 locate の `cd`: 別 CWD（`/tmp`）から絶対パスで呼んでもリポジトリルートに解決することを確認
- Kotlin ソース非変更（`./gradlew check` 対象の回帰なし）

## 残（ユーザーの web 実操作）

修正後の UI セットアップスクリプトで新規クラウドセッションを立て、`./gradlew check` が緑になること・Custom 許可ドメインの過不足を確定し、doc に反映する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
