### PR TITLE
fix: #611 web-setup の検証を java スコープに限定し全ツール auto-install を防ぐ

### DIFF
--- a/docs/claude-code-on-the-web.md
+++ b/docs/claude-code-on-the-web.md
@@ -26,7 +26,7 @@ UI の「セットアップスクリプト」欄に次を貼る（本体はリ�
 bash "$(find / -type f -name web-setup.sh -path '*/scripts/web-setup.sh' 2>/dev/null | head -n1)"
 ```
 
-`scripts/web-setup.sh` は mise を導入し、`mise install java`（JDK 25 のみ）を実行して toolchain を検証する。全ツールは入れない（`./gradlew check` に不要なため）。
+`scripts/web-setup.sh` は mise を導入し、`mise install java`（JDK 25 のみ）を実行して toolchain を検証する。全ツールは入れない（`./gradlew check` に不要なため）。検証の `mise exec` は **java にスコープする**（`mise exec java -- ...`）。ツール未指定の `mise exec -- ...` は mise.toml の全ツールを auto-install してしまい、スコープ外の kotlin-lsp（JetBrains ホストは Custom 未許可）や GitHub API のレート制限（未認証 60/h）で落ちるため（実測）。
 
 > **なぜ `bash scripts/web-setup.sh` ではなく `find` で絶対パス解決するか**: セットアップスクリプトの実行時 CWD は公式ドキュメントに記載がなく、リポジトリルートである保証がない。repo 相対パスで呼ぶと `exit 127: No such file or directory` になる（実測）。リポジトリのクローン自体は setup 実行時点で存在する（"Cloud sessions start from a fresh clone ... Everything committed is available"）が、クローン先パスも未文書化のため、コミット済みヘルパーを `find` で引いて絶対パスで実行する。ヘルパー側は自分の位置からリポジトリルートへ `cd` するので、以降の `mise trust` / `mise install`（`mise.toml` を読む）は正しく走る。
 
@@ -36,14 +36,18 @@ bash "$(find / -type f -name web-setup.sh -path '*/scripts/web-setup.sh' 2>/dev/
 
 クラウド環境のデフォルト Trusted には Maven Central・`plugins.gradle.org`・`services.gradle.org`・`spring.io`・`repo.spring.io`・`kotlinlang.org`・Docker Hub（`registry-1.docker.io` / `auth.docker.io` / `production.cloudfront.docker.com`）が含まれる。したがって Gradle 依存解決と Testcontainers の image pull は追加設定なしで通る見込み。
 
-デフォルト Trusted に**無く、Custom に足す必要がある**のは mise 本体・ツール取得系:
+デフォルト Trusted に**無く、Custom に足す必要がある**のは mise 本体・ツール取得系（実クラウドで確認済み）:
 
-- `mise.jdx.dev`
-- `mise-versions.jdx.dev`
+- `mise.run` … mise インストールスクリプトの配信元（`curl https://mise.run | sh`）
+- `mise.jdx.dev` … mise バイナリの取得先（GitHub が使えない場合のフォールバック）
+- `mise-versions.jdx.dev` … `mise install` のバージョン解決
+- `mise-java.jdx.dev` … `mise install java` が JVM メタデータ（tar の所在）を引く先
 
-加えて mise の java（Temurin）取得先が Trusted に無ければ足す（実セッションで確認。候補は Adoptium API / GitHub Releases 系）。
+GitHub（`github.com` / `objects.githubusercontent.com`）は default Trusted なので追加不要（mise バイナリ・チェックサム・JDK tar 実体はそこから来る）。`api.adoptium.net` は不要だった（mise は `mise-java.jdx.dev` 経由で解決する）。
 
-> Custom ドメインの**出所は [`.devcontainer/allowed-domains.txt`](../.devcontainer/allowed-domains.txt)**（コミット共有の許可リスト）。web の Custom 欄はデフォルト Trusted との**差分だけ**を足す。値をこのドキュメントに転記して二重管理しない。過不足は下記「検証」で確定する。
+> これらは `.devcontainer/allowed-domains.txt` には**無い web 固有の要求**である。devcontainer は mise を feature で導入するため `mise.run`／`mise-java.jdx.dev` を使わないが、web は素の VM に `curl mise.run` でブートストラップするため追加で要る。Docker Hub 等の重複する既定 Trusted 分は上記のとおり `.devcontainer/allowed-domains.txt` を出所として二重管理しない。`./gradlew check` を実際に緑にする過程で更に不足ホストが出たら追記する。
+
+> **クローン先**: 実測でリポジトリは `/home/user/toy-box` に置かれた（`mise trusted /home/user/toy-box`）。ただしこのパスは公式未文書化なので UI では `find` による絶対パス解決（上記「1. セットアップスクリプト」）に依存する。
 
 ### 3. 環境変数
 

--- a/scripts/web-setup.sh
+++ b/scripts/web-setup.sh
@@ -46,8 +46,11 @@ echo "installing JDK 25 via mise (java only) ..."
 mise install java
 
 # 検証: JDK 25 が解決でき、Gradle が toolchain を満たせること。
+# `mise exec` は**必ず java にスコープする**（`mise exec java -- ...`）。ツール未指定の
+# `mise exec -- ...` は mise.toml の全ツールを auto-install してしまい、スコープ外の
+# kotlin-lsp（JetBrains ホストは Custom 未許可）や GitHub API レート制限で落ちる。
 echo "verifying toolchain ..."
-mise exec -- java -version
-mise exec -- ./gradlew --version
+mise exec java -- java -version
+mise exec java -- ./gradlew --version
 
 echo "web-setup done. Run './gradlew check' to validate the session."


### PR DESCRIPTION
## 概要

#611 の follow-up（実クラウド検証で判明）。前段の CWD 修正（#614）で mise 導入と JDK 25 インストールまで到達したが、検証行 `mise exec -- ./gradlew --version`（ツール未指定）が **mise.toml の全ツールを auto-install** してしまい、スコープ外の kotlin-lsp（JetBrains ホスト未許可）と GitHub API レート制限（未認証 60/h）で `exit 1` になった。

`mise install java`（JDK 25）自体は成功しており、根因は検証の `mise exec` が全ツールを巻き込むこと。「java のみ」の設計が `mise exec` で骨抜きになっていた。

## 変更内容

- **`scripts/web-setup.sh`**: 検証の `mise exec` を java にスコープ（`mise exec java -- java -version` / `mise exec java -- ./gradlew --version`）し、他ツールの auto-install を止める。
- **`docs/claude-code-on-the-web.md`**: Custom 許可ドメインを**実測の確定セット**に更新。
  - 必要: `mise.run` / `mise.jdx.dev` / `mise-versions.jdx.dev` / `mise-java.jdx.dev`
  - 不要だった: `api.adoptium.net`（mise は `mise-java.jdx.dev` 経由で解決）
  - default Trusted（追加不要）: GitHub（mise バイナリ・チェックサム・JDK tar）
  - これらが devcontainer の `allowed-domains.txt` に無い web 固有要求である理由、クローン先 `/home/user/toy-box`、java スコープ検証の理由を追記。

## 実クラウドで確認済み（この修正まで）

- `curl https://mise.run | sh` → mise 導入成功
- 自己 locate の `cd` → `mise trusted /home/user/toy-box`（CWD 非依存で repo root へ移動）
- `mise install java` → JDK 25 インストール成功（上記 4 ドメイン許可下）

## 残（この PR マージ後に再検証）

修正後のスクリプトで新規セッションを立て、検証が java スコープで完走 → `./gradlew check` が緑になること、Testcontainers（Docker Hub は Trusted）挙動を確認。追加で不足ホストが出たら追記する。

## ローカル検証

`shellcheck` / `bash -n` / `ec`（EditorConfig）いずれもクリーン。Kotlin ソース非変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
