### PR TITLE
fix: #611 web-setup で egress プロキシ CA を JDK cacerts に取り込む

### DIFF
--- a/docs/claude-code-on-the-web.md
+++ b/docs/claude-code-on-the-web.md
@@ -28,6 +28,8 @@ bash "$(find / -type f -name web-setup.sh -path '*/scripts/web-setup.sh' 2>/dev/
 
 `scripts/web-setup.sh` は mise を導入し、`mise install java`（JDK 25 のみ）を実行して toolchain を検証する。全ツールは入れない（`./gradlew check` に不要なため）。検証の `mise exec` は **java にスコープする**（`mise exec java -- ...`）。ツール未指定の `mise exec -- ...` は mise.toml の全ツールを auto-install してしまい、スコープ外の kotlin-lsp（JetBrains ホストは Custom 未許可）や GitHub API のレート制限（未認証 60/h）で落ちるため（実測）。
 
+> **TLS 傍受プロキシの CA を JDK に信頼させる（重要）**: クラウドの egress は TLS を終端・再署名する [HTTP/HTTPS セキュリティプロキシ](https://code.claude.com/docs/en/claude-code-on-the-web#security-proxy)（MITM）経由。`curl` / `apt` はシステム CA ストア（プロキシ CA 込み）で通るが、mise 導入の Temurin は**独自 cacerts** を使うため、素のままだと Gradle の HTTPS ダウンロード（`services.gradle.org` 等）が `javax.net.ssl.SSLHandshakeException: PKIX path building failed` で落ちる（実測）。`scripts/web-setup.sh` はシステム CA バンドル（`/etc/ssl/certs/ca-certificates.crt`）を JDK の `cacerts` に取り込んでこれを解消する（バンドルは複数証明書の連結で `keytool` は先頭 1 件しか読まないため分割して個別 import）。プロキシ CA のパスや JVM 向けの信頼手順は公式未文書化のため、システムバンドル全体を取り込む方式にしている。
+
 > **なぜ `bash scripts/web-setup.sh` ではなく `find` で絶対パス解決するか**: セットアップスクリプトの実行時 CWD は公式ドキュメントに記載がなく、リポジトリルートである保証がない。repo 相対パスで呼ぶと `exit 127: No such file or directory` になる（実測）。リポジトリのクローン自体は setup 実行時点で存在する（"Cloud sessions start from a fresh clone ... Everything committed is available"）が、クローン先パスも未文書化のため、コミット済みヘルパーを `find` で引いて絶対パスで実行する。ヘルパー側は自分の位置からリポジトリルートへ `cd` するので、以降の `mise trust` / `mise install`（`mise.toml` を読む）は正しく走る。
 
 > **なぜ SessionStart フックでなく setup スクリプトか**: 公式は「ランタイム/CLI の導入は setup スクリプト、両環境で要るプロジェクト設定は SessionStart フック」を推奨している。mise + JDK の導入は前者にあたる。加えて SessionStart フックに寄せると、初回セッションで mise 未導入のまま既存の `session-start-mise.sh`（`mise hook-env`）が空振りし PATH が注入されない順序問題が起きる。setup スクリプトは Claude Code 起動前に完走するのでこれを避けられる。

--- a/scripts/web-setup.sh
+++ b/scripts/web-setup.sh
@@ -45,6 +45,36 @@ mise trust
 echo "installing JDK 25 via mise (java only) ..."
 mise install java
 
+# クラウドの egress は TLS 傍受プロキシ（自前 CA で再署名する MITM）経由。curl / apt は
+# システム CA ストア（プロキシ CA 込み）で通るが、mise 導入の Temurin は独自 cacerts を使うため、
+# 素のままだと Gradle の HTTPS ダウンロード（services.gradle.org 等）が
+# 「PKIX path building failed」で落ちる。システム CA バンドルを JDK cacerts に取り込んで
+# プロキシ CA を JVM に信頼させる。バンドルは複数証明書の連結で keytool は先頭 1 件しか
+# 読まないため、分割して個別に import する。
+# ガード: システム CA バンドルは Debian/Ubuntu（＝クラウド VM）のパス。macOS 等では存在せずスキップ。
+sys_ca_bundle=/etc/ssl/certs/ca-certificates.crt
+# JAVA_HOME は mise が設定した値を内側の bash で展開させる（外側で展開させない）。
+# shellcheck disable=SC2016
+java_home_dir="$(mise exec java -- bash -lc 'printf %s "${JAVA_HOME}"')"
+if [ -n "${java_home_dir}" ] && [ -f "${sys_ca_bundle}" ] && [ -f "${java_home_dir}/lib/security/cacerts" ]; then
+  echo "importing system CA bundle into JDK cacerts (trust the egress proxy CA) ..."
+  ca_tmp="$(mktemp -d)"
+  # BEGIN CERTIFICATE ごとに 1 ファイルへ分割する（先頭のコメント行は n=0 で捨てる）。
+  awk -v d="${ca_tmp}" '
+    /-----BEGIN CERTIFICATE-----/ { n++ }
+    n > 0 { print > sprintf("%s/ca-%03d.pem", d, n) }
+  ' "${sys_ca_bundle}"
+  for cert in "${ca_tmp}"/ca-*.pem; do
+    [ -s "${cert}" ] || continue
+    # 既存 alias（再実行時）や取り込めない行は無視する。
+    "${java_home_dir}/bin/keytool" -importcert -noprompt -trustcacerts \
+      -alias "syscacert-$(basename "${cert}" .pem)" -file "${cert}" \
+      -keystore "${java_home_dir}/lib/security/cacerts" -storepass changeit \
+      >/dev/null 2>&1 || true
+  done
+  rm -rf "${ca_tmp}"
+fi
+
 # 検証: JDK 25 が解決でき、Gradle が toolchain を満たせること。
 # `mise exec` は**必ず java にスコープする**（`mise exec java -- ...`）。ツール未指定の
 # `mise exec -- ...` は mise.toml の全ツールを auto-install してしまい、スコープ外の


### PR DESCRIPTION
## 概要

#611 の follow-up（実クラウド検証で判明・3 段目）。前段（#615）で JDK 25 導入まで到達したが、検証の `mise exec java -- ./gradlew --version` で **Gradle wrapper が Gradle 配布を `services.gradle.org` から取得する際に JVM の TLS 検証が失敗**した:

```
javax.net.ssl.SSLHandshakeException: PKIX path building failed:
  unable to find valid certification path to requested target
```

クラウドの egress は TLS を終端・再署名する [HTTP/HTTPS セキュリティプロキシ](https://code.claude.com/docs/en/claude-code-on-the-web#security-proxy)（MITM）経由。`curl` / `apt` はシステム CA ストア（プロキシ CA 込み）で通るが、mise 導入の Temurin は**独自 cacerts** を使うためプロキシ CA を信頼できていなかった。これは setup 検証だけでなく本番 `./gradlew check` の HTTPS 全般に効く根本問題。

## 変更内容

- **`scripts/web-setup.sh`**: JDK 導入後、システム CA バンドル（`/etc/ssl/certs/ca-certificates.crt`）を分割して JDK の `cacerts` へ個別 import し、プロキシ CA を JVM に信頼させる（`keytool` は連結バンドルの先頭 1 件しか読まないため分割）。Debian/Ubuntu のバンドルパス存在をガードにし、macOS 等（ローカル）ではスキップ。
- **`docs/claude-code-on-the-web.md`**: TLS 傍受プロキシ CA を JDK に信頼させる必要と対処を追記（公式 `security-proxy` 節を典拠）。

## 実クラウドで確認済み（この修正の手前まで）

`curl mise.run` 成功 → 自己 locate cd で `/home/user/toy-box` trust → `mise install java`（JDK 25）成功 → java スコープ検証で全ツール auto-install は起きず → **Gradle 配布 DL の TLS で失敗**（本 PR で対処）。

## 残（この PR マージ後に再検証）

修正後スクリプトで新規セッションを立て、`mise exec java -- ./gradlew --version` が TLS を通って完走 → `./gradlew check` が緑になること・Testcontainers（Docker Hub は Trusted）挙動を確認。新たな不足ホストが出たら追記する。

## ローカル検証

`shellcheck`（SC2016 は内側 bash 展開のため意図的に disable）/ `bash -n` / `ec`（EditorConfig）いずれもクリーン。awk 分割ロジックはサンプルで確認。CA import ブロックは Linux バンドルパスのガードで macOS ローカルでは実行されない。Kotlin ソース非変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
