### PR TITLE
fix: #611 web-setup に UTF-8 ロケールを入れ実測結果で手順を確定する

### DIFF
--- a/docs/claude-code-on-the-web.md
+++ b/docs/claude-code-on-the-web.md
@@ -36,33 +36,50 @@ bash "$(find / -type f -name web-setup.sh -path '*/scripts/web-setup.sh' 2>/dev/
 
 ### 2. Custom 許可ドメイン
 
-クラウド環境のデフォルト Trusted には Maven Central・`plugins.gradle.org`・`services.gradle.org`・`spring.io`・`repo.spring.io`・`kotlinlang.org`・Docker Hub（`registry-1.docker.io` / `auth.docker.io` / `production.cloudfront.docker.com`）が含まれる。したがって Gradle 依存解決と Testcontainers の image pull は追加設定なしで通る見込み。
+Gradle 依存解決（Maven Central・`plugins.gradle.org`・`services.gradle.org`・`spring.io`・`kotlinlang.org` 等）はデフォルト Trusted で通る。**Custom に足す必要があるもの**（すべて実クラウドで確認済み）:
 
-デフォルト Trusted に**無く、Custom に足す必要がある**のは mise 本体・ツール取得系（実クラウドで確認済み）:
+| ドメイン | 用途 |
+|---------|------|
+| `mise.run` | mise インストールスクリプトの配信元（`curl https://mise.run \| sh`） |
+| `mise.jdx.dev` | mise バイナリの取得先（GitHub が使えない場合のフォールバック） |
+| `mise-versions.jdx.dev` | `mise install` のバージョン解決 |
+| `mise-java.jdx.dev` | `mise install java` が JVM メタデータ（tar の所在）を引く先 |
+| `production.cloudfront.docker.com` | **Docker Hub の blob CDN**。Testcontainers のイメージ取得（`postgres:17-alpine` / Ryuk）に必須 |
 
-- `mise.run` … mise インストールスクリプトの配信元（`curl https://mise.run | sh`）
-- `mise.jdx.dev` … mise バイナリの取得先（GitHub が使えない場合のフォールバック）
-- `mise-versions.jdx.dev` … `mise install` のバージョン解決
-- `mise-java.jdx.dev` … `mise install java` が JVM メタデータ（tar の所在）を引く先
+- **Docker Hub はデフォルト Trusted ではない**（当初そう見込んでいたが実測で否定された）。レジストリ API（`registry-1.docker.io`）までは通るが、**blob 取得が CDN で 403 になり** Testcontainers が `ContainerFetchException` で落ちる。CDN ホストを Custom に足すこと（`registry-1.docker.io` / `auth.docker.io` も 403 が出るなら併せて足す）。
+- GitHub（`github.com` / `objects.githubusercontent.com`）は Trusted で追加不要（mise バイナリ・チェックサム・JDK tar 実体はそこから来る）。
+- `api.adoptium.net` は**不要**（mise は `mise-java.jdx.dev` 経由で解決する）。
 
-GitHub（`github.com` / `objects.githubusercontent.com`）は default Trusted なので追加不要（mise バイナリ・チェックサム・JDK tar 実体はそこから来る）。`api.adoptium.net` は不要だった（mise は `mise-java.jdx.dev` 経由で解決する）。
+> これらは `.devcontainer/allowed-domains.txt` には**無い web 固有の要求**を含む。devcontainer は mise を feature で導入するため `mise.run` / `mise-java.jdx.dev` を使わないが、web は素の VM に `curl mise.run` でブートストラップするため追加で要る。
 
-> これらは `.devcontainer/allowed-domains.txt` には**無い web 固有の要求**である。devcontainer は mise を feature で導入するため `mise.run`／`mise-java.jdx.dev` を使わないが、web は素の VM に `curl mise.run` でブートストラップするため追加で要る。Docker Hub 等の重複する既定 Trusted 分は上記のとおり `.devcontainer/allowed-domains.txt` を出所として二重管理しない。`./gradlew check` を実際に緑にする過程で更に不足ホストが出たら追記する。
-
-> **クローン先**: 実測でリポジトリは `/home/user/toy-box` に置かれた（`mise trusted /home/user/toy-box`）。ただしこのパスは公式未文書化なので UI では `find` による絶対パス解決（上記「1. セットアップスクリプト」）に依存する。
+> **クローン先**: 実測でリポジトリは `/home/user/toy-box` に置かれた。ただしこのパスは公式未文書化なので UI では `find` による絶対パス解決（上記「1. セットアップスクリプト」）に依存する。
 
 ### 3. 環境変数
 
-現状、`./gradlew check` に必要な環境変数は無い。将来 GH_TOKEN 等が要るようになったらここに追記する。
+**UTF-8 ロケールを必ず設定する**（`./gradlew check` に必須）:
+
+```
+LANG=C.utf8
+LC_ALL=C.utf8
+```
+
+クラウド VM の既定ロケールは `POSIX`(C) で、JVM の `sun.jnu.encoding`（ファイル名エンコーディング）が非 UTF-8 になる。本リポジトリは**テストメソッド名を日本語で書く**規約のため、そこから生成される `.class` のパスを書き出せず、Kotlin コンパイラが `InvalidPathException: Malformed input or input contains unmappable characters` を伴う内部エラーで落ちる（実測。`:compileTestKotlin` が失敗）。`sun.jnu.encoding` は OS ロケール由来で `-D` 指定が効かないことがあるため、**ロケール自体を UTF-8 にする**のが確実。
+
+`scripts/web-setup.sh` も自身の JVM 実行のために UTF-8 ロケールを export するが、**セッション側に効かせるにはこの UI 環境変数の設定が要る**。
+
+## TLS 傍受プロキシと JVM（実測メモ）
+
+クラウドの egress は TLS を再署名する[セキュリティプロキシ](https://code.claude.com/docs/en/claude-code-on-the-web#security-proxy)経由で、証明書の発行者は `O = Anthropic, CN = Egress Gateway SDS Issuing CA (production)`。
+
+- **セッション**には CA 入り truststore が `JAVA_TOOL_OPTIONS`（`-Djavax.net.ssl.trustStore=…/java-truststore.p12` + プロキシ設定）で渡るため、JVM は素で TLS を通せる。CA バンドルの実体は `NODE_EXTRA_CA_CERTS` / `SSL_CERT_FILE` / `CURL_CA_BUNDLE` / `REQUESTS_CA_BUNDLE` が指すファイル。
+- **setup スクリプトの実行コンテキストには `JAVA_TOOL_OPTIONS` が渡らない**。そのため mise 導入直後の Temurin は独自 cacerts のままで、Gradle の HTTPS ダウンロードが `PKIX path building failed` で落ちる。`scripts/web-setup.sh` はプロキシ CA を JDK の cacerts に取り込んでこれを解消する。
 
 ## 検証（初回セッションで実施）
 
-初回のクラウドセッションで次を確認し、結果を本ドキュメントに反映する:
-
 1. セッション開始後、`./gradlew check` が緑になること。
    - PATH は既存の `.claude/hooks/session-start-mise.sh`（SessionStart フック）が `mise hook-env` で注入するので、`mise exec --` プレフィックス無しで `./gradlew` が動く。
-2. 16 GB RAM で Testcontainers Postgres（`postgres:17-alpine` + Ryuk）が起動し JDBC 契約テストが通ること。
-3. ドメイン不足で pull / 依存解決が落ちたら、落ちたホストを Custom 許可ドメインに足して再実行する。確定したら上記「2. Custom 許可ドメイン」を実測値に更新する。
+2. Testcontainers Postgres（`postgres:17-alpine` + Ryuk）が起動し JDBC 契約テストが通ること（上記 Docker Hub CDN の許可が要る）。
+3. ドメイン不足で pull / 依存解決が落ちたら、落ちたホストを Custom 許可ドメインに足して再実行し、上表を実測値に更新する。
 
 ## スコープ外（別 Issue で扱う）
 

--- a/scripts/web-setup.sh
+++ b/scripts/web-setup.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 # Claude Code on the web のクラウドセッション用セットアップ。
 #
-# クラウド環境 UI の「セットアップスクリプト」欄から呼ぶ本体。呼び出し方は
-# docs/claude-code-on-the-web.md 参照（クローン位置は setup 実行時の CWD からは不定なので
-# 絶対パスで呼ぶ）。クラウド VM は素の JDK 21 だが本リポジトリの Gradle toolchain は 25 を
-# 要求するため、mise で Temurin 25 を供給してギャップを埋める。PATH 注入は既存の
-# .claude/hooks/session-start-mise.sh（SessionStart フック）が毎セッション担うので、
-# ここでは「mise 導入 → mise install java → mise activate 仕込み」までを一度だけ行う。
+# クラウド環境 UI の「セットアップスクリプト」欄から呼ぶ本体。呼び出し方・UI 側に必要な設定
+# （Custom 許可ドメイン・環境変数）は docs/claude-code-on-the-web.md 参照。クラウド VM は素の
+# JDK 21 だが本リポジトリの Gradle toolchain は 25 を要求するため、mise で Temurin 25 を供給する。
+# PATH 注入は既存の .claude/hooks/session-start-mise.sh（SessionStart フック）が毎セッション担うので、
+# ここでは「mise 導入 → mise install java → mise activate 仕込み → プロキシ CA の信頼」を一度だけ行う。
 #
 # スコープは `./gradlew check` を緑にすることに限定し、`mise install`（全ツール）ではなく
 # `mise install java`（JDK 25 のみ）だけを入れる。kotlin-lsp（JetBrains ホスト・スコープ外）や
@@ -20,6 +19,20 @@ set -euo pipefail
 # repo 相対パスで呼ぶと 127（No such file or directory）になる。後続の `mise trust` /
 # `mise install`（mise.toml を読む）はリポジトリルートで実行する必要がある。
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# UTF-8 ロケールを使う。クラウド VM の既定ロケールは POSIX(C) で、JVM の sun.jnu.encoding
+# （ファイル名エンコーディング）が非 UTF-8 になる。すると日本語のテストメソッド名から生成される
+# .class のパスを書き出せず、Kotlin コンパイラが InvalidPathException で内部エラーになる。
+# sun.jnu.encoding は OS ロケール由来で -D 指定が効かないことがあるため、ロケール自体を UTF-8 にする。
+# ここでの export は本スクリプト内の JVM 実行にのみ効く。セッション側にも効かせるには
+# クラウド環境 UI の環境変数に LANG / LC_ALL を設定すること（docs/claude-code-on-the-web.md 参照）。
+for locale_candidate in C.utf8 C.UTF-8; do
+  if locale -a 2>/dev/null | grep -qixF "${locale_candidate}"; then
+    export LANG="${locale_candidate}"
+    export LC_ALL="${locale_candidate}"
+    break
+  fi
+done
 
 # mise 本体が無ければ導入し、このスクリプト内でも使えるよう PATH に載せる。
 if ! command -v mise >/dev/null 2>&1; then
@@ -45,43 +58,39 @@ mise trust
 echo "installing JDK 25 via mise (java only) ..."
 mise install java
 
-# クラウドの egress は TLS 傍受プロキシ（自前 CA で再署名する MITM）経由。curl / apt は
-# システム CA ストア（プロキシ CA 込み）で通るが、mise 導入の Temurin は独自 cacerts を使うため、
-# 素のままだと Gradle の HTTPS ダウンロード（services.gradle.org 等）が
+# クラウドの egress は TLS を再署名する傍受プロキシ（issuer: Anthropic Egress Gateway CA）経由。
+# セッションには CA 入り truststore が JAVA_TOOL_OPTIONS で渡るが、**この setup スクリプトの実行
+# コンテキストには渡らない**ため、素のままだと Gradle の HTTPS ダウンロード（services.gradle.org）が
 # 「PKIX path building failed」で落ちる。プロキシ CA を JDK cacerts に取り込んで JVM に信頼させる。
-# プロキシ CA の所在は公式未文書化のため、候補（env var が指す CA ファイル群 + システムバンドル）を
-# 広めに集めて取り込む。バンドルは複数証明書の連結で keytool は先頭 1 件しか読まないため分割する。
-# JAVA_HOME はインストールパス直取り（mise where）で得る。ガードにより CA が無い環境ではスキップする。
+# CA の実体は環境変数（NODE_EXTRA_CA_CERTS 等）が指すバンドル。所在は公式未文書化のため候補を広く見る。
+# バンドルは複数証明書の連結で keytool は先頭 1 件しか読まないため、分割して個別に import する。
 java_home_dir="$(mise where java 2>/dev/null || true)"
 cacerts="${java_home_dir}/lib/security/cacerts"
-echo "diag: java_home_dir=${java_home_dir:-empty}"
-echo "diag: cacerts=$( [ -f "${cacerts}" ] && echo present || echo missing )"
-echo "diag: NODE_EXTRA_CA_CERTS=${NODE_EXTRA_CA_CERTS:-unset}"
-echo "diag: SSL_CERT_FILE=${SSL_CERT_FILE:-unset}"
-echo "diag: CURL_CA_BUNDLE=${CURL_CA_BUNDLE:-unset}"
-echo "diag: REQUESTS_CA_BUNDLE=${REQUESTS_CA_BUNDLE:-unset}"
 
-# 取り込み候補 CA ファイル（存在するものだけ）。
 ca_sources=""
-for f in "${NODE_EXTRA_CA_CERTS:-}" "${SSL_CERT_FILE:-}" "${CURL_CA_BUNDLE:-}" \
-         "${REQUESTS_CA_BUNDLE:-}" /etc/ssl/certs/ca-certificates.crt; do
-  [ -n "${f}" ] && [ -f "${f}" ] && ca_sources="${ca_sources} ${f}"
+for ca_file in "${NODE_EXTRA_CA_CERTS:-}" "${SSL_CERT_FILE:-}" "${CURL_CA_BUNDLE:-}" \
+               "${REQUESTS_CA_BUNDLE:-}" /etc/ssl/certs/ca-certificates.crt; do
+  { [ -n "${ca_file}" ] && [ -f "${ca_file}" ]; } || continue
+  # 同じバンドルを複数の環境変数が指すので重複を除く。
+  case " ${ca_sources} " in
+    *" ${ca_file} "*) continue ;;
+  esac
+  ca_sources="${ca_sources} ${ca_file}"
 done
-echo "diag: ca_sources=${ca_sources:-none}"
 
 if [ -n "${java_home_dir}" ] && [ -f "${cacerts}" ] && [ -n "${ca_sources}" ]; then
   imported=0
-  for src in ${ca_sources}; do
+  for ca_src in ${ca_sources}; do
     ca_tmp="$(mktemp -d)"
     # BEGIN CERTIFICATE ごとに 1 ファイルへ分割する（先頭のコメント行は n=0 で捨てる）。
     awk -v d="${ca_tmp}" '
       /-----BEGIN CERTIFICATE-----/ { n++ }
       n > 0 { print > sprintf("%s/ca-%03d.pem", d, n) }
-    ' "${src}"
-    src_alias="$(printf %s "${src}" | tr '/.' '__')"
+    ' "${ca_src}"
+    src_alias="$(printf %s "${ca_src}" | tr '/.' '__')"
     for cert in "${ca_tmp}"/ca-*.pem; do
       [ -s "${cert}" ] || continue
-      # 既存 alias（再実行時）や取り込めない行は無視する。成功したものだけ数える。
+      # 既に取り込み済み（再実行時）や証明書でない断片は無視する。成功したものだけ数える。
       if "${java_home_dir}/bin/keytool" -importcert -noprompt -trustcacerts \
           -alias "proxyca-${src_alias}-$(basename "${cert}" .pem)" -file "${cert}" \
           -keystore "${cacerts}" -storepass changeit >/dev/null 2>&1; then
@@ -90,26 +99,15 @@ if [ -n "${java_home_dir}" ] && [ -f "${cacerts}" ] && [ -n "${ca_sources}" ]; t
     done
     rm -rf "${ca_tmp}"
   done
-  echo "diag: newly imported ${imported} cert(s) into JDK cacerts"
+  echo "imported ${imported} CA cert(s) into JDK cacerts (trust the egress proxy CA)"
 fi
 
-# プロキシが提示する証明書チェーンの発行者を診断（非致命）。
-if command -v openssl >/dev/null 2>&1; then
-  echo "diag: openssl probe services.gradle.org:443 (issuer/subject) ..."
-  printf '' | openssl s_client -connect services.gradle.org:443 \
-      -servername services.gradle.org 2>/dev/null \
-    | grep -E '^(depth|verify|subject|issuer|s:|i:)' | head -n 20 || true
-fi
-
-# 検証: JDK 25 が解決でき、Gradle が toolchain を満たせること（**非致命**）。
-# 検証で落ちてもセッション自体は立ち上げたいので警告に留め、末尾に要約を出す。
+# 検証: JDK 25 が解決でき、Gradle が toolchain を満たせること。
 # `mise exec` は**必ず java にスコープする**（`mise exec java -- ...`）。ツール未指定の
 # `mise exec -- ...` は mise.toml の全ツールを auto-install してしまい、スコープ外の
 # kotlin-lsp（JetBrains ホストは Custom 未許可）や GitHub API レート制限で落ちる。
-echo "verifying toolchain (non-fatal) ..."
-mise exec java -- java -version || echo "WARN: 'java -version' failed"
-if mise exec java -- ./gradlew --version; then
-  echo "web-setup: OK — JDK 25 + Gradle が解決できました。'./gradlew check' で検証してください。"
-else
-  echo "WARN: 'gradlew --version' が失敗しました（TLS/プロキシ CA の可能性）。上の diag: 行を確認してください。セッションは起動します。"
-fi
+echo "verifying toolchain ..."
+mise exec java -- java -version
+mise exec java -- ./gradlew --version
+
+echo "web-setup done. Run './gradlew check' to validate the session."


### PR DESCRIPTION
## 概要

#611 の follow-up（実クラウド検証の仕上げ）。前段までで **TLS/プロキシ問題は解決**し、依存解決・Gradle 実行・コンパイルまで到達した。残った 2 つの詰まりを確定し、手順を実測値で固める。

## 判明した 2 つの詰まり

### ① ロケール（`:compileTestKotlin` が内部エラー）

クラウド VM の既定ロケールが `POSIX`(C) で、JVM の `sun.jnu.encoding`（ファイル名エンコーディング）が非 UTF-8 になる。本リポジトリは**テストメソッド名を日本語で書く**規約のため、そこから生成される `.class` のパスを書き出せず落ちる:

```
java.nio.file.InvalidPathException: Malformed input or input contains unmappable characters:
  .../RegisterHorseTransactionRollbackTest$輸入馬血統登録で…$$inlined$assertThrows$1.class
```

`sun.jnu.encoding` は OS ロケール由来で `-D` 指定が効かないことがあるため、**ロケール自体を UTF-8 にする**のが確実な対処。

### ② Docker Hub は default Trusted ではなかった

Testcontainers が `ContainerFetchException`。レジストリ API までは通るが **blob 取得が `production.cloudfront.docker.com` で 403**。当初 doc は「Docker Hub は default Trusted」と書いていたが**実測で否定された**。Custom 許可ドメインに足す必要がある。

## 変更内容

- **`scripts/web-setup.sh`**
  - UTF-8 ロケール（`C.utf8`）を export。候補が無い環境（macOS 等）ではスキップするガード付き。
  - プロキシ CA 取り込みを整理（複数の環境変数が同じバンドルを指すので重複除去）、診断出力を実用的な 1 行に縮約。
  - toolchain 検証を再び致命化（実測で通ることを確認済み）。
- **`docs/claude-code-on-the-web.md`**
  - Custom 許可ドメインを**確定表**に更新（`production.cloudfront.docker.com` を必須として追加）。
  - 環境変数に **`LANG` / `LC_ALL` = `C.utf8`** を必須として明記（理由込み）。
  - **TLS 傍受プロキシと JVM の実測メモ**を追加：issuer は `O = Anthropic, CN = Egress Gateway SDS Issuing CA (production)`。セッションには CA 入り truststore が `JAVA_TOOL_OPTIONS` で渡るが、**setup スクリプトのコンテキストには渡らない**ため CA 取り込みが要る。

## 実クラウドでの到達点

`ktfmtCheck` / `detekt` / `compileKotlin` / `compileTestKotlin`（ロケール修正後）すべて成功、**535 テスト中 453 PASS**。残る 82 失敗はすべて Testcontainers の Docker イメージ取得不可（本 PR の ② で対処）。

## UI 側で必要な設定（この PR とセット）

- 環境変数: `LANG=C.utf8` / `LC_ALL=C.utf8`
- Custom 許可ドメイン: `production.cloudfront.docker.com` を追加

## ローカル検証

`shellcheck` / `bash -n` / `ec`（EditorConfig）いずれもクリーン。ロケールガードは macOS で正しくスキップ（ローカル JDK・環境を汚さない）。Kotlin ソース非変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
