### PR TITLE
chore: セッション開始時に Docker デーモンを起動する SessionStart フックを追加

### DIFF
--- a/.claude/hooks/session-start-docker.sh
+++ b/.claude/hooks/session-start-docker.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# SessionStart hook: Docker デーモンが未起動なら（安全に起動できる場合のみ）起動する。
+#
+# Testcontainers を使う統合テスト（PostgresContainerSupport → Jdbc*ContractTest や
+# SecurityConfigTest 等）と、それらを回す `./gradlew check` は Docker デーモンを要求する。
+# CCR リモートコンテナのようにデーモンが自動起動しない環境では、これが無いと
+# Testcontainers が /var/run/docker.sock を見つけられずコンテキスト初期化で全滅する。
+#
+# ポータビリティのためのガード（共有フックなので環境依存にしない）:
+#   - `docker` CLI が無ければ何もしない。
+#   - 既に `docker info` が通る（＝デーモン稼働中。ローカルの Docker Desktop 等）なら no-op。
+#   - 未起動でも、無確認で起動できる場合（root もしくは passwordless sudo）に限り起動する。
+#     パスワードプロンプトを出す `sudo` には決してフォールバックしない。
+# これによりローカル開発機では実質何もせず、デーモンが要る環境でだけ立ち上げる。
+
+command -v docker >/dev/null 2>&1 || exit 0
+
+# 既に使えるなら何もしない。
+if docker info >/dev/null 2>&1; then
+  exit 0
+fi
+
+command -v dockerd >/dev/null 2>&1 || exit 0
+
+# 無確認で dockerd を起動する手段を決める（プロンプトが出る sudo は使わない）。
+if [ "$(id -u)" = "0" ]; then
+  runner=()
+elif sudo -n true >/dev/null 2>&1; then
+  runner=(sudo)
+else
+  # 権限が無い環境では黙って諦める（ローカル等では docker info 側で既に抜けている想定）。
+  exit 0
+fi
+
+log_file="${TMPDIR:-/tmp}/claude-session-dockerd.log"
+nohup "${runner[@]}" dockerd >"$log_file" 2>&1 &
+
+# ソケットが立ち上がるまで短時間だけ待つ（後続の gradle check で race しないように）。
+for _ in $(seq 1 30); do
+  if docker info >/dev/null 2>&1; then
+    echo "Docker デーモンを起動しました（Testcontainers / gradle check 用）。"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Docker デーモンの起動を試みましたが応答待ちで確認できませんでした（ログ: $log_file）。" >&2
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,6 +52,12 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start-mise.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start-docker.sh",
+            "timeout": 40,
+            "statusMessage": "Docker デーモン起動確認中..."
           }
         ]
       }

--- a/mise.lock
+++ b/mise.lock
@@ -48,9 +48,21 @@ checksum = "sha256:fe1c7106e15a5365d485b098a8c338f91e3b7ba71cb0e4963b98a3a098763
 url = "https://github.com/aquasecurity/trivy/releases/download/v0.71.2/trivy_0.71.2_Linux-ARM64.tar.gz"
 provenance = "cosign"
 
+[tools."aqua:aquasecurity/trivy"."platforms.linux-arm64-musl"]
+checksum = "sha256:fe1c7106e15a5365d485b098a8c338f91e3b7ba71cb0e4963b98a3a098763cfc"
+url = "https://github.com/aquasecurity/trivy/releases/download/v0.71.2/trivy_0.71.2_Linux-ARM64.tar.gz"
+url_api = "https://api.github.com/repos/aquasecurity/trivy/releases/assets/452086441"
+provenance = "cosign"
+
 [tools."aqua:aquasecurity/trivy"."platforms.linux-x64"]
 checksum = "sha256:0510e71e2fd39bf863856d499c8dc19feb4e7336546394c502a8f5cc7ab27460"
 url = "https://github.com/aquasecurity/trivy/releases/download/v0.71.2/trivy_0.71.2_Linux-64bit.tar.gz"
+provenance = "cosign"
+
+[tools."aqua:aquasecurity/trivy"."platforms.linux-x64-musl"]
+checksum = "sha256:0510e71e2fd39bf863856d499c8dc19feb4e7336546394c502a8f5cc7ab27460"
+url = "https://github.com/aquasecurity/trivy/releases/download/v0.71.2/trivy_0.71.2_Linux-64bit.tar.gz"
+url_api = "https://api.github.com/repos/aquasecurity/trivy/releases/assets/452086497"
 provenance = "cosign"
 
 [tools."aqua:aquasecurity/trivy"."platforms.macos-arm64"]
@@ -309,11 +321,23 @@ url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8
 version = "262.8190.0"
 backend = "http:kotlin-lsp"
 
+[tools."http:kotlin-lsp".options]
+rename_exe = "kotlin-lsp"
+strip_components = "1"
+
 [tools."http:kotlin-lsp"."platforms.linux-arm64"]
 checksum = "sha256:c3edd59ef34a7faa4d04f3517afb7a932b19c3f9cf17d1a14e9da17b0b5440ad"
 url = "https://download-cdn.jetbrains.com/language-server/kotlin-server/262.8190.0/kotlin-server-262.8190.0-aarch64.tar.gz"
 
+[tools."http:kotlin-lsp"."platforms.linux-arm64-musl"]
+checksum = "sha256:c3edd59ef34a7faa4d04f3517afb7a932b19c3f9cf17d1a14e9da17b0b5440ad"
+url = "https://download-cdn.jetbrains.com/language-server/kotlin-server/262.8190.0/kotlin-server-262.8190.0-aarch64.tar.gz"
+
 [tools."http:kotlin-lsp"."platforms.linux-x64"]
+checksum = "sha256:8b4c70e95065420e7867c99aaf9f18e0b4e76311ec453e4c1a39e3f6ae774cbf"
+url = "https://download-cdn.jetbrains.com/language-server/kotlin-server/262.8190.0/kotlin-server-262.8190.0.tar.gz"
+
+[tools."http:kotlin-lsp"."platforms.linux-x64-musl"]
 checksum = "sha256:8b4c70e95065420e7867c99aaf9f18e0b4e76311ec453e4c1a39e3f6ae774cbf"
 url = "https://download-cdn.jetbrains.com/language-server/kotlin-server/262.8190.0/kotlin-server-262.8190.0.tar.gz"
 
@@ -333,7 +357,15 @@ backend = "http:tfctl"
 checksum = "sha256:1060b2903cd8f9cb0af5c878cf89790e0f588b735b6715d2eeadd52c5a71f8c5"
 url = "https://releases.hashicorp.com/tfctl/0.3.0/tfctl_0.3.0_linux_arm64.zip"
 
+[tools."http:tfctl"."platforms.linux-arm64-musl"]
+checksum = "sha256:1060b2903cd8f9cb0af5c878cf89790e0f588b735b6715d2eeadd52c5a71f8c5"
+url = "https://releases.hashicorp.com/tfctl/0.3.0/tfctl_0.3.0_linux_arm64.zip"
+
 [tools."http:tfctl"."platforms.linux-x64"]
+checksum = "sha256:5526b438bb66c5bc872f55c4bbb7325bb3e9d162ddd392eed3d60f407598cf62"
+url = "https://releases.hashicorp.com/tfctl/0.3.0/tfctl_0.3.0_linux_amd64.zip"
+
+[tools."http:tfctl"."platforms.linux-x64-musl"]
 checksum = "sha256:5526b438bb66c5bc872f55c4bbb7325bb3e9d162ddd392eed3d60f407598cf62"
 url = "https://releases.hashicorp.com/tfctl/0.3.0/tfctl_0.3.0_linux_amd64.zip"
 


### PR DESCRIPTION
.claude/hooks/session-start-docker.sh:
- Testcontainers 系統合テスト（PostgresContainerSupport → Jdbc*ContractTest
  や SecurityConfigTest 等）と `./gradlew check` が要求する Docker デーモンを、
  未起動時に限り起動する SessionStart フックを新規追加。
- ポータビリティのためのガードを実装: `docker` CLI が無ければ何もしない／
  既に `docker info` が通る（ローカルの Docker Desktop 等）なら no-op／
  未起動でも無確認で起動できる場合（root もしくは passwordless sudo）のみ起動し、
  パスワードプロンプトを出す sudo にはフォールバックしない。ソケット起動を
  短時間ポーリングして後続の gradle check と race しないようにする。

.claude/settings.json:
- SessionStart フックに session-start-docker.sh を追加（session-start-mise.sh の後段、
  timeout 40 秒・statusMessage 付き）。

mise.lock:
- セッション開始時に mise が解決した linux-arm64-musl / linux-x64-musl プラットフォーム
  項目（trivy / kotlin-lsp / tfctl）と kotlin-lsp の options（rename_exe / strip_components）
  を記録。既存の gnu/通常 linux 項目と同一チェックサムで追加のみ（削除なし）。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PLE3iC8TGhqapAZp91Prvq