### PR TITLE
chore: Claude Code の応答言語を日本語に設定する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "language": "japanese",
   "enabledPlugins": {
     "kotlin-lsp@claude-plugins-official": true
   },


### PR DESCRIPTION
## 背景

Claude Code on the web のクラウドセッションが日本語で応答してくれない問題への対処。

原因は、応答言語の指示（「日本語で応答すること」）が個人ローカルの `~/.claude/CLAUDE.md` に置かれていたこと。[公式ドキュメント](https://code.claude.com/docs/en/claude-code-on-the-web.md) の "What's available in cloud sessions" のとおり、web セッションは **リポジトリに commit された内容だけ**を読み、個人ローカルの `~/.claude/CLAUDE.md` は読み込まない。

## 変更

`.claude/settings.json` に `"language": "japanese"` を追加する。

- `language` は Claude Code settings の一級キー（[JSON schema](https://www.schemastore.org/claude-code-settings.json) 定義済み。"Configure Claude's preferred response language ... Claude will respond in this language by default."）。言語系の設定キーはこれのみ（`outputLanguage` / `responseLanguage` / `locale` は存在しない）。
- commit 済み `.claude/settings.json` は web セッションも読むため、web・ローカル双方で日本語応答を担保できる。散文で CLAUDE.md に書くより一級の設定キーで指定する方が素直。

## 補足・確認事項

- schema にキーはあるが、**web セッションで `language` が効くかは公式ドキュメント未記載**。マージ後に web セッションで実挙動を確認したい。
- `.claude/settings.local.json`（gitignore）や `~/.claude/settings.json` に書く手もあるが、いずれも web には届かないため、今回の目的には commit 対象の `.claude/settings.json` が適切。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
