### PR TITLE
ci: Kotlin ロックステップ依存を dependabot で集約する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,14 +12,23 @@ updates:
     # Keep PRs manageable by limiting the number of open PRs
     open-pull-requests-limit: 5
     groups:
-      # Kotlin プラグインは KGP 互換（Spring / detekt / ktfmt）で手作業が要りがちなので分離し、
-      # 一般グループ（gradle-minor-patch）を軽く緑に保つ。2 プラグインは常に同一版で足並みを揃える。
+      # Kotlin コンパイラ版と歩調を揃える必要がある依存を 1 グループに束ね、一般グループ
+      # （gradle-minor-patch）を軽く緑に保つ。以下は常に同一 PR で足並みを揃える:
+      # - kotlin.jvm / kotlin.plugin.spring / kotlin.plugin.power-assert:
+      #   3 プラグインは version catalog で version.ref = "kotlin" を共有し、同じ kotlin 行を書き換える。
+      #   別グループに散らすと同一 1 行を書く重複 PR が量産される（#242/#245/#575 の実績）。
+      # - detekt: detekt は Kotlin コンパイラを埋め込み、「compiled with Kotlin X / running with Y」の
+      #   実行時一致を要求する。Kotlin と別 PR にすると双方が単独では緑にならないデッドロックになる
+      #   （Kotlin 単独 → detekt 非互換で :detekt 失敗 / detekt 単独 → 同じく失敗）。
       kotlin:
         patterns:
           - "org.jetbrains.kotlin.jvm"
           - "org.jetbrains.kotlin.plugin.spring"
+          - "org.jetbrains.kotlin.plugin.power-assert"
+          - "dev.detekt"
       # 残りの minor / patch を集約。Spring Boot は Spring 管理 BOM を巻き込むため個別（除外）、
-      # Kotlin プラグインは上の専用グループへ回す（除外）。major も個別 PR に残る。
+      # Kotlin ロックステップ依存（kotlin プラグイン群 + detekt）は上の専用グループへ回す（除外）。
+      # major も個別 PR に残る。
       gradle-minor-patch:
         update-types:
           - "minor"
@@ -30,6 +39,8 @@ updates:
           - "org.springframework.boot"
           - "org.jetbrains.kotlin.jvm"
           - "org.jetbrains.kotlin.plugin.spring"
+          - "org.jetbrains.kotlin.plugin.power-assert"
+          - "dev.detekt"
 
   # Enable updates for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## 背景 — Dependabot PR のデッドロック / 重複

Kotlin バージョン更新まわりで、Dependabot の 4 PR が構造的に膠着していた:

| PR | 変更 | `:detekt` 系の失敗 |
|----|------|------|
| #242 / #245 / #575 | `kotlin` → 2.4.0（実質同一 1 行） | `detekt was compiled with Kotlin 2.3.21 but running with 2.4.0` |
| #359 | `detekt` → 2.0.0-alpha.5 | `detekt was compiled with Kotlin 2.4.0 but running with 2.3.21` |

原因は 2 つ:

1. **`version.ref = "kotlin"` の共有** — `kotlin.plugin.power-assert` はカタログで `kotlin` 版を共有しており、`kotlin` 行そのものを書き換える。従来は `gradle-minor-patch` グループに落ちていたため、`kotlin` 更新と**同一 1 行を書く重複 PR**（#242 / #245 / #575）が量産されていた。
2. **detekt の実行時版一致要求** — detekt は Kotlin コンパイラを埋め込み、「compiled with Kotlin X / running with Y」の一致を要求する。Kotlin と別 PR にすると、双方が単独ではグリーンにならない**相互デッドロック**になる。

## この PR の変更

`.github/dependabot.yml` の `kotlin` グループを「Kotlin コンパイラ版と歩調を揃える必要がある依存」のロックステップ・グループに拡張:

- `kotlin` グループの `patterns` に `org.jetbrains.kotlin.plugin.power-assert` と `dev.detekt` を追加。
- `gradle-minor-patch` の `exclude-patterns` に同 2 つを追加し、専用グループへ回す。
- グルーピング意図（`version.ref` 共有・detekt の実行時版一致）をコメントに明記。

これにより、今後は **Kotlin・power-assert・spring・detekt が常に 1 本の PR** で提案され、デッドロックも重複も構造的に発生しなくなる。

## 版バンプ（Kotlin 2.4.0）自体は見送り

当初は「Kotlin 2.4.0 + detekt alpha.5」を 1 コミットにまとめてマージする案だったが、`./gradlew check` で第 3 の壁に当たった:

- detekt **alpha.4 / alpha.5 に上流のパッケージングバグ**があり（[detekt#9409](https://github.com/detekt/detekt/issues/9409)、CLOSED/COMPLETED）、`detekt-test` が要求する `detekt-api` の test-fixtures 本体 variant が Maven Central に公開されていない。カスタムルールモジュール `:detekt-rules` のテスト（`detekt-test` を利用）が `No matching variant ... capability 'dev.detekt:detekt-api-test-fixtures'` で解決不能になる。
- 修正は上流 main にマージ済みだが、**最新リリース alpha.5（2026-06-17）より後（2026-07-01）**のため、修正入り版（alpha.6+）は**未公開**。
- alpha.3 は test-fixtures が健全だが Kotlin 2.3.21 ビルドで 2.4.0 に使えない。

→ 「Kotlin 2.4.0 対応」かつ「test-fixtures 消費可能」を両立する detekt が現時点で存在せず、**Kotlin 2.4.0 の取り込みは detekt の次リリース待ち**。この PR はグルーピング修正のみに絞り、版バンプは追跡 Issue へ切り出す。

## 追従

- 停滞していた #242 / #245 / #575 / #359 はクローズ（detekt#9409 待ち）。
- detekt alpha.6+ が出れば、本 PR のグルーピングにより Kotlin + power-assert + detekt が 1 本の PR で再提案される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
