### PR TITLE
chore: Claude Code on the web で gh CLI + GH_TOKEN 運用を可能にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,7 +210,7 @@ LEFTHOOK_EXCLUDE=ktfmt-check git commit -m "メッセージ"   # 特定コマン
 
 同じ「リポジトリ管理で宣言・共有」の方針で、**Claude Code の LSP プラグインは `.claude/settings.json` の `enabledPlugins` に宣言**する（現状 `kotlin-lsp@claude-plugins-official`＝Kotlin の編集時診断・コードナビ）。要求バイナリ `kotlin-lsp`（JetBrains 公式）は mise 管理で供給する（`mise install`）。LSP はゲート（detekt / ArchUnit / gradle check）を置き換えない補助で、採否と供給方法は [ADR-0046](docs/adr/0046-adopt-kotlin-lsp-plugin.md)。
 
-**GitHub 操作は MCP ではなく `gh` CLI で行う**（[ADR-0001](docs/adr/0001-drop-github-mcp-use-gh-cli.md)）。サンドボックス下の TLS 問題（`OSStatus -26276`）は、`gh` を `.claude/settings.local.json` の `sandbox.excludedCommands` に `"gh"` と `"gh *"` の両方で登録して sandbox 外で実行し回避する。複合コマンド（`A && gh ...`）はマッチしないので `gh` は単体コマンドで実行する。
+**GitHub 操作は MCP ではなく `gh` CLI で行う**（[ADR-0001](docs/adr/0001-drop-github-mcp-use-gh-cli.md)）。サンドボックス下の TLS 問題（`OSStatus -26276`）は、`gh` を `.claude/settings.local.json` の `sandbox.excludedCommands` に `"gh"` と `"gh *"` の両方で登録して sandbox 外で実行し回避する。複合コマンド（`A && gh ...`）はマッチしないので `gh` は単体コマンドで実行する。Claude Code on the web のクラウドセッションでは `gh auth login` の代わりに UI の Secrets に登録した自前 PAT（`GH_TOKEN`・`repo` + `project` スコープ）を gh が自動採用する（導入は `mise.toml` の `aqua:cli/cli`。認証運用は [ADR-0066](docs/adr/0066-gh-cli-via-gh-token-on-web.md)、手順は [docs/claude-code-on-the-web.md](docs/claude-code-on-the-web.md)）。
 
 ## シークレット管理（fnox + 1Password）
 

--- a/docs/adr/0066-gh-cli-via-gh-token-on-web.md
+++ b/docs/adr/0066-gh-cli-via-gh-token-on-web.md
@@ -1,0 +1,56 @@
+# 0066. Claude Code on the web で gh CLI を GH_TOKEN 認証で使う
+
+- Status: Accepted
+- Date: 2026-07-13
+- Deciders: ptiringo
+
+## Context（背景・課題）
+
+[ADR-0065](0065-claude-code-on-the-web-support.md) は Claude Code on the web を**最小構成**（`./gradlew check` が緑）でサポートし、`gh` + `GH_TOKEN` による Projects・PR マージ運用は**スコープ外**（必要になったら別 Issue）とした。#628 がその follow-up で、クラウド／モバイルから `gh` で Issue/PR・Projects #4（Priority 運用）・PR マージ（`--admin`）を回せるようにしたい。
+
+前提として次が確定している。
+
+- **対象はクラウドセッションのみ**。ローカルの GitHub 操作は `gh` CLI 直接利用（[ADR-0001](0001-drop-github-mcp-use-gh-cli.md)）で、認証は不要（sandbox 外実行で解決済み）。web だけがギャップ。
+- **`gh` はクラウド VM に未プリインストール**（#611 実測。`./gradlew check` には不要だった）。導入導線が要る。
+- クラウドセッションは毎回 fresh clone で起動し、ローカルの環境変数・mise 管理ツールを引き継がない。セットアップスクリプト・環境変数・Custom 許可ドメインは**クラウド環境 UI 側に保存され、リポジトリにコミットできない**（ADR-0065 と同じ非ポータブル性）。
+
+論点は「導入方式」と「認証方式」の 2 つ。
+
+### 導入方式
+
+- **mise.toml に一元化（採用）**: ツールバージョンの唯一の出所は `mise.toml`、という既存方針（CLAUDE.md）に従う。バックエンドは `mise registry gh` が指す `aqua:cli/cli`。
+- devcontainer features / apt: バージョンを二重管理するため不採用（既存の他ツールと非対称になる）。
+
+### 認証方式
+
+- **UI の Secrets に自前 PAT を `GH_TOKEN` として登録し、gh に自動採用させる（採用）**: `gh` は env の `GH_TOKEN`（無ければ `GITHUB_TOKEN`）を自動採用するため `gh auth login` が不要。Projects #4 操作には `project` スコープが要る（`gh auth refresh -s project` 相当）ので PAT に `repo` + `project` を持たせる。
+- `gh auth login`: クラウドセッションは fresh clone で揮発し対話認証のトークン保存先も残らないため不採用。
+- `.env` ファイル: gitignore された `.env` は fresh clone に存在しない（構造的に持てない）ため不採用。
+
+### 実測（この follow-up の実装セッション）
+
+「env が非対話シェルに来るか」を**手を動かす前に実機確認**した（#611 の実測主義。落とし穴3＝env が setup フェーズに来ないパターンを疑う）。
+
+- `echo ${GH_TOKEN:+set}` → **set**（`GITHUB_TOKEN` も）。**env は非対話シェルに届く**。したがって devcontainer 側の env 橋渡し（remoteEnv / containerEnv / post-create）は**不要**。
+- `gh api user -q .login` → **`ptiringo`**。gh が `GH_TOKEN` を採用し user レベル API が通る。
+- `gh api rate_limit -i` の `X-Oauth-Scopes` → `repo, project, read:org, ...`。**`repo` + `project` スコープを確認**。
+- `gh auth status` は「token is invalid」と表示するが、実 API 呼び出しは通る（gh 独自の検証ヒューリスティックの表示に過ぎない）。
+- ただし**実装セッション固有のプロキシ制限**として、`gh issue list` / `gh pr list` / `gh project view`（GraphQL）と repo REST はこのセッションでは 403 だった（egress プロキシが GraphQL/repo REST を Claude GitHub App 経由にゲートしていたため）。ユーザーが対話的に開くセッション（GitHub が Trusted・自前 PAT）ではこの制限はない見込み。差の詳細と実測表は [docs/claude-code-on-the-web.md](../claude-code-on-the-web.md) の「gh CLI（GitHub 操作）」節に記録した。
+
+## Decision（決定）
+
+Claude Code on the web のクラウドセッションで `gh` CLI を使えるようにする。
+
+- **導入**: `gh` を `mise.toml` の `[tools]` に `aqua:cli/cli`（バージョンピン）で追加する。`scripts/web-setup.sh` が toolchain 検証の後に `mise install aqua:cli/cli` を **best-effort** で実行する（`./gradlew check` のクリティカルパスではないため、取得失敗しても setup を止めない）。PATH は既存の `session-start-mise.sh`（`mise hook-env`）が注入する。
+- **認証**: UI の Secrets に自前 PAT を `GH_TOKEN` として登録し、gh に自動採用させる（`gh auth login` はしない）。PAT は `repo` + `project` スコープ（Projects #4 運用のため）。`.env` は使わない。env は非対話シェルに届くことを実測済みのため、env 橋渡しのフォールバックは入れない。
+- **許可ドメイン**: `gh` の通信先（api.github.com / github.com / objects.githubusercontent.com）は GitHub でデフォルト Trusted のため Custom 追加は不要。
+- **非ポータブル設定の記録**: UI 側にしか置けない `GH_TOKEN` の登録手順・PAT スコープ・実測結果は `docs/claude-code-on-the-web.md` に残す（ADR-0065 と同じ方針。値は UI・手順はコミット）。
+- ローカルの GitHub 操作方針（[ADR-0001](0001-drop-github-mcp-use-gh-cli.md)）と整合する（どちらも MCP でなく `gh` CLI。差は認証だけで、ローカルは sandbox 外実行、web は `GH_TOKEN`）。
+
+## Consequences（結果・影響）
+
+- クラウド／モバイルから `gh` で Issue/PR・Projects #4・PR マージを回せるようになる。GitHub 操作の出所がローカル／web ともに `gh` CLI で揃う。
+- `GH_TOKEN`（自前 PAT）は UI 側に保存され共有できないため、各自が `docs/claude-code-on-the-web.md` の手順で PAT を発行・登録する必要がある。この非ポータブル性はドキュメントによる再現手順で補償する（ADR-0065 と同じトレードオフ）。
+- PAT は自前発行のため、スコープ（`repo` + `project`）と有効期限の管理は各自の責任になる。最小権限で発行し、不要になれば失効させる。
+- `gh` を best-effort 導入にしたことで、GitHub 取得の一時失敗やレート制限で `./gradlew check` の土台を止めない。gh 無しでも check は緑になる。
+- 実装セッションでは egress プロキシの制限で repo/org/GraphQL 操作が 403 だった。ユーザーの対話セッションでの `gh issue list` 等の疎通は、初回に実測して `docs/claude-code-on-the-web.md` の表を確定する運用とする。

--- a/docs/claude-code-on-the-web.md
+++ b/docs/claude-code-on-the-web.md
@@ -6,7 +6,12 @@
 
 ## ゴール
 
-クラウドセッションで `./gradlew check`（ビルド + テスト + Testcontainers + カバレッジゲート）が緑になること。加えて kotlin-lsp（編集時診断・コードナビ）を **best-effort** で有効化する（#627。失敗しても check 緑には影響しない補助。手順は「kotlin-lsp の有効化」節）。gh + Projects 運用 / terraform MCP のフル同等化はスコープ外（本ドキュメント末尾「スコープ外」参照）。
+クラウドセッションで `./gradlew check`（ビルド + テスト + Testcontainers + カバレッジゲート）が緑になること。加えて次を **best-effort** で有効化する（いずれも失敗しても check 緑には影響しない補助）:
+
+- kotlin-lsp（編集時診断・コードナビ。#627。手順は「kotlin-lsp の有効化」節）。
+- `gh` CLI（Issue/PR・Projects #4・PR マージ。#628。手順は「gh CLI（GitHub 操作）」節）。
+
+terraform MCP（`docker run`）のフル同等化はスコープ外（本ドキュメント末尾「スコープ外」参照）。
 
 ## 前提（クラウド VM のプリインストール）
 
@@ -68,6 +73,18 @@ LC_ALL=C.utf8
 
 `scripts/web-setup.sh` も自身の JVM 実行のために UTF-8 ロケールを export するが、**セッション側に効かせるにはこの UI 環境変数の設定が要る**。
 
+#### GitHub 操作用（`gh` CLI）
+
+クラウド／モバイルから `gh` で Issue/PR・Projects #4（Priority）・PR マージを回すために、**自前 PAT を `GH_TOKEN` として UI の Secrets に登録する**（設計・認証運用は [ADR-0066](adr/0066-gh-cli-via-gh-token-on-web.md)、#628）。
+
+```
+GH_TOKEN=<自前 PAT>
+```
+
+- **PAT の発行**: GitHub の Fine-grained（対象リポジトリに Contents / Issues / Pull requests、Organization/User の Projects を Read and write）または Classic（`repo` + `project` スコープ）で発行する。Projects #4 の操作に **`project` スコープが必須**（`gh auth refresh -s project` 相当）。
+- **`gh auth login` は不要**。gh は env の `GH_TOKEN`（無ければ `GITHUB_TOKEN`）を自動採用する。この env は**非対話シェルにも渡る**ことを実測済み（後述「gh CLI（GitHub 操作）」の検証表）。`.env` は使わない（クラウドセッションは毎回 fresh clone で揮発し、gitignore された `.env` は存在しないため。構造的に不採用）。
+- トークンが UI 側に保存され非ポータブルになる点は `LANG` 等の環境変数と同じトレードオフ（[ADR-0065](adr/0065-claude-code-on-the-web-support.md)）。ローカルは fnox + 1Password で解決済み（[secrets 規約](../.claude/rules/secrets.md)）なので UI 登録は web 環境限定。
+
 ## TLS 傍受プロキシと JVM（実測メモ）
 
 クラウドの egress は TLS を再署名する[セキュリティプロキシ](https://code.claude.com/docs/en/claude-code-on-the-web#security-proxy)経由で、証明書の発行者は `O = Anthropic, CN = Egress Gateway SDS Issuing CA (production)`。
@@ -109,7 +126,32 @@ Claude Code の `kotlin-lsp@claude-plugins-official` プラグイン（`.claude/
 - **Linux x64 の kotlin-lsp が起動・動作するか**（[ADR-0046](adr/0046-adopt-kotlin-lsp-plugin.md) は Linux を未実機検証と明記。クラウド VM は Linux）。
 - ランチャ `kotlin-lsp.sh` がセッションの JDK 25（mise hook-env 注入 PATH）を使えるか。ランタイムはセッションの `JAVA_TOOL_OPTIONS`（プロキシ CA 入り truststore）が効く想定。
 
+## gh CLI（GitHub 操作）（#628）
+
+クラウド／モバイルから GitHub の Issue/PR・Projects #4（Priority 運用）・PR マージ（`--admin` マージ）を `gh` で回せるようにする。ローカルの GitHub 操作方針（MCP でなく `gh` CLI = [ADR-0001](adr/0001-drop-github-mcp-use-gh-cli.md)）とクラウドを揃える follow-up。設計・認証運用は [ADR-0066](adr/0066-gh-cli-via-gh-token-on-web.md)。
+
+### 導入と認証
+
+- **導入**: `gh` は `mise.toml`（`aqua:cli/cli`）に一元管理する（features / apt は使わない = ツールバージョンの唯一の出所は `mise.toml`）。`scripts/web-setup.sh` が toolchain 検証の後に `mise install aqua:cli/cli` を **best-effort** で実行する（失敗しても setup は止めず check 緑に影響しない）。PATH は既存の `session-start-mise.sh`（`mise hook-env`）が注入するので `gh` を素で呼べる。
+- **認証**: UI の Secrets に登録した `GH_TOKEN`（自前 PAT）を gh が**自動採用**する。`gh auth login` はしない。PAT のスコープ・登録手順は「UI 側に設定する内容 → 3. 環境変数 → GitHub 操作用」を参照。
+- **許可ドメイン**: `gh`（api.github.com / github.com / objects.githubusercontent.com）は GitHub なので**デフォルト Trusted・Custom 追加不要**（`mise install aqua:cli/cli` の api 参照・バイナリ取得も同経路。GH_TOKEN があると未認証 60/h レート制限も避けられる）。
+
+### 検証結果（この follow-up セッションで実測）
+
+> **重要な前提**: この follow-up の実装セッションは自動起動の管理環境で、egress が**リポジトリスコープの egress プロキシ**越しだった。ユーザーが対話的に開く「Claude Code on the web」セッション（自前 PAT を Secrets に登録）とは egress ポリシーが異なる。両者の差を明示する。
+
+`echo ${GH_TOKEN:+set}` と `gh` の各操作を実機で叩いた結果:
+
+| 検証 | 結果 | 意味 |
+|------|------|------|
+| `echo ${GH_TOKEN:+set}` | **set**（`GITHUB_TOKEN` も） | **env は非対話シェルに届く**。setup フェーズ限定で消える #611 の落とし穴3（env が来ない）は**再発しない**。devcontainer 側の env 橋渡し（remoteEnv 等）は**不要**。 |
+| `gh api user -q .login` | **`ptiringo`** | user レベルの認証・API は通る。gh が `GH_TOKEN` を採用できている。 |
+| `gh api rate_limit -i`（`X-Oauth-Scopes`） | `repo, project, read:org, ...` | 背後トークンは **`repo` + `project` スコープを保持**。Projects 操作の前提は満たす。 |
+| `gh auth status` | 「token is invalid」と表示 | gh 独自の検証ヒューリスティックが表示するだけで、実 API 呼び出し（上記 `gh api user`）は通る。**表示に反して機能する**。 |
+| `gh issue list` / `gh pr list` / `gh project view 4` | このセッションでは **403**（GraphQL 未許可） | 上記プロキシが GraphQL/repo REST を Claude GitHub App 経由にゲートしていたため。**ユーザーの対話セッション（自前 PAT・GitHub Trusted）ではこの制限はなく、repo/org/Projects 操作が通る想定**。 |
+
+**結論**: `GH_TOKEN` を Secrets に登録すれば gh は非対話シェルで自動採用され、user レベル API は実機で通ることを確認した。トークンは `repo` + `project` スコープを持つ。repo/org/GraphQL 操作の実 403 は**実装セッション固有のプロキシ制限**で、ユーザーの対話セッション（GitHub が Trusted・自前 PAT）では発生しない見込み。**env 橋渡しのフォールバックは不要**（env が非対話シェルに届くことを実測で確認済み）。この差はユーザーの対話セッションで `gh issue list` 等を叩いて確定すること。
+
 ## スコープ外（別 Issue で扱う）
 
-- gh + `GH_TOKEN` による Projects・PR マージ運用（#628）。
 - terraform MCP（`docker run`）のクラウド動作確認（#629）。

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -7,9 +7,13 @@
 #
 # http backend で供給する kotlin-lsp / tfctl は、mise が per-platform の SHA を mise.lock に
 # 永続化しない（`mise lock` が書かない）ため `mise install --locked`（Linux CI）を満たせず、
-# mise-action を使う CI ジョブを落とす（#510 回帰）。どちらも CI では不要なので除外する:
+# mise-action を使う CI ジョブを落とす（#510 回帰）。gh（aqua backend）は lock 可能だが CI では
+# 一切使わない（GitHub 操作は Actions の GITHUB_TOKEN / MCP が担い、gh CLI は人間のクラウド操作用。
+# ADR-0066）。`--locked` は install_args のツールだけでなく config 上の全ツールを lock に照合するため、
+# CI で使わない・または lock を満たせないツールはここで除外する（install_args とは役割が別）:
 #   - http:kotlin-lsp … 編集時診断・コードナビ用の LSP（ADR-0046）。CI に用途なし。
 #   - http:tfctl      … HCP Terraform の対話操作 CLI（ADR-0034）。CI に用途なし。
+#   - aqua:cli/cli    … GitHub CLI（ADR-0066 / #628）。クラウドセッションの人間操作用で CI に用途なし。
 # ローカル開発では base の mise.toml 定義がそのまま有効なので影響しない。
 [settings]
-disable_tools = ["http:kotlin-lsp", "http:tfctl"]
+disable_tools = ["http:kotlin-lsp", "http:tfctl", "aqua:cli/cli"]

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@ lockfile = true
 
 [tools]
 actionlint = "1.7.12"
+"aqua:cli/cli" = "2.96.0"
 editorconfig-checker = "3.7.0"
 fnox = "1.27.1"
 "github:sbdchd/squawk" = "2.58.0"

--- a/scripts/web-setup.sh
+++ b/scripts/web-setup.sh
@@ -147,4 +147,25 @@ else
   echo "warn: 編集時診断は無効のまま続行する（./gradlew check には影響しない）。" >&2
 fi
 
+# gh CLI（GitHub の Issue/PR/Projects 操作）を best-effort で導入する。ローカルの GitHub 操作方針
+# （MCP でなく gh CLI）と揃え、クラウド／モバイルからも gh で回せるようにする。採否・認証運用は
+# ADR-0066、UI 側の PAT 登録手順は docs/claude-code-on-the-web.md を参照。#628。
+#
+# **check-緑のクリティカルパスではない**ため verify の後に置き、失敗しても setup を止めない。
+# 認証は `gh auth login` を使わず、UI の Secrets に登録した GH_TOKEN（自前 PAT・repo + project
+# スコープ）を gh が自動採用する（env が非対話シェルに来ることは実測済み。ADR-0066）。ここでは
+# 導入のみで、トークン検証はセッション側（GH_TOKEN あり）に委ねる。
+#
+# **`aqua:cli/cli` だけを名指しする**（java / http:kotlin-lsp と混ぜない）。ツール未指定の
+# `mise install` は mise.toml の全ツールを入れにいき GitHub API レート制限等で落ちる。aqua backend の
+# api.github.com 参照とバイナリ取得は GitHub（Trusted）越しで、GH_TOKEN があると未認証 60/h の
+# レート制限も避けられる。`if` で包むのは best-effort（非ゼロ終了で set -e に巻き込まれないため）。
+echo "installing gh (GitHub CLI) via mise (best-effort) ..."
+if mise install "aqua:cli/cli"; then
+  echo "gh installed. UI の Secrets に GH_TOKEN（PAT）があれば 'gh api user' 等がそのまま通る。"
+else
+  echo "warn: gh の導入に失敗（GitHub 取得の一時失敗 or レート制限の可能性）。" >&2
+  echo "warn: gh 無しで続行する（./gradlew check には影響しない）。" >&2
+fi
+
 echo "web-setup done. Run './gradlew check' to validate the session."


### PR DESCRIPTION
## 概要

#611 / [ADR-0065](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0065-claude-code-on-the-web-support.md) の follow-up（#628）。Claude Code on the web のクラウドセッションから `gh` CLI で GitHub 操作（Issue/PR・Projects #4 の Priority 運用・`--admin` マージ）を回せるようにする。

実装前に **「env が非対話シェルに来るか」を先に実機確認**（#611 の実測主義。落とし穴3＝env が来ないパターンを疑う）し、`GH_TOKEN` が非対話シェルに届くことを確認したうえで、env 橋渡しのフォールバックは**不要**と判断して最小の導線のみ入れた。

## 変更内容

- **mise.toml**: `[tools]` に `gh` を `aqua:cli/cli`（2.96.0 ピン）で追加。features / apt は使わずツールバージョンの唯一の出所を `mise.toml` に保つ（`mise registry gh` で確認）。`mise.lock` の gh エントリは github-Trusted 環境の次回 `mise install` で自動追記される（実装セッションは egress プロキシで github.com 取得が 403 のため未生成。CI ゲートは無し）。
- **scripts/web-setup.sh**: toolchain 検証の後に `mise install aqua:cli/cli` を **best-effort** で実行（kotlin-lsp と同方式）。check-緑のクリティカルパスではないため失敗しても setup を止めない。認証は `gh auth login` を使わず UI Secrets の `GH_TOKEN` を gh が自動採用する前提。
- **docs/claude-code-on-the-web.md**: 環境変数節に GitHub 操作用 `GH_TOKEN`（自前 PAT・`repo` + `project` スコープ）の登録手順を追加。「gh CLI（GitHub 操作）」節を新設し、導入・認証・許可ドメインと**実測結果**を記録。スコープ外から #628 を外す。
- **docs/adr/0066-gh-cli-via-gh-token-on-web.md**: 新規 ADR。導入方式（mise.toml 一元化）と認証方式（UI Secrets の `GH_TOKEN` 自動採用・`gh auth login`/`.env` 不採用）の決定・実測・ADR-0001 / ADR-0065 との整合を記録。
- **CLAUDE.md**: GitHub 操作方針（ADR-0001）の行に web セッションの `GH_TOKEN` 自動採用と ADR-0066 / docs へのポインタを追記。

## 動作確認

この実装セッションの Bash で実機検証（出力を証拠として ADR-0066 / docs に記録）:

- [x] `echo ${GH_TOKEN:+set}` → **set**（`GITHUB_TOKEN` も）。env は**非対話シェルに届く** → フォールバック不要。
- [x] `gh api user -q .login` → **`ptiringo`**。gh が `GH_TOKEN` を採用し user レベル API が通る。
- [x] `gh api rate_limit -i` の `X-Oauth-Scopes` → `repo, project, read:org, ...`。**`repo` + `project` スコープを確認**。
- [x] `gh --version` → 2.96.0（本セッションは github.com 取得が 403 のため Go module proxy からソースビルドして検証）。
- [ ] `gh issue list` / `gh pr list` / `gh project view 4` → **本セッションでは 403**（egress プロキシが GraphQL/repo REST を Claude GitHub App 経由にゲート）。**ユーザーの対話セッション（GitHub Trusted・自前 PAT）で疎通を確定すること**（docs に実測 TODO として記載）。

> **注意**: この実装セッションは自動起動の管理環境で egress ポリシーがユーザーの対話セッションと異なる。repo/org/GraphQL 操作の 403 は実装セッション固有のプロキシ制限で、ユーザーが自前 PAT を Secrets に登録して開くセッションでは発生しない見込み。この差は docs に明記した。

Closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015GdMrdK3jDj2BRZCpMk7L6)_