### PR TITLE
docs: web の gh 認証を /web-setup 優先に改める（PAT は最小・短命フォールバック）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,7 +210,7 @@ LEFTHOOK_EXCLUDE=ktfmt-check git commit -m "メッセージ"   # 特定コマン
 
 同じ「リポジトリ管理で宣言・共有」の方針で、**Claude Code の LSP プラグインは `.claude/settings.json` の `enabledPlugins` に宣言**する（現状 `kotlin-lsp@claude-plugins-official`＝Kotlin の編集時診断・コードナビ）。要求バイナリ `kotlin-lsp`（JetBrains 公式）は mise 管理で供給する（`mise install`）。LSP はゲート（detekt / ArchUnit / gradle check）を置き換えない補助で、採否と供給方法は [ADR-0046](docs/adr/0046-adopt-kotlin-lsp-plugin.md)。
 
-**GitHub 操作は MCP ではなく `gh` CLI で行う**（[ADR-0001](docs/adr/0001-drop-github-mcp-use-gh-cli.md)）。サンドボックス下の TLS 問題（`OSStatus -26276`）は、`gh` を `.claude/settings.local.json` の `sandbox.excludedCommands` に `"gh"` と `"gh *"` の両方で登録して sandbox 外で実行し回避する。複合コマンド（`A && gh ...`）はマッチしないので `gh` は単体コマンドで実行する。Claude Code on the web のクラウドセッションでは `gh auth login` の代わりに UI の Secrets に登録した自前 PAT（`GH_TOKEN`・`repo` + `project` スコープ）を gh が自動採用する（導入は `mise.toml` の `aqua:cli/cli`。認証運用は [ADR-0066](docs/adr/0066-gh-cli-via-gh-token-on-web.md)、手順は [docs/claude-code-on-the-web.md](docs/claude-code-on-the-web.md)）。
+**GitHub 操作は MCP ではなく `gh` CLI で行う**（[ADR-0001](docs/adr/0001-drop-github-mcp-use-gh-cli.md)）。サンドボックス下の TLS 問題（`OSStatus -26276`）は、`gh` を `.claude/settings.local.json` の `sandbox.excludedCommands` に `"gh"` と `"gh *"` の両方で登録して sandbox 外で実行し回避する。複合コマンド（`A && gh ...`）はマッチしないので `gh` は単体コマンドで実行する。Claude Code on the web のクラウドセッションでは、認証は `/web-setup`（ローカルの gh トークンを Claude アカウントにマネージド同期）を第一候補とし、届かないスコープに限り fine-grained・短命 PAT を環境変数 `GH_TOKEN` に置く（環境変数は平文・編集者可視で秘密ストアではないため長命 PAT は常設しない。導入は `mise.toml` の `aqua:cli/cli`。認証運用は [ADR-0066](docs/adr/0066-gh-cli-via-gh-token-on-web.md)、手順は [docs/claude-code-on-the-web.md](docs/claude-code-on-the-web.md)）。
 
 ## シークレット管理（fnox + 1Password）
 

--- a/docs/adr/0066-gh-cli-via-gh-token-on-web.md
+++ b/docs/adr/0066-gh-cli-via-gh-token-on-web.md
@@ -1,18 +1,20 @@
-# 0066. Claude Code on the web で gh CLI を GH_TOKEN 認証で使う
+# 0066. Claude Code on the web で gh CLI を使う（認証は /web-setup 優先）
 
 - Status: Accepted
 - Date: 2026-07-13
 - Deciders: ptiringo
+- 改訂: 2026-07-14 — 初版は「UI の環境変数に自前 PAT を `GH_TOKEN` として登録」を第一の認証方式としたが、環境変数が**専用の秘密ストアではなく平文で保存され、環境を編集できる人に見える**（公式明記）ことを踏まえ、`/web-setup`（マネージド同期）を第一候補に改める。PAT は `/web-setup` で届かないスコープに限ったフォールバックへ格下げ。
 
 ## Context（背景・課題）
 
-[ADR-0065](0065-claude-code-on-the-web-support.md) は Claude Code on the web を**最小構成**（`./gradlew check` が緑）でサポートし、`gh` + `GH_TOKEN` による Projects・PR マージ運用は**スコープ外**（必要になったら別 Issue）とした。#628 がその follow-up で、クラウド／モバイルから `gh` で Issue/PR・Projects #4（Priority 運用）・PR マージ（`--admin`）を回せるようにしたい。
+[ADR-0065](0065-claude-code-on-the-web-support.md) は Claude Code on the web を**最小構成**（`./gradlew check` が緑）でサポートし、`gh` による Projects・PR マージ運用は**スコープ外**（必要になったら別 Issue）とした。#628 がその follow-up で、クラウド／モバイルから `gh` で Issue/PR・Projects #4（Priority 運用）・PR マージ（`--admin`）を回せるようにしたい。
 
 前提として次が確定している。
 
 - **対象はクラウドセッションのみ**。ローカルの GitHub 操作は `gh` CLI 直接利用（[ADR-0001](0001-drop-github-mcp-use-gh-cli.md)）で、認証は不要（sandbox 外実行で解決済み）。web だけがギャップ。
 - **`gh` はクラウド VM に未プリインストール**（#611 実測。`./gradlew check` には不要だった）。導入導線が要る。
 - クラウドセッションは毎回 fresh clone で起動し、ローカルの環境変数・mise 管理ツールを引き継がない。セットアップスクリプト・環境変数・Custom 許可ドメインは**クラウド環境 UI 側に保存され、リポジトリにコミットできない**（ADR-0065 と同じ非ポータブル性）。
+- **環境変数は秘密ストアではない**（公式明記）: "A dedicated secrets store is not yet available. Both environment variables and setup scripts are stored in the environment configuration, **visible to anyone who can edit that environment**." したがって長命・広スコープの PAT を環境変数に置くのは at-rest のセキュリティ姿勢が弱い。
 
 論点は「導入方式」と「認証方式」の 2 つ。
 
@@ -23,34 +25,39 @@
 
 ### 認証方式
 
-- **UI の Secrets に自前 PAT を `GH_TOKEN` として登録し、gh に自動採用させる（採用）**: `gh` は env の `GH_TOKEN`（無ければ `GITHUB_TOKEN`）を自動採用するため `gh auth login` が不要。Projects #4 操作には `project` スコープが要る（`gh auth refresh -s project` 相当）ので PAT に `repo` + `project` を持たせる。
-- `gh auth login`: クラウドセッションは fresh clone で揮発し対話認証のトークン保存先も残らないため不採用。
-- `.env` ファイル: gitignore された `.env` は fresh clone に存在しない（構造的に持てない）ため不採用。
+**平文の環境変数に長命 PAT を置かない**を軸に、次の優先順位を採る。
+
+- **第一候補: `/web-setup`（マネージド。採用）**: ローカルの Claude Code CLI で `/web-setup` を実行し、ローカルの `gh` トークンを **Claude アカウントに紐付ける**（"reads your local `gh` token, links it to your Claude account"）。資格情報は**平文 env config には入らない**。Projects #4 操作には `project` スコープが要るので、事前にローカルで `gh auth refresh -s project` してから `/web-setup` する。
+- **フォールバック: fine-grained・短命 PAT を環境変数に（限定採用）**: `/web-setup` で届かないスコープ（例: Projects の GraphQL）が残る場合に限り、**対象リポジトリ 1 つ・権限は Contents / Issues / Pull requests / Projects のみ・短い有効期限**の fine-grained PAT を発行し `GH_TOKEN` に置く。gh は env の `GH_TOKEN`（無ければ `GITHUB_TOKEN`）を自動採用するため `gh auth login` は不要。平文保存・編集者可視を許容したうえで、最小権限＋短命＋ローテーションで被害範囲を絞る。
+- **不採用**: `gh auth login`（fresh clone で対話トークンの保存先が揮発）。長命・広スコープ PAT を環境変数へ常設（at-rest が弱い。上記フォールバックは最小権限・短命に限定）。
+- **組み込み GitHub App のみ**では git（clone/push）は資格情報プロキシが担うが、`gh` の repo/org/Projects（GraphQL）API までは届かない見込み（下記実測）。
 
 ### 実測（この follow-up の実装セッション）
 
-「env が非対話シェルに来るか」を**手を動かす前に実機確認**した（#611 の実測主義。落とし穴3＝env が setup フェーズに来ないパターンを疑う）。
+「env が非対話シェルに来るか」を**手を動かす前に実機確認**した（#611 の実測主義）。ただしこの実装セッションは自動起動の管理環境で、`GH_TOKEN` は**プロキシ注入の資格情報**（自前 PAT でも `/web-setup` トークンでもない）であり、`/web-setup` は実行できなかった点に注意。
 
-- `echo ${GH_TOKEN:+set}` → **set**（`GITHUB_TOKEN` も）。**env は非対話シェルに届く**。したがって devcontainer 側の env 橋渡し（remoteEnv / containerEnv / post-create）は**不要**。
-- `gh api user -q .login` → **`ptiringo`**。gh が `GH_TOKEN` を採用し user レベル API が通る。
-- `gh api rate_limit -i` の `X-Oauth-Scopes` → `repo, project, read:org, ...`。**`repo` + `project` スコープを確認**。
-- `gh auth status` は「token is invalid」と表示するが、実 API 呼び出しは通る（gh 独自の検証ヒューリスティックの表示に過ぎない）。
-- ただし**実装セッション固有のプロキシ制限**として、`gh issue list` / `gh pr list` / `gh project view`（GraphQL）と repo REST はこのセッションでは 403 だった（egress プロキシが GraphQL/repo REST を Claude GitHub App 経由にゲートしていたため）。ユーザーが対話的に開くセッション（GitHub が Trusted・自前 PAT）ではこの制限はない見込み。差の詳細と実測表は [docs/claude-code-on-the-web.md](../claude-code-on-the-web.md) の「gh CLI（GitHub 操作）」節に記録した。
+- `echo ${GH_TOKEN:+set}` → **set**（`GITHUB_TOKEN` も）。**env は非対話シェルに届く**（env 橋渡しは不要）。
+- `gh api user -q .login` → **`ptiringo`**。gh が env の `GH_TOKEN` を採用し user レベル API が通る。
+- `gh api rate_limit -i` の `X-Oauth-Scopes` → `repo, project, read:org, ...`。
+- `gh auth status` は「token is invalid」と表示するが実 API は通る（gh のヒューリスティック表示に過ぎない）。
+- `gh issue list` / `gh pr list` / `gh project view`（GraphQL）と repo REST は**このセッションでは 403**（egress プロキシが GraphQL/repo REST を Claude GitHub App 経由にゲート。実装セッション固有）。
+
+**`/web-setup` が Projects 操作まで満たすかは自動セッションでは検証できていない**。ユーザーの対話セッションで実測し `docs/claude-code-on-the-web.md` の「gh CLI（GitHub 操作）」節を確定する。
 
 ## Decision（決定）
 
 Claude Code on the web のクラウドセッションで `gh` CLI を使えるようにする。
 
-- **導入**: `gh` を `mise.toml` の `[tools]` に `aqua:cli/cli`（バージョンピン）で追加する。`scripts/web-setup.sh` が toolchain 検証の後に `mise install aqua:cli/cli` を **best-effort** で実行する（`./gradlew check` のクリティカルパスではないため、取得失敗しても setup を止めない）。PATH は既存の `session-start-mise.sh`（`mise hook-env`）が注入する。
-- **認証**: UI の Secrets に自前 PAT を `GH_TOKEN` として登録し、gh に自動採用させる（`gh auth login` はしない）。PAT は `repo` + `project` スコープ（Projects #4 運用のため）。`.env` は使わない。env は非対話シェルに届くことを実測済みのため、env 橋渡しのフォールバックは入れない。
+- **導入**: `gh` を `mise.toml` の `[tools]` に `aqua:cli/cli`（バージョンピン）で追加する。`scripts/web-setup.sh` が toolchain 検証の後に `mise install aqua:cli/cli` を **best-effort** で実行する（`./gradlew check` のクリティカルパスではないため、取得失敗しても setup を止めない）。PATH は既存の `session-start-mise.sh`（`mise hook-env`）が注入する。CI では gh を使わないため `mise.ci.toml` の `disable_tools` で `--locked` 解決の対象外にする。
+- **認証**: **`/web-setup` を第一候補**とし、ローカルの `gh` トークン（`project` スコープ付き）を Claude アカウントにマネージド同期する。`/web-setup` で届かないスコープが残る場合に限り、**fine-grained・短命 PAT を環境変数 `GH_TOKEN`** に置く（最小権限・短命・ローテーション前提）。**長命・広スコープ PAT を環境変数に常設しない**（環境変数は平文・編集者可視で秘密ストアではないため）。
 - **許可ドメイン**: `gh` の通信先（api.github.com / github.com / objects.githubusercontent.com）は GitHub でデフォルト Trusted のため Custom 追加は不要。
-- **非ポータブル設定の記録**: UI 側にしか置けない `GH_TOKEN` の登録手順・PAT スコープ・実測結果は `docs/claude-code-on-the-web.md` に残す（ADR-0065 と同じ方針。値は UI・手順はコミット）。
-- ローカルの GitHub 操作方針（[ADR-0001](0001-drop-github-mcp-use-gh-cli.md)）と整合する（どちらも MCP でなく `gh` CLI。差は認証だけで、ローカルは sandbox 外実行、web は `GH_TOKEN`）。
+- **設定手順の記録**: UI 側にしか置けない設定（`/web-setup` 手順・フォールバック PAT のスコープ・実測結果）は `docs/claude-code-on-the-web.md` に残す（ADR-0065 と同じ方針。値は UI・手順はコミット）。
+- ローカルの GitHub 操作方針（[ADR-0001](0001-drop-github-mcp-use-gh-cli.md)）と整合する（どちらも MCP でなく `gh` CLI。差は認証だけで、ローカルは sandbox 外実行、web は `/web-setup` または `GH_TOKEN`）。
 
 ## Consequences（結果・影響）
 
 - クラウド／モバイルから `gh` で Issue/PR・Projects #4・PR マージを回せるようになる。GitHub 操作の出所がローカル／web ともに `gh` CLI で揃う。
-- `GH_TOKEN`（自前 PAT）は UI 側に保存され共有できないため、各自が `docs/claude-code-on-the-web.md` の手順で PAT を発行・登録する必要がある。この非ポータブル性はドキュメントによる再現手順で補償する（ADR-0065 と同じトレードオフ）。
-- PAT は自前発行のため、スコープ（`repo` + `project`）と有効期限の管理は各自の責任になる。最小権限で発行し、不要になれば失効させる。
+- **at-rest の姿勢が改善**する: 第一候補の `/web-setup` は資格情報を Claude アカウントにマネージド保存し、平文 env config に PAT を置かない。フォールバック PAT も最小権限・短命に限定し、常設の長命秘密を避ける。
+- `/web-setup` が Projects（GraphQL）まで満たすかは未検証。対話セッションで実測して確定し、満たさない操作があればその操作に限り fine-grained・短命 PAT で補う。実測結果は `docs/claude-code-on-the-web.md` に反映する運用とする。
+- 認証は各自のローカル環境・Claude アカウントに依存し共有できない（非ポータブル）。ドキュメントの再現手順で補償する（ADR-0065 と同じトレードオフ）。ローカルの秘密は引き続き fnox + 1Password で解決し、web の割り切りはそちらに波及させない。
 - `gh` を best-effort 導入にしたことで、GitHub 取得の一時失敗やレート制限で `./gradlew check` の土台を止めない。gh 無しでも check は緑になる。
-- 実装セッションでは egress プロキシの制限で repo/org/GraphQL 操作が 403 だった。ユーザーの対話セッションでの `gh issue list` 等の疎通は、初回に実測して `docs/claude-code-on-the-web.md` の表を確定する運用とする。

--- a/docs/claude-code-on-the-web.md
+++ b/docs/claude-code-on-the-web.md
@@ -73,17 +73,7 @@ LC_ALL=C.utf8
 
 `scripts/web-setup.sh` も自身の JVM 実行のために UTF-8 ロケールを export するが、**セッション側に効かせるにはこの UI 環境変数の設定が要る**。
 
-#### GitHub 操作用（`gh` CLI）
-
-クラウド／モバイルから `gh` で Issue/PR・Projects #4（Priority）・PR マージを回すために、**自前 PAT を `GH_TOKEN` として UI の Secrets に登録する**（設計・認証運用は [ADR-0066](adr/0066-gh-cli-via-gh-token-on-web.md)、#628）。
-
-```
-GH_TOKEN=<自前 PAT>
-```
-
-- **PAT の発行**: GitHub の Fine-grained（対象リポジトリに Contents / Issues / Pull requests、Organization/User の Projects を Read and write）または Classic（`repo` + `project` スコープ）で発行する。Projects #4 の操作に **`project` スコープが必須**（`gh auth refresh -s project` 相当）。
-- **`gh auth login` は不要**。gh は env の `GH_TOKEN`（無ければ `GITHUB_TOKEN`）を自動採用する。この env は**非対話シェルにも渡る**ことを実測済み（後述「gh CLI（GitHub 操作）」の検証表）。`.env` は使わない（クラウドセッションは毎回 fresh clone で揮発し、gitignore された `.env` は存在しないため。構造的に不採用）。
-- トークンが UI 側に保存され非ポータブルになる点は `LANG` 等の環境変数と同じトレードオフ（[ADR-0065](adr/0065-claude-code-on-the-web-support.md)）。ローカルは fnox + 1Password で解決済み（[secrets 規約](../.claude/rules/secrets.md)）なので UI 登録は web 環境限定。
+> **GitHub 認証（`gh`）はここ（環境変数）ではなく `/web-setup` を第一候補にする。** 詳細は本ドキュメント末尾の「gh CLI（GitHub 操作）」節を参照。環境変数への PAT 登録は `/web-setup` で足りない場合のフォールバックに限る（**環境変数は専用の秘密ストアではなく、環境を編集できる人に平文で見える**ため）。
 
 ## TLS 傍受プロキシと JVM（実測メモ）
 
@@ -130,27 +120,39 @@ Claude Code の `kotlin-lsp@claude-plugins-official` プラグイン（`.claude/
 
 クラウド／モバイルから GitHub の Issue/PR・Projects #4（Priority 運用）・PR マージ（`--admin` マージ）を `gh` で回せるようにする。ローカルの GitHub 操作方針（MCP でなく `gh` CLI = [ADR-0001](adr/0001-drop-github-mcp-use-gh-cli.md)）とクラウドを揃える follow-up。設計・認証運用は [ADR-0066](adr/0066-gh-cli-via-gh-token-on-web.md)。
 
-### 導入と認証
+### 導入（`gh` バイナリ）
 
-- **導入**: `gh` は `mise.toml`（`aqua:cli/cli`）に一元管理する（features / apt は使わない = ツールバージョンの唯一の出所は `mise.toml`）。`scripts/web-setup.sh` が toolchain 検証の後に `mise install aqua:cli/cli` を **best-effort** で実行する（失敗しても setup は止めず check 緑に影響しない）。PATH は既存の `session-start-mise.sh`（`mise hook-env`）が注入するので `gh` を素で呼べる。
-- **認証**: UI の Secrets に登録した `GH_TOKEN`（自前 PAT）を gh が**自動採用**する。`gh auth login` はしない。PAT のスコープ・登録手順は「UI 側に設定する内容 → 3. 環境変数 → GitHub 操作用」を参照。
-- **許可ドメイン**: `gh`（api.github.com / github.com / objects.githubusercontent.com）は GitHub なので**デフォルト Trusted・Custom 追加不要**（`mise install aqua:cli/cli` の api 参照・バイナリ取得も同経路。GH_TOKEN があると未認証 60/h レート制限も避けられる）。
+- `gh` は `mise.toml`（`aqua:cli/cli`）に一元管理する（features / apt は使わない = ツールバージョンの唯一の出所は `mise.toml`）。`scripts/web-setup.sh` が toolchain 検証の後に `mise install aqua:cli/cli` を **best-effort** で実行する（失敗しても setup は止めず check 緑に影響しない）。PATH は既存の `session-start-mise.sh`（`mise hook-env`）が注入するので `gh` を素で呼べる。
+- **許可ドメイン**: `gh`（api.github.com / github.com / objects.githubusercontent.com）は GitHub なので**デフォルト Trusted・Custom 追加不要**（`mise install aqua:cli/cli` の api 参照・バイナリ取得も同経路）。
 
-### 検証結果（この follow-up セッションで実測）
+### 認証（`/web-setup` を第一候補にする）
 
-> **重要な前提**: この follow-up の実装セッションは自動起動の管理環境で、egress が**リポジトリスコープの egress プロキシ**越しだった。ユーザーが対話的に開く「Claude Code on the web」セッション（自前 PAT を Secrets に登録）とは egress ポリシーが異なる。両者の差を明示する。
+GitHub 認証の資格情報を**平文の環境変数に長命 PAT で置かない**方針を採る（[ADR-0066](adr/0066-gh-cli-via-gh-token-on-web.md)）。環境変数は公式明記のとおり**専用の秘密ストアではなく、環境を編集できる人に平文で見える**（"A dedicated secrets store is not yet available. ... visible to anyone who can edit this environment."）。優先順位は次のとおり:
 
-`echo ${GH_TOKEN:+set}` と `gh` の各操作を実機で叩いた結果:
+1. **第一候補: `/web-setup`（マネージド）** — ローカルの Claude Code CLI で `/web-setup` を実行し、ローカルの `gh` トークンを**Claude アカウントに紐付ける**（平文 env config には入らない）。Projects #4 操作には `project` スコープが要るので、事前にローカルで `gh auth refresh -s project` してから `/web-setup` する。
+   - 手順: ローカルで `gh auth login`（未認証なら）→ `gh auth refresh -s project` → Claude Code CLI で `/login` → `/web-setup`。
+2. **フォールバック: fine-grained・短命 PAT を環境変数に**（`/web-setup` でスコープが届かない場合のみ）。**対象リポジトリ 1 つ・権限は Contents / Issues / Pull requests / Projects（Read and write）のみ・短い有効期限（例 30 日）**の fine-grained PAT を発行し、`GH_TOKEN=<PAT>`（`.env` 形式・引用符なし）を環境変数に置く。gh は env の `GH_TOKEN`（無ければ `GITHUB_TOKEN`）を自動採用する（`gh auth login` 不要）。**平文で保存され編集者に見える**点を許容したうえで、最小権限＋短命＋ローテーションで被害範囲を絞る。ローカルは fnox + 1Password で解決済み（[secrets 規約](../.claude/rules/secrets.md)）なので、この平文保存は web 環境限定の割り切り。
+3. **組み込み GitHub App のみ**では、git（clone/push）は資格情報プロキシが担うが、`gh` の repo/org/Projects（GraphQL）API までは届かない見込み（下表の実測）。基本的な git/PR 以上を回すには 1 か 2 が要る。
+
+### 実測メモ（この follow-up の実装セッション）
+
+> **重要な前提**: この実装セッションは**自動起動の管理環境**で、egress が**リポジトリスコープの egress プロキシ**越し・`GH_TOKEN` は**プロキシ注入の資格情報**（自前 PAT でも `/web-setup` トークンでもない）だった。ユーザーが対話的に開くセッションとは条件が異なるため、下表は「env と gh の素の挙動」の参考にとどめる。
 
 | 検証 | 結果 | 意味 |
 |------|------|------|
-| `echo ${GH_TOKEN:+set}` | **set**（`GITHUB_TOKEN` も） | **env は非対話シェルに届く**。setup フェーズ限定で消える #611 の落とし穴3（env が来ない）は**再発しない**。devcontainer 側の env 橋渡し（remoteEnv 等）は**不要**。 |
-| `gh api user -q .login` | **`ptiringo`** | user レベルの認証・API は通る。gh が `GH_TOKEN` を採用できている。 |
-| `gh api rate_limit -i`（`X-Oauth-Scopes`） | `repo, project, read:org, ...` | 背後トークンは **`repo` + `project` スコープを保持**。Projects 操作の前提は満たす。 |
-| `gh auth status` | 「token is invalid」と表示 | gh 独自の検証ヒューリスティックが表示するだけで、実 API 呼び出し（上記 `gh api user`）は通る。**表示に反して機能する**。 |
-| `gh issue list` / `gh pr list` / `gh project view 4` | このセッションでは **403**（GraphQL 未許可） | 上記プロキシが GraphQL/repo REST を Claude GitHub App 経由にゲートしていたため。**ユーザーの対話セッション（自前 PAT・GitHub Trusted）ではこの制限はなく、repo/org/Projects 操作が通る想定**。 |
+| `echo ${GH_TOKEN:+set}` | **set**（`GITHUB_TOKEN` も） | env は**非対話シェルに届く**。#611 の落とし穴3（env が setup 後に消える）は再発せず、env 橋渡し（remoteEnv 等）は不要。 |
+| `gh api user -q .login` | **`ptiringo`** | gh が env の `GH_TOKEN` を採用し user レベル API は通る。 |
+| `gh api rate_limit -i`（`X-Oauth-Scopes`） | `repo, project, read:org, ...` | 背後トークンは `repo` + `project` スコープを保持。 |
+| `gh auth status` | 「token is invalid」と表示 | gh 独自の検証ヒューリスティックの表示に過ぎず、実 API（上記）は通る。 |
+| `gh issue list` / `gh pr list` / `gh project view 4` | このセッションでは **403** | プロキシが GraphQL/repo REST を Claude GitHub App 経由にゲートしていたため（実装セッション固有）。 |
 
-**結論**: `GH_TOKEN` を Secrets に登録すれば gh は非対話シェルで自動採用され、user レベル API は実機で通ることを確認した。トークンは `repo` + `project` スコープを持つ。repo/org/GraphQL 操作の実 403 は**実装セッション固有のプロキシ制限**で、ユーザーの対話セッション（GitHub が Trusted・自前 PAT）では発生しない見込み。**env 橋渡しのフォールバックは不要**（env が非対話シェルに届くことを実測で確認済み）。この差はユーザーの対話セッションで `gh issue list` 等を叩いて確定すること。
+### ユーザーの対話セッションで確定すべき点（実測 TODO）
+
+自動セッションでは `/web-setup` を実行できず、Projects 操作の 403 も実装環境固有だった。**対話的な Web セッションで次を実測し、本節を確定すること**:
+
+- `/web-setup`（`project` スコープ付き）だけで `gh issue list` / `gh pr list` / `gh project view 4 --owner ptiringo` / PR マージが通るか。
+- 通れば **1（`/web-setup`）で完結**——環境変数への PAT 登録は不要。
+- Projects（GraphQL）等が届かない操作があれば、その操作に限って **2（fine-grained・短命 PAT）** で補い、本節に「どの操作が PAT を要したか」を記録する。
 
 ## スコープ外（別 Issue で扱う）
 

--- a/scripts/web-setup.sh
+++ b/scripts/web-setup.sh
@@ -149,20 +149,21 @@ fi
 
 # gh CLI（GitHub の Issue/PR/Projects 操作）を best-effort で導入する。ローカルの GitHub 操作方針
 # （MCP でなく gh CLI）と揃え、クラウド／モバイルからも gh で回せるようにする。採否・認証運用は
-# ADR-0066、UI 側の PAT 登録手順は docs/claude-code-on-the-web.md を参照。#628。
+# ADR-0066、認証の設定手順は docs/claude-code-on-the-web.md を参照。#628。
 #
 # **check-緑のクリティカルパスではない**ため verify の後に置き、失敗しても setup を止めない。
-# 認証は `gh auth login` を使わず、UI の Secrets に登録した GH_TOKEN（自前 PAT・repo + project
-# スコープ）を gh が自動採用する（env が非対話シェルに来ることは実測済み。ADR-0066）。ここでは
-# 導入のみで、トークン検証はセッション側（GH_TOKEN あり）に委ねる。
+# ここでは gh バイナリの導入のみを担い、認証は本スクリプトの外で決める（ADR-0066）:
+#   第一候補は `/web-setup`（ローカルの gh トークンを Claude アカウントにマネージド同期）。
+#   足りなければ fine-grained・短命 PAT を環境変数 GH_TOKEN に置く（gh が自動採用。gh auth login 不要）。
+# 平文の環境変数に長命 PAT を置かない方針のため、本スクリプトはトークンを扱わない。
 #
 # **`aqua:cli/cli` だけを名指しする**（java / http:kotlin-lsp と混ぜない）。ツール未指定の
 # `mise install` は mise.toml の全ツールを入れにいき GitHub API レート制限等で落ちる。aqua backend の
-# api.github.com 参照とバイナリ取得は GitHub（Trusted）越しで、GH_TOKEN があると未認証 60/h の
-# レート制限も避けられる。`if` で包むのは best-effort（非ゼロ終了で set -e に巻き込まれないため）。
+# api.github.com 参照とバイナリ取得は GitHub（Trusted）越し。`if` で包むのは best-effort
+# （非ゼロ終了で set -e に巻き込まれないため）。
 echo "installing gh (GitHub CLI) via mise (best-effort) ..."
 if mise install "aqua:cli/cli"; then
-  echo "gh installed. UI の Secrets に GH_TOKEN（PAT）があれば 'gh api user' 等がそのまま通る。"
+  echo "gh installed. 認証は /web-setup（推奨）か環境変数 GH_TOKEN で（docs/claude-code-on-the-web.md）。"
 else
   echo "warn: gh の導入に失敗（GitHub 取得の一時失敗 or レート制限の可能性）。" >&2
   echo "warn: gh 無しで続行する（./gradlew check には影響しない）。" >&2


### PR DESCRIPTION
## 概要

#644（#628）の follow-up。マージ後に、Claude Code on the web の**環境変数が専用の秘密ストアではなく平文で保存され環境の編集者に見える**（公式明記）ことが判明したため、認証方針を見直す。

長命 PAT を環境変数に常設する初版の方針を改め、**マネージド同期の `/web-setup` を第一候補**とし、PAT は `/web-setup` で届かないスコープに限った **fine-grained・短命フォールバック**へ格下げする。

> 公式ドキュメント: _"A dedicated secrets store is not yet available. Both environment variables and setup scripts are stored in the environment configuration, visible to anyone who can edit that environment."_

## 変更内容

- **docs/adr/0066-gh-cli-via-gh-token-on-web.md**: タイトルを「/web-setup 優先」に改題し改訂注記（2026-07-14）を追加。Context に「環境変数は秘密ストアではない」公式引用を追加。認証方式を **/web-setup 第一候補・fine-grained 短命 PAT フォールバック・長命 PAT 常設は不採用**に再構成。Decision / Consequences を at-rest 改善（マネージド保存・最小権限・短命）に更新。`/web-setup` が Projects(GraphQL) を満たすかは未検証で対話セッションで確定する旨を明記。
- **docs/claude-code-on-the-web.md**: 「3. 環境変数」の GitHub サブセクションを PAT 登録手順から **/web-setup 優先のポインタ**（環境変数は平文・秘密ストアでない旨付き）へ置換。「gh CLI（GitHub 操作）」節を導入 / 認証（/web-setup 優先・PAT フォールバック）/ 実測メモ / **対話セッションでの実測 TODO** に再構成。
- **scripts/web-setup.sh**: gh 導入コメントと完了メッセージを /web-setup 優先に更新。スクリプトはトークンを扱わず gh バイナリ導入のみを担う旨を明記。
- **CLAUDE.md**: GitHub 操作方針の web セッション記述を /web-setup 優先・長命 PAT 非常設に更新。

`mise.toml` / `mise.ci.toml`（gh 導入）は認証方式に依存しないため変更なし。

## 動作確認

- [x] `shellcheck scripts/web-setup.sh` → PASS
- [x] editorconfig（末尾改行・行末空白）・残存する「Secrets」参照無しを確認
- [ ] **ユーザーの対話セッションで実測**（本 PR の docs に TODO として明記）: `gh auth refresh -s project` → `/web-setup` だけで `gh issue list` / `gh pr list` / `gh project view 4 --owner ptiringo` / PR マージが通るか。通れば /web-setup で完結、届かない操作があればその操作に限り fine-grained・短命 PAT で補う。

## 背景

この方針転換は、`/web-setup`・環境変数・GitHub App の 3 方式を at-rest セキュリティと `project` スコープ到達性で比較した結果によるもの（ADR-0066 の認証方式節に記録）。ローカルの秘密は引き続き fnox + 1Password で解決し、web の割り切りはそちらへ波及させない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015GdMrdK3jDj2BRZCpMk7L6)_