### PR TITLE
feat: #606 studbook の書き込みユースケースにロール認可を敷く (2/3)

### DIFF
--- a/src/main/kotlin/com/example/api/application/studbook/breeding/RecordCoveringUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/RecordCoveringUseCase.kt
@@ -1,6 +1,10 @@
 package com.example.api.application.studbook.breeding
 
+import com.example.api.application.shared.AuthorizationError
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.Permission
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BlankBreedingRegion
 import com.example.api.domain.studbook.model.breeding.BlankCoveringCertificateNumber
 import com.example.api.domain.studbook.model.breeding.BlankStudCertificateNumber
@@ -17,6 +21,7 @@ import com.example.api.domain.studbook.model.breeding.StudCertificate
 import com.example.api.domain.studbook.model.breeding.StudCertificateNumber
 import com.example.api.domain.studbook.model.breeding.ValidityPeriod
 import com.example.api.domain.studbook.service.breeding.recordCovering
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.getOrElse
@@ -98,6 +103,10 @@ sealed interface RecordCoveringUseCaseError {
      * 個別バリアント（登録ロールが繁殖牝馬／種牡馬でない・同一繁殖年の重複など）は [RecordCoveringError] を参照する。
      */
     data class PreconditionViolated(val cause: RecordCoveringError) : RecordCoveringUseCaseError
+
+    /** 種付記録に必要な権限を持たない。 */
+    data class Forbidden(override val permission: Permission) :
+        RecordCoveringUseCaseError, AuthorizationError
 }
 
 /**
@@ -117,61 +126,68 @@ class RecordCoveringUseCase(
 ) {
     @Transactional
     operator fun invoke(
-        command: Command<RecordCoveringCommand>
-    ): Result<BreedingResult, RecordCoveringUseCaseError> = binding {
-        val input = command.payload
+        actor: Actor,
+        command: Command<RecordCoveringCommand>,
+    ): Result<BreedingResult, RecordCoveringUseCaseError> {
+        val permission = StudbookPermissions.BREEDING_RESULT_RECORD_COVERING
+        if (!actor.can(permission)) {
+            return Err(RecordCoveringUseCaseError.Forbidden(permission))
+        }
+        return binding {
+            val input = command.payload
 
-        val certificateNumber =
-            CoveringCertificateNumber.create(input.certificateNumber)
-                .mapError { _: BlankCoveringCertificateNumber ->
-                    RecordCoveringUseCaseError.InvalidCertificateNumber
-                }
-                .bind()
+            val certificateNumber =
+                CoveringCertificateNumber.create(input.certificateNumber)
+                    .mapError { _: BlankCoveringCertificateNumber ->
+                        RecordCoveringUseCaseError.InvalidCertificateNumber
+                    }
+                    .bind()
 
-        val coveringPlace =
-            BreedingRegion.create(input.coveringPlace)
-                .mapError { _: BlankBreedingRegion ->
-                    RecordCoveringUseCaseError.InvalidCoveringPlace
-                }
-                .bind()
+            val coveringPlace =
+                BreedingRegion.create(input.coveringPlace)
+                    .mapError { _: BlankBreedingRegion ->
+                        RecordCoveringUseCaseError.InvalidCoveringPlace
+                    }
+                    .bind()
 
-        val studCertificate = buildStudCertificate(input.studCertificate).bind()
+            val studCertificate = buildStudCertificate(input.studCertificate).bind()
 
-        val broodmareRegistration =
-            breedingRegistrationRepository
-                .findById(BreedingRegistrationId(input.breedingRegistrationId))
-                .toResultOr {
-                    RecordCoveringUseCaseError.BreedingRegistrationNotFound(
-                        input.breedingRegistrationId
+            val broodmareRegistration =
+                breedingRegistrationRepository
+                    .findById(BreedingRegistrationId(input.breedingRegistrationId))
+                    .toResultOr {
+                        RecordCoveringUseCaseError.BreedingRegistrationNotFound(
+                            input.breedingRegistrationId
+                        )
+                    }
+                    .bind()
+
+            val stallionRegistration =
+                breedingRegistrationRepository
+                    .findById(BreedingRegistrationId(input.stallionRegistrationId))
+                    .toResultOr {
+                        RecordCoveringUseCaseError.StallionRegistrationNotFound(
+                            input.stallionRegistrationId
+                        )
+                    }
+                    .bind()
+
+            val breedingResult =
+                recordCovering(
+                        broodmareRegistration,
+                        stallionRegistration,
+                        input.coveringDate,
+                        certificateNumber,
+                        breedingResultRepository,
+                        studCertificate,
+                        coveringPlace,
                     )
-                }
-                .bind()
+                    .mapError { RecordCoveringUseCaseError.PreconditionViolated(it) }
+                    .bind()
 
-        val stallionRegistration =
-            breedingRegistrationRepository
-                .findById(BreedingRegistrationId(input.stallionRegistrationId))
-                .toResultOr {
-                    RecordCoveringUseCaseError.StallionRegistrationNotFound(
-                        input.stallionRegistrationId
-                    )
-                }
-                .bind()
-
-        val breedingResult =
-            recordCovering(
-                    broodmareRegistration,
-                    stallionRegistration,
-                    input.coveringDate,
-                    certificateNumber,
-                    breedingResultRepository,
-                    studCertificate,
-                    coveringPlace,
-                )
-                .mapError { RecordCoveringUseCaseError.PreconditionViolated(it) }
-                .bind()
-
-        breedingResultRepository.save(breedingResult).getOrElse {
-            error("新規の繁殖成績の保存で楽観ロック競合はありえない: id=${breedingResult.id.value}")
+            breedingResultRepository.save(breedingResult).getOrElse {
+                error("新規の繁殖成績の保存で楽観ロック競合はありえない: id=${breedingResult.id.value}")
+            }
         }
     }
 

--- a/src/main/kotlin/com/example/api/application/studbook/breeding/RecordUncoveredUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/RecordUncoveredUseCase.kt
@@ -1,12 +1,17 @@
 package com.example.api.application.studbook.breeding
 
+import com.example.api.application.shared.AuthorizationError
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.Permission
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationId
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
 import com.example.api.domain.studbook.model.breeding.BreedingResult
 import com.example.api.domain.studbook.model.breeding.BreedingResultRepository
 import com.example.api.domain.studbook.model.breeding.RecordUncoveredError
 import com.example.api.domain.studbook.service.breeding.recordUncovered
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.getOrElse
@@ -40,6 +45,10 @@ sealed interface RecordUncoveredUseCaseError {
      * 個別バリアント（登録ロールが繁殖牝馬でない・同一繁殖年の重複）は [RecordUncoveredError] を参照する。
      */
     data class PreconditionViolated(val cause: RecordUncoveredError) : RecordUncoveredUseCaseError
+
+    /** 種付せず記録に必要な権限を持たない。 */
+    data class Forbidden(override val permission: Permission) :
+        RecordUncoveredUseCaseError, AuthorizationError
 }
 
 /**
@@ -59,27 +68,34 @@ class RecordUncoveredUseCase(
 ) {
     @Transactional
     operator fun invoke(
-        command: Command<RecordUncoveredCommand>
-    ): Result<BreedingResult, RecordUncoveredUseCaseError> = binding {
-        val input = command.payload
+        actor: Actor,
+        command: Command<RecordUncoveredCommand>,
+    ): Result<BreedingResult, RecordUncoveredUseCaseError> {
+        val permission = StudbookPermissions.BREEDING_RESULT_RECORD_UNCOVERED
+        if (!actor.can(permission)) {
+            return Err(RecordUncoveredUseCaseError.Forbidden(permission))
+        }
+        return binding {
+            val input = command.payload
 
-        val broodmareRegistration =
-            breedingRegistrationRepository
-                .findById(BreedingRegistrationId(input.breedingRegistrationId))
-                .toResultOr {
-                    RecordUncoveredUseCaseError.BreedingRegistrationNotFound(
-                        input.breedingRegistrationId
-                    )
-                }
-                .bind()
+            val broodmareRegistration =
+                breedingRegistrationRepository
+                    .findById(BreedingRegistrationId(input.breedingRegistrationId))
+                    .toResultOr {
+                        RecordUncoveredUseCaseError.BreedingRegistrationNotFound(
+                            input.breedingRegistrationId
+                        )
+                    }
+                    .bind()
 
-        val breedingResult =
-            recordUncovered(broodmareRegistration, input.breedingYear, breedingResultRepository)
-                .mapError { RecordUncoveredUseCaseError.PreconditionViolated(it) }
-                .bind()
+            val breedingResult =
+                recordUncovered(broodmareRegistration, input.breedingYear, breedingResultRepository)
+                    .mapError { RecordUncoveredUseCaseError.PreconditionViolated(it) }
+                    .bind()
 
-        breedingResultRepository.save(breedingResult).getOrElse {
-            error("新規の繁殖成績の保存で楽観ロック競合はありえない: id=${breedingResult.id.value}")
+            breedingResultRepository.save(breedingResult).getOrElse {
+                error("新規の繁殖成績の保存で楽観ロック競合はありえない: id=${breedingResult.id.value}")
+            }
         }
     }
 }

--- a/src/main/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCase.kt
@@ -1,12 +1,17 @@
 package com.example.api.application.studbook.breeding
 
+import com.example.api.application.shared.AuthorizationError
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.Permission
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BlankBreedingRegistrationNumber
 import com.example.api.domain.studbook.model.breeding.BreedingRegistration
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationNumber
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.getOrElse
@@ -37,6 +42,10 @@ sealed interface RegisterBreedingRegistrationUseCaseError {
 
     /** 繁殖登録の対象として指定された軽種馬が存在しない。 */
     data class HorseNotFound(val bloodHorseId: UUID) : RegisterBreedingRegistrationUseCaseError
+
+    /** 繁殖登録に必要な権限を持たない。 */
+    data class Forbidden(override val permission: Permission) :
+        RegisterBreedingRegistrationUseCaseError, AuthorizationError
 }
 
 /**
@@ -58,28 +67,35 @@ class RegisterBreedingRegistrationUseCase(
 ) {
     @Transactional
     operator fun invoke(
-        command: Command<RegisterBreedingRegistrationCommand>
-    ): Result<BreedingRegistration, RegisterBreedingRegistrationUseCaseError> = binding {
-        val input = command.payload
+        actor: Actor,
+        command: Command<RegisterBreedingRegistrationCommand>,
+    ): Result<BreedingRegistration, RegisterBreedingRegistrationUseCaseError> {
+        val permission = StudbookPermissions.BREEDING_REGISTRATION_REGISTER
+        if (!actor.can(permission)) {
+            return Err(RegisterBreedingRegistrationUseCaseError.Forbidden(permission))
+        }
+        return binding {
+            val input = command.payload
 
-        val registrationNumber =
-            BreedingRegistrationNumber.create(input.registrationNumber)
-                .mapError { _: BlankBreedingRegistrationNumber ->
-                    RegisterBreedingRegistrationUseCaseError.InvalidRegistrationNumber
-                }
-                .bind()
+            val registrationNumber =
+                BreedingRegistrationNumber.create(input.registrationNumber)
+                    .mapError { _: BlankBreedingRegistrationNumber ->
+                        RegisterBreedingRegistrationUseCaseError.InvalidRegistrationNumber
+                    }
+                    .bind()
 
-        val horse =
-            bloodHorseRepository
-                .findById(BloodHorseId(input.bloodHorseId))
-                .toResultOr {
-                    RegisterBreedingRegistrationUseCaseError.HorseNotFound(input.bloodHorseId)
-                }
-                .bind()
+            val horse =
+                bloodHorseRepository
+                    .findById(BloodHorseId(input.bloodHorseId))
+                    .toResultOr {
+                        RegisterBreedingRegistrationUseCaseError.HorseNotFound(input.bloodHorseId)
+                    }
+                    .bind()
 
-        val registration = BreedingRegistration.create(registrationNumber, horse)
-        breedingRegistrationRepository.save(registration).getOrElse {
-            error("新規の繁殖登録の保存で楽観ロック競合はありえない: id=${registration.id.value}")
+            val registration = BreedingRegistration.create(registrationNumber, horse)
+            breedingRegistrationRepository.save(registration).getOrElse {
+                error("新規の繁殖登録の保存で楽観ロック競合はありえない: id=${registration.id.value}")
+            }
         }
     }
 }

--- a/src/main/kotlin/com/example/api/application/studbook/breeding/ReportFoalingUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/ReportFoalingUseCase.kt
@@ -1,11 +1,16 @@
 package com.example.api.application.studbook.breeding
 
+import com.example.api.application.shared.AuthorizationError
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.Permission
 import com.example.api.domain.shared.UpdateConflict
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingResult
 import com.example.api.domain.studbook.model.breeding.BreedingResultId
 import com.example.api.domain.studbook.model.breeding.BreedingResultRepository
 import com.example.api.domain.studbook.model.breeding.FoalingOutcome
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.mapError
@@ -47,6 +52,10 @@ sealed interface ReportFoalingUseCaseError {
      * @property breedingResultId 競合した繁殖成績ID
      */
     data class ConcurrentModification(val breedingResultId: UUID) : ReportFoalingUseCaseError
+
+    /** 分娩結果報告に必要な権限を持たない。 */
+    data class Forbidden(override val permission: Permission) :
+        ReportFoalingUseCaseError, AuthorizationError
 }
 
 /**
@@ -62,29 +71,36 @@ sealed interface ReportFoalingUseCaseError {
 class ReportFoalingUseCase(private val breedingResultRepository: BreedingResultRepository) {
     @Transactional
     operator fun invoke(
-        command: Command<ReportFoalingCommand>
-    ): Result<BreedingResult, ReportFoalingUseCaseError> = binding {
-        val input = command.payload
+        actor: Actor,
+        command: Command<ReportFoalingCommand>,
+    ): Result<BreedingResult, ReportFoalingUseCaseError> {
+        val permission = StudbookPermissions.BREEDING_RESULT_REPORT_FOALING
+        if (!actor.can(permission)) {
+            return Err(ReportFoalingUseCaseError.Forbidden(permission))
+        }
+        return binding {
+            val input = command.payload
 
-        val breedingResult =
+            val breedingResult =
+                breedingResultRepository
+                    .findById(BreedingResultId(input.breedingResultId))
+                    .toResultOr {
+                        ReportFoalingUseCaseError.BreedingResultNotFound(input.breedingResultId)
+                    }
+                    .bind()
+
+            val reported =
+                breedingResult
+                    .recordFoaling(input.outcome)
+                    .mapError { ReportFoalingUseCaseError.AlreadyReported(it.current) }
+                    .bind()
+
             breedingResultRepository
-                .findById(BreedingResultId(input.breedingResultId))
-                .toResultOr {
-                    ReportFoalingUseCaseError.BreedingResultNotFound(input.breedingResultId)
+                .save(reported)
+                .mapError { _: UpdateConflict ->
+                    ReportFoalingUseCaseError.ConcurrentModification(input.breedingResultId)
                 }
                 .bind()
-
-        val reported =
-            breedingResult
-                .recordFoaling(input.outcome)
-                .mapError { ReportFoalingUseCaseError.AlreadyReported(it.current) }
-                .bind()
-
-        breedingResultRepository
-            .save(reported)
-            .mapError { _: UpdateConflict ->
-                ReportFoalingUseCaseError.ConcurrentModification(input.breedingResultId)
-            }
-            .bind()
+        }
     }
 }

--- a/src/main/kotlin/com/example/api/application/studbook/breeding/SubmitBreedingReportUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/SubmitBreedingReportUseCase.kt
@@ -1,12 +1,17 @@
 package com.example.api.application.studbook.breeding
 
+import com.example.api.application.shared.AuthorizationError
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.Permission
 import com.example.api.domain.shared.UpdateConflict
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingReportDeadline
 import com.example.api.domain.studbook.model.breeding.BreedingResult
 import com.example.api.domain.studbook.model.breeding.BreedingResultId
 import com.example.api.domain.studbook.model.breeding.BreedingResultRepository
 import com.example.api.domain.studbook.model.breeding.SubmitBreedingReportError
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.mapError
@@ -46,6 +51,10 @@ sealed interface SubmitBreedingReportUseCaseError {
      * @property breedingResultId 競合した繁殖成績ID
      */
     data class ConcurrentModification(val breedingResultId: UUID) : SubmitBreedingReportUseCaseError
+
+    /** 繁殖成績報告提出に必要な権限を持たない。 */
+    data class Forbidden(override val permission: Permission) :
+        SubmitBreedingReportUseCaseError, AuthorizationError
 }
 
 /**
@@ -63,29 +72,38 @@ sealed interface SubmitBreedingReportUseCaseError {
 class SubmitBreedingReportUseCase(private val breedingResultRepository: BreedingResultRepository) {
     @Transactional
     operator fun invoke(
-        command: Command<SubmitBreedingReportCommand>
-    ): Result<BreedingResult, SubmitBreedingReportUseCaseError> = binding {
-        val input = command.payload
+        actor: Actor,
+        command: Command<SubmitBreedingReportCommand>,
+    ): Result<BreedingResult, SubmitBreedingReportUseCaseError> {
+        val permission = StudbookPermissions.BREEDING_RESULT_SUBMIT_REPORT
+        if (!actor.can(permission)) {
+            return Err(SubmitBreedingReportUseCaseError.Forbidden(permission))
+        }
+        return binding {
+            val input = command.payload
 
-        val breedingResult =
+            val breedingResult =
+                breedingResultRepository
+                    .findById(BreedingResultId(input.breedingResultId))
+                    .toResultOr {
+                        SubmitBreedingReportUseCaseError.BreedingResultNotFound(
+                            input.breedingResultId
+                        )
+                    }
+                    .bind()
+
+            val submitted =
+                breedingResult
+                    .submitReport(BreedingReportDeadline.submissionDateOf(command.issuedAt))
+                    .mapError { SubmitBreedingReportUseCaseError.PreconditionViolated(it) }
+                    .bind()
+
             breedingResultRepository
-                .findById(BreedingResultId(input.breedingResultId))
-                .toResultOr {
-                    SubmitBreedingReportUseCaseError.BreedingResultNotFound(input.breedingResultId)
+                .save(submitted)
+                .mapError { _: UpdateConflict ->
+                    SubmitBreedingReportUseCaseError.ConcurrentModification(input.breedingResultId)
                 }
                 .bind()
-
-        val submitted =
-            breedingResult
-                .submitReport(BreedingReportDeadline.submissionDateOf(command.issuedAt))
-                .mapError { SubmitBreedingReportUseCaseError.PreconditionViolated(it) }
-                .bind()
-
-        breedingResultRepository
-            .save(submitted)
-            .mapError { _: UpdateConflict ->
-                SubmitBreedingReportUseCaseError.ConcurrentModification(input.breedingResultId)
-            }
-            .bind()
+        }
     }
 }

--- a/src/main/kotlin/com/example/api/application/studbook/breeding/SubmitCoveringReportUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/SubmitCoveringReportUseCase.kt
@@ -1,6 +1,10 @@
 package com.example.api.application.studbook.breeding
 
+import com.example.api.application.shared.AuthorizationError
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.Permission
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationId
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
 import com.example.api.domain.studbook.model.breeding.CoveringReport
@@ -8,6 +12,7 @@ import com.example.api.domain.studbook.model.breeding.CoveringReportDeadline
 import com.example.api.domain.studbook.model.breeding.CoveringReportRepository
 import com.example.api.domain.studbook.model.breeding.SubmitCoveringReportError
 import com.example.api.domain.studbook.service.breeding.submitCoveringReport
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.getOrElse
@@ -45,6 +50,10 @@ sealed interface SubmitCoveringReportUseCaseError {
      */
     data class PreconditionViolated(val cause: SubmitCoveringReportError) :
         SubmitCoveringReportUseCaseError
+
+    /** 種付成績報告提出に必要な権限を持たない。 */
+    data class Forbidden(override val permission: Permission) :
+        SubmitCoveringReportUseCaseError, AuthorizationError
 }
 
 /**
@@ -68,32 +77,39 @@ class SubmitCoveringReportUseCase(
 ) {
     @Transactional
     operator fun invoke(
-        command: Command<SubmitCoveringReportCommand>
-    ): Result<CoveringReport, SubmitCoveringReportUseCaseError> = binding {
-        val input = command.payload
+        actor: Actor,
+        command: Command<SubmitCoveringReportCommand>,
+    ): Result<CoveringReport, SubmitCoveringReportUseCaseError> {
+        val permission = StudbookPermissions.COVERING_REPORT_SUBMIT
+        if (!actor.can(permission)) {
+            return Err(SubmitCoveringReportUseCaseError.Forbidden(permission))
+        }
+        return binding {
+            val input = command.payload
 
-        val stallionRegistration =
-            breedingRegistrationRepository
-                .findById(BreedingRegistrationId(input.stallionBreedingRegistrationId))
-                .toResultOr {
-                    SubmitCoveringReportUseCaseError.StallionRegistrationNotFound(
-                        input.stallionBreedingRegistrationId
+            val stallionRegistration =
+                breedingRegistrationRepository
+                    .findById(BreedingRegistrationId(input.stallionBreedingRegistrationId))
+                    .toResultOr {
+                        SubmitCoveringReportUseCaseError.StallionRegistrationNotFound(
+                            input.stallionBreedingRegistrationId
+                        )
+                    }
+                    .bind()
+
+            val coveringReport =
+                submitCoveringReport(
+                        stallionRegistration,
+                        Year.of(input.coveringYear),
+                        CoveringReportDeadline.submissionDateOf(command.issuedAt),
+                        coveringReportRepository,
                     )
-                }
-                .bind()
+                    .mapError { SubmitCoveringReportUseCaseError.PreconditionViolated(it) }
+                    .bind()
 
-        val coveringReport =
-            submitCoveringReport(
-                    stallionRegistration,
-                    Year.of(input.coveringYear),
-                    CoveringReportDeadline.submissionDateOf(command.issuedAt),
-                    coveringReportRepository,
-                )
-                .mapError { SubmitCoveringReportUseCaseError.PreconditionViolated(it) }
-                .bind()
-
-        coveringReportRepository.save(coveringReport).getOrElse {
-            error("新規の種付成績報告の保存で楽観ロック競合はありえない: id=${coveringReport.id.value}")
+            coveringReportRepository.save(coveringReport).getOrElse {
+                error("新規の種付成績報告の保存で楽観ロック競合はありえない: id=${coveringReport.id.value}")
+            }
         }
     }
 }

--- a/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/NameHorseUseCase.kt
@@ -1,7 +1,11 @@
 package com.example.api.application.studbook.horse
 
+import com.example.api.application.shared.AuthorizationError
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.Permission
 import com.example.api.domain.shared.UpdateConflict
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
 import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
@@ -9,6 +13,7 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.InvalidHorseName
 import com.example.api.domain.studbook.model.horse.bloodhorse.NameHorseError
 import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
 import com.example.api.domain.studbook.service.horse.nameHorse
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.mapError
@@ -64,6 +69,10 @@ sealed interface NameHorseUseCaseError {
      * @property bloodHorseId 競合した軽種馬ID
      */
     data class ConcurrentModification(val bloodHorseId: UUID) : NameHorseUseCaseError
+
+    /** 馬名登録に必要な権限を持たない。 */
+    data class Forbidden(override val permission: Permission) :
+        NameHorseUseCaseError, AuthorizationError
 }
 
 /**
@@ -87,57 +96,64 @@ class NameHorseUseCase(
 ) {
     @Transactional
     operator fun invoke(
-        command: Command<NameHorseCommand>
-    ): Result<RegisteredBloodHorse, NameHorseUseCaseError> = binding {
-        val input = command.payload
+        actor: Actor,
+        command: Command<NameHorseCommand>,
+    ): Result<RegisteredBloodHorse, NameHorseUseCaseError> {
+        val permission = StudbookPermissions.HORSE_NAME
+        if (!actor.can(permission)) {
+            return Err(NameHorseUseCaseError.Forbidden(permission))
+        }
+        return binding {
+            val input = command.payload
 
-        val horseName =
-            HorseName.create(input.name)
-                .mapError { _: InvalidHorseName -> NameHorseUseCaseError.InvalidName }
-                .bind()
+            val horseName =
+                HorseName.create(input.name)
+                    .mapError { _: InvalidHorseName -> NameHorseUseCaseError.InvalidName }
+                    .bind()
 
-        val horse =
-            bloodHorseRepository
-                .findById(BloodHorseId(input.bloodHorseId))
-                .toResultOr { NameHorseUseCaseError.HorseNotFound(input.bloodHorseId) }
-                .bind()
+            val horse =
+                bloodHorseRepository
+                    .findById(BloodHorseId(input.bloodHorseId))
+                    .toResultOr { NameHorseUseCaseError.HorseNotFound(input.bloodHorseId) }
+                    .bind()
 
-        val transition =
-            nameHorse(horse, horseName, bloodHorseRepository)
-                .mapError { error ->
-                    when (error) {
-                        is NameHorseError.NameAlreadyTaken ->
-                            NameHorseUseCaseError.NameAlreadyTaken(error.name.value)
-                        is NameHorseError.AlreadyNamed ->
-                            NameHorseUseCaseError.AlreadyNamed(error.currentName.value)
+            val transition =
+                nameHorse(horse, horseName, bloodHorseRepository)
+                    .mapError { error ->
+                        when (error) {
+                            is NameHorseError.NameAlreadyTaken ->
+                                NameHorseUseCaseError.NameAlreadyTaken(error.name.value)
+                            is NameHorseError.AlreadyNamed ->
+                                NameHorseUseCaseError.AlreadyNamed(error.currentName.value)
+                        }
                     }
-                }
-                .bind()
+                    .bind()
 
-        // response（マイクロチップを露出）の組み立てに審査が要るため、改名の保存前に引き当てる。
-        // inspectionId は命名遷移で変わらないため save 前に引き当てて問題ない。
-        // 審査が欠落（InspectionNotFound）なら改名を save せず返す（エラーなのに改名済みになるのを避ける）。
-        // 血統登録時に審査を必ず生成・保存しているため、欠落は通常ありえない内部不整合相当。
-        val inspection =
-            horseInspectionRepository
-                .findById(transition.aggregate.inspectionId)
-                .toResultOr {
-                    NameHorseUseCaseError.InspectionNotFound(
-                        transition.aggregate.inspectionId.value
-                    )
-                }
-                .bind()
+            // response（マイクロチップを露出）の組み立てに審査が要るため、改名の保存前に引き当てる。
+            // inspectionId は命名遷移で変わらないため save 前に引き当てて問題ない。
+            // 審査が欠落（InspectionNotFound）なら改名を save せず返す（エラーなのに改名済みになるのを避ける）。
+            // 血統登録時に審査を必ず生成・保存しているため、欠落は通常ありえない内部不整合相当。
+            val inspection =
+                horseInspectionRepository
+                    .findById(transition.aggregate.inspectionId)
+                    .toResultOr {
+                        NameHorseUseCaseError.InspectionNotFound(
+                            transition.aggregate.inspectionId.value
+                        )
+                    }
+                    .bind()
 
-        val named =
-            bloodHorseRepository
-                .save(transition.aggregate)
-                .mapError { _: UpdateConflict ->
-                    NameHorseUseCaseError.ConcurrentModification(input.bloodHorseId)
-                }
-                .bind()
-        // 発行はトランザクション内で行うが、AFTER_COMMIT 購読者への配送はコミット確定後（ADR-0050）。
-        eventPublisher.publishEvent(transition.event)
+            val named =
+                bloodHorseRepository
+                    .save(transition.aggregate)
+                    .mapError { _: UpdateConflict ->
+                        NameHorseUseCaseError.ConcurrentModification(input.bloodHorseId)
+                    }
+                    .bind()
+            // 発行はトランザクション内で行うが、AFTER_COMMIT 購読者への配送はコミット確定後（ADR-0050）。
+            eventPublisher.publishEvent(transition.event)
 
-        RegisteredBloodHorse(named, inspection)
+            RegisteredBloodHorse(named, inspection)
+        }
     }
 }

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
@@ -1,6 +1,10 @@
 package com.example.api.application.studbook.horse
 
+import com.example.api.application.shared.AuthorizationError
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.Permission
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
 import com.example.api.domain.studbook.model.breeding.BreedingResult
 import com.example.api.domain.studbook.model.breeding.BreedingResultId
@@ -23,6 +27,7 @@ import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
 import com.example.api.domain.studbook.service.horse.RegisterFoalError
 import com.example.api.domain.studbook.service.horse.registerFoal
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.getOrElse
@@ -93,6 +98,10 @@ sealed interface RegisterFoalUseCaseError {
      * 個別バリアント（分娩結果が生産でない・父が雄でない・品種不整合など）は [RegisterFoalError] を参照する。
      */
     data class PreconditionViolated(val cause: RegisterFoalError) : RegisterFoalUseCaseError
+
+    /** 生産産駒登録に必要な権限を持たない。 */
+    data class Forbidden(override val permission: Permission) :
+        RegisterFoalUseCaseError, AuthorizationError
 }
 
 /**
@@ -113,60 +122,74 @@ class RegisterFoalUseCase(
 ) {
     @Transactional
     operator fun invoke(
-        command: Command<RegisterFoalCommand>
-    ): Result<RegisteredBloodHorse, RegisterFoalUseCaseError> = binding {
-        val input = command.payload
+        actor: Actor,
+        command: Command<RegisterFoalCommand>,
+    ): Result<RegisteredBloodHorse, RegisterFoalUseCaseError> {
+        val permission = StudbookPermissions.HORSE_REGISTER_FOAL
+        if (!actor.can(permission)) {
+            return Err(RegisterFoalUseCaseError.Forbidden(permission))
+        }
+        return binding {
+            val input = command.payload
 
-        val registrationNumber =
-            PedigreeRegistrationNumber.create(input.registrationNumber)
-                .mapError { _: BlankPedigreeRegistrationNumber ->
-                    RegisterFoalUseCaseError.InvalidRegistrationNumber
-                }
-                .bind()
-        // 審査をメモリ内で組み立てる。前提条件検証（registerFoal）を通った後にのみ永続化し、
-        // 業務ルール違反での却下時に孤児レコードが残るのを防ぐ。
-        val inspection = buildInspection(input).bind()
-        val foalIdentity = buildFoalIdentity(input).bind()
+            val registrationNumber =
+                PedigreeRegistrationNumber.create(input.registrationNumber)
+                    .mapError { _: BlankPedigreeRegistrationNumber ->
+                        RegisterFoalUseCaseError.InvalidRegistrationNumber
+                    }
+                    .bind()
+            // 審査をメモリ内で組み立てる。前提条件検証（registerFoal）を通った後にのみ永続化し、
+            // 業務ルール違反での却下時に孤児レコードが残るのを防ぐ。
+            val inspection = buildInspection(input).bind()
+            val foalIdentity = buildFoalIdentity(input).bind()
 
-        val breedingResult =
-            breedingResultRepository
-                .findById(BreedingResultId(input.breedingResultId))
-                .toResultOr {
-                    RegisterFoalUseCaseError.BreedingResultNotFound(input.breedingResultId)
-                }
-                .bind()
+            val breedingResult =
+                breedingResultRepository
+                    .findById(BreedingResultId(input.breedingResultId))
+                    .toResultOr {
+                        RegisterFoalUseCaseError.BreedingResultNotFound(input.breedingResultId)
+                    }
+                    .bind()
 
-        val breedingRegistration =
-            breedingRegistrationRepository
-                .findById(breedingResult.breedingRegistrationId)
-                .toResultOr {
-                    RegisterFoalUseCaseError.BreedingRegistrationNotFound(
-                        breedingResult.breedingRegistrationId.value
+            val breedingRegistration =
+                breedingRegistrationRepository
+                    .findById(breedingResult.breedingRegistrationId)
+                    .toResultOr {
+                        RegisterFoalUseCaseError.BreedingRegistrationNotFound(
+                            breedingResult.breedingRegistrationId.value
+                        )
+                    }
+                    .bind()
+
+            val sire = resolveSire(breedingResult).bind()
+
+            val damId = breedingRegistration.registeredHorseId
+            val dam =
+                bloodHorseRepository
+                    .findById(damId)
+                    .toResultOr { RegisterFoalUseCaseError.DamNotFound(damId.value) }
+                    .bind()
+
+            val bloodHorse =
+                registerFoal(
+                        breedingResult,
+                        sire,
+                        dam,
+                        foalIdentity,
+                        inspection,
+                        registrationNumber,
                     )
+                    .mapError { RegisterFoalUseCaseError.PreconditionViolated(it) }
+                    .bind()
+
+            // 審査と軽種馬の 2 集約書き込みは invoke の @Transactional 境界内で原子的に行う（#483）。
+            horseInspectionRepository.save(inspection)
+            val saved =
+                bloodHorseRepository.save(bloodHorse).getOrElse {
+                    error("新規の軽種馬の保存で楽観ロック競合はありえない: id=${bloodHorse.id.value}")
                 }
-                .bind()
-
-        val sire = resolveSire(breedingResult).bind()
-
-        val damId = breedingRegistration.registeredHorseId
-        val dam =
-            bloodHorseRepository
-                .findById(damId)
-                .toResultOr { RegisterFoalUseCaseError.DamNotFound(damId.value) }
-                .bind()
-
-        val bloodHorse =
-            registerFoal(breedingResult, sire, dam, foalIdentity, inspection, registrationNumber)
-                .mapError { RegisterFoalUseCaseError.PreconditionViolated(it) }
-                .bind()
-
-        // 審査と軽種馬の 2 集約書き込みは invoke の @Transactional 境界内で原子的に行う（#483）。
-        horseInspectionRepository.save(inspection)
-        val saved =
-            bloodHorseRepository.save(bloodHorse).getOrElse {
-                error("新規の軽種馬の保存で楽観ロック競合はありえない: id=${bloodHorse.id.value}")
-            }
-        RegisteredBloodHorse(saved, inspection)
+            RegisteredBloodHorse(saved, inspection)
+        }
     }
 
     /** 仔馬の個体識別を組み立てる（生産者を VO 検証）。形式不正は 400 系の入力エラーにマップする。 */

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
@@ -1,6 +1,10 @@
 package com.example.api.application.studbook.horse
 
+import com.example.api.application.shared.AuthorizationError
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.Permission
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.horse.bloodhorse.BlankBreeder
 import com.example.api.domain.studbook.model.horse.bloodhorse.BlankOriginCountry
 import com.example.api.domain.studbook.model.horse.bloodhorse.BlankPedigreeRegistrationNumber
@@ -20,6 +24,7 @@ import com.example.api.domain.studbook.model.inspection.HorseInspectionRepositor
 import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.getOrElse
@@ -70,6 +75,10 @@ sealed interface RegisterImportedHorseUseCaseError {
 
     /** 原産国名がブランク。 */
     data object BlankOriginCountry : RegisterImportedHorseUseCaseError
+
+    /** 輸入馬血統登録に必要な権限を持たない。 */
+    data class Forbidden(override val permission: Permission) :
+        RegisterImportedHorseUseCaseError, AuthorizationError
 }
 
 /**
@@ -88,60 +97,67 @@ class RegisterImportedHorseUseCase(
 ) {
     @Transactional
     operator fun invoke(
-        command: Command<RegisterImportedHorseCommand>
-    ): Result<RegisteredBloodHorse, RegisterImportedHorseUseCaseError> = binding {
-        val input = command.payload
+        actor: Actor,
+        command: Command<RegisterImportedHorseCommand>,
+    ): Result<RegisteredBloodHorse, RegisterImportedHorseUseCaseError> {
+        val permission = StudbookPermissions.HORSE_REGISTER_IMPORTED
+        if (!actor.can(permission)) {
+            return Err(RegisterImportedHorseUseCaseError.Forbidden(permission))
+        }
+        return binding {
+            val input = command.payload
 
-        val registrationNumber =
-            PedigreeRegistrationNumber.create(input.registrationNumber)
-                .mapError { _: BlankPedigreeRegistrationNumber ->
-                    RegisterImportedHorseUseCaseError.InvalidRegistrationNumber
+            val registrationNumber =
+                PedigreeRegistrationNumber.create(input.registrationNumber)
+                    .mapError { _: BlankPedigreeRegistrationNumber ->
+                        RegisterImportedHorseUseCaseError.InvalidRegistrationNumber
+                    }
+                    .bind()
+            val microchipNumber =
+                MicrochipNumber.create(input.microchipNumber)
+                    .mapError { _: InvalidMicrochipNumber ->
+                        RegisterImportedHorseUseCaseError.InvalidMicrochipNumber
+                    }
+                    .bind()
+            val breeder =
+                Breeder.create(input.breeder)
+                    .mapError { _: BlankBreeder -> RegisterImportedHorseUseCaseError.BlankBreeder }
+                    .bind()
+            val originCountry =
+                OriginCountry.create(input.originCountry)
+                    .mapError { _: BlankOriginCountry ->
+                        RegisterImportedHorseUseCaseError.BlankOriginCountry
+                    }
+                    .bind()
+
+            val entry =
+                ImportedHorseEntry(
+                    sex = input.sex,
+                    coatColor = input.coatColor,
+                    breedType = input.breedType,
+                    dateOfBirth = DateOfBirth(input.dateOfBirth),
+                    breeder = breeder,
+                    originCountry = originCountry,
+                    landingDate = LandingDate(input.landingDate),
+                )
+
+            // 審査をメモリ内で組み立て、createImported 後に永続化する（登録系ユースケースで一貫した順序）。
+            // createImported は失敗しないが、内国産馬登録との一貫性のため「組み立て → create → save」の順に揃える。
+            val inspection =
+                HorseInspection.create(
+                    microchipNumber = microchipNumber,
+                    parentage = ParentageDetermination.NotApplicable,
+                )
+
+            val bloodHorse = BloodHorse.createImported(entry, inspection, registrationNumber)
+
+            // 審査と軽種馬の 2 集約書き込みは invoke の @Transactional 境界内で原子的に行う（#483）。
+            horseInspectionRepository.save(inspection)
+            val saved =
+                bloodHorseRepository.save(bloodHorse).getOrElse {
+                    error("新規の軽種馬の保存で楽観ロック競合はありえない: id=${bloodHorse.id.value}")
                 }
-                .bind()
-        val microchipNumber =
-            MicrochipNumber.create(input.microchipNumber)
-                .mapError { _: InvalidMicrochipNumber ->
-                    RegisterImportedHorseUseCaseError.InvalidMicrochipNumber
-                }
-                .bind()
-        val breeder =
-            Breeder.create(input.breeder)
-                .mapError { _: BlankBreeder -> RegisterImportedHorseUseCaseError.BlankBreeder }
-                .bind()
-        val originCountry =
-            OriginCountry.create(input.originCountry)
-                .mapError { _: BlankOriginCountry ->
-                    RegisterImportedHorseUseCaseError.BlankOriginCountry
-                }
-                .bind()
-
-        val entry =
-            ImportedHorseEntry(
-                sex = input.sex,
-                coatColor = input.coatColor,
-                breedType = input.breedType,
-                dateOfBirth = DateOfBirth(input.dateOfBirth),
-                breeder = breeder,
-                originCountry = originCountry,
-                landingDate = LandingDate(input.landingDate),
-            )
-
-        // 審査をメモリ内で組み立て、createImported 後に永続化する（登録系ユースケースで一貫した順序）。
-        // createImported は失敗しないが、内国産馬登録との一貫性のため「組み立て → create → save」の順に揃える。
-        val inspection =
-            HorseInspection.create(
-                microchipNumber = microchipNumber,
-                parentage = ParentageDetermination.NotApplicable,
-            )
-
-        val bloodHorse = BloodHorse.createImported(entry, inspection, registrationNumber)
-
-        // 審査と軽種馬の 2 集約書き込みは invoke の @Transactional 境界内で原子的に行う（#483）。
-        horseInspectionRepository.save(inspection)
-        val saved =
-            bloodHorseRepository.save(bloodHorse).getOrElse {
-                error("新規の軽種馬の保存で楽観ロック競合はありえない: id=${bloodHorse.id.value}")
-            }
-        RegisteredBloodHorse(saved, inspection)
+            RegisteredBloodHorse(saved, inspection)
+        }
     }
 }

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
@@ -1,6 +1,10 @@
 package com.example.api.application.studbook.horse
 
+import com.example.api.application.shared.AuthorizationError
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.Permission
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.horse.bloodhorse.BlankBreeder
 import com.example.api.domain.studbook.model.horse.bloodhorse.BlankPedigreeRegistrationNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorse
@@ -20,6 +24,7 @@ import com.example.api.domain.studbook.model.inspection.HorseInspectionRepositor
 import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.getOrElse
@@ -85,6 +90,10 @@ sealed interface RegisterInStudBookUseCaseError {
      */
     data class PreconditionViolated(val cause: RegisterInStudBookError) :
         RegisterInStudBookUseCaseError
+
+    /** 血統登録に必要な権限を持たない。 */
+    data class Forbidden(override val permission: Permission) :
+        RegisterInStudBookUseCaseError, AuthorizationError
 }
 
 /**
@@ -103,68 +112,75 @@ class RegisterInStudBookUseCase(
 ) {
     @Transactional
     operator fun invoke(
-        command: Command<RegisterInStudBookCommand>
-    ): Result<RegisteredBloodHorse, RegisterInStudBookUseCaseError> = binding {
-        val input = command.payload
+        actor: Actor,
+        command: Command<RegisterInStudBookCommand>,
+    ): Result<RegisteredBloodHorse, RegisterInStudBookUseCaseError> {
+        val permission = StudbookPermissions.HORSE_REGISTER
+        if (!actor.can(permission)) {
+            return Err(RegisterInStudBookUseCaseError.Forbidden(permission))
+        }
+        return binding {
+            val input = command.payload
 
-        val registrationNumber =
-            PedigreeRegistrationNumber.create(input.registrationNumber)
-                .mapError { _: BlankPedigreeRegistrationNumber ->
-                    RegisterInStudBookUseCaseError.InvalidRegistrationNumber
+            val registrationNumber =
+                PedigreeRegistrationNumber.create(input.registrationNumber)
+                    .mapError { _: BlankPedigreeRegistrationNumber ->
+                        RegisterInStudBookUseCaseError.InvalidRegistrationNumber
+                    }
+                    .bind()
+            val microchipNumber =
+                MicrochipNumber.create(input.microchipNumber)
+                    .mapError { _: InvalidMicrochipNumber ->
+                        RegisterInStudBookUseCaseError.InvalidMicrochipNumber
+                    }
+                    .bind()
+            val breeder =
+                Breeder.create(input.breeder)
+                    .mapError { _: BlankBreeder -> RegisterInStudBookUseCaseError.BlankBreeder }
+                    .bind()
+
+            // 父・母を 1 回の一括 lookup で引き当てる（逐次往復と sireId==damId の二重取得を避ける）。
+            val sireId = BloodHorseId(input.sireId)
+            val damId = BloodHorseId(input.damId)
+            val found = bloodHorseRepository.findAllById(setOf(sireId, damId))
+            val sire =
+                found[sireId]
+                    .toResultOr { RegisterInStudBookUseCaseError.SireNotFound(input.sireId) }
+                    .bind()
+            val dam =
+                found[damId]
+                    .toResultOr { RegisterInStudBookUseCaseError.DamNotFound(input.damId) }
+                    .bind()
+
+            val entry =
+                StudBookEntry(
+                    sex = input.sex,
+                    coatColor = input.coatColor,
+                    breedType = input.breedType,
+                    dateOfBirth = DateOfBirth(input.dateOfBirth),
+                    breeder = breeder,
+                )
+
+            // 審査をメモリ内で組み立てる。前提条件検証（BloodHorse.create）を通った後にのみ永続化し、
+            // 業務ルール違反での却下時に孤児レコードが残るのを防ぐ。
+            val inspection =
+                HorseInspection.create(
+                    microchipNumber = microchipNumber,
+                    parentage = ParentageDetermination.ByDna(input.dnaParentage),
+                )
+
+            val bloodHorse =
+                BloodHorse.create(sire, dam, entry, inspection, registrationNumber)
+                    .mapError { RegisterInStudBookUseCaseError.PreconditionViolated(it) }
+                    .bind()
+
+            // 審査と軽種馬の 2 集約書き込みは invoke の @Transactional 境界内で原子的に行う（#483）。
+            horseInspectionRepository.save(inspection)
+            val saved =
+                bloodHorseRepository.save(bloodHorse).getOrElse {
+                    error("新規の軽種馬の保存で楽観ロック競合はありえない: id=${bloodHorse.id.value}")
                 }
-                .bind()
-        val microchipNumber =
-            MicrochipNumber.create(input.microchipNumber)
-                .mapError { _: InvalidMicrochipNumber ->
-                    RegisterInStudBookUseCaseError.InvalidMicrochipNumber
-                }
-                .bind()
-        val breeder =
-            Breeder.create(input.breeder)
-                .mapError { _: BlankBreeder -> RegisterInStudBookUseCaseError.BlankBreeder }
-                .bind()
-
-        // 父・母を 1 回の一括 lookup で引き当てる（逐次往復と sireId==damId の二重取得を避ける）。
-        val sireId = BloodHorseId(input.sireId)
-        val damId = BloodHorseId(input.damId)
-        val found = bloodHorseRepository.findAllById(setOf(sireId, damId))
-        val sire =
-            found[sireId]
-                .toResultOr { RegisterInStudBookUseCaseError.SireNotFound(input.sireId) }
-                .bind()
-        val dam =
-            found[damId]
-                .toResultOr { RegisterInStudBookUseCaseError.DamNotFound(input.damId) }
-                .bind()
-
-        val entry =
-            StudBookEntry(
-                sex = input.sex,
-                coatColor = input.coatColor,
-                breedType = input.breedType,
-                dateOfBirth = DateOfBirth(input.dateOfBirth),
-                breeder = breeder,
-            )
-
-        // 審査をメモリ内で組み立てる。前提条件検証（BloodHorse.create）を通った後にのみ永続化し、
-        // 業務ルール違反での却下時に孤児レコードが残るのを防ぐ。
-        val inspection =
-            HorseInspection.create(
-                microchipNumber = microchipNumber,
-                parentage = ParentageDetermination.ByDna(input.dnaParentage),
-            )
-
-        val bloodHorse =
-            BloodHorse.create(sire, dam, entry, inspection, registrationNumber)
-                .mapError { RegisterInStudBookUseCaseError.PreconditionViolated(it) }
-                .bind()
-
-        // 審査と軽種馬の 2 集約書き込みは invoke の @Transactional 境界内で原子的に行う（#483）。
-        horseInspectionRepository.save(inspection)
-        val saved =
-            bloodHorseRepository.save(bloodHorse).getOrElse {
-                error("新規の軽種馬の保存で楽観ロック競合はありえない: id=${bloodHorse.id.value}")
-            }
-        RegisteredBloodHorse(saved, inspection)
+            RegisteredBloodHorse(saved, inspection)
+        }
     }
 }

--- a/src/main/kotlin/com/example/api/application/studbook/inspection/RecordHorseInspectionUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/inspection/RecordHorseInspectionUseCase.kt
@@ -1,14 +1,20 @@
 package com.example.api.application.studbook.inspection
 
+import com.example.api.application.shared.AuthorizationError
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.Permission
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.inspection.HorseInspection
 import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
 import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
 import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.map
+import com.github.michaelbull.result.mapError
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -29,17 +35,28 @@ data class RecordHorseInspectionCommand(
 )
 
 /**
+ * 審査記録時に発生しうる失敗。
+ *
+ * 権限不足（#606）が加わり失敗のしかたが 2 種類になったため、単一型からここへ昇格させた （error-handling.md「2 種類以上なら sealed へ昇格」）。
+ */
+sealed interface RecordHorseInspectionUseCaseError {
+    /** マイクロチップ番号が 15 桁の数字でない。 */
+    data object InvalidMicrochip : RecordHorseInspectionUseCaseError
+
+    /** 審査記録に必要な権限を持たない。 */
+    data class Forbidden(override val permission: Permission) :
+        RecordHorseInspectionUseCaseError, AuthorizationError
+}
+
+/**
  * 審査記録ユースケース。
  *
  * 血統登録の内部で審査を生成する経路（[com.example.api.application.studbook.horse.RegisterInStudBookUseCase]）とは
  * 独立に、確定済みの審査を単独で記録する対外 API 経路（#484。登録フロー側は不変）。境界の生入力を [MicrochipNumber]
- * に検証変換し、[HorseInspection.create] で採番・生成して保存する。
- *
- * 失敗のしかたはマイクロチップ形式不正の 1 種類のみのため、専用の sealed は作らずドメインの [InvalidMicrochipNumber]
- * をそのまま返す（error-handling.md「1 種類なら単一型」。増えたら sealed へ昇格）。単一集約の save のみで
+ * に検証変換し、[HorseInspection.create] で採番・生成して保存する。単一集約の save のみで
  * トランザクション論点はないが、書き込みユースケースの規約一様性（ADR-0051）のため `@Transactional` を付与する。`create` はドメインイベントを返さない。
  *
- * @return 保存後の [HorseInspection]、またはマイクロチップ形式不正を表す [InvalidMicrochipNumber]
+ * @return 保存後の [HorseInspection]、または業務ルール違反を表す [RecordHorseInspectionUseCaseError]
  */
 @Service
 class RecordHorseInspectionUseCase(
@@ -47,17 +64,26 @@ class RecordHorseInspectionUseCase(
 ) {
     @Transactional
     operator fun invoke(
-        command: Command<RecordHorseInspectionCommand>
-    ): Result<HorseInspection, InvalidMicrochipNumber> {
-        val input = command.payload
-        return MicrochipNumber.create(input.microchipNumber).map { microchipNumber ->
-            horseInspectionRepository.save(
-                HorseInspection.create(
-                    microchipNumber = microchipNumber,
-                    parentage = input.parentage,
-                    features = input.features,
-                )
-            )
+        actor: Actor,
+        command: Command<RecordHorseInspectionCommand>,
+    ): Result<HorseInspection, RecordHorseInspectionUseCaseError> {
+        val permission = StudbookPermissions.INSPECTION_RECORD
+        if (!actor.can(permission)) {
+            return Err(RecordHorseInspectionUseCaseError.Forbidden(permission))
         }
+        val input = command.payload
+        return MicrochipNumber.create(input.microchipNumber)
+            .mapError { _: InvalidMicrochipNumber ->
+                RecordHorseInspectionUseCaseError.InvalidMicrochip
+            }
+            .map { microchipNumber ->
+                horseInspectionRepository.save(
+                    HorseInspection.create(
+                        microchipNumber = microchipNumber,
+                        parentage = input.parentage,
+                        features = input.features,
+                    )
+                )
+            }
     }
 }

--- a/src/main/kotlin/com/example/api/controller/ActorArgumentResolver.kt
+++ b/src/main/kotlin/com/example/api/controller/ActorArgumentResolver.kt
@@ -21,6 +21,10 @@ import org.springframework.web.method.support.ModelAndViewContainer
  *
  * 認可の判断そのものは application 層のユースケースが行う（ADR-0064）。ここは「誰が」を DB から 引き当てて渡すだけで、権限の検査はしない。`account`
  * が未登録なら、認証は通っていても何も許可されて いない利用者なので 403 を投げる。
+ *
+ * この resolver が動くのは `Actor` 引数を取る書き込みハンドラ＝`authenticated` なエンドポイントに限る。 したがって認証情報が無いままここに来るのは
+ * SecurityConfig の設定漏れ（本来 `permitAll` でないパスが 認証を通さず素通りした）を意味する。空の subject で DB を引くと
+ * `AccountNotFound`＝403 に化けて設定バグを 隠すため、認証情報が無い／subject が空のときは fail-loud で 500 にする。
  */
 @Component
 class ActorArgumentResolver(private val resolveActor: ResolveActorUseCase) :
@@ -35,7 +39,10 @@ class ActorArgumentResolver(private val resolveActor: ResolveActorUseCase) :
         webRequest: NativeWebRequest,
         binderFactory: WebDataBinderFactory?,
     ): Actor {
-        val subject = SecurityContextHolder.getContext().authentication?.name.orEmpty()
+        val subject = SecurityContextHolder.getContext().authentication?.name
+        check(!subject.isNullOrBlank()) {
+            "認証済みのはずのエンドポイントで Actor を解決しようとしたが認証情報が無い（SecurityConfig の設定漏れの疑い）"
+        }
         return resolveActor(ResolveActorQuery(subject)).getOrElse { error ->
             when (error) {
                 is ResolveActorUseCaseError.AccountNotFound -> {

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationController.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingRegistrationController.kt
@@ -5,6 +5,7 @@ import com.example.api.controller.breeding.problem.toProblemDetail
 import com.example.api.controller.breeding.request.RegisterBreedingRegistrationRequest
 import com.example.api.controller.breeding.request.toCommand
 import com.example.api.controller.orThrowProblem
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
 import com.github.michaelbull.result.mapError
 import io.swagger.v3.oas.annotations.Operation
@@ -81,11 +82,12 @@ class BreedingRegistrationController(
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/breedingRegistrations")
     fun register(
+        actor: Actor,
         @OperationRequestBody(description = "成立させる繁殖登録（対象個体・繁殖登録番号）")
         @RequestBody
-        request: RegisterBreedingRegistrationRequest
+        request: RegisterBreedingRegistrationRequest,
     ): BreedingRegistrationResponse =
-        registerBreedingRegistration(Command.now(request.toCommand(), clock))
+        registerBreedingRegistration(actor, Command.now(request.toCommand(), clock))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()
             .toResponse()

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultController.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultController.kt
@@ -13,6 +13,7 @@ import com.example.api.controller.breeding.request.toCoveringCommand
 import com.example.api.controller.breeding.request.toOutcome
 import com.example.api.controller.breeding.request.toUncoveredCommand
 import com.example.api.controller.orThrowProblem
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
 import com.github.michaelbull.result.mapError
 import io.swagger.v3.oas.annotations.Operation
@@ -106,19 +107,20 @@ class BreedingResultController(
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/breedingResults")
     fun record(
+        actor: Actor,
         @OperationRequestBody(description = "起票する繁殖成績の年次レコード（種付記録／種付せず）")
         @RequestBody
-        request: RecordBreedingResultRequest
+        request: RecordBreedingResultRequest,
     ): BreedingResultResponse {
         val covering = request.covering
         return if (covering != null) {
-            recordCovering(Command.now(request.toCoveringCommand(covering), clock))
+            recordCovering(actor, Command.now(request.toCoveringCommand(covering), clock))
                 .mapError { it.toProblemDetail() }
                 .orThrowProblem()
                 .toResponse()
         } else {
             val command = request.toUncoveredCommand().orThrowProblem()
-            recordUncovered(Command.now(command, clock))
+            recordUncovered(actor, Command.now(command, clock))
                 .mapError { it.toProblemDetail() }
                 .orThrowProblem()
                 .toResponse()
@@ -182,11 +184,15 @@ class BreedingResultController(
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/api/breedingResults/{breedingResultId}:reportFoaling")
     fun reportFoaling(
+        actor: Actor,
         @Parameter(description = "分娩結果を報告する繁殖成績の生 UUID") @PathVariable breedingResultId: UUID,
         @OperationRequestBody(description = "報告する分娩結果") @RequestBody request: ReportFoalingRequest,
     ): BreedingResultResponse {
         val outcome = request.toOutcome().orThrowProblem()
-        return reportFoaling(Command.now(ReportFoalingCommand(breedingResultId, outcome), clock))
+        return reportFoaling(
+                actor,
+                Command.now(ReportFoalingCommand(breedingResultId, outcome), clock),
+            )
             .mapError { it.toProblemDetail() }
             .orThrowProblem()
             .toResponse()
@@ -251,9 +257,10 @@ class BreedingResultController(
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/api/breedingResults/{breedingResultId}:submitReport")
     fun submitReport(
-        @Parameter(description = "繁殖成績報告を提出する繁殖成績の生 UUID") @PathVariable breedingResultId: UUID
+        actor: Actor,
+        @Parameter(description = "繁殖成績報告を提出する繁殖成績の生 UUID") @PathVariable breedingResultId: UUID,
     ): BreedingResultResponse =
-        submitReport(Command.now(SubmitBreedingReportCommand(breedingResultId), clock))
+        submitReport(actor, Command.now(SubmitBreedingReportCommand(breedingResultId), clock))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()
             .toResponse()

--- a/src/main/kotlin/com/example/api/controller/breeding/CoveringReportController.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/CoveringReportController.kt
@@ -5,6 +5,7 @@ import com.example.api.controller.breeding.problem.toProblemDetail
 import com.example.api.controller.breeding.request.SubmitCoveringReportRequest
 import com.example.api.controller.breeding.request.toCommand
 import com.example.api.controller.orThrowProblem
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
 import com.github.michaelbull.result.mapError
 import io.swagger.v3.oas.annotations.Operation
@@ -82,11 +83,12 @@ class CoveringReportController(
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/coveringReports")
     fun submit(
+        actor: Actor,
         @OperationRequestBody(description = "提出する種付成績報告（種牡馬の繁殖登録ID・種付年）")
         @RequestBody
-        request: SubmitCoveringReportRequest
+        request: SubmitCoveringReportRequest,
     ): CoveringReportResponse =
-        submitCoveringReport(Command.now(request.toCommand(), clock))
+        submitCoveringReport(actor, Command.now(request.toCommand(), clock))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()
             .toResponse()

--- a/src/main/kotlin/com/example/api/controller/breeding/problem/BreedingRegistrationProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/problem/BreedingRegistrationProblem.kt
@@ -2,6 +2,7 @@ package com.example.api.controller.breeding.problem
 
 import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationUseCaseError
 import com.example.api.controller.problem
+import com.example.api.controller.problem.forbidden
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 
@@ -35,4 +36,5 @@ fun RegisterBreedingRegistrationUseCaseError.toProblemDetail(): ProblemDetail =
                     detail = "繁殖登録の対象として指定された軽種馬が存在しません。",
                 )
                 .apply { setProperty("blood_horse_id", bloodHorseId) }
+        is RegisterBreedingRegistrationUseCaseError.Forbidden -> forbidden(permission)
     }

--- a/src/main/kotlin/com/example/api/controller/breeding/problem/BreedingResultProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/problem/BreedingResultProblem.kt
@@ -5,6 +5,7 @@ import com.example.api.application.studbook.breeding.RecordUncoveredUseCaseError
 import com.example.api.application.studbook.breeding.ReportFoalingUseCaseError
 import com.example.api.application.studbook.breeding.SubmitBreedingReportUseCaseError
 import com.example.api.controller.problem
+import com.example.api.controller.problem.forbidden
 import com.example.api.domain.studbook.model.breeding.CoveringValidityError
 import com.example.api.domain.studbook.model.breeding.RecordCoveringError
 import com.example.api.domain.studbook.model.breeding.RecordUncoveredError
@@ -84,6 +85,7 @@ fun RecordCoveringUseCaseError.toProblemDetail(): ProblemDetail =
                 )
                 .apply { setProperty("stallion_registration_id", stallionRegistrationId) }
         is RecordCoveringUseCaseError.PreconditionViolated -> cause.toProblemDetail()
+        is RecordCoveringUseCaseError.Forbidden -> forbidden(permission)
     }
 
 private fun RecordCoveringError.toProblemDetail(): ProblemDetail =
@@ -167,6 +169,7 @@ fun RecordUncoveredUseCaseError.toProblemDetail(): ProblemDetail =
                 )
                 .apply { setProperty("breeding_registration_id", breedingRegistrationId) }
         is RecordUncoveredUseCaseError.PreconditionViolated -> cause.toProblemDetail()
+        is RecordUncoveredUseCaseError.Forbidden -> forbidden(permission)
     }
 
 private fun RecordUncoveredError.toProblemDetail(): ProblemDetail =
@@ -223,6 +226,7 @@ fun ReportFoalingUseCaseError.toProblemDetail(): ProblemDetail =
                     detail = "対象の繁殖成績が他の更新と競合しました。最新の状態を取得してやり直してください。",
                 )
                 .apply { setProperty("breeding_result_id", breedingResultId) }
+        is ReportFoalingUseCaseError.Forbidden -> forbidden(permission)
     }
 
 /**
@@ -252,6 +256,7 @@ fun SubmitBreedingReportUseCaseError.toProblemDetail(): ProblemDetail =
                     detail = "対象の繁殖成績が他の更新と競合しました。最新の状態を取得してやり直してください。",
                 )
                 .apply { setProperty("breeding_result_id", breedingResultId) }
+        is SubmitBreedingReportUseCaseError.Forbidden -> forbidden(permission)
     }
 
 private fun SubmitBreedingReportError.toProblemDetail(): ProblemDetail =

--- a/src/main/kotlin/com/example/api/controller/breeding/problem/CoveringReportProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/problem/CoveringReportProblem.kt
@@ -2,6 +2,7 @@ package com.example.api.controller.breeding.problem
 
 import com.example.api.application.studbook.breeding.SubmitCoveringReportUseCaseError
 import com.example.api.controller.problem
+import com.example.api.controller.problem.forbidden
 import com.example.api.domain.studbook.model.breeding.SubmitCoveringReportError
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
@@ -26,6 +27,7 @@ fun SubmitCoveringReportUseCaseError.toProblemDetail(): ProblemDetail =
                     setProperty("stallion_breeding_registration_id", stallionBreedingRegistrationId)
                 }
         is SubmitCoveringReportUseCaseError.PreconditionViolated -> cause.toProblemDetail()
+        is SubmitCoveringReportUseCaseError.Forbidden -> forbidden(permission)
     }
 
 private fun SubmitCoveringReportError.toProblemDetail(): ProblemDetail =

--- a/src/main/kotlin/com/example/api/controller/horse/BloodHorseController.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/BloodHorseController.kt
@@ -9,6 +9,7 @@ import com.example.api.controller.horse.request.RegisterHorseNameRequest
 import com.example.api.controller.horse.request.RegisterImportedHorseRequest
 import com.example.api.controller.horse.request.toCommand
 import com.example.api.controller.orThrowProblem
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
 import com.github.michaelbull.result.mapError
 import io.swagger.v3.oas.annotations.Operation
@@ -88,11 +89,12 @@ class BloodHorseController(
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/bloodHorses")
     fun register(
+        actor: Actor,
         @OperationRequestBody(description = "血統登録する軽種馬の登録申請フォーム")
         @RequestBody
-        request: RegisterBloodHorseRequest
+        request: RegisterBloodHorseRequest,
     ): BloodHorseResponse =
-        registerInStudBook(Command.now(request.toCommand(), clock))
+        registerInStudBook(actor, Command.now(request.toCommand(), clock))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()
             .toResponse()
@@ -132,11 +134,12 @@ class BloodHorseController(
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/bloodHorses:registerImported")
     fun registerImported(
+        actor: Actor,
         @OperationRequestBody(description = "血統登録する輸入馬・基礎輸入馬の登録申請フォーム")
         @RequestBody
-        request: RegisterImportedHorseRequest
+        request: RegisterImportedHorseRequest,
     ): BloodHorseResponse =
-        registerImportedHorse(Command.now(request.toCommand(), clock))
+        registerImportedHorse(actor, Command.now(request.toCommand(), clock))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()
             .toResponse()
@@ -196,10 +199,11 @@ class BloodHorseController(
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/api/bloodHorses/{bloodHorseId}:registerName")
     fun registerName(
+        actor: Actor,
         @Parameter(description = "馬名を登録する軽種馬の生 UUID") @PathVariable bloodHorseId: UUID,
         @OperationRequestBody(description = "馬名") @RequestBody request: RegisterHorseNameRequest,
     ): BloodHorseResponse =
-        nameHorse(Command.now(request.toCommand(bloodHorseId), clock))
+        nameHorse(actor, Command.now(request.toCommand(bloodHorseId), clock))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()
             .toResponse()

--- a/src/main/kotlin/com/example/api/controller/horse/problem/BloodHorseProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/problem/BloodHorseProblem.kt
@@ -4,6 +4,7 @@ import com.example.api.application.studbook.horse.NameHorseUseCaseError
 import com.example.api.application.studbook.horse.RegisterImportedHorseUseCaseError
 import com.example.api.application.studbook.horse.RegisterInStudBookUseCaseError
 import com.example.api.controller.problem
+import com.example.api.controller.problem.forbidden
 import com.example.api.domain.studbook.model.horse.bloodhorse.RegisterInStudBookError
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
@@ -74,6 +75,7 @@ fun NameHorseUseCaseError.toProblemDetail(): ProblemDetail =
                     detail = "対象の軽種馬が他の更新と競合しました。最新の状態を取得してやり直してください。",
                 )
                 .apply { setProperty("blood_horse_id", bloodHorseId) }
+        is NameHorseUseCaseError.Forbidden -> forbidden(permission)
     }
 
 /**
@@ -123,6 +125,7 @@ fun RegisterInStudBookUseCaseError.toProblemDetail(): ProblemDetail =
                 )
                 .apply { setProperty("dam_id", damId) }
         is RegisterInStudBookUseCaseError.PreconditionViolated -> cause.toProblemDetail()
+        is RegisterInStudBookUseCaseError.Forbidden -> forbidden(permission)
     }
 
 private fun RegisterInStudBookError.toProblemDetail(): ProblemDetail =
@@ -193,4 +196,5 @@ fun RegisterImportedHorseUseCaseError.toProblemDetail(): ProblemDetail =
                 title = "Origin country is blank",
                 detail = "origin_country は空であってはいけません。",
             )
+        is RegisterImportedHorseUseCaseError.Forbidden -> forbidden(permission)
     }

--- a/src/main/kotlin/com/example/api/controller/inspection/HorseInspectionController.kt
+++ b/src/main/kotlin/com/example/api/controller/inspection/HorseInspectionController.kt
@@ -7,6 +7,7 @@ import com.example.api.controller.inspection.problem.toProblemDetail
 import com.example.api.controller.inspection.request.RecordHorseInspectionRequest
 import com.example.api.controller.inspection.request.toCommand
 import com.example.api.controller.orThrowProblem
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
 import com.github.michaelbull.result.mapError
 import io.swagger.v3.oas.annotations.Operation
@@ -74,11 +75,12 @@ class HorseInspectionController(
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/horseInspections")
     fun record(
+        actor: Actor,
         @OperationRequestBody(description = "記録する審査（個体識別・親子判定）")
         @RequestBody
-        request: RecordHorseInspectionRequest
+        request: RecordHorseInspectionRequest,
     ): HorseInspectionResponse =
-        recordHorseInspection(Command.now(request.toCommand(), clock))
+        recordHorseInspection(actor, Command.now(request.toCommand(), clock))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()
             .toResponse()

--- a/src/main/kotlin/com/example/api/controller/inspection/problem/HorseInspectionProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/inspection/problem/HorseInspectionProblem.kt
@@ -1,8 +1,9 @@
 package com.example.api.controller.inspection.problem
 
 import com.example.api.application.studbook.inspection.HorseInspectionNotFound
+import com.example.api.application.studbook.inspection.RecordHorseInspectionUseCaseError
 import com.example.api.controller.problem
-import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
+import com.example.api.controller.problem.forbidden
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 
@@ -13,18 +14,22 @@ import org.springframework.http.ProblemDetail
  */
 
 /**
- * [InvalidMicrochipNumber]（マイクロチップ形式不正）を 400 Bad Request の [ProblemDetail] に変換する。
+ * [RecordHorseInspectionUseCaseError] を各バリアントに応じた [ProblemDetail] に変換する。
  *
- * VO 検証エラー（形式不正）は入力不正として 400 とする（api-design.md）。`errorCode` は血統登録の同種エラー
- * （`BloodHorseProblem`）と同一文言を踏襲する。
+ * マイクロチップ形式不正は VO 検証エラー（入力不正）として 400 とする（api-design.md）。`errorCode` は血統登録の
+ * 同種エラー（`BloodHorseProblem`）と同一文言を踏襲する。権限不足は共通描画 [forbidden] に委譲する。
  */
-fun InvalidMicrochipNumber.toProblemDetail(): ProblemDetail =
-    problem(
-        status = HttpStatus.BAD_REQUEST,
-        code = "invalid-microchip-number",
-        title = "Invalid microchip number",
-        detail = "microchip_number は 15 桁の数字でなければなりません。",
-    )
+fun RecordHorseInspectionUseCaseError.toProblemDetail(): ProblemDetail =
+    when (this) {
+        is RecordHorseInspectionUseCaseError.InvalidMicrochip ->
+            problem(
+                status = HttpStatus.BAD_REQUEST,
+                code = "invalid-microchip-number",
+                title = "Invalid microchip number",
+                detail = "microchip_number は 15 桁の数字でなければなりません。",
+            )
+        is RecordHorseInspectionUseCaseError.Forbidden -> forbidden(permission)
+    }
 
 /**
  * [HorseInspectionNotFound]（照会対象の審査不在）を 404 Not Found の [ProblemDetail] に変換する。

--- a/src/replay/kotlin/com/example/api/replay/ReplayEngine.kt
+++ b/src/replay/kotlin/com/example/api/replay/ReplayEngine.kt
@@ -17,7 +17,11 @@ import com.example.api.application.studbook.horse.NameHorseUseCase
 import com.example.api.application.studbook.horse.RegisterFoalCommand
 import com.example.api.application.studbook.horse.RegisterFoalUseCase
 import com.example.api.application.studbook.horse.RegisterImportedHorseUseCase
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.shared.generateId
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.horse.bloodhorse.BreedType
 import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
@@ -48,6 +52,26 @@ class ReplayEngine(
     private val nameHorse: NameHorseUseCase,
     private val submitBreedingReport: SubmitBreedingReportUseCase,
 ) {
+    /**
+     * replay ハーネス専用の全権 Actor。実運用の認可判断（#606）は Controller 経由の Actor 解決で行うため、
+     * ここでは繁殖ワークフロー全段を駆動できるよう必要な権限をすべて持たせる。
+     */
+    private val replayActor =
+        Actor(
+            AccountId(generateId()),
+            setOf(
+                StudbookPermissions.HORSE_REGISTER_IMPORTED,
+                StudbookPermissions.HORSE_REGISTER_FOAL,
+                StudbookPermissions.HORSE_NAME,
+                StudbookPermissions.BREEDING_REGISTRATION_REGISTER,
+                StudbookPermissions.BREEDING_RESULT_RECORD_COVERING,
+                StudbookPermissions.BREEDING_RESULT_RECORD_UNCOVERED,
+                StudbookPermissions.BREEDING_RESULT_REPORT_FOALING,
+                StudbookPermissions.BREEDING_RESULT_SUBMIT_REPORT,
+                StudbookPermissions.COVERING_REPORT_SUBMIT,
+            ),
+        )
+
     fun run(fixture: HorseFixture): HorseReplayOutcome =
         when (fixture) {
             is CoveredSeasonFixture -> runCovered(fixture)
@@ -69,20 +93,22 @@ class ReplayEngine(
             session.step(
                 ReplayStep.REGISTER_STALLION,
                 registerImportedHorse(
+                    replayActor,
                     Command.now(
                         importedCommand(facts.stallion, synth.stallion),
                         seasonClock(neutralInstant),
-                    )
+                    ),
                 ),
             ) ?: return session.stop()
         val broodmare =
             session.step(
                 ReplayStep.REGISTER_BROODMARE,
                 registerImportedHorse(
+                    replayActor,
                     Command.now(
                         importedCommand(facts.broodmare, synth.broodmare),
                         seasonClock(neutralInstant),
-                    )
+                    ),
                 ),
             ) ?: return session.stop()
 
@@ -91,26 +117,28 @@ class ReplayEngine(
             session.step(
                 ReplayStep.REGISTER_STALLION_BREEDING,
                 registerBreedingRegistration(
+                    replayActor,
                     Command.now(
                         RegisterBreedingRegistrationCommand(
                             stallion.bloodHorse.id.value,
                             synth.stallion.breedingRegistrationNumber,
                         ),
                         seasonClock(neutralInstant),
-                    )
+                    ),
                 ),
             ) ?: return session.stop()
         val broodmareBreeding =
             session.step(
                 ReplayStep.REGISTER_BROODMARE_BREEDING,
                 registerBreedingRegistration(
+                    replayActor,
                     Command.now(
                         RegisterBreedingRegistrationCommand(
                             broodmare.bloodHorse.id.value,
                             synth.broodmare.breedingRegistrationNumber,
                         ),
                         seasonClock(neutralInstant),
-                    )
+                    ),
                 ),
             ) ?: return session.stop()
 
@@ -119,6 +147,7 @@ class ReplayEngine(
             session.step(
                 ReplayStep.RECORD_COVERING,
                 recordCovering(
+                    replayActor,
                     Command.now(
                         RecordCoveringCommand(
                             breedingRegistrationId = broodmareBreeding.id.value,
@@ -129,7 +158,7 @@ class ReplayEngine(
                             studCertificate = synth.covering.studCertificate.toInput(),
                         ),
                         seasonClock(neutralInstant),
-                    )
+                    ),
                 ),
             ) ?: return session.stop()
 
@@ -137,6 +166,7 @@ class ReplayEngine(
         session.step(
             ReplayStep.SUBMIT_COVERING_REPORT,
             submitCoveringReport(
+                replayActor,
                 Command.now(
                     SubmitCoveringReportCommand(stallionBreeding.id.value, synth.coveringYear),
                     seasonClock(
@@ -144,7 +174,7 @@ class ReplayEngine(
                             LocalDate.parse(synth.submissions.coveringReportSubmittedOn)
                         )
                     ),
-                )
+                ),
             ),
         ) ?: return session.stop()
 
@@ -152,10 +182,11 @@ class ReplayEngine(
         session.step(
             ReplayStep.REPORT_FOALING,
             reportFoaling(
+                replayActor,
                 Command.now(
                     ReportFoalingCommand(breedingResult.id.value, facts.foaling.toOutcome()),
                     seasonClock(neutralInstant),
-                )
+                ),
             ),
         ) ?: return session.stop()
 
@@ -168,6 +199,7 @@ class ReplayEngine(
                 session.step(
                     ReplayStep.REGISTER_FOAL,
                     registerFoal(
+                        replayActor,
                         Command.now(
                             RegisterFoalCommand(
                                 breedingResultId = breedingResult.id.value,
@@ -180,7 +212,7 @@ class ReplayEngine(
                                 registrationNumber = foalSynth.pedigreeRegistrationNumber,
                             ),
                             seasonClock(neutralInstant),
-                        )
+                        ),
                     ),
                 ) ?: return session.stop()
 
@@ -189,10 +221,11 @@ class ReplayEngine(
                 session.step(
                     ReplayStep.NAME_FOAL,
                     nameHorse(
+                        replayActor,
                         Command.now(
                             NameHorseCommand(registeredFoal.bloodHorse.id.value, foalName),
                             seasonClock(neutralInstant),
-                        )
+                        ),
                     ),
                 ) ?: return session.stop()
             }
@@ -202,6 +235,7 @@ class ReplayEngine(
         session.step(
             ReplayStep.SUBMIT_BREEDING_REPORT,
             submitBreedingReport(
+                replayActor,
                 Command.now(
                     SubmitBreedingReportCommand(breedingResult.id.value),
                     seasonClock(
@@ -209,7 +243,7 @@ class ReplayEngine(
                             LocalDate.parse(synth.submissions.breedingReportSubmittedOn)
                         )
                     ),
-                )
+                ),
             ),
         ) ?: return session.stop()
 
@@ -235,10 +269,11 @@ class ReplayEngine(
             session.step(
                 ReplayStep.REGISTER_BROODMARE,
                 registerImportedHorse(
+                    replayActor,
                     Command.now(
                         importedCommand(facts.broodmare, synth.broodmare),
                         seasonClock(neutralInstant),
-                    )
+                    ),
                 ),
             ) ?: return session.stop()
 
@@ -247,13 +282,14 @@ class ReplayEngine(
             session.step(
                 ReplayStep.REGISTER_BROODMARE_BREEDING,
                 registerBreedingRegistration(
+                    replayActor,
                     Command.now(
                         RegisterBreedingRegistrationCommand(
                             broodmare.bloodHorse.id.value,
                             synth.broodmare.breedingRegistrationNumber,
                         ),
                         seasonClock(neutralInstant),
-                    )
+                    ),
                 ),
             ) ?: return session.stop()
 
@@ -262,13 +298,14 @@ class ReplayEngine(
             session.step(
                 ReplayStep.RECORD_UNCOVERED,
                 recordUncovered(
+                    replayActor,
                     Command.now(
                         RecordUncoveredCommand(
                             breedingRegistrationId = broodmareBreeding.id.value,
                             breedingYear = Year.of(synth.breedingYear),
                         ),
                         seasonClock(neutralInstant),
-                    )
+                    ),
                 ),
             ) ?: return session.stop()
 
@@ -276,6 +313,7 @@ class ReplayEngine(
         session.step(
             ReplayStep.SUBMIT_BREEDING_REPORT,
             submitBreedingReport(
+                replayActor,
                 Command.now(
                     SubmitBreedingReportCommand(breedingResult.id.value),
                     seasonClock(
@@ -283,7 +321,7 @@ class ReplayEngine(
                             LocalDate.parse(synth.submissions.breedingReportSubmittedOn)
                         )
                     ),
-                )
+                ),
             ),
         ) ?: return session.stop()
 

--- a/src/test/kotlin/com/example/api/application/studbook/breeding/RecordCoveringUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/breeding/RecordCoveringUseCaseTest.kt
@@ -1,6 +1,9 @@
 package com.example.api.application.studbook.breeding
 
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationId
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
@@ -20,6 +23,12 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class RecordCoveringUseCaseTest {
+
+    private val actor =
+        Actor(
+            AccountId(UUID.randomUUID()),
+            setOf(StudbookPermissions.BREEDING_RESULT_RECORD_COVERING),
+        )
 
     /** すべて正しい既定のペイロード。変種は `copy` で 1 項目だけ差し替える。 */
     private fun validPayload(breedingRegistrationId: UUID, stallionRegistrationId: UUID) =
@@ -61,12 +70,13 @@ class RecordCoveringUseCaseTest {
 
             val result =
                 useCase(
+                        actor,
                         command(
                             validPayload(
                                 broodmareRegistration.id.value,
                                 stallionRegistration.id.value,
                             )
-                        )
+                        ),
                     )
                     .unwrap()
 
@@ -92,10 +102,11 @@ class RecordCoveringUseCaseTest {
 
             val result =
                 useCase(
+                    actor,
                     command(
                         validPayload(UUID.randomUUID(), UUID.randomUUID())
                             .copy(certificateNumber = "")
-                    )
+                    ),
                 )
 
             assert(result.getError() == RecordCoveringUseCaseError.InvalidCertificateNumber)
@@ -113,9 +124,10 @@ class RecordCoveringUseCaseTest {
 
             val result =
                 useCase(
+                    actor,
                     command(
                         validPayload(UUID.randomUUID(), UUID.randomUUID()).copy(coveringPlace = "")
-                    )
+                    ),
                 )
 
             assert(result.getError() == RecordCoveringUseCaseError.InvalidCoveringPlace)
@@ -134,9 +146,10 @@ class RecordCoveringUseCaseTest {
             val payload = validPayload(UUID.randomUUID(), UUID.randomUUID())
             val result =
                 useCase(
+                    actor,
                     command(
                         payload.copy(studCertificate = payload.studCertificate.copy(number = ""))
-                    )
+                    ),
                 )
 
             assert(result.getError() == RecordCoveringUseCaseError.InvalidStudCertificateNumber)
@@ -155,12 +168,13 @@ class RecordCoveringUseCaseTest {
             val payload = validPayload(UUID.randomUUID(), UUID.randomUUID())
             val result =
                 useCase(
+                    actor,
                     command(
                         payload.copy(
                             studCertificate =
                                 payload.studCertificate.copy(validRegions = listOf("北海道", ""))
                         )
-                    )
+                    ),
                 )
 
             assert(result.getError() == RecordCoveringUseCaseError.InvalidValidRegion)
@@ -179,12 +193,13 @@ class RecordCoveringUseCaseTest {
             val payload = validPayload(UUID.randomUUID(), UUID.randomUUID())
             val result =
                 useCase(
+                    actor,
                     command(
                         payload.copy(
                             studCertificate =
                                 payload.studCertificate.copy(validRegions = emptyList())
                         )
-                    )
+                    ),
                 )
 
             assert(result.getError() == RecordCoveringUseCaseError.EmptyValidRegions)
@@ -203,6 +218,7 @@ class RecordCoveringUseCaseTest {
             val payload = validPayload(UUID.randomUUID(), UUID.randomUUID())
             val result =
                 useCase(
+                    actor,
                     command(
                         payload.copy(
                             studCertificate =
@@ -211,7 +227,7 @@ class RecordCoveringUseCaseTest {
                                     validPeriodEnd = LocalDate.of(2024, 1, 1),
                                 )
                         )
-                    )
+                    ),
                 )
 
             assert(result.getError() == RecordCoveringUseCaseError.InvalidValidityPeriod)
@@ -228,7 +244,8 @@ class RecordCoveringUseCaseTest {
             val breedingResultRepository = mockk<BreedingResultRepository>()
             val useCase = RecordCoveringUseCase(registrationRepository, breedingResultRepository)
 
-            val result = useCase(command(validPayload(breedingRegistrationId, UUID.randomUUID())))
+            val result =
+                useCase(actor, command(validPayload(breedingRegistrationId, UUID.randomUUID())))
 
             assert(
                 result.getError() ==
@@ -251,7 +268,8 @@ class RecordCoveringUseCaseTest {
 
             val result =
                 useCase(
-                    command(validPayload(broodmareRegistration.id.value, stallionRegistrationId))
+                    actor,
+                    command(validPayload(broodmareRegistration.id.value, stallionRegistrationId)),
                 )
 
             assert(
@@ -278,12 +296,13 @@ class RecordCoveringUseCaseTest {
 
             val result =
                 useCase(
+                    actor,
                     command(
                         validPayload(
                             broodmareRegistration.id.value,
                             notStallionRegistration.id.value,
                         )
-                    )
+                    ),
                 )
 
             assert(
@@ -317,9 +336,10 @@ class RecordCoveringUseCaseTest {
 
             val result =
                 useCase(
+                    actor,
                     command(
                         validPayload(broodmareRegistration.id.value, stallionRegistration.id.value)
-                    )
+                    ),
                 )
 
             assert(
@@ -328,6 +348,29 @@ class RecordCoveringUseCaseTest {
                         RecordCoveringError.AlreadyRecordedForYear(Year.of(2024), existing.id)
                     )
             )
+            verify(exactly = 0) { breedingResultRepository.save(any()) }
+        }
+
+        @Test
+        fun `権限を持たない Actor で呼ぶと Forbidden を返し引き当ても永続化もしない`() {
+            val registrationRepository = mockk<BreedingRegistrationRepository>()
+            val breedingResultRepository = mockk<BreedingResultRepository>()
+            val useCase = RecordCoveringUseCase(registrationRepository, breedingResultRepository)
+            val noPermissionActor = Actor(AccountId(UUID.randomUUID()), emptySet())
+
+            val result =
+                useCase(
+                    noPermissionActor,
+                    command(validPayload(UUID.randomUUID(), UUID.randomUUID())),
+                )
+
+            assert(
+                result.getError() ==
+                    RecordCoveringUseCaseError.Forbidden(
+                        StudbookPermissions.BREEDING_RESULT_RECORD_COVERING
+                    )
+            )
+            verify(exactly = 0) { registrationRepository.findById(any()) }
             verify(exactly = 0) { breedingResultRepository.save(any()) }
         }
     }

--- a/src/test/kotlin/com/example/api/application/studbook/breeding/RecordUncoveredUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/breeding/RecordUncoveredUseCaseTest.kt
@@ -1,6 +1,9 @@
 package com.example.api.application.studbook.breeding
 
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationId
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
@@ -20,6 +23,12 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class RecordUncoveredUseCaseTest {
+
+    private val actor =
+        Actor(
+            AccountId(UUID.randomUUID()),
+            setOf(StudbookPermissions.BREEDING_RESULT_RECORD_UNCOVERED),
+        )
 
     private fun command(payload: RecordUncoveredCommand): Command<RecordUncoveredCommand> =
         Command(payload, Instant.now())
@@ -42,9 +51,10 @@ class RecordUncoveredUseCaseTest {
 
             val result =
                 useCase(
+                        actor,
                         command(
                             RecordUncoveredCommand(broodmareRegistration.id.value, Year.of(2024))
-                        )
+                        ),
                     )
                     .unwrap()
 
@@ -69,7 +79,10 @@ class RecordUncoveredUseCaseTest {
             val useCase = RecordUncoveredUseCase(registrationRepository, breedingResultRepository)
 
             val result =
-                useCase(command(RecordUncoveredCommand(breedingRegistrationId, Year.of(2024))))
+                useCase(
+                    actor,
+                    command(RecordUncoveredCommand(breedingRegistrationId, Year.of(2024))),
+                )
 
             assert(
                 result.getError() ==
@@ -93,7 +106,8 @@ class RecordUncoveredUseCaseTest {
 
             val result =
                 useCase(
-                    command(RecordUncoveredCommand(stallionRegistration.id.value, Year.of(2024)))
+                    actor,
+                    command(RecordUncoveredCommand(stallionRegistration.id.value, Year.of(2024))),
                 )
 
             assert(
@@ -130,7 +144,8 @@ class RecordUncoveredUseCaseTest {
 
             val result =
                 useCase(
-                    command(RecordUncoveredCommand(broodmareRegistration.id.value, Year.of(2024)))
+                    actor,
+                    command(RecordUncoveredCommand(broodmareRegistration.id.value, Year.of(2024))),
                 )
 
             assert(
@@ -139,6 +154,29 @@ class RecordUncoveredUseCaseTest {
                         RecordUncoveredError.AlreadyRecordedForYear(Year.of(2024), existing.id)
                     )
             )
+            verify(exactly = 0) { breedingResultRepository.save(any()) }
+        }
+
+        @Test
+        fun `権限を持たない Actor で呼ぶと Forbidden を返し引き当ても永続化もしない`() {
+            val registrationRepository = mockk<BreedingRegistrationRepository>()
+            val breedingResultRepository = mockk<BreedingResultRepository>()
+            val useCase = RecordUncoveredUseCase(registrationRepository, breedingResultRepository)
+            val noPermissionActor = Actor(AccountId(UUID.randomUUID()), emptySet())
+
+            val result =
+                useCase(
+                    noPermissionActor,
+                    command(RecordUncoveredCommand(UUID.randomUUID(), Year.of(2024))),
+                )
+
+            assert(
+                result.getError() ==
+                    RecordUncoveredUseCaseError.Forbidden(
+                        StudbookPermissions.BREEDING_RESULT_RECORD_UNCOVERED
+                    )
+            )
+            verify(exactly = 0) { registrationRepository.findById(any()) }
             verify(exactly = 0) { breedingResultRepository.save(any()) }
         }
     }

--- a/src/test/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCaseTest.kt
@@ -1,6 +1,9 @@
 package com.example.api.application.studbook.breeding
 
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
 import com.example.api.domain.studbook.model.breeding.BreedingRole
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
@@ -19,6 +22,12 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class RegisterBreedingRegistrationUseCaseTest {
+
+    private val actor =
+        Actor(
+            AccountId(UUID.randomUUID()),
+            setOf(StudbookPermissions.BREEDING_REGISTRATION_REGISTER),
+        )
 
     private fun command(
         payload: RegisterBreedingRegistrationCommand
@@ -42,7 +51,10 @@ class RegisterBreedingRegistrationUseCaseTest {
                 )
 
             val result =
-                useCase(command(RegisterBreedingRegistrationCommand(mare.id.value, "B-2024-0001")))
+                useCase(
+                        actor,
+                        command(RegisterBreedingRegistrationCommand(mare.id.value, "B-2024-0001")),
+                    )
                     .unwrap()
 
             assert(result.registeredHorseId == mare.id)
@@ -69,9 +81,10 @@ class RegisterBreedingRegistrationUseCaseTest {
 
             val result =
                 useCase(
+                        actor,
                         command(
                             RegisterBreedingRegistrationCommand(stallion.id.value, "B-2024-0002")
-                        )
+                        ),
                     )
                     .unwrap()
 
@@ -92,7 +105,8 @@ class RegisterBreedingRegistrationUseCaseTest {
                     breedingRegistrationRepository,
                 )
 
-            val result = useCase(command(RegisterBreedingRegistrationCommand(mare.id.value, "   ")))
+            val result =
+                useCase(actor, command(RegisterBreedingRegistrationCommand(mare.id.value, "   ")))
 
             assert(
                 result.getError() ==
@@ -116,12 +130,42 @@ class RegisterBreedingRegistrationUseCaseTest {
                 )
 
             val result =
-                useCase(command(RegisterBreedingRegistrationCommand(bloodHorseId, "B-2024-0001")))
+                useCase(
+                    actor,
+                    command(RegisterBreedingRegistrationCommand(bloodHorseId, "B-2024-0001")),
+                )
 
             assert(
                 result.getError() ==
                     RegisterBreedingRegistrationUseCaseError.HorseNotFound(bloodHorseId)
             )
+            verify(exactly = 0) { breedingRegistrationRepository.save(any()) }
+        }
+
+        @Test
+        fun `権限を持たない Actor で呼ぶと Forbidden を返し引き当ても永続化もしない`() {
+            val bloodHorseRepository = mockk<BloodHorseRepository>()
+            val breedingRegistrationRepository = mockk<BreedingRegistrationRepository>()
+            val useCase =
+                RegisterBreedingRegistrationUseCase(
+                    bloodHorseRepository,
+                    breedingRegistrationRepository,
+                )
+            val noPermissionActor = Actor(AccountId(UUID.randomUUID()), emptySet())
+
+            val result =
+                useCase(
+                    noPermissionActor,
+                    command(RegisterBreedingRegistrationCommand(UUID.randomUUID(), "B-2024-0001")),
+                )
+
+            assert(
+                result.getError() ==
+                    RegisterBreedingRegistrationUseCaseError.Forbidden(
+                        StudbookPermissions.BREEDING_REGISTRATION_REGISTER
+                    )
+            )
+            verify(exactly = 0) { bloodHorseRepository.findById(any()) }
             verify(exactly = 0) { breedingRegistrationRepository.save(any()) }
         }
     }

--- a/src/test/kotlin/com/example/api/application/studbook/breeding/ReportFoalingUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/breeding/ReportFoalingUseCaseTest.kt
@@ -1,7 +1,10 @@
 package com.example.api.application.studbook.breeding
 
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
 import com.example.api.domain.shared.UpdateConflict
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
 import com.example.api.domain.studbook.model.breeding.BreedingResultId
 import com.example.api.domain.studbook.model.breeding.BreedingResultRepository
@@ -21,6 +24,12 @@ import org.junit.jupiter.api.Test
 
 class ReportFoalingUseCaseTest {
 
+    private val actor =
+        Actor(
+            AccountId(UUID.randomUUID()),
+            setOf(StudbookPermissions.BREEDING_RESULT_REPORT_FOALING),
+        )
+
     private fun command(payload: ReportFoalingCommand): Command<ReportFoalingCommand> =
         Command(payload, Instant.now())
 
@@ -38,7 +47,8 @@ class ReportFoalingUseCaseTest {
             val useCase = ReportFoalingUseCase(repository)
 
             val result =
-                useCase(command(ReportFoalingCommand(breedingResult.id.value, outcome))).unwrap()
+                useCase(actor, command(ReportFoalingCommand(breedingResult.id.value, outcome)))
+                    .unwrap()
 
             assert(result.outcome == outcome)
             assert(result.id == breedingResult.id)
@@ -60,7 +70,8 @@ class ReportFoalingUseCaseTest {
 
             val result =
                 useCase(
-                    command(ReportFoalingCommand(breedingResultId, FoalingOutcome.NotConceived))
+                    actor,
+                    command(ReportFoalingCommand(breedingResultId, FoalingOutcome.NotConceived)),
                 )
 
             assert(
@@ -80,7 +91,8 @@ class ReportFoalingUseCaseTest {
 
             val result =
                 useCase(
-                    command(ReportFoalingCommand(reported.id.value, FoalingOutcome.NotConceived))
+                    actor,
+                    command(ReportFoalingCommand(reported.id.value, FoalingOutcome.NotConceived)),
                 )
 
             assert(result.getError() == ReportFoalingUseCaseError.AlreadyReported(first))
@@ -99,15 +111,38 @@ class ReportFoalingUseCaseTest {
 
             val result =
                 useCase(
+                    actor,
                     command(
                         ReportFoalingCommand(breedingResult.id.value, FoalingOutcome.NotConceived)
-                    )
+                    ),
                 )
 
             assert(
                 result.getError() ==
                     ReportFoalingUseCaseError.ConcurrentModification(breedingResult.id.value)
             )
+        }
+
+        @Test
+        fun `権限を持たない Actor で呼ぶと Forbidden を返し引き当ても永続化もしない`() {
+            val repository = mockk<BreedingResultRepository>()
+            val useCase = ReportFoalingUseCase(repository)
+            val noPermissionActor = Actor(AccountId(UUID.randomUUID()), emptySet())
+
+            val result =
+                useCase(
+                    noPermissionActor,
+                    command(ReportFoalingCommand(UUID.randomUUID(), FoalingOutcome.NotConceived)),
+                )
+
+            assert(
+                result.getError() ==
+                    ReportFoalingUseCaseError.Forbidden(
+                        StudbookPermissions.BREEDING_RESULT_REPORT_FOALING
+                    )
+            )
+            verify(exactly = 0) { repository.findById(any()) }
+            verify(exactly = 0) { repository.save(any()) }
         }
     }
 }

--- a/src/test/kotlin/com/example/api/application/studbook/breeding/SubmitBreedingReportUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/breeding/SubmitBreedingReportUseCaseTest.kt
@@ -1,7 +1,10 @@
 package com.example.api.application.studbook.breeding
 
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
 import com.example.api.domain.shared.UpdateConflict
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
 import com.example.api.domain.studbook.model.breeding.BreedingResult
 import com.example.api.domain.studbook.model.breeding.BreedingResultId
@@ -22,6 +25,12 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class SubmitBreedingReportUseCaseTest {
+
+    private val actor =
+        Actor(
+            AccountId(UUID.randomUUID()),
+            setOf(StudbookPermissions.BREEDING_RESULT_SUBMIT_REPORT),
+        )
 
     /** 分娩結果確定済み（提出可能）な繁殖成績。繁殖年 2024 → 提出期限は 2025-05-31。 */
     private fun reportedResult(): BreedingResult =
@@ -49,7 +58,7 @@ class SubmitBreedingReportUseCaseTest {
             // UTC 15:00 = JST 翌日 0:00 → 提出日は 6/1（期限 5/31 を超過）
             val issuedAt = Instant.parse("2025-05-31T15:00:00Z")
 
-            val result = useCase(command(reported.id.value, issuedAt)).unwrap()
+            val result = useCase(actor, command(reported.id.value, issuedAt)).unwrap()
 
             assert(result.reportSubmittedOn == LocalDate.of(2025, 6, 1))
             assert(result.reportSubmittedLate == true)
@@ -69,7 +78,8 @@ class SubmitBreedingReportUseCaseTest {
                 }
             val useCase = SubmitBreedingReportUseCase(repository)
 
-            val result = useCase(command(breedingResultId, Instant.parse("2025-05-01T00:00:00Z")))
+            val result =
+                useCase(actor, command(breedingResultId, Instant.parse("2025-05-01T00:00:00Z")))
 
             assert(
                 result.getError() ==
@@ -88,7 +98,7 @@ class SubmitBreedingReportUseCaseTest {
             val useCase = SubmitBreedingReportUseCase(repository)
 
             val result =
-                useCase(command(unreported.id.value, Instant.parse("2025-05-01T00:00:00Z")))
+                useCase(actor, command(unreported.id.value, Instant.parse("2025-05-01T00:00:00Z")))
 
             assert(
                 result.getError() ==
@@ -108,7 +118,8 @@ class SubmitBreedingReportUseCaseTest {
                 }
             val useCase = SubmitBreedingReportUseCase(repository)
 
-            val result = useCase(command(submitted.id.value, Instant.parse("2025-05-02T00:00:00Z")))
+            val result =
+                useCase(actor, command(submitted.id.value, Instant.parse("2025-05-02T00:00:00Z")))
 
             assert(
                 result.getError() ==
@@ -129,12 +140,35 @@ class SubmitBreedingReportUseCaseTest {
                 }
             val useCase = SubmitBreedingReportUseCase(repository)
 
-            val result = useCase(command(reported.id.value, Instant.parse("2025-05-01T00:00:00Z")))
+            val result =
+                useCase(actor, command(reported.id.value, Instant.parse("2025-05-01T00:00:00Z")))
 
             assert(
                 result.getError() ==
                     SubmitBreedingReportUseCaseError.ConcurrentModification(reported.id.value)
             )
+        }
+
+        @Test
+        fun `権限を持たない Actor で呼ぶと Forbidden を返し引き当ても永続化もしない`() {
+            val repository = mockk<BreedingResultRepository>()
+            val useCase = SubmitBreedingReportUseCase(repository)
+            val noPermissionActor = Actor(AccountId(UUID.randomUUID()), emptySet())
+
+            val result =
+                useCase(
+                    noPermissionActor,
+                    command(UUID.randomUUID(), Instant.parse("2025-05-01T00:00:00Z")),
+                )
+
+            assert(
+                result.getError() ==
+                    SubmitBreedingReportUseCaseError.Forbidden(
+                        StudbookPermissions.BREEDING_RESULT_SUBMIT_REPORT
+                    )
+            )
+            verify(exactly = 0) { repository.findById(any()) }
+            verify(exactly = 0) { repository.save(any()) }
         }
     }
 }

--- a/src/test/kotlin/com/example/api/application/studbook/breeding/SubmitCoveringReportUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/breeding/SubmitCoveringReportUseCaseTest.kt
@@ -1,6 +1,9 @@
 package com.example.api.application.studbook.breeding
 
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationId
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
@@ -20,6 +23,9 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class SubmitCoveringReportUseCaseTest {
+
+    private val actor =
+        Actor(AccountId(UUID.randomUUID()), setOf(StudbookPermissions.COVERING_REPORT_SUBMIT))
 
     private fun command(
         stallionBreedingRegistrationId: UUID,
@@ -51,7 +57,8 @@ class SubmitCoveringReportUseCaseTest {
             // UTC 15:00 = JST 翌日 0:00 → 提出日は 10/1（期限 9/30 を超過）
             val issuedAt = Instant.parse("2024-09-30T15:00:00Z")
 
-            val result = useCase(command(stallionRegistration.id.value, 2024, issuedAt)).unwrap()
+            val result =
+                useCase(actor, command(stallionRegistration.id.value, 2024, issuedAt)).unwrap()
 
             assert(result.submittedOn == LocalDate.of(2024, 10, 1))
             assert(result.submittedLate)
@@ -75,11 +82,12 @@ class SubmitCoveringReportUseCaseTest {
 
             val result =
                 useCase(
+                        actor,
                         command(
                             stallionRegistration.id.value,
                             2024,
                             Instant.parse("2024-09-01T00:00:00Z"),
-                        )
+                        ),
                     )
                     .unwrap()
 
@@ -99,7 +107,8 @@ class SubmitCoveringReportUseCaseTest {
             val reportRepository = mockk<CoveringReportRepository>()
             val useCase = SubmitCoveringReportUseCase(registrationRepository, reportRepository)
 
-            val result = useCase(command(unknownId, 2024, Instant.parse("2024-09-01T00:00:00Z")))
+            val result =
+                useCase(actor, command(unknownId, 2024, Instant.parse("2024-09-01T00:00:00Z")))
 
             assert(
                 result.getError() ==
@@ -123,11 +132,12 @@ class SubmitCoveringReportUseCaseTest {
 
             val result =
                 useCase(
+                    actor,
                     command(
                         broodmareRegistration.id.value,
                         2024,
                         Instant.parse("2024-09-01T00:00:00Z"),
-                    )
+                    ),
                 )
 
             assert(
@@ -161,11 +171,12 @@ class SubmitCoveringReportUseCaseTest {
 
             val result =
                 useCase(
+                    actor,
                     command(
                         stallionRegistration.id.value,
                         2024,
                         Instant.parse("2024-09-01T00:00:00Z"),
-                    )
+                    ),
                 )
 
             assert(
@@ -177,6 +188,29 @@ class SubmitCoveringReportUseCaseTest {
                         )
                     )
             )
+            verify(exactly = 0) { reportRepository.save(any()) }
+        }
+
+        @Test
+        fun `権限を持たない Actor で呼ぶと Forbidden を返し引き当ても永続化もしない`() {
+            val registrationRepository = mockk<BreedingRegistrationRepository>()
+            val reportRepository = mockk<CoveringReportRepository>()
+            val useCase = SubmitCoveringReportUseCase(registrationRepository, reportRepository)
+            val noPermissionActor = Actor(AccountId(UUID.randomUUID()), emptySet())
+
+            val result =
+                useCase(
+                    noPermissionActor,
+                    command(UUID.randomUUID(), 2024, Instant.parse("2024-09-01T00:00:00Z")),
+                )
+
+            assert(
+                result.getError() ==
+                    SubmitCoveringReportUseCaseError.Forbidden(
+                        StudbookPermissions.COVERING_REPORT_SUBMIT
+                    )
+            )
+            verify(exactly = 0) { registrationRepository.findById(any()) }
             verify(exactly = 0) { reportRepository.save(any()) }
         }
     }

--- a/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCasePublishAfterCommitTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCasePublishAfterCommitTest.kt
@@ -1,7 +1,10 @@
 package com.example.api.application.studbook.horse
 
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
 import com.example.api.domain.shared.generateId
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorse
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
@@ -51,6 +54,7 @@ class NameHorseUseCasePublishAfterCommitTest(
 ) : PostgresContainerSupport() {
 
     private val transactionTemplate = TransactionTemplate(transactionManager)
+    private val actor = Actor(AccountId(generateId()), setOf(StudbookPermissions.HORSE_NAME))
 
     @BeforeEach
     fun resetRecordingListener() {
@@ -61,7 +65,8 @@ class NameHorseUseCasePublishAfterCommitTest(
     fun `馬名登録ユースケースが成功するとコミット後に HorseNamed が購読者へ届く`() {
         val horse = persistUnnamedHorse()
 
-        nameHorse(Command(NameHorseCommand(horse.id.value, "アフターコミット"), Instant.now())).unwrap()
+        nameHorse(actor, Command(NameHorseCommand(horse.id.value, "アフターコミット"), Instant.now()))
+            .unwrap()
 
         val event = recordingListener.received.single()
         assert(event.bloodHorseId == horse.id)

--- a/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/NameHorseUseCaseTest.kt
@@ -1,7 +1,10 @@
 package com.example.api.application.studbook.horse
 
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
 import com.example.api.domain.shared.UpdateConflict
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
@@ -22,6 +25,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
 
 class NameHorseUseCaseTest {
+
+    private val actor = Actor(AccountId(UUID.randomUUID()), setOf(StudbookPermissions.HORSE_NAME))
 
     private fun command(bloodHorseId: UUID, name: String): Command<NameHorseCommand> =
         Command(NameHorseCommand(bloodHorseId = bloodHorseId, name = name), Instant.now())
@@ -48,7 +53,7 @@ class NameHorseUseCaseTest {
                 }
             val useCase = NameHorseUseCase(repository, inspectionRepository(), eventPublisher)
 
-            val registered = useCase(command(horse.id.value, "オグリキャップ")).unwrap()
+            val registered = useCase(actor, command(horse.id.value, "オグリキャップ")).unwrap()
 
             assert(registered.bloodHorse.id == horse.id)
             assert(registered.bloodHorse.name?.value == "オグリキャップ")
@@ -70,7 +75,7 @@ class NameHorseUseCaseTest {
             val repository = mockk<BloodHorseRepository>()
             val useCase = NameHorseUseCase(repository, inspectionRepository(), eventPublisher)
 
-            val result = useCase(command(UUID.randomUUID(), "ア"))
+            val result = useCase(actor, command(UUID.randomUUID(), "ア"))
 
             assert(result.getError() == NameHorseUseCaseError.InvalidName)
             verify(exactly = 0) { repository.findById(any()) }
@@ -85,7 +90,7 @@ class NameHorseUseCaseTest {
                 mockk<BloodHorseRepository> { every { findById(BloodHorseId(id)) } returns null }
             val useCase = NameHorseUseCase(repository, inspectionRepository(), eventPublisher)
 
-            val result = useCase(command(id, "オグリキャップ"))
+            val result = useCase(actor, command(id, "オグリキャップ"))
 
             assert(result.getError() == NameHorseUseCaseError.HorseNotFound(id))
             verify(exactly = 0) { repository.save(any()) }
@@ -102,7 +107,7 @@ class NameHorseUseCaseTest {
                 }
             val useCase = NameHorseUseCase(repository, inspectionRepository(), eventPublisher)
 
-            val result = useCase(command(horse.id.value, "オグリキャップ"))
+            val result = useCase(actor, command(horse.id.value, "オグリキャップ"))
 
             assert(result.getError() == NameHorseUseCaseError.NameAlreadyTaken("オグリキャップ"))
             verify(exactly = 0) { repository.save(any()) }
@@ -123,7 +128,7 @@ class NameHorseUseCaseTest {
                 }
             val useCase = NameHorseUseCase(repository, inspectionRepository(), eventPublisher)
 
-            val result = useCase(command(named.id.value, "トウカイテイオー"))
+            val result = useCase(actor, command(named.id.value, "トウカイテイオー"))
 
             assert(result.getError() == NameHorseUseCaseError.AlreadyNamed("オグリキャップ"))
             verify(exactly = 0) { repository.save(any()) }
@@ -143,7 +148,7 @@ class NameHorseUseCaseTest {
                 mockk<HorseInspectionRepository> { every { findById(any()) } returns null }
             val useCase = NameHorseUseCase(repository, inspectionRepository, eventPublisher)
 
-            val result = useCase(command(horse.id.value, "オグリキャップ"))
+            val result = useCase(actor, command(horse.id.value, "オグリキャップ"))
 
             assert(
                 result.getError() ==
@@ -165,12 +170,28 @@ class NameHorseUseCaseTest {
                 }
             val useCase = NameHorseUseCase(repository, inspectionRepository(), eventPublisher)
 
-            val result = useCase(command(horse.id.value, "オグリキャップ"))
+            val result = useCase(actor, command(horse.id.value, "オグリキャップ"))
 
             assert(
                 result.getError() == NameHorseUseCaseError.ConcurrentModification(horse.id.value)
             )
             // 保存に失敗した以上、イベントは発行しない
+            verify(exactly = 0) { eventPublisher.publishEvent(any()) }
+        }
+
+        @Test
+        fun `権限を持たない Actor で呼ぶと Forbidden を返し引き当ても永続化もしない`() {
+            val repository = mockk<BloodHorseRepository>()
+            val useCase = NameHorseUseCase(repository, inspectionRepository(), eventPublisher)
+            val noPermissionActor = Actor(AccountId(UUID.randomUUID()), emptySet())
+
+            val result = useCase(noPermissionActor, command(UUID.randomUUID(), "オグリキャップ"))
+
+            assert(
+                result.getError() == NameHorseUseCaseError.Forbidden(StudbookPermissions.HORSE_NAME)
+            )
+            verify(exactly = 0) { repository.findById(any()) }
+            verify(exactly = 0) { repository.save(any()) }
             verify(exactly = 0) { eventPublisher.publishEvent(any()) }
         }
     }

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCaseTest.kt
@@ -1,6 +1,9 @@
 package com.example.api.application.studbook.horse
 
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
 import com.example.api.domain.studbook.model.breeding.BreedingRegistration
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
@@ -32,6 +35,9 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class RegisterFoalUseCaseTest {
+
+    private val actor =
+        Actor(AccountId(UUID.randomUUID()), setOf(StudbookPermissions.HORSE_REGISTER_FOAL))
 
     private val foalingDate = LocalDate.of(2024, 3, 20)
 
@@ -103,7 +109,7 @@ class RegisterFoalUseCaseTest {
         fun `産駒が血統登録され父母が繁殖記録から解決され出生日が分娩日になる`() {
             val w = Wiring()
 
-            val registered = w.useCase()(command(w.breedingResult.id.value)).unwrap()
+            val registered = w.useCase()(actor, command(w.breedingResult.id.value)).unwrap()
 
             val bloodHorse = registered.bloodHorse
             assert(bloodHorse.origin == Origin.Domestic(sireId = w.sire.id, damId = w.dam.id))
@@ -119,7 +125,8 @@ class RegisterFoalUseCaseTest {
         fun `血統登録番号がブランクだと InvalidRegistrationNumber を返す`() {
             val w = Wiring()
 
-            val result = w.useCase()(command(w.breedingResult.id.value, registrationNumber = ""))
+            val result =
+                w.useCase()(actor, command(w.breedingResult.id.value, registrationNumber = ""))
 
             assert(result.getError() == RegisterFoalUseCaseError.InvalidRegistrationNumber)
             verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
@@ -129,7 +136,8 @@ class RegisterFoalUseCaseTest {
         fun `マイクロチップ番号が不正だと InvalidMicrochipNumber を返す`() {
             val w = Wiring()
 
-            val result = w.useCase()(command(w.breedingResult.id.value, microchipNumber = "123"))
+            val result =
+                w.useCase()(actor, command(w.breedingResult.id.value, microchipNumber = "123"))
 
             assert(result.getError() == RegisterFoalUseCaseError.InvalidMicrochipNumber)
             verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
@@ -139,7 +147,7 @@ class RegisterFoalUseCaseTest {
         fun `生産者名がブランクだと BlankBreeder を返す`() {
             val w = Wiring()
 
-            val result = w.useCase()(command(w.breedingResult.id.value, breeder = ""))
+            val result = w.useCase()(actor, command(w.breedingResult.id.value, breeder = ""))
 
             assert(result.getError() == RegisterFoalUseCaseError.BlankBreeder)
             verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
@@ -163,7 +171,7 @@ class RegisterFoalUseCaseTest {
                     mockk(relaxed = true),
                 )
 
-            val result = useCase(command(breedingResultId))
+            val result = useCase(actor, command(breedingResultId))
 
             assert(
                 result.getError() ==
@@ -177,7 +185,7 @@ class RegisterFoalUseCaseTest {
             every { w.breedingRegistrationRepository.findById(w.breedingRegistration.id) } returns
                 null
 
-            val result = w.useCase()(command(w.breedingResult.id.value))
+            val result = w.useCase()(actor, command(w.breedingResult.id.value))
 
             assert(
                 result.getError() ==
@@ -193,7 +201,7 @@ class RegisterFoalUseCaseTest {
             val w = Wiring()
             every { w.bloodHorseRepository.findById(w.sire.id) } returns null
 
-            val result = w.useCase()(command(w.breedingResult.id.value))
+            val result = w.useCase()(actor, command(w.breedingResult.id.value))
 
             assert(result.getError() == RegisterFoalUseCaseError.SireNotFound(w.sire.id.value))
             verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
@@ -204,7 +212,7 @@ class RegisterFoalUseCaseTest {
             val w = Wiring()
             every { w.bloodHorseRepository.findById(w.dam.id) } returns null
 
-            val result = w.useCase()(command(w.breedingResult.id.value))
+            val result = w.useCase()(actor, command(w.breedingResult.id.value))
 
             assert(result.getError() == RegisterFoalUseCaseError.DamNotFound(w.dam.id.value))
             verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
@@ -223,7 +231,7 @@ class RegisterFoalUseCaseTest {
                 )
             every { w.breedingResultRepository.findById(notReported.id) } returns notReported
 
-            val result = w.useCase()(command(notReported.id.value))
+            val result = w.useCase()(actor, command(notReported.id.value))
 
             assert(
                 result.getError() ==
@@ -243,7 +251,7 @@ class RegisterFoalUseCaseTest {
                 )
             every { w.breedingResultRepository.findById(uncovered.id) } returns uncovered
 
-            val result = w.useCase()(command(uncovered.id.value))
+            val result = w.useCase()(actor, command(uncovered.id.value))
 
             assert(
                 result.getError() ==
@@ -261,7 +269,7 @@ class RegisterFoalUseCaseTest {
             val female = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
             every { w.bloodHorseRepository.findById(w.sire.id) } returns female
 
-            val result = w.useCase()(command(w.breedingResult.id.value))
+            val result = w.useCase()(actor, command(w.breedingResult.id.value))
 
             assert(
                 result.getError() ==
@@ -288,9 +296,27 @@ class RegisterFoalUseCaseTest {
                     strictInspectionRepository,
                 )
 
-            useCase(command(w.breedingResult.id.value))
+            useCase(actor, command(w.breedingResult.id.value))
 
             verify(exactly = 0) { strictInspectionRepository.save(any()) }
+        }
+    }
+
+    @Nested
+    inner class AuthorizationFailureCase {
+        @Test
+        fun `権限を持たない Actor で呼ぶと Forbidden を返し引き当ても永続化もしない`() {
+            val w = Wiring()
+            val noPermissionActor = Actor(AccountId(UUID.randomUUID()), emptySet())
+
+            val result = w.useCase()(noPermissionActor, command(w.breedingResult.id.value))
+
+            assert(
+                result.getError() ==
+                    RegisterFoalUseCaseError.Forbidden(StudbookPermissions.HORSE_REGISTER_FOAL)
+            )
+            verify(exactly = 0) { w.breedingResultRepository.findById(any()) }
+            verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
         }
     }
 }

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterHorseTransactionRollbackTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterHorseTransactionRollbackTest.kt
@@ -1,7 +1,10 @@
 package com.example.api.application.studbook.horse
 
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
 import com.example.api.domain.shared.UpdateConflict
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorse
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
@@ -22,6 +25,7 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.unwrap
 import java.time.Instant
 import java.time.LocalDate
+import java.util.UUID
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -54,6 +58,10 @@ class RegisterHorseTransactionRollbackTest(
 ) : PostgresContainerSupport() {
 
     private val seeder = StudbookSeeder(inspectionRows, bloodHorseRows, registrationRows)
+    private val registerImportedActor =
+        Actor(AccountId(UUID.randomUUID()), setOf(StudbookPermissions.HORSE_REGISTER_IMPORTED))
+    private val registerActor =
+        Actor(AccountId(UUID.randomUUID()), setOf(StudbookPermissions.HORSE_REGISTER))
 
     @TestConfiguration
     class FailingSaveConfiguration {
@@ -75,7 +83,7 @@ class RegisterHorseTransactionRollbackTest(
         failingRepository.failOnSave = true
 
         assertThrows<DataAccessResourceFailureException> {
-            registerImportedHorse(command(importedHorseCommand()))
+            registerImportedHorse(registerImportedActor, command(importedHorseCommand()))
         }
 
         assert(inspectionRows.count() == 0L) { "審査が孤児として残っている" }
@@ -93,7 +101,7 @@ class RegisterHorseTransactionRollbackTest(
         failingRepository.failOnSave = true
 
         assertThrows<DataAccessResourceFailureException> {
-            registerInStudBook(command(domesticCommand(sire, dam)))
+            registerInStudBook(registerActor, command(domesticCommand(sire, dam)))
         }
 
         // 父・母の審査（seed 分の 2 行）は残り、ロールバックされた仔馬の審査は残らない

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCaseTest.kt
@@ -1,6 +1,9 @@
 package com.example.api.application.studbook.horse
 
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
 import com.example.api.domain.studbook.model.horse.bloodhorse.BreedType
 import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
@@ -15,10 +18,14 @@ import io.mockk.mockk
 import io.mockk.verify
 import java.time.Instant
 import java.time.LocalDate
+import java.util.UUID
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class RegisterImportedHorseUseCaseTest {
+
+    private val actor =
+        Actor(AccountId(UUID.randomUUID()), setOf(StudbookPermissions.HORSE_REGISTER_IMPORTED))
 
     /** すべて正しい既定のペイロード。変種は `copy` で 1 項目だけ差し替える。 */
     private fun validPayload() =
@@ -50,7 +57,7 @@ class RegisterImportedHorseUseCaseTest {
                 mockk<BloodHorseRepository> { every { save(any()) } answers { Ok(firstArg()) } }
             val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
 
-            val registered = useCase(command(validPayload())).unwrap()
+            val registered = useCase(actor, command(validPayload())).unwrap()
 
             val bloodHorse = registered.bloodHorse
             val origin = bloodHorse.origin
@@ -70,7 +77,7 @@ class RegisterImportedHorseUseCaseTest {
             val repository = mockk<BloodHorseRepository>()
             val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
 
-            val result = useCase(command(validPayload().copy(registrationNumber = "")))
+            val result = useCase(actor, command(validPayload().copy(registrationNumber = "")))
 
             assert(result.getError() == RegisterImportedHorseUseCaseError.InvalidRegistrationNumber)
             verify(exactly = 0) { repository.save(any()) }
@@ -81,7 +88,7 @@ class RegisterImportedHorseUseCaseTest {
             val repository = mockk<BloodHorseRepository>()
             val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
 
-            val result = useCase(command(validPayload().copy(microchipNumber = "123")))
+            val result = useCase(actor, command(validPayload().copy(microchipNumber = "123")))
 
             assert(result.getError() == RegisterImportedHorseUseCaseError.InvalidMicrochipNumber)
             verify(exactly = 0) { repository.save(any()) }
@@ -92,10 +99,29 @@ class RegisterImportedHorseUseCaseTest {
             val repository = mockk<BloodHorseRepository>()
             val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
 
-            val result = useCase(command(validPayload().copy(originCountry = "")))
+            val result = useCase(actor, command(validPayload().copy(originCountry = "")))
 
             assert(result.getError() == RegisterImportedHorseUseCaseError.BlankOriginCountry)
             verify(exactly = 0) { repository.save(any()) }
+        }
+
+        @Test
+        fun `権限を持たない Actor で呼ぶと Forbidden を返し永続化されない`() {
+            val repository = mockk<BloodHorseRepository>()
+            val inspectionRepository = mockk<HorseInspectionRepository>()
+            val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository)
+            val noPermissionActor = Actor(AccountId(UUID.randomUUID()), emptySet())
+
+            val result = useCase(noPermissionActor, command(validPayload()))
+
+            assert(
+                result.getError() ==
+                    RegisterImportedHorseUseCaseError.Forbidden(
+                        StudbookPermissions.HORSE_REGISTER_IMPORTED
+                    )
+            )
+            verify(exactly = 0) { repository.save(any()) }
+            verify(exactly = 0) { inspectionRepository.save(any()) }
         }
     }
 }

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCaseTest.kt
@@ -1,6 +1,9 @@
 package com.example.api.application.studbook.horse
 
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
@@ -24,6 +27,9 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class RegisterInStudBookUseCaseTest {
+
+    private val actor =
+        Actor(AccountId(UUID.randomUUID()), setOf(StudbookPermissions.HORSE_REGISTER))
 
     /** すべて正しい既定のペイロード。変種は `copy` で 1 項目だけ差し替える。 */
     private fun validPayload(sireId: UUID, damId: UUID) =
@@ -61,7 +67,8 @@ class RegisterInStudBookUseCaseTest {
                 }
             val useCase = RegisterInStudBookUseCase(repository, inspectionRepository())
 
-            val registered = useCase(command(validPayload(sire.id.value, dam.id.value))).unwrap()
+            val registered =
+                useCase(actor, command(validPayload(sire.id.value, dam.id.value))).unwrap()
 
             val bloodHorse = registered.bloodHorse
             assert(bloodHorse.origin == Origin.Domestic(sireId = sire.id, damId = dam.id))
@@ -84,10 +91,11 @@ class RegisterInStudBookUseCaseTest {
 
             val result =
                 useCase(
+                    actor,
                     command(
                         validPayload(UUID.randomUUID(), UUID.randomUUID())
                             .copy(registrationNumber = "")
-                    )
+                    ),
                 )
 
             assert(result.getError() == RegisterInStudBookUseCaseError.InvalidRegistrationNumber)
@@ -101,10 +109,11 @@ class RegisterInStudBookUseCaseTest {
 
             val result =
                 useCase(
+                    actor,
                     command(
                         validPayload(UUID.randomUUID(), UUID.randomUUID())
                             .copy(microchipNumber = "123")
-                    )
+                    ),
                 )
 
             assert(result.getError() == RegisterInStudBookUseCaseError.InvalidMicrochipNumber)
@@ -123,7 +132,7 @@ class RegisterInStudBookUseCaseTest {
                 }
             val useCase = RegisterInStudBookUseCase(repository, inspectionRepository())
 
-            val result = useCase(command(validPayload(sireId, damId)))
+            val result = useCase(actor, command(validPayload(sireId, damId)))
 
             assert(result.getError() == RegisterInStudBookUseCaseError.SireNotFound(sireId))
             verify(exactly = 0) { repository.save(any()) }
@@ -141,7 +150,7 @@ class RegisterInStudBookUseCaseTest {
                 }
             val useCase = RegisterInStudBookUseCase(repository, inspectionRepository())
 
-            val result = useCase(command(validPayload(sireId, damId)))
+            val result = useCase(actor, command(validPayload(sireId, damId)))
 
             assert(result.getError() == RegisterInStudBookUseCaseError.DamNotFound(damId))
             verify(exactly = 0) { repository.save(any()) }
@@ -158,7 +167,7 @@ class RegisterInStudBookUseCaseTest {
                 }
             val useCase = RegisterInStudBookUseCase(repository, inspectionRepository())
 
-            val result = useCase(command(validPayload(sire.id.value, dam.id.value)))
+            val result = useCase(actor, command(validPayload(sire.id.value, dam.id.value)))
 
             assert(
                 result.getError() ==
@@ -182,8 +191,30 @@ class RegisterInStudBookUseCaseTest {
             val inspectionRepository = mockk<HorseInspectionRepository>()
             val useCase = RegisterInStudBookUseCase(bloodHorseRepository, inspectionRepository)
 
-            useCase(command(validPayload(sire.id.value, dam.id.value)))
+            useCase(actor, command(validPayload(sire.id.value, dam.id.value)))
 
+            verify(exactly = 0) { inspectionRepository.save(any()) }
+        }
+
+        @Test
+        fun `権限を持たない Actor で呼ぶと Forbidden を返し引き当ても永続化もしない`() {
+            val bloodHorseRepository = mockk<BloodHorseRepository>()
+            val inspectionRepository = mockk<HorseInspectionRepository>()
+            val useCase = RegisterInStudBookUseCase(bloodHorseRepository, inspectionRepository)
+            val noPermissionActor = Actor(AccountId(UUID.randomUUID()), emptySet())
+
+            val result =
+                useCase(
+                    noPermissionActor,
+                    command(validPayload(UUID.randomUUID(), UUID.randomUUID())),
+                )
+
+            assert(
+                result.getError() ==
+                    RegisterInStudBookUseCaseError.Forbidden(StudbookPermissions.HORSE_REGISTER)
+            )
+            verify(exactly = 0) { bloodHorseRepository.findAllById(any()) }
+            verify(exactly = 0) { bloodHorseRepository.save(any()) }
             verify(exactly = 0) { inspectionRepository.save(any()) }
         }
     }

--- a/src/test/kotlin/com/example/api/application/studbook/inspection/RecordHorseInspectionUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/inspection/RecordHorseInspectionUseCaseTest.kt
@@ -1,18 +1,23 @@
 package com.example.api.application.studbook.inspection
 
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.inspection.DnaParentageResult
 import com.example.api.domain.studbook.model.inspection.HorseInspection
 import com.example.api.domain.studbook.model.inspection.HorseInspectionRepository
 import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
-import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
 import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getError
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import java.time.Instant
+import java.util.UUID
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 /**
@@ -24,6 +29,8 @@ import org.junit.jupiter.api.Test
 class RecordHorseInspectionUseCaseTest {
     private val horseInspectionRepository = mockk<HorseInspectionRepository>()
     private val recordHorseInspection = RecordHorseInspectionUseCase(horseInspectionRepository)
+    private val actor =
+        Actor(AccountId(UUID.randomUUID()), setOf(StudbookPermissions.INSPECTION_RECORD))
 
     private fun command(
         microchipNumber: String,
@@ -48,11 +55,12 @@ class RecordHorseInspectionUseCaseTest {
 
         val result =
             recordHorseInspection(
+                actor,
                 command(
                     microchipNumber = "392140000000001",
                     parentage = ParentageDetermination.ByBloodType,
                     features = features,
-                )
+                ),
             )
 
         val inspection = result.get()
@@ -64,10 +72,32 @@ class RecordHorseInspectionUseCaseTest {
     }
 
     @Test
-    fun `マイクロチップ番号が15桁数字でなければInvalidMicrochipNumberを返し保存しない`() {
-        val result = recordHorseInspection(command(microchipNumber = "123"))
+    fun `マイクロチップ番号が15桁数字でなければInvalidMicrochipを返し保存しない`() {
+        val result = recordHorseInspection(actor, command(microchipNumber = "123"))
 
         // save をスタブしていない strict mockk のため、save に到達すればここより前に失敗する
-        assert(result.getError() == InvalidMicrochipNumber)
+        assert(result.getError() == RecordHorseInspectionUseCaseError.InvalidMicrochip)
+    }
+
+    @Nested
+    inner class AuthorizationFailureCase {
+        @Test
+        fun `権限を持たない Actor で呼ぶと Forbidden を返し保存しない`() {
+            val noPermissionActor = Actor(AccountId(UUID.randomUUID()), emptySet())
+
+            val result =
+                recordHorseInspection(
+                    noPermissionActor,
+                    command(microchipNumber = "392140000000001"),
+                )
+
+            assert(
+                result.getError() ==
+                    RecordHorseInspectionUseCaseError.Forbidden(
+                        StudbookPermissions.INSPECTION_RECORD
+                    )
+            )
+            verify(exactly = 0) { horseInspectionRepository.save(any()) }
+        }
     }
 }

--- a/src/test/kotlin/com/example/api/controller/ActorArgumentResolverTest.kt
+++ b/src/test/kotlin/com/example/api/controller/ActorArgumentResolverTest.kt
@@ -106,5 +106,26 @@ class ActorArgumentResolverTest {
             assert((thrown as ErrorResponseException).statusCode.value() == 403)
             assert(thrown.body.properties?.get("error_code") == "account-not-provisioned")
         }
+
+        @Test
+        fun `認証情報が無いときは fail-loud で IllegalStateException を投げる`() {
+            // authenticate を呼ばない＝SecurityContext に認証が無い状態。authenticated なはずの
+            // エンドポイントに認証が無いのは設定漏れなので、空の subject で DB を引かず 500 に落とす。
+            val useCase = mockk<ResolveActorUseCase>()
+            val resolver = ActorArgumentResolver(useCase)
+
+            val thrown =
+                runCatching {
+                        resolver.resolveArgument(
+                            actorParameter(),
+                            null,
+                            mockk<NativeWebRequest>(),
+                            null,
+                        )
+                    }
+                    .exceptionOrNull()
+
+            assert(thrown is IllegalStateException)
+        }
     }
 }

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
@@ -8,11 +8,13 @@ import com.example.api.config.ClockConfiguration
 import com.example.api.domain.shared.Command
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
 import com.example.api.support.TestActors
+import com.example.api.support.TestSecurityContext
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import java.util.UUID
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
@@ -40,7 +42,13 @@ class BreedingRegistrationControllerTest(val mockMvc: MockMvc) {
 
     @BeforeEach
     fun stubResolveActor() {
+        TestSecurityContext.authenticate()
         every { resolveActor(any()) } returns Ok(TestActors.studbookFullyPermitted())
+    }
+
+    @AfterEach
+    fun clearSecurityContext() {
+        TestSecurityContext.clear()
     }
 
     private val uri = "/api/breedingRegistrations"

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
@@ -5,13 +5,17 @@ import com.example.api.application.studbook.breeding.RegisterBreedingRegistratio
 import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationUseCase
 import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationUseCaseError
 import com.example.api.config.ClockConfiguration
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import java.util.UUID
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
@@ -36,6 +40,17 @@ class BreedingRegistrationControllerTest(val mockMvc: MockMvc) {
 
     private val tester = MockMvcTester.create(mockMvc)
 
+    @BeforeEach
+    fun stubResolveActor() {
+        every { resolveActor(any()) } returns
+            Ok(
+                Actor(
+                    AccountId(UUID.randomUUID()),
+                    setOf(StudbookPermissions.BREEDING_REGISTRATION_REGISTER),
+                )
+            )
+    }
+
     private val uri = "/api/breedingRegistrations"
 
     /** デシリアライズに通る正しい繁殖登録リクエストボディ。ユースケースはモックのため中身の整合は問われない。 */
@@ -52,7 +67,7 @@ class BreedingRegistrationControllerTest(val mockMvc: MockMvc) {
     fun `正常な入力で 201 Created と成立した繁殖登録が返ること`() {
         val saved = BreedingFixture.breedingRegistration()
         every {
-            registerBreedingRegistration(any<Command<RegisterBreedingRegistrationCommand>>())
+            registerBreedingRegistration(any(), any<Command<RegisterBreedingRegistrationCommand>>())
         } returns Ok(saved)
 
         tester
@@ -70,7 +85,7 @@ class BreedingRegistrationControllerTest(val mockMvc: MockMvc) {
     @Test
     fun `InvalidRegistrationNumber で 400 と problem+json が返ること`() {
         every {
-            registerBreedingRegistration(any<Command<RegisterBreedingRegistrationCommand>>())
+            registerBreedingRegistration(any(), any<Command<RegisterBreedingRegistrationCommand>>())
         } returns Err(RegisterBreedingRegistrationUseCaseError.InvalidRegistrationNumber)
 
         tester
@@ -90,7 +105,7 @@ class BreedingRegistrationControllerTest(val mockMvc: MockMvc) {
     fun `HorseNotFound で 422 と bloodHorseId 付きの problem+json が返ること`() {
         val id = UUID.fromString("11111111-1111-1111-1111-111111111111")
         every {
-            registerBreedingRegistration(any<Command<RegisterBreedingRegistrationCommand>>())
+            registerBreedingRegistration(any(), any<Command<RegisterBreedingRegistrationCommand>>())
         } returns Err(RegisterBreedingRegistrationUseCaseError.HorseNotFound(id))
 
         tester

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
@@ -5,11 +5,9 @@ import com.example.api.application.studbook.breeding.RegisterBreedingRegistratio
 import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationUseCase
 import com.example.api.application.studbook.breeding.RegisterBreedingRegistrationUseCaseError
 import com.example.api.config.ClockConfiguration
-import com.example.api.domain.shared.AccountId
-import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
-import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
+import com.example.api.support.TestActors
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.ninjasquad.springmockk.MockkBean
@@ -42,13 +40,7 @@ class BreedingRegistrationControllerTest(val mockMvc: MockMvc) {
 
     @BeforeEach
     fun stubResolveActor() {
-        every { resolveActor(any()) } returns
-            Ok(
-                Actor(
-                    AccountId(UUID.randomUUID()),
-                    setOf(StudbookPermissions.BREEDING_REGISTRATION_REGISTER),
-                )
-            )
+        every { resolveActor(any()) } returns Ok(TestActors.studbookFullyPermitted())
     }
 
     private val uri = "/api/breedingRegistrations"

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
@@ -14,10 +14,7 @@ import com.example.api.application.studbook.breeding.SubmitBreedingReportCommand
 import com.example.api.application.studbook.breeding.SubmitBreedingReportUseCase
 import com.example.api.application.studbook.breeding.SubmitBreedingReportUseCaseError
 import com.example.api.config.ClockConfiguration
-import com.example.api.domain.shared.AccountId
-import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
-import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
 import com.example.api.domain.studbook.model.breeding.BreedingRegion
 import com.example.api.domain.studbook.model.breeding.CoveringValidityError
@@ -26,6 +23,7 @@ import com.example.api.domain.studbook.model.breeding.RecordCoveringError
 import com.example.api.domain.studbook.model.breeding.RecordUncoveredError
 import com.example.api.domain.studbook.model.breeding.SubmitBreedingReportError
 import com.example.api.domain.studbook.model.breeding.ValidityPeriod
+import com.example.api.support.TestActors
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.unwrap
@@ -64,18 +62,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
 
     @BeforeEach
     fun stubResolveActor() {
-        every { resolveActor(any()) } returns
-            Ok(
-                Actor(
-                    AccountId(UUID.randomUUID()),
-                    setOf(
-                        StudbookPermissions.BREEDING_RESULT_RECORD_COVERING,
-                        StudbookPermissions.BREEDING_RESULT_RECORD_UNCOVERED,
-                        StudbookPermissions.BREEDING_RESULT_REPORT_FOALING,
-                        StudbookPermissions.BREEDING_RESULT_SUBMIT_REPORT,
-                    ),
-                )
-            )
+        every { resolveActor(any()) } returns Ok(TestActors.studbookFullyPermitted())
     }
 
     @Nested

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
@@ -24,6 +24,7 @@ import com.example.api.domain.studbook.model.breeding.RecordUncoveredError
 import com.example.api.domain.studbook.model.breeding.SubmitBreedingReportError
 import com.example.api.domain.studbook.model.breeding.ValidityPeriod
 import com.example.api.support.TestActors
+import com.example.api.support.TestSecurityContext
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.unwrap
@@ -32,6 +33,7 @@ import io.mockk.every
 import java.time.LocalDate
 import java.time.Year
 import java.util.UUID
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -62,7 +64,13 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
 
     @BeforeEach
     fun stubResolveActor() {
+        TestSecurityContext.authenticate()
         every { resolveActor(any()) } returns Ok(TestActors.studbookFullyPermitted())
+    }
+
+    @AfterEach
+    fun clearSecurityContext() {
+        TestSecurityContext.clear()
     }
 
     @Nested

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
@@ -14,7 +14,10 @@ import com.example.api.application.studbook.breeding.SubmitBreedingReportCommand
 import com.example.api.application.studbook.breeding.SubmitBreedingReportUseCase
 import com.example.api.application.studbook.breeding.SubmitBreedingReportUseCaseError
 import com.example.api.config.ClockConfiguration
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
 import com.example.api.domain.studbook.model.breeding.BreedingRegion
 import com.example.api.domain.studbook.model.breeding.CoveringValidityError
@@ -31,6 +34,7 @@ import io.mockk.every
 import java.time.LocalDate
 import java.time.Year
 import java.util.UUID
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
@@ -57,6 +61,22 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
     @MockkBean private lateinit var submitReport: SubmitBreedingReportUseCase
 
     private val tester = MockMvcTester.create(mockMvc)
+
+    @BeforeEach
+    fun stubResolveActor() {
+        every { resolveActor(any()) } returns
+            Ok(
+                Actor(
+                    AccountId(UUID.randomUUID()),
+                    setOf(
+                        StudbookPermissions.BREEDING_RESULT_RECORD_COVERING,
+                        StudbookPermissions.BREEDING_RESULT_RECORD_UNCOVERED,
+                        StudbookPermissions.BREEDING_RESULT_REPORT_FOALING,
+                        StudbookPermissions.BREEDING_RESULT_SUBMIT_REPORT,
+                    ),
+                )
+            )
+    }
 
     @Nested
     inner class RecordCoveringCase {
@@ -86,7 +106,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
         @Test
         fun `正常な入力で 201 Created と起票された繁殖成績が返ること`() {
             val saved = BreedingFixture.breedingResult()
-            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns Ok(saved)
+            every { recordCovering(any(), any<Command<RecordCoveringCommand>>()) } returns Ok(saved)
 
             tester
                 .post()
@@ -102,7 +122,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
 
         @Test
         fun `InvalidCertificateNumber で 400 と problem+json が返ること`() {
-            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+            every { recordCovering(any(), any<Command<RecordCoveringCommand>>()) } returns
                 Err(RecordCoveringUseCaseError.InvalidCertificateNumber)
 
             tester
@@ -120,7 +140,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
 
         @Test
         fun `InvalidStudCertificateNumber で 400 と problem+json が返ること`() {
-            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+            every { recordCovering(any(), any<Command<RecordCoveringCommand>>()) } returns
                 Err(RecordCoveringUseCaseError.InvalidStudCertificateNumber)
 
             tester
@@ -139,7 +159,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
         @Test
         fun `BreedingRegistrationNotFound で 422 と breedingRegistrationId 付きの problem+json が返ること`() {
             val id = UUID.fromString("11111111-1111-1111-1111-111111111111")
-            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+            every { recordCovering(any(), any<Command<RecordCoveringCommand>>()) } returns
                 Err(RecordCoveringUseCaseError.BreedingRegistrationNotFound(id))
 
             tester
@@ -158,7 +178,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
         @Test
         fun `StallionRegistrationNotFound で 422 と stallionRegistrationId 付きの problem+json が返ること`() {
             val id = UUID.fromString("22222222-2222-2222-2222-222222222222")
-            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+            every { recordCovering(any(), any<Command<RecordCoveringCommand>>()) } returns
                 Err(RecordCoveringUseCaseError.StallionRegistrationNotFound(id))
 
             tester
@@ -176,7 +196,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
 
         @Test
         fun `前提条件違反（NotStallion）が 422 と problem+json に変換されること`() {
-            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+            every { recordCovering(any(), any<Command<RecordCoveringCommand>>()) } returns
                 Err(
                     RecordCoveringUseCaseError.PreconditionViolated(RecordCoveringError.NotStallion)
                 )
@@ -196,7 +216,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
 
         @Test
         fun `前提条件違反（NotBroodmare）が 422 と problem+json に変換されること`() {
-            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+            every { recordCovering(any(), any<Command<RecordCoveringCommand>>()) } returns
                 Err(
                     RecordCoveringUseCaseError.PreconditionViolated(
                         RecordCoveringError.NotBroodmare
@@ -220,7 +240,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
         fun `有効期間外（InvalidCovering OutsideValidPeriod）が 422 と problem+json に変換されること`() {
             val period =
                 ValidityPeriod.create(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 3, 31)).unwrap()
-            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+            every { recordCovering(any(), any<Command<RecordCoveringCommand>>()) } returns
                 Err(
                     RecordCoveringUseCaseError.PreconditionViolated(
                         RecordCoveringError.InvalidCovering(
@@ -249,7 +269,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
         fun `有効区域外（InvalidCovering OutsideValidRegion）が 422 と problem+json に変換されること`() {
             val hokkaido = BreedingRegion.create("北海道").unwrap()
             val aomori = BreedingRegion.create("青森").unwrap()
-            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+            every { recordCovering(any(), any<Command<RecordCoveringCommand>>()) } returns
                 Err(
                     RecordCoveringUseCaseError.PreconditionViolated(
                         RecordCoveringError.InvalidCovering(
@@ -274,7 +294,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
         @Test
         fun `重複記録（AlreadyRecordedForYear）が 409 と繁殖年つきの problem+json に変換されること`() {
             val existing = BreedingFixture.breedingResult()
-            every { recordCovering(any<Command<RecordCoveringCommand>>()) } returns
+            every { recordCovering(any(), any<Command<RecordCoveringCommand>>()) } returns
                 Err(
                     RecordCoveringUseCaseError.PreconditionViolated(
                         RecordCoveringError.AlreadyRecordedForYear(Year.of(2024), existing.id)
@@ -312,7 +332,8 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
         @Test
         fun `covering 無しの入力で 201 Created と種付せずの繁殖成績が返ること`() {
             val saved = BreedingFixture.uncoveredBreedingResult()
-            every { recordUncovered(any<Command<RecordUncoveredCommand>>()) } returns Ok(saved)
+            every { recordUncovered(any(), any<Command<RecordUncoveredCommand>>()) } returns
+                Ok(saved)
 
             tester
                 .post()
@@ -346,7 +367,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
         @Test
         fun `BreedingRegistrationNotFound で 422 と breedingRegistrationId 付きの problem+json が返ること`() {
             val id = UUID.fromString("11111111-1111-1111-1111-111111111111")
-            every { recordUncovered(any<Command<RecordUncoveredCommand>>()) } returns
+            every { recordUncovered(any(), any<Command<RecordUncoveredCommand>>()) } returns
                 Err(RecordUncoveredUseCaseError.BreedingRegistrationNotFound(id))
 
             tester
@@ -364,7 +385,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
 
         @Test
         fun `前提条件違反（NotBroodmare）が 422 と problem+json に変換されること`() {
-            every { recordUncovered(any<Command<RecordUncoveredCommand>>()) } returns
+            every { recordUncovered(any(), any<Command<RecordUncoveredCommand>>()) } returns
                 Err(
                     RecordUncoveredUseCaseError.PreconditionViolated(
                         RecordUncoveredError.NotBroodmare
@@ -387,7 +408,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
         @Test
         fun `重複記録（AlreadyRecordedForYear）が 409 と繁殖年つきの problem+json に変換されること`() {
             val existing = BreedingFixture.uncoveredBreedingResult()
-            every { recordUncovered(any<Command<RecordUncoveredCommand>>()) } returns
+            every { recordUncovered(any(), any<Command<RecordUncoveredCommand>>()) } returns
                 Err(
                     RecordUncoveredUseCaseError.PreconditionViolated(
                         RecordUncoveredError.AlreadyRecordedForYear(Year.of(2024), existing.id)
@@ -420,7 +441,8 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
                 BreedingFixture.breedingResult()
                     .recordFoaling(FoalingOutcome.LiveFoal(LocalDate.of(2025, 3, 20)))
                     .unwrap()
-            every { reportFoaling(any<Command<ReportFoalingCommand>>()) } returns Ok(reported)
+            every { reportFoaling(any(), any<Command<ReportFoalingCommand>>()) } returns
+                Ok(reported)
 
             tester
                 .post()
@@ -452,7 +474,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
         @Test
         fun `BreedingResultNotFound で 404 と breedingResultId 付きの problem+json が返ること`() {
             val id = UUID.fromString(breedingResultId)
-            every { reportFoaling(any<Command<ReportFoalingCommand>>()) } returns
+            every { reportFoaling(any(), any<Command<ReportFoalingCommand>>()) } returns
                 Err(ReportFoalingUseCaseError.BreedingResultNotFound(id))
 
             tester
@@ -470,7 +492,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
 
         @Test
         fun `AlreadyReported で 409 と problem+json が返ること`() {
-            every { reportFoaling(any<Command<ReportFoalingCommand>>()) } returns
+            every { reportFoaling(any(), any<Command<ReportFoalingCommand>>()) } returns
                 Err(
                     ReportFoalingUseCaseError.AlreadyReported(
                         FoalingOutcome.LiveFoal(LocalDate.of(2025, 3, 20))
@@ -493,7 +515,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
         @Test
         fun `ConcurrentModification で 409 と problem+json が返ること`() {
             val id = UUID.fromString(breedingResultId)
-            every { reportFoaling(any<Command<ReportFoalingCommand>>()) } returns
+            every { reportFoaling(any(), any<Command<ReportFoalingCommand>>()) } returns
                 Err(ReportFoalingUseCaseError.ConcurrentModification(id))
 
             tester
@@ -525,7 +547,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
 
         @Test
         fun `正常な提出で 200 OK と提出日・期限超過付きの繁殖成績が返ること`() {
-            every { submitReport(any<Command<SubmitBreedingReportCommand>>()) } returns
+            every { submitReport(any(), any<Command<SubmitBreedingReportCommand>>()) } returns
                 Ok(submittedResult())
 
             tester
@@ -540,7 +562,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
 
         @Test
         fun `期限超過の提出は report_submitted_late が true で返ること`() {
-            every { submitReport(any<Command<SubmitBreedingReportCommand>>()) } returns
+            every { submitReport(any(), any<Command<SubmitBreedingReportCommand>>()) } returns
                 Ok(submittedResult())
 
             tester
@@ -556,7 +578,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
         @Test
         fun `BreedingResultNotFound で 404 と breeding_result_id 付きの problem+json が返ること`() {
             val id = UUID.fromString(breedingResultId)
-            every { submitReport(any<Command<SubmitBreedingReportCommand>>()) } returns
+            every { submitReport(any(), any<Command<SubmitBreedingReportCommand>>()) } returns
                 Err(SubmitBreedingReportUseCaseError.BreedingResultNotFound(id))
 
             tester
@@ -572,7 +594,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
 
         @Test
         fun `分娩結果未確定で 422 と problem+json が返ること`() {
-            every { submitReport(any<Command<SubmitBreedingReportCommand>>()) } returns
+            every { submitReport(any(), any<Command<SubmitBreedingReportCommand>>()) } returns
                 Err(
                     SubmitBreedingReportUseCaseError.PreconditionViolated(
                         SubmitBreedingReportError.OutcomeNotRecorded
@@ -592,7 +614,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
 
         @Test
         fun `提出済みで 409 と既存提出日付きの problem+json が返ること`() {
-            every { submitReport(any<Command<SubmitBreedingReportCommand>>()) } returns
+            every { submitReport(any(), any<Command<SubmitBreedingReportCommand>>()) } returns
                 Err(
                     SubmitBreedingReportUseCaseError.PreconditionViolated(
                         SubmitBreedingReportError.ReportAlreadySubmitted(LocalDate.of(2025, 5, 1))
@@ -623,7 +645,7 @@ class BreedingResultControllerTest(val mockMvc: MockMvc) {
         @Test
         fun `ConcurrentModification で 409 と problem+json が返ること`() {
             val id = UUID.fromString(breedingResultId)
-            every { submitReport(any<Command<SubmitBreedingReportCommand>>()) } returns
+            every { submitReport(any(), any<Command<SubmitBreedingReportCommand>>()) } returns
                 Err(SubmitBreedingReportUseCaseError.ConcurrentModification(id))
 
             tester

--- a/src/test/kotlin/com/example/api/controller/breeding/CoveringReportControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/CoveringReportControllerTest.kt
@@ -9,6 +9,7 @@ import com.example.api.domain.shared.Command
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
 import com.example.api.domain.studbook.model.breeding.SubmitCoveringReportError
 import com.example.api.support.TestActors
+import com.example.api.support.TestSecurityContext
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.ninjasquad.springmockk.MockkBean
@@ -16,6 +17,7 @@ import io.mockk.every
 import java.time.LocalDate
 import java.time.Year
 import java.util.UUID
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
@@ -42,7 +44,13 @@ class CoveringReportControllerTest(val mockMvc: MockMvc) {
 
     @BeforeEach
     fun stubResolveActor() {
+        TestSecurityContext.authenticate()
         every { resolveActor(any()) } returns Ok(TestActors.studbookFullyPermitted())
+    }
+
+    @AfterEach
+    fun clearSecurityContext() {
+        TestSecurityContext.clear()
     }
 
     private val uri = "/api/coveringReports"

--- a/src/test/kotlin/com/example/api/controller/breeding/CoveringReportControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/CoveringReportControllerTest.kt
@@ -5,12 +5,10 @@ import com.example.api.application.studbook.breeding.SubmitCoveringReportCommand
 import com.example.api.application.studbook.breeding.SubmitCoveringReportUseCase
 import com.example.api.application.studbook.breeding.SubmitCoveringReportUseCaseError
 import com.example.api.config.ClockConfiguration
-import com.example.api.domain.shared.AccountId
-import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
-import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
 import com.example.api.domain.studbook.model.breeding.SubmitCoveringReportError
+import com.example.api.support.TestActors
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.ninjasquad.springmockk.MockkBean
@@ -44,13 +42,7 @@ class CoveringReportControllerTest(val mockMvc: MockMvc) {
 
     @BeforeEach
     fun stubResolveActor() {
-        every { resolveActor(any()) } returns
-            Ok(
-                Actor(
-                    AccountId(UUID.randomUUID()),
-                    setOf(StudbookPermissions.COVERING_REPORT_SUBMIT),
-                )
-            )
+        every { resolveActor(any()) } returns Ok(TestActors.studbookFullyPermitted())
     }
 
     private val uri = "/api/coveringReports"

--- a/src/test/kotlin/com/example/api/controller/breeding/CoveringReportControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/CoveringReportControllerTest.kt
@@ -5,7 +5,10 @@ import com.example.api.application.studbook.breeding.SubmitCoveringReportCommand
 import com.example.api.application.studbook.breeding.SubmitCoveringReportUseCase
 import com.example.api.application.studbook.breeding.SubmitCoveringReportUseCaseError
 import com.example.api.config.ClockConfiguration
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.breeding.BreedingFixture
 import com.example.api.domain.studbook.model.breeding.SubmitCoveringReportError
 import com.github.michaelbull.result.Err
@@ -15,6 +18,7 @@ import io.mockk.every
 import java.time.LocalDate
 import java.time.Year
 import java.util.UUID
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
@@ -38,6 +42,17 @@ class CoveringReportControllerTest(val mockMvc: MockMvc) {
 
     private val tester = MockMvcTester.create(mockMvc)
 
+    @BeforeEach
+    fun stubResolveActor() {
+        every { resolveActor(any()) } returns
+            Ok(
+                Actor(
+                    AccountId(UUID.randomUUID()),
+                    setOf(StudbookPermissions.COVERING_REPORT_SUBMIT),
+                )
+            )
+    }
+
     private val uri = "/api/coveringReports"
 
     /** デシリアライズに通る正しい提出リクエストボディ。ユースケースはモックのため中身の整合は問われない。 */
@@ -57,7 +72,7 @@ class CoveringReportControllerTest(val mockMvc: MockMvc) {
                 coveringYear = Year.of(2024),
                 submittedOn = LocalDate.of(2024, 10, 1),
             )
-        every { submitCoveringReport(any<Command<SubmitCoveringReportCommand>>()) } returns
+        every { submitCoveringReport(any(), any<Command<SubmitCoveringReportCommand>>()) } returns
             Ok(saved)
 
         tester
@@ -74,7 +89,7 @@ class CoveringReportControllerTest(val mockMvc: MockMvc) {
 
     @Test
     fun `StallionRegistrationNotFound で 422 と problem+json が返ること`() {
-        every { submitCoveringReport(any<Command<SubmitCoveringReportCommand>>()) } returns
+        every { submitCoveringReport(any(), any<Command<SubmitCoveringReportCommand>>()) } returns
             Err(SubmitCoveringReportUseCaseError.StallionRegistrationNotFound(UUID.randomUUID()))
 
         tester
@@ -92,7 +107,7 @@ class CoveringReportControllerTest(val mockMvc: MockMvc) {
 
     @Test
     fun `NotStallion で 422 と problem+json が返ること`() {
-        every { submitCoveringReport(any<Command<SubmitCoveringReportCommand>>()) } returns
+        every { submitCoveringReport(any(), any<Command<SubmitCoveringReportCommand>>()) } returns
             Err(
                 SubmitCoveringReportUseCaseError.PreconditionViolated(
                     SubmitCoveringReportError.NotStallion
@@ -115,7 +130,7 @@ class CoveringReportControllerTest(val mockMvc: MockMvc) {
     @Test
     fun `AlreadySubmittedForYear で 409 と problem+json が返ること`() {
         val existing = BreedingFixture.coveringReport()
-        every { submitCoveringReport(any<Command<SubmitCoveringReportCommand>>()) } returns
+        every { submitCoveringReport(any(), any<Command<SubmitCoveringReportCommand>>()) } returns
             Err(
                 SubmitCoveringReportUseCaseError.PreconditionViolated(
                     SubmitCoveringReportError.AlreadySubmittedForYear(Year.of(2024), existing.id)

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -19,6 +19,7 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
 import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
 import com.example.api.domain.studbook.model.horse.bloodhorse.RegisterInStudBookError
 import com.example.api.support.TestActors
+import com.example.api.support.TestSecurityContext
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.unwrap
@@ -27,6 +28,7 @@ import io.mockk.every
 import java.time.LocalDate
 import java.util.UUID
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -57,7 +59,13 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
 
     @BeforeEach
     fun stubResolveActor() {
+        TestSecurityContext.authenticate()
         every { resolveActor(any()) } returns Ok(TestActors.studbookFullyPermitted())
+    }
+
+    @AfterEach
+    fun clearSecurityContext() {
+        TestSecurityContext.clear()
     }
 
     /**

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -14,13 +14,11 @@ import com.example.api.application.studbook.horse.RegisteredBloodHorse
 import com.example.api.config.ClockConfiguration
 import com.example.api.controller.horse.request.RegisterBloodHorseRequest
 import com.example.api.controller.horse.request.RegisterImportedHorseRequest
-import com.example.api.domain.shared.AccountId
-import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
-import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
 import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
 import com.example.api.domain.studbook.model.horse.bloodhorse.RegisterInStudBookError
+import com.example.api.support.TestActors
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.unwrap
@@ -59,17 +57,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
 
     @BeforeEach
     fun stubResolveActor() {
-        every { resolveActor(any()) } returns
-            Ok(
-                Actor(
-                    AccountId(UUID.randomUUID()),
-                    setOf(
-                        StudbookPermissions.HORSE_REGISTER,
-                        StudbookPermissions.HORSE_REGISTER_IMPORTED,
-                        StudbookPermissions.HORSE_NAME,
-                    ),
-                )
-            )
+        every { resolveActor(any()) } returns Ok(TestActors.studbookFullyPermitted())
     }
 
     /**

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -14,7 +14,10 @@ import com.example.api.application.studbook.horse.RegisteredBloodHorse
 import com.example.api.config.ClockConfiguration
 import com.example.api.controller.horse.request.RegisterBloodHorseRequest
 import com.example.api.controller.horse.request.RegisterImportedHorseRequest
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseFixture
 import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
 import com.example.api.domain.studbook.model.horse.bloodhorse.RegisterInStudBookError
@@ -26,6 +29,7 @@ import io.mockk.every
 import java.time.LocalDate
 import java.util.UUID
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
@@ -52,6 +56,21 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
     @MockkBean private lateinit var nameHorse: NameHorseUseCase
 
     private val tester = MockMvcTester.create(mockMvc)
+
+    @BeforeEach
+    fun stubResolveActor() {
+        every { resolveActor(any()) } returns
+            Ok(
+                Actor(
+                    AccountId(UUID.randomUUID()),
+                    setOf(
+                        StudbookPermissions.HORSE_REGISTER,
+                        StudbookPermissions.HORSE_REGISTER_IMPORTED,
+                        StudbookPermissions.HORSE_NAME,
+                    ),
+                )
+            )
+    }
 
     /**
      * デシリアライズに通る正しいリクエストボディ。ユースケースはモックのため中身の整合は問われない。
@@ -84,7 +103,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
                     BloodHorseFixture.domesticBloodHorse(),
                     BloodHorseFixture.inspection(),
                 )
-            every { registerInStudBook(any<Command<RegisterInStudBookCommand>>()) } returns
+            every { registerInStudBook(any(), any<Command<RegisterInStudBookCommand>>()) } returns
                 Ok(saved)
 
             tester
@@ -104,7 +123,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
     inner class FailureCase {
         @Test
         fun `InvalidMicrochipNumber で 400 と problem+json が返ること`() {
-            every { registerInStudBook(any<Command<RegisterInStudBookCommand>>()) } returns
+            every { registerInStudBook(any(), any<Command<RegisterInStudBookCommand>>()) } returns
                 Err(RegisterInStudBookUseCaseError.InvalidMicrochipNumber)
 
             tester
@@ -123,7 +142,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
         @Test
         fun `SireNotFound で 422 と sireId 付きの problem+json が返ること`() {
             val sireId = UUID.fromString("11111111-1111-1111-1111-111111111111")
-            every { registerInStudBook(any<Command<RegisterInStudBookCommand>>()) } returns
+            every { registerInStudBook(any(), any<Command<RegisterInStudBookCommand>>()) } returns
                 Err(RegisterInStudBookUseCaseError.SireNotFound(sireId))
 
             tester
@@ -141,7 +160,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
 
         @Test
         fun `前提条件違反（SireNotMale）が 422 と problem+json に変換されること`() {
-            every { registerInStudBook(any<Command<RegisterInStudBookCommand>>()) } returns
+            every { registerInStudBook(any(), any<Command<RegisterInStudBookCommand>>()) } returns
                 Err(
                     RegisterInStudBookUseCaseError.PreconditionViolated(
                         RegisterInStudBookError.SireNotMale
@@ -164,7 +183,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
         @Test
         fun `DamNotFound で 422 と damId 付きの problem+json が返ること`() {
             val damId = UUID.fromString("22222222-2222-2222-2222-222222222222")
-            every { registerInStudBook(any<Command<RegisterInStudBookCommand>>()) } returns
+            every { registerInStudBook(any(), any<Command<RegisterInStudBookCommand>>()) } returns
                 Err(RegisterInStudBookUseCaseError.DamNotFound(damId))
 
             tester
@@ -182,7 +201,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
 
         @Test
         fun `前提条件違反（DamNotFemale）が 422 と problem+json に変換されること`() {
-            every { registerInStudBook(any<Command<RegisterInStudBookCommand>>()) } returns
+            every { registerInStudBook(any(), any<Command<RegisterInStudBookCommand>>()) } returns
                 Err(
                     RegisterInStudBookUseCaseError.PreconditionViolated(
                         RegisterInStudBookError.DamNotFemale
@@ -204,7 +223,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
 
         @Test
         fun `前提条件違反（ParentageNotConfirmed）が 422 と problem+json に変換されること`() {
-            every { registerInStudBook(any<Command<RegisterInStudBookCommand>>()) } returns
+            every { registerInStudBook(any(), any<Command<RegisterInStudBookCommand>>()) } returns
                 Err(
                     RegisterInStudBookUseCaseError.PreconditionViolated(
                         RegisterInStudBookError.ParentageNotConfirmed
@@ -226,7 +245,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
 
         @Test
         fun `前提条件違反（BreedMismatch）が 422 と problem+json に変換されること`() {
-            every { registerInStudBook(any<Command<RegisterInStudBookCommand>>()) } returns
+            every { registerInStudBook(any(), any<Command<RegisterInStudBookCommand>>()) } returns
                 Err(
                     RegisterInStudBookUseCaseError.PreconditionViolated(
                         RegisterInStudBookError.BreedMismatch
@@ -260,7 +279,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
                     .assignName(HorseName.create("オグリキャップ").unwrap())
                     .unwrap()
                     .aggregate
-            every { nameHorse(any<Command<NameHorseCommand>>()) } returns
+            every { nameHorse(any(), any<Command<NameHorseCommand>>()) } returns
                 Ok(RegisteredBloodHorse(named, BloodHorseFixture.inspection()))
 
             tester
@@ -277,7 +296,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
 
         @Test
         fun `InvalidName で 400 と problem+json が返ること`() {
-            every { nameHorse(any<Command<NameHorseCommand>>()) } returns
+            every { nameHorse(any(), any<Command<NameHorseCommand>>()) } returns
                 Err(NameHorseUseCaseError.InvalidName)
 
             tester
@@ -296,7 +315,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
         @Test
         fun `HorseNotFound で 404 と bloodHorseId 付きの problem+json が返ること`() {
             val id = UUID.fromString(bloodHorseId)
-            every { nameHorse(any<Command<NameHorseCommand>>()) } returns
+            every { nameHorse(any(), any<Command<NameHorseCommand>>()) } returns
                 Err(NameHorseUseCaseError.HorseNotFound(id))
 
             tester
@@ -314,7 +333,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
 
         @Test
         fun `AlreadyNamed で 409 と problem+json が返ること`() {
-            every { nameHorse(any<Command<NameHorseCommand>>()) } returns
+            every { nameHorse(any(), any<Command<NameHorseCommand>>()) } returns
                 Err(NameHorseUseCaseError.AlreadyNamed("トウカイテイオー"))
 
             tester
@@ -332,7 +351,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
 
         @Test
         fun `NameAlreadyTaken で 409 と problem+json が返ること`() {
-            every { nameHorse(any<Command<NameHorseCommand>>()) } returns
+            every { nameHorse(any(), any<Command<NameHorseCommand>>()) } returns
                 Err(NameHorseUseCaseError.NameAlreadyTaken("オグリキャップ"))
 
             tester
@@ -351,7 +370,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
         @Test
         fun `ConcurrentModification で 409 と problem+json が返ること`() {
             val id = UUID.fromString(bloodHorseId)
-            every { nameHorse(any<Command<NameHorseCommand>>()) } returns
+            every { nameHorse(any(), any<Command<NameHorseCommand>>()) } returns
                 Err(NameHorseUseCaseError.ConcurrentModification(id))
 
             tester
@@ -370,7 +389,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
         @Test
         fun `InspectionNotFound で 422 と inspection_id 付きの problem+json が返ること`() {
             val inspectionId = UUID.fromString("55555555-5555-5555-5555-555555555555")
-            every { nameHorse(any<Command<NameHorseCommand>>()) } returns
+            every { nameHorse(any(), any<Command<NameHorseCommand>>()) } returns
                 Err(NameHorseUseCaseError.InspectionNotFound(inspectionId))
 
             val result =
@@ -421,8 +440,9 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
                     BloodHorseFixture.importedBloodHorse(),
                     BloodHorseFixture.inspection(),
                 )
-            every { registerImportedHorse(any<Command<RegisterImportedHorseCommand>>()) } returns
-                Ok(saved)
+            every {
+                registerImportedHorse(any(), any<Command<RegisterImportedHorseCommand>>())
+            } returns Ok(saved)
 
             tester
                 .post()
@@ -438,8 +458,9 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
 
         @Test
         fun `BlankOriginCountry で 400 と problem+json が返ること`() {
-            every { registerImportedHorse(any<Command<RegisterImportedHorseCommand>>()) } returns
-                Err(RegisterImportedHorseUseCaseError.BlankOriginCountry)
+            every {
+                registerImportedHorse(any(), any<Command<RegisterImportedHorseCommand>>())
+            } returns Err(RegisterImportedHorseUseCaseError.BlankOriginCountry)
 
             tester
                 .post()

--- a/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
@@ -11,16 +11,14 @@ import com.example.api.application.studbook.inspection.RecordHorseInspectionUseC
 import com.example.api.config.ClockConfiguration
 import com.example.api.controller.horse.DnaParentageResultDto
 import com.example.api.controller.inspection.request.RecordHorseInspectionRequest
-import com.example.api.domain.shared.AccountId
-import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
 import com.example.api.domain.shared.generateId
-import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.inspection.DnaParentageResult
 import com.example.api.domain.studbook.model.inspection.HorseInspection
 import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.example.api.support.TestActors
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.unwrap
@@ -58,8 +56,7 @@ class HorseInspectionControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMa
 
     @BeforeEach
     fun stubResolveActor() {
-        every { resolveActor(any()) } returns
-            Ok(Actor(AccountId(UUID.randomUUID()), setOf(StudbookPermissions.INSPECTION_RECORD)))
+        every { resolveActor(any()) } returns Ok(TestActors.studbookFullyPermitted())
     }
 
     /** DNA 判定＋特徴記述子つきの審査集約を組む（レスポンス表現の検証用）。 */

--- a/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
@@ -7,15 +7,18 @@ import com.example.api.application.studbook.inspection.HorseInspectionNotFound
 import com.example.api.application.studbook.inspection.HorseInspectionView
 import com.example.api.application.studbook.inspection.RecordHorseInspectionCommand
 import com.example.api.application.studbook.inspection.RecordHorseInspectionUseCase
+import com.example.api.application.studbook.inspection.RecordHorseInspectionUseCaseError
 import com.example.api.config.ClockConfiguration
 import com.example.api.controller.horse.DnaParentageResultDto
 import com.example.api.controller.inspection.request.RecordHorseInspectionRequest
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
 import com.example.api.domain.shared.Command
 import com.example.api.domain.shared.generateId
+import com.example.api.domain.studbook.model.StudbookPermissions
 import com.example.api.domain.studbook.model.inspection.DnaParentageResult
 import com.example.api.domain.studbook.model.inspection.HorseInspection
 import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
-import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
 import com.github.michaelbull.result.Err
@@ -26,6 +29,7 @@ import io.mockk.every
 import io.mockk.slot
 import java.util.UUID
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
@@ -51,6 +55,12 @@ class HorseInspectionControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMa
     @MockkBean private lateinit var findHorseInspection: FindHorseInspectionUseCase
 
     private val tester = MockMvcTester.create(mockMvc)
+
+    @BeforeEach
+    fun stubResolveActor() {
+        every { resolveActor(any()) } returns
+            Ok(Actor(AccountId(UUID.randomUUID()), setOf(StudbookPermissions.INSPECTION_RECORD)))
+    }
 
     /** DNA 判定＋特徴記述子つきの審査集約を組む（レスポンス表現の検証用）。 */
     private fun inspectionWithFeatures(): HorseInspection =
@@ -81,8 +91,9 @@ class HorseInspectionControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMa
 
         @Test
         fun `正常な入力で 201 Created と DNA 判定つきの審査リソースが返ること`() {
-            every { recordHorseInspection(any<Command<RecordHorseInspectionCommand>>()) } returns
-                Ok(inspectionWithFeatures())
+            every {
+                recordHorseInspection(any(), any<Command<RecordHorseInspectionCommand>>())
+            } returns Ok(inspectionWithFeatures())
 
             tester
                 .post()
@@ -103,8 +114,9 @@ class HorseInspectionControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMa
                     microchipNumber = MicrochipNumber.create("392140000000002").unwrap(),
                     parentage = ParentageDetermination.NotApplicable,
                 )
-            every { recordHorseInspection(any<Command<RecordHorseInspectionCommand>>()) } returns
-                Ok(saved)
+            every {
+                recordHorseInspection(any(), any<Command<RecordHorseInspectionCommand>>())
+            } returns Ok(saved)
 
             tester
                 .post()
@@ -129,7 +141,8 @@ class HorseInspectionControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMa
         @Test
         fun `全フィールド null の features はコマンドで不在（null）へ正規化されること`() {
             val command = slot<Command<RecordHorseInspectionCommand>>()
-            every { recordHorseInspection(capture(command)) } returns Ok(inspectionWithFeatures())
+            every { recordHorseInspection(any(), capture(command)) } returns
+                Ok(inspectionWithFeatures())
 
             tester
                 .post()
@@ -157,8 +170,9 @@ class HorseInspectionControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMa
 
         @Test
         fun `InvalidMicrochipNumber で 400 と problem+json が返ること`() {
-            every { recordHorseInspection(any<Command<RecordHorseInspectionCommand>>()) } returns
-                Err(InvalidMicrochipNumber)
+            every {
+                recordHorseInspection(any(), any<Command<RecordHorseInspectionCommand>>())
+            } returns Err(RecordHorseInspectionUseCaseError.InvalidMicrochip)
 
             tester
                 .post()

--- a/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
@@ -19,6 +19,7 @@ import com.example.api.domain.studbook.model.inspection.IdentificationFeatures
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
 import com.example.api.support.TestActors
+import com.example.api.support.TestSecurityContext
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.unwrap
@@ -27,6 +28,7 @@ import io.mockk.every
 import io.mockk.slot
 import java.util.UUID
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -56,7 +58,13 @@ class HorseInspectionControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMa
 
     @BeforeEach
     fun stubResolveActor() {
+        TestSecurityContext.authenticate()
         every { resolveActor(any()) } returns Ok(TestActors.studbookFullyPermitted())
+    }
+
+    @AfterEach
+    fun clearSecurityContext() {
+        TestSecurityContext.clear()
     }
 
     /** DNA 判定＋特徴記述子つきの審査集約を組む（レスポンス表現の検証用）。 */

--- a/src/test/kotlin/com/example/api/support/TestActors.kt
+++ b/src/test/kotlin/com/example/api/support/TestActors.kt
@@ -1,0 +1,34 @@
+package com.example.api.support
+
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Actor
+import com.example.api.domain.studbook.model.StudbookPermissions
+import java.util.UUID
+
+/**
+ * テスト用の [Actor] ファクトリ。
+ *
+ * `@WebMvcTest` の slice テストは HTTP 契約（シリアライズ・ステータス・ProblemDetail 描画）の検証が目的で、 認可分岐（権限不足で 403）は
+ * UseCase 単体テストの責務。したがって slice テストは「権限が足りて素通りする
+ * Actor」だけあればよく、必要権限のサブセットを各テストへ書き並べる必要はない。新しい書き込み権限が増えても ここ 1 箇所で追随できるよう、seed となる全権限 Actor を集約する。
+ */
+object TestActors {
+    /** studbook の全書き込み権限を持つ Actor。slice テストの happy-path 用。 */
+    fun studbookFullyPermitted(): Actor =
+        Actor(
+            AccountId(UUID.randomUUID()),
+            setOf(
+                StudbookPermissions.HORSE_REGISTER,
+                StudbookPermissions.HORSE_REGISTER_IMPORTED,
+                StudbookPermissions.HORSE_REGISTER_FOAL,
+                StudbookPermissions.HORSE_NAME,
+                StudbookPermissions.INSPECTION_RECORD,
+                StudbookPermissions.BREEDING_REGISTRATION_REGISTER,
+                StudbookPermissions.BREEDING_RESULT_RECORD_COVERING,
+                StudbookPermissions.BREEDING_RESULT_RECORD_UNCOVERED,
+                StudbookPermissions.BREEDING_RESULT_REPORT_FOALING,
+                StudbookPermissions.BREEDING_RESULT_SUBMIT_REPORT,
+                StudbookPermissions.COVERING_REPORT_SUBMIT,
+            ),
+        )
+}

--- a/src/test/kotlin/com/example/api/support/TestSecurityContext.kt
+++ b/src/test/kotlin/com/example/api/support/TestSecurityContext.kt
@@ -1,0 +1,32 @@
+package com.example.api.support
+
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+
+/**
+ * `@WebMvcTest` slice テスト用の [SecurityContextHolder] セットアップ。
+ *
+ * slice テストは `@AutoConfigureMockMvc(addFilters = false)` で認証フィルタを無効化するが、`Actor` 引数を 取るハンドラでは
+ * `ActorArgumentResolver` が動き、認証済み JWT の `sub` を要求する（未認証は設定漏れとして fail-loud で
+ * 500）。本番と同じく「認証は済んでいる」状態を再現するため、ダミーの JWT 認証を差し込む。 MockMvc はリクエストを同一スレッドで同期実行し、フィルタ無効下では誰も
+ * `SecurityContextHolder` を消さないため、 `@BeforeEach` で差した認証がハンドラ処理まで生きる。テスト間のリークを避けるため `@AfterEach` で
+ * [clear] する。
+ */
+object TestSecurityContext {
+    /** ダミーの JWT 認証を [SecurityContextHolder] に差す。`subject`（＝`sub`）は resolver が引く識別子。 */
+    fun authenticate(subject: String = "test-subject") {
+        val jwt =
+            Jwt.withTokenValue("token")
+                .header("alg", "RS256")
+                .subject(subject)
+                .claim("sub", subject)
+                .build()
+        SecurityContextHolder.getContext().authentication = JwtAuthenticationToken(jwt)
+    }
+
+    /** [SecurityContextHolder] を空にする（スレッド再利用によるリーク防止）。 */
+    fun clear() {
+        SecurityContextHolder.clearContext()
+    }
+}


### PR DESCRIPTION
## 概要（#606 の 2/3: studbook への認可適用 + fail-loud）

Issue #606（認可 RBAC）を 3 分割した **2 本目**。1 本目で用意した基盤（`Actor` / iam / `ArgumentResolver`）を、**studbook の全書き込みユースケースへ実際に適用**する。

> [!IMPORTANT]
> **base は `feat/606-authz-foundation`（1 本目）**。1 本目をマージしてから、この PR をマージすること。マージ順: (1/3) → **(2/3) この PR** → (3/3)。

分割:
- (1/3) 基盤
- **(2/3) studbook 適用 + fail-loud ← この PR**
- (3/3) jockey 適用 + E2E + ドキュメント（Closes #606）

## この PR の範囲

- **studbook の書き込み 11 ユースケースに認可を敷く**。各 `invoke` の第 1 引数に `Actor` を取り、`binding {}` の外で early-return（`if (!actor.can(p)) return Err(...Forbidden(p))`）。権限不足は `AuthorizationError` を実装した `Forbidden` で表し、adapter が 403（`error_code=forbidden`）へ写す。Controller 6 本の配線・problem マッパー・テストを追随。
- **slice テストの seed Actor を `TestActors` に集約**（権限サブセットの列挙を 1 箇所へ）。
- **未認証で `Actor` を解決しようとしたら fail-loud で 500**（`ArgumentResolver`）。空の `sub` で DB を引いて 403 に化けさせない。slice テストは `addFilters=false` で認証を持たないため、`TestSecurityContext` で本番同様の認証を用意する。

## 検証

`./gradlew check` 緑（ktfmt + detekt + ArchUnit + test + koverVerifyMature）。この時点で jockey はまだ未適用のため、既存の `JockeyApiE2eTest` も無傷。

Part of #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)
