### PR TITLE
feat: #652 登録番号（血統・繁殖）の一意性を二層防御で担保する

### DIFF
--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -39,7 +39,7 @@
 | BloodHorse | 軽種馬 | 集約ルート | 血統及び個体識別を明らかにする血統登録の成立によって誕生する個体。ライフサイクル全体を通じて同一の `BloodHorse` が各ロールを担う。 | 禁止: 単に「Horse」と呼ぶと文脈で曖昧。父母・ロールも別個体として扱わない |
 | HorseName | 馬名 | 値オブジェクト | 血統登録済みの個体に一度だけ付与できる名。出生時は未命名（`null`）。 | — |
 | HorseNamed | 馬名登録された | ドメインイベント | 馬名登録（`BloodHorse.assignName`）の成功時に「起きたこと」を表すイベント。遷移後の集約とともに `StateTransition` で同梱して返し、発行は application 層が担う（[ADR-0029](adr/0029-domain-events-via-state-transition-return.md)）。 | 禁止: `Command`（何をしたいか）と混同しない。本型は結果（何が起きたか） |
-| PedigreeRegistrationNumber | 血統登録番号 | 値オブジェクト | 血統登録の成立時に交付される番号。 | — |
+| PedigreeRegistrationNumber | 血統登録番号 | 値オブジェクト | 血統登録の成立時に交付される番号。血統登録原簿の中で一意（登録規程 第3〜4条）。繁殖登録番号とは別の採番空間。 | — |
 | MicrochipNumber | マイクロチップ番号 | 値オブジェクト | 個体識別に用いるマイクロチップの番号。 | — |
 | StudBookEntry | 血統登録申請（個体識別の束） | 値オブジェクト | 申請者が持ち込む仔馬自身の個体識別情報の束。父母は集約をまたぐためここには含めない。 | — |
 | DnaParentageResult | DNA 型親子判定結果 | 値オブジェクト | 申告された父母との親子関係の DNA 型検査結果（`CONSISTENT` のときのみ血統登録可）。 | — |
@@ -69,7 +69,7 @@
 | CoveringValidityError | 種付有効性違反 | 値オブジェクト（sealed） | 種付が種畜証明書の有効区域外（`OutsideValidRegion`）／有効期間外（`OutsideValidPeriod`）であることを表す。 | sealed 親型は jMolecules 非付与のためカタログには出ない |
 | FoalingOutcome | 分娩結果 | 値オブジェクト（sealed） | 種付した繁殖牝馬がその年に迎えた帰結。生産（`LiveFoal`）と産駒なし各区分の sealed 語彙。 | sealed 親型自体は jMolecules 非付与（カタログには variant のみ出る） |
 | FoalingOutcome.LiveFoal | 生産（産駒あり） | 値オブジェクト | 分娩により生存産駒を得た帰結。血統登録（`BloodHorse.create`）の入力に接続する。 | — |
-| BreedingRegistrationNumber | 繁殖登録番号 | 値オブジェクト | 繁殖登録に交付される番号。 | — |
+| BreedingRegistrationNumber | 繁殖登録番号 | 値オブジェクト | 繁殖登録に交付される番号。繁殖登録原簿の中で一意（登録規程 第5条）。血統登録番号とは別の採番空間。 | — |
 | BreedingResultSummaryView | 繁殖成績年次集計 | 読み取りモデル（@QueryModel） | (種牡馬, 種付年) 単位の繁殖成績。様式第2号（繁殖登録原簿〈雄〉）に対応。種付雌馬数・受胎数・生産数・受胎率・生産率を持つ。 | 軽量 CQRS（L2）の読みモデルのため application 層に置く |
 | 種付雌馬数 | 種付雌馬数 | 集計値 | その種牡馬がその年に種付けした雌馬数（`covering` を持つ年次成績の件数）。 | — |
 | 受胎数／受胎率 | 受胎数／受胎率 | 集計値 | 種付雌馬数のうち受胎が確認された件数（不受胎を除く。流産・死産・生後直死は受胎に含む）／その種付雌馬数比。 | — |

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -306,6 +306,7 @@ graph LR
 | CoveringReportRepository | リポジトリポート | domain.studbook.model.breeding |
 | HorseInspectionRepository | リポジトリポート | domain.studbook.model.inspection |
 | HorseNamed | ドメインイベント | domain.studbook.model.horse.bloodhorse |
+| ensureBreedingRegistrationNumberAvailable | ドメインサービス | domain.studbook.service.breeding |
 | ensurePedigreeRegistrationNumberAvailable | ドメインサービス | domain.studbook.service.horse |
 | nameHorse | ドメインサービス | domain.studbook.service.horse |
 | recordCovering | ドメインサービス | domain.studbook.service.breeding |

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -306,6 +306,7 @@ graph LR
 | CoveringReportRepository | リポジトリポート | domain.studbook.model.breeding |
 | HorseInspectionRepository | リポジトリポート | domain.studbook.model.inspection |
 | HorseNamed | ドメインイベント | domain.studbook.model.horse.bloodhorse |
+| ensurePedigreeRegistrationNumberAvailable | ドメインサービス | domain.studbook.service.horse |
 | nameHorse | ドメインサービス | domain.studbook.service.horse |
 | recordCovering | ドメインサービス | domain.studbook.service.breeding |
 | recordUncovered | ドメインサービス | domain.studbook.service.breeding |

--- a/src/main/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCase.kt
@@ -11,6 +11,7 @@ import com.example.api.domain.studbook.model.breeding.BreedingRegistrationNumber
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.studbook.service.breeding.ensureBreedingRegistrationNumberAvailable
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
@@ -42,6 +43,10 @@ sealed interface RegisterBreedingRegistrationUseCaseError {
 
     /** 繁殖登録の対象として指定された軽種馬が存在しない。 */
     data class HorseNotFound(val bloodHorseId: UUID) : RegisterBreedingRegistrationUseCaseError
+
+    /** 繁殖登録番号が既に他の繁殖登録に採番済み。 */
+    data class RegistrationNumberAlreadyTaken(val registrationNumber: String) :
+        RegisterBreedingRegistrationUseCaseError
 
     /** 繁殖登録に必要な権限を持たない。 */
     data class Forbidden(override val permission: Permission) :
@@ -83,6 +88,17 @@ class RegisterBreedingRegistrationUseCase(
                         RegisterBreedingRegistrationUseCaseError.InvalidRegistrationNumber
                     }
                     .bind()
+
+            ensureBreedingRegistrationNumberAvailable(
+                    registrationNumber,
+                    breedingRegistrationRepository,
+                )
+                .mapError {
+                    RegisterBreedingRegistrationUseCaseError.RegistrationNumberAlreadyTaken(
+                        it.number.value
+                    )
+                }
+                .bind()
 
             val horse =
                 bloodHorseRepository

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
@@ -26,6 +26,7 @@ import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
 import com.example.api.domain.studbook.service.horse.RegisterFoalError
+import com.example.api.domain.studbook.service.horse.ensurePedigreeRegistrationNumberAvailable
 import com.example.api.domain.studbook.service.horse.registerFoal
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
@@ -72,6 +73,10 @@ data class RegisterFoalCommand(
 sealed interface RegisterFoalUseCaseError {
     /** 血統登録番号がブランク。 */
     data object InvalidRegistrationNumber : RegisterFoalUseCaseError
+
+    /** 血統登録番号が既に他の軽種馬に採番済み。 */
+    data class RegistrationNumberAlreadyTaken(val registrationNumber: String) :
+        RegisterFoalUseCaseError
 
     /** マイクロチップ番号が 15 桁の数字でない。 */
     data object InvalidMicrochipNumber : RegisterFoalUseCaseError
@@ -138,6 +143,7 @@ class RegisterFoalUseCase(
                         RegisterFoalUseCaseError.InvalidRegistrationNumber
                     }
                     .bind()
+            ensureRegistrationNumberAvailable(registrationNumber).bind()
             // 審査をメモリ内で組み立てる。前提条件検証（registerFoal）を通った後にのみ永続化し、
             // 業務ルール違反での却下時に孤児レコードが残るのを防ぐ。
             val inspection = buildInspection(input).bind()
@@ -191,6 +197,13 @@ class RegisterFoalUseCase(
             RegisteredBloodHorse(saved, inspection)
         }
     }
+
+    /** 血統登録番号の一意性を検証する。既に採番済みなら [RegisterFoalUseCaseError.RegistrationNumberAlreadyTaken] に写す。 */
+    private fun ensureRegistrationNumberAvailable(
+        registrationNumber: PedigreeRegistrationNumber
+    ): Result<Unit, RegisterFoalUseCaseError> =
+        ensurePedigreeRegistrationNumberAvailable(registrationNumber, bloodHorseRepository)
+            .mapError { RegisterFoalUseCaseError.RegistrationNumberAlreadyTaken(it.number.value) }
 
     /** 仔馬の個体識別を組み立てる（生産者を VO 検証）。形式不正は 400 系の入力エラーにマップする。 */
     private fun buildFoalIdentity(

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
@@ -24,6 +24,7 @@ import com.example.api.domain.studbook.model.inspection.HorseInspectionRepositor
 import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.example.api.domain.studbook.service.horse.ensurePedigreeRegistrationNumberAvailable
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
@@ -66,6 +67,10 @@ data class RegisterImportedHorseCommand(
 sealed interface RegisterImportedHorseUseCaseError {
     /** 血統登録番号がブランク。 */
     data object InvalidRegistrationNumber : RegisterImportedHorseUseCaseError
+
+    /** 血統登録番号が既に他の軽種馬に採番済み。 */
+    data class RegistrationNumberAlreadyTaken(val registrationNumber: String) :
+        RegisterImportedHorseUseCaseError
 
     /** マイクロチップ番号が 15 桁の数字でない。 */
     data object InvalidMicrochipNumber : RegisterImportedHorseUseCaseError
@@ -113,6 +118,13 @@ class RegisterImportedHorseUseCase(
                         RegisterImportedHorseUseCaseError.InvalidRegistrationNumber
                     }
                     .bind()
+            ensurePedigreeRegistrationNumberAvailable(registrationNumber, bloodHorseRepository)
+                .mapError {
+                    RegisterImportedHorseUseCaseError.RegistrationNumberAlreadyTaken(
+                        it.number.value
+                    )
+                }
+                .bind()
             val microchipNumber =
                 MicrochipNumber.create(input.microchipNumber)
                     .mapError { _: InvalidMicrochipNumber ->

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
@@ -24,6 +24,7 @@ import com.example.api.domain.studbook.model.inspection.HorseInspectionRepositor
 import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.example.api.domain.studbook.service.horse.ensurePedigreeRegistrationNumberAvailable
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
@@ -70,6 +71,10 @@ data class RegisterInStudBookCommand(
 sealed interface RegisterInStudBookUseCaseError {
     /** 血統登録番号がブランク。 */
     data object InvalidRegistrationNumber : RegisterInStudBookUseCaseError
+
+    /** 血統登録番号が既に他の軽種馬に採番済み。 */
+    data class RegistrationNumberAlreadyTaken(val registrationNumber: String) :
+        RegisterInStudBookUseCaseError
 
     /** マイクロチップ番号が 15 桁の数字でない。 */
     data object InvalidMicrochipNumber : RegisterInStudBookUseCaseError
@@ -128,6 +133,7 @@ class RegisterInStudBookUseCase(
                         RegisterInStudBookUseCaseError.InvalidRegistrationNumber
                     }
                     .bind()
+            ensureRegistrationNumberAvailable(registrationNumber).bind()
             val microchipNumber =
                 MicrochipNumber.create(input.microchipNumber)
                     .mapError { _: InvalidMicrochipNumber ->
@@ -183,4 +189,15 @@ class RegisterInStudBookUseCase(
             RegisteredBloodHorse(saved, inspection)
         }
     }
+
+    /**
+     * 血統登録番号の一意性を検証する。既に採番済みなら [RegisterInStudBookUseCaseError.RegistrationNumberAlreadyTaken] に写す。
+     */
+    private fun ensureRegistrationNumberAvailable(
+        registrationNumber: PedigreeRegistrationNumber
+    ): Result<Unit, RegisterInStudBookUseCaseError> =
+        ensurePedigreeRegistrationNumberAvailable(registrationNumber, bloodHorseRepository)
+            .mapError {
+                RegisterInStudBookUseCaseError.RegistrationNumberAlreadyTaken(it.number.value)
+            }
 }

--- a/src/main/kotlin/com/example/api/controller/breeding/problem/BreedingRegistrationProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/problem/BreedingRegistrationProblem.kt
@@ -36,5 +36,13 @@ fun RegisterBreedingRegistrationUseCaseError.toProblemDetail(): ProblemDetail =
                     detail = "繁殖登録の対象として指定された軽種馬が存在しません。",
                 )
                 .apply { setProperty("blood_horse_id", bloodHorseId) }
+        is RegisterBreedingRegistrationUseCaseError.RegistrationNumberAlreadyTaken ->
+            problem(
+                    status = HttpStatus.CONFLICT,
+                    code = "breeding-registration-number-already-taken",
+                    title = "Breeding registration number already taken",
+                    detail = "申請された繁殖登録番号は既に他の繁殖登録に採番されています。",
+                )
+                .apply { setProperty("registration_number", registrationNumber) }
         is RegisterBreedingRegistrationUseCaseError.Forbidden -> forbidden(permission)
     }

--- a/src/main/kotlin/com/example/api/controller/horse/problem/BloodHorseProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/problem/BloodHorseProblem.kt
@@ -82,6 +82,7 @@ fun NameHorseUseCaseError.toProblemDetail(): ProblemDetail =
  * [RegisterInStudBookUseCaseError] を RFC 9457 (`application/problem+json`) の [ProblemDetail] に変換する。
  *
  * - VO 検証エラーは入力不正として 400 Bad Request
+ * - 申請された血統登録番号が既に他の軽種馬で使用済みは、原簿の既存登録番号と衝突するため 409 Conflict
  * - 父母の不在（ボディ内 sire_id / dam_id の参照先不在）・ドメイン前提条件違反は、整った入力だが意味的に 処理できないため 422 Unprocessable
  *   Entity（判断基準は ADR-0018 / ADR-0021、api-design.md「404 vs 422」）
  */
@@ -94,6 +95,14 @@ fun RegisterInStudBookUseCaseError.toProblemDetail(): ProblemDetail =
                 title = "Invalid registration number",
                 detail = "registration_number は空であってはいけません。",
             )
+        is RegisterInStudBookUseCaseError.RegistrationNumberAlreadyTaken ->
+            problem(
+                    status = HttpStatus.CONFLICT,
+                    code = "registration-number-already-taken",
+                    title = "Registration number already taken",
+                    detail = "申請された血統登録番号は既に他の軽種馬で使用されています。",
+                )
+                .apply { setProperty("registration_number", registrationNumber) }
         RegisterInStudBookUseCaseError.InvalidMicrochipNumber ->
             problem(
                 status = HttpStatus.BAD_REQUEST,
@@ -164,7 +173,8 @@ private fun RegisterInStudBookError.toProblemDetail(): ProblemDetail =
  * [RegisterImportedHorseUseCaseError] を RFC 9457 (`application/problem+json`) の [ProblemDetail] に
  * 変換する。
  *
- * 輸入馬登録は父母の引き当てを行わないため、失敗は VO 検証エラー（入力不正）のみで、すべて 400 Bad Request とする。
+ * 輸入馬登録は父母の引き当てを行わないため、失敗は VO 検証エラー（入力不正）のみで、原則 400 Bad Request とする。
+ * ただし申請された血統登録番号が既に他の軽種馬で使用済みの場合のみ、原簿の既存登録番号と衝突するため 409 Conflict とする。
  */
 fun RegisterImportedHorseUseCaseError.toProblemDetail(): ProblemDetail =
     when (this) {
@@ -175,6 +185,14 @@ fun RegisterImportedHorseUseCaseError.toProblemDetail(): ProblemDetail =
                 title = "Invalid registration number",
                 detail = "registration_number は空であってはいけません。",
             )
+        is RegisterImportedHorseUseCaseError.RegistrationNumberAlreadyTaken ->
+            problem(
+                    status = HttpStatus.CONFLICT,
+                    code = "registration-number-already-taken",
+                    title = "Registration number already taken",
+                    detail = "申請された血統登録番号は既に他の軽種馬で使用されています。",
+                )
+                .apply { setProperty("registration_number", registrationNumber) }
         RegisterImportedHorseUseCaseError.InvalidMicrochipNumber ->
             problem(
                 status = HttpStatus.BAD_REQUEST,

--- a/src/main/kotlin/com/example/api/domain/studbook/model/breeding/BreedingRegistrationNumberAlreadyTaken.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/breeding/BreedingRegistrationNumberAlreadyTaken.kt
@@ -1,0 +1,10 @@
+package com.example.api.domain.studbook.model.breeding
+
+/**
+ * 繁殖登録番号が既に他の繁殖登録に採番済み（繁殖登録原簿の一意性違反）。
+ *
+ * 繁殖登録番号は登録原簿の中で一意（登録規程 第5条）。血統登録番号とは別の採番空間。ドメインサービス
+ * [com.example.api.domain.studbook.service.breeding.ensureBreedingRegistrationNumberAvailable] が
+ * 既存レコード集合を引き当てて検証し、衝突時にこれを返す。
+ */
+data class BreedingRegistrationNumberAlreadyTaken(val number: BreedingRegistrationNumber)

--- a/src/main/kotlin/com/example/api/domain/studbook/model/breeding/BreedingRegistrationRepository.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/breeding/BreedingRegistrationRepository.kt
@@ -24,4 +24,7 @@ interface BreedingRegistrationRepository {
     fun save(
         breedingRegistration: BreedingRegistration
     ): Result<BreedingRegistration, UpdateConflict>
+
+    /** 指定の繁殖登録番号が既にいずれかの繁殖登録に採番されているかを判定する（繁殖登録番号の一意性照合用）。 */
+    fun existsByRegistrationNumber(number: BreedingRegistrationNumber): Boolean
 }

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseRepository.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseRepository.kt
@@ -32,4 +32,7 @@ interface BloodHorseRepository {
 
     /** 指定の馬名が既に他の軽種馬に付与されているかを判定する（馬名の一意性照合用）。 */
     fun existsByName(name: HorseName): Boolean
+
+    /** 指定の血統登録番号が既にいずれかの軽種馬に採番されているかを判定する（血統登録番号の一意性照合用）。 */
+    fun existsByRegistrationNumber(number: PedigreeRegistrationNumber): Boolean
 }

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/PedigreeRegistrationNumberAlreadyTaken.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/PedigreeRegistrationNumberAlreadyTaken.kt
@@ -1,0 +1,10 @@
+package com.example.api.domain.studbook.model.horse.bloodhorse
+
+/**
+ * 血統登録番号が既に他の軽種馬に採番済み（血統登録原簿の一意性違反）。
+ *
+ * 血統登録番号は登録原簿の中で一意（登録規程 第3条・第4条）。ドメインサービス
+ * [com.example.api.domain.studbook.service.horse.ensurePedigreeRegistrationNumberAvailable] が
+ * 既存レコード集合を引き当てて検証し、衝突時にこれを返す。
+ */
+data class PedigreeRegistrationNumberAlreadyTaken(val number: PedigreeRegistrationNumber)

--- a/src/main/kotlin/com/example/api/domain/studbook/service/breeding/EnsureBreedingRegistrationNumberAvailable.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/service/breeding/EnsureBreedingRegistrationNumberAvailable.kt
@@ -1,0 +1,29 @@
+package com.example.api.domain.studbook.service.breeding
+
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationNumber
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationNumberAlreadyTaken
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+
+/**
+ * 繁殖登録番号の一意性を検証するドメインサービス。
+ *
+ * 繁殖登録番号が繁殖登録原簿の中で一意であること（登録規程 第5条）は、既存レコード集合への問い合わせが なければ判定できない集合制約。よって本サービスがリポジトリポート [repository]
+ * を直接受け取り既存の採番を 引き当てる（読み取りのみ。ADR-0022）。血統登録番号とは別の採番空間のため、本サービスは繁殖登録原簿
+ * （[BreedingRegistrationRepository]）のみを見る。
+ *
+ * @param number 検証する繁殖登録番号
+ * @param repository 既存の採番を引き当てる繁殖登録ポート（読み取りのみ）
+ * @return 未使用なら [Ok]（[Unit]）、既に採番済みなら [BreedingRegistrationNumberAlreadyTaken]
+ */
+fun ensureBreedingRegistrationNumberAvailable(
+    number: BreedingRegistrationNumber,
+    repository: BreedingRegistrationRepository,
+): Result<Unit, BreedingRegistrationNumberAlreadyTaken> =
+    if (repository.existsByRegistrationNumber(number)) {
+        Err(BreedingRegistrationNumberAlreadyTaken(number))
+    } else {
+        Ok(Unit)
+    }

--- a/src/main/kotlin/com/example/api/domain/studbook/service/horse/EnsurePedigreeRegistrationNumberAvailable.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/service/horse/EnsurePedigreeRegistrationNumberAvailable.kt
@@ -1,0 +1,30 @@
+package com.example.api.domain.studbook.service.horse
+
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
+import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumberAlreadyTaken
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+
+/**
+ * 血統登録番号の一意性を検証するドメインサービス。
+ *
+ * 血統登録番号が登録原簿の中で一意であること（登録規程 第3条＝血統登録は個体識別を明らかにする登録／
+ * 第4条＝血統登録原簿に登録番号を記載）は、既存レコード集合への問い合わせがなければ判定できない 集合制約であり、単一集約の構築時不変条件では完結しない。よって本サービスがリポジトリポート
+ * [repository] を直接受け取り既存の採番を引き当てる（読み取りのみ。ADR-0022）。血統登録番号と繁殖登録番号は
+ * 別の採番空間のため、本サービスは血統登録原簿（[BloodHorseRepository]）のみを見る。
+ *
+ * @param number 検証する血統登録番号
+ * @param repository 既存の採番を引き当てる軽種馬ポート（読み取りのみ）
+ * @return 未使用なら [Ok]（[Unit]）、既に採番済みなら [PedigreeRegistrationNumberAlreadyTaken]
+ */
+fun ensurePedigreeRegistrationNumberAvailable(
+    number: PedigreeRegistrationNumber,
+    repository: BloodHorseRepository,
+): Result<Unit, PedigreeRegistrationNumberAlreadyTaken> =
+    if (repository.existsByRegistrationNumber(number)) {
+        Err(PedigreeRegistrationNumberAlreadyTaken(number))
+    } else {
+        Ok(Unit)
+    }

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/BreedingRegistrationSpringDataRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/BreedingRegistrationSpringDataRepository.kt
@@ -10,4 +10,7 @@ import org.springframework.data.repository.CrudRepository
  * [com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository] とは別物。
  * ドメインポートの実装は本リポジトリを委譲先に持つアダプタ [JdbcBreedingRegistrationRepository] が担う。
  */
-interface BreedingRegistrationSpringDataRepository : CrudRepository<BreedingRegistrationRow, UUID>
+interface BreedingRegistrationSpringDataRepository : CrudRepository<BreedingRegistrationRow, UUID> {
+    /** 繁殖登録番号（`breeding_registration.registration_number`）が一致する行が存在するか。登録番号の一意性照合に用いる。 */
+    fun existsByRegistrationNumber(registrationNumber: String): Boolean
+}

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepository.kt
@@ -45,6 +45,9 @@ class JdbcBreedingRegistrationRepository(
             Err(UpdateConflict)
         }
 
+    override fun existsByRegistrationNumber(number: BreedingRegistrationNumber): Boolean =
+        rows.existsByRegistrationNumber(number.value)
+
     /**
      * 永続化モデルからドメイン集約を再構成する（検証・採番なし）。
      *

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/horse/BloodHorseSpringDataRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/horse/BloodHorseSpringDataRepository.kt
@@ -13,4 +13,7 @@ import org.springframework.data.repository.CrudRepository
 interface BloodHorseSpringDataRepository : CrudRepository<BloodHorseRow, UUID> {
     /** 馬名（`blood_horse.name`）が一致する行が存在するか。馬名の一意性照合に用いる。 */
     fun existsByName(name: String): Boolean
+
+    /** 血統登録番号（`blood_horse.registration_number`）が一致する行が存在するか。登録番号の一意性照合に用いる。 */
+    fun existsByRegistrationNumber(registrationNumber: String): Boolean
 }

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepository.kt
@@ -63,6 +63,9 @@ class JdbcBloodHorseRepository(private val rows: BloodHorseSpringDataRepository)
 
     override fun existsByName(name: HorseName): Boolean = rows.existsByName(name.value)
 
+    override fun existsByRegistrationNumber(number: PedigreeRegistrationNumber): Boolean =
+        rows.existsByRegistrationNumber(number.value)
+
     /**
      * 永続化モデルからドメイン集約を再構成する（検証・採番なし）。
      *

--- a/src/main/resources/db/migration/V16__add_registration_number_unique_backstop.sql
+++ b/src/main/resources/db/migration/V16__add_registration_number_unique_backstop.sql
@@ -1,0 +1,25 @@
+-- 血統登録番号・繁殖登録番号の一意性に対する DB UNIQUE 制約の backstop（#652）。
+-- ドメインサービス（ensurePedigreeRegistrationNumberAvailable / ensureBreedingRegistrationNumberAvailable）
+-- は既存レコードを読み取って一意性を検証するが、READ COMMITTED 下の read-then-insert には並行競合の窓が
+-- ある（#532）。検証をすり抜けた敗者の insert を DB 側で拒否する多層防御。
+--
+-- 血統登録番号（blood_horse）と繁殖登録番号（breeding_registration）は別の採番空間なので、原簿ごとに
+-- 独立した UNIQUE を張る（登録規程 第3〜5条）。
+--
+-- ロック: 既存テーブルへの UNIQUE 追加は索引構築のあいだ ACCESS EXCLUSIVE を取り、読み書きを止める。
+-- 現行のデータ量では一瞬で終わるため受け入れる。テーブルが育ったら CONCURRENTLY へ移す（ADR-0062）。
+--
+-- PostgreSQL は NOT VALID を UNIQUE に使えないため、ADR-0052 の「VALIDATE を別マイグレーションへ分離」規約は
+-- 本ファイルの対象外。squawk の constraint-missing-not-valid / disallowed-unique-constraint は当該文に限って抑止する。
+--
+-- registration_number は両テーブルとも NOT NULL（V2 / V3）のため、馬名（NULL 可）のような NULL 論点は無い。
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+ALTER TABLE studbook.blood_horse
+-- squawk-ignore disallowed-unique-constraint,constraint-missing-not-valid
+ADD CONSTRAINT uq_blood_horse_registration_number UNIQUE (registration_number);
+
+ALTER TABLE studbook.breeding_registration
+-- squawk-ignore disallowed-unique-constraint,constraint-missing-not-valid
+ADD CONSTRAINT uq_breeding_registration_registration_number UNIQUE (registration_number);

--- a/src/test/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCaseTest.kt
@@ -42,6 +42,7 @@ class RegisterBreedingRegistrationUseCaseTest {
                 mockk<BloodHorseRepository> { every { findById(mare.id) } returns mare }
             val breedingRegistrationRepository =
                 mockk<BreedingRegistrationRepository> {
+                    every { existsByRegistrationNumber(any()) } returns false
                     every { save(any()) } answers { Ok(firstArg()) }
                 }
             val useCase =
@@ -71,6 +72,7 @@ class RegisterBreedingRegistrationUseCaseTest {
                 mockk<BloodHorseRepository> { every { findById(stallion.id) } returns stallion }
             val breedingRegistrationRepository =
                 mockk<BreedingRegistrationRepository> {
+                    every { existsByRegistrationNumber(any()) } returns false
                     every { save(any()) } answers { Ok(firstArg()) }
                 }
             val useCase =
@@ -122,7 +124,10 @@ class RegisterBreedingRegistrationUseCaseTest {
                 mockk<BloodHorseRepository> {
                     every { findById(BloodHorseId(bloodHorseId)) } returns null
                 }
-            val breedingRegistrationRepository = mockk<BreedingRegistrationRepository>()
+            val breedingRegistrationRepository =
+                mockk<BreedingRegistrationRepository> {
+                    every { existsByRegistrationNumber(any()) } returns false
+                }
             val useCase =
                 RegisterBreedingRegistrationUseCase(
                     bloodHorseRepository,
@@ -163,6 +168,35 @@ class RegisterBreedingRegistrationUseCaseTest {
                 result.getError() ==
                     RegisterBreedingRegistrationUseCaseError.Forbidden(
                         StudbookPermissions.BREEDING_REGISTRATION_REGISTER
+                    )
+            )
+            verify(exactly = 0) { bloodHorseRepository.findById(any()) }
+            verify(exactly = 0) { breedingRegistrationRepository.save(any()) }
+        }
+
+        @Test
+        fun `繁殖登録番号が既に使用済みのとき RegistrationNumberAlreadyTaken を返し永続化されない`() {
+            val breedingRegistrationRepository =
+                mockk<BreedingRegistrationRepository> {
+                    every { existsByRegistrationNumber(any()) } returns true
+                }
+            val bloodHorseRepository = mockk<BloodHorseRepository>()
+            val useCase =
+                RegisterBreedingRegistrationUseCase(
+                    bloodHorseRepository,
+                    breedingRegistrationRepository,
+                )
+
+            val result =
+                useCase(
+                    actor,
+                    command(RegisterBreedingRegistrationCommand(UUID.randomUUID(), "B-2024-0001")),
+                )
+
+            assert(
+                result.getError() ==
+                    RegisterBreedingRegistrationUseCaseError.RegistrationNumberAlreadyTaken(
+                        "B-2024-0001"
                     )
             )
             verify(exactly = 0) { bloodHorseRepository.findById(any()) }

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCaseTest.kt
@@ -87,6 +87,7 @@ class RegisterFoalUseCaseTest {
             }
         val bloodHorseRepository =
             mockk<BloodHorseRepository> {
+                every { existsByRegistrationNumber(any()) } returns false
                 every { findById(sire.id) } returns sire
                 every { findById(dam.id) } returns dam
                 every { save(any()) } answers { Ok(firstArg()) }
@@ -151,6 +152,24 @@ class RegisterFoalUseCaseTest {
 
             assert(result.getError() == RegisterFoalUseCaseError.BlankBreeder)
             verify(exactly = 0) { w.bloodHorseRepository.save(any()) }
+        }
+
+        @Test
+        fun `血統登録番号が既に使用済みのとき RegistrationNumberAlreadyTaken を返し永続化されない`() {
+            val bloodHorseRepository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(any()) } returns true
+                }
+            val useCase = RegisterFoalUseCase(mockk(), mockk(), bloodHorseRepository, mockk())
+
+            val result =
+                useCase(actor, command(UUID.randomUUID(), registrationNumber = "2024104567"))
+
+            assert(
+                result.getError() ==
+                    RegisterFoalUseCaseError.RegistrationNumberAlreadyTaken("2024104567")
+            )
+            verify(exactly = 0) { bloodHorseRepository.save(any()) }
         }
     }
 

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterHorseTransactionRollbackTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterHorseTransactionRollbackTest.kt
@@ -12,6 +12,7 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseReposito
 import com.example.api.domain.studbook.model.horse.bloodhorse.BreedType
 import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
 import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
+import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
 import com.example.api.domain.studbook.model.inspection.DnaParentageResult
 import com.example.api.infrastructure.studbook.StudbookSeeder
@@ -159,4 +160,7 @@ class FailingBloodHorseRepository(private val delegate: BloodHorseRepository) :
     }
 
     override fun existsByName(name: HorseName): Boolean = delegate.existsByName(name)
+
+    override fun existsByRegistrationNumber(number: PedigreeRegistrationNumber): Boolean =
+        delegate.existsByRegistrationNumber(number)
 }

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterHorseTransactionRollbackTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterHorseTransactionRollbackTest.kt
@@ -93,8 +93,10 @@ class RegisterHorseTransactionRollbackTest(
 
     @Test
     fun `内国産血統登録で軽種馬の保存がインフラ障害で失敗すると先行する審査の保存もロールバックされる`() {
-        val sireFixture = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
-        val damFixture = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        val sireFixture =
+            BloodHorseFixture.bloodHorse(sex = Sex.MALE, registrationNumber = "SIRE-2023100001")
+        val damFixture =
+            BloodHorseFixture.bloodHorse(sex = Sex.FEMALE, registrationNumber = "DAM-2023100001")
         seeder.seedInspectionFor(sireFixture)
         seeder.seedInspectionFor(damFixture)
         val sire = failingRepository.save(sireFixture).unwrap()

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCaseTest.kt
@@ -54,7 +54,10 @@ class RegisterImportedHorseUseCaseTest {
         @Test
         fun `正しい入力のとき父母不明の輸入馬が登録され永続化される`() {
             val repository =
-                mockk<BloodHorseRepository> { every { save(any()) } answers { Ok(firstArg()) } }
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(any()) } returns false
+                    every { save(any()) } answers { Ok(firstArg()) }
+                }
             val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
 
             val registered = useCase(actor, command(validPayload())).unwrap()
@@ -85,7 +88,10 @@ class RegisterImportedHorseUseCaseTest {
 
         @Test
         fun `マイクロチップ番号が不正なとき InvalidMicrochipNumber を返し永続化されない`() {
-            val repository = mockk<BloodHorseRepository>()
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(any()) } returns false
+                }
             val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
 
             val result = useCase(actor, command(validPayload().copy(microchipNumber = "123")))
@@ -96,12 +102,32 @@ class RegisterImportedHorseUseCaseTest {
 
         @Test
         fun `原産国がブランクのとき BlankOriginCountry を返し永続化されない`() {
-            val repository = mockk<BloodHorseRepository>()
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(any()) } returns false
+                }
             val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
 
             val result = useCase(actor, command(validPayload().copy(originCountry = "")))
 
             assert(result.getError() == RegisterImportedHorseUseCaseError.BlankOriginCountry)
+            verify(exactly = 0) { repository.save(any()) }
+        }
+
+        @Test
+        fun `血統登録番号が既に使用済みのとき RegistrationNumberAlreadyTaken を返し永続化されない`() {
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(any()) } returns true
+                }
+            val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
+
+            val result = useCase(actor, command(validPayload()))
+
+            assert(
+                result.getError() ==
+                    RegisterImportedHorseUseCaseError.RegistrationNumberAlreadyTaken("2020900001")
+            )
             verify(exactly = 0) { repository.save(any()) }
         }
 

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCaseTest.kt
@@ -61,6 +61,7 @@ class RegisterInStudBookUseCaseTest {
             val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
             val repository =
                 mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(any()) } returns false
                     every { findAllById(setOf(sire.id, dam.id)) } returns
                         mapOf(sire.id to sire, dam.id to dam)
                     every { save(any()) } answers { Ok(firstArg()) }
@@ -104,7 +105,10 @@ class RegisterInStudBookUseCaseTest {
 
         @Test
         fun `マイクロチップ番号が不正なとき InvalidMicrochipNumber を返し永続化されない`() {
-            val repository = mockk<BloodHorseRepository>()
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(any()) } returns false
+                }
             val useCase = RegisterInStudBookUseCase(repository, inspectionRepository())
 
             val result =
@@ -121,12 +125,31 @@ class RegisterInStudBookUseCaseTest {
         }
 
         @Test
+        fun `血統登録番号が既に使用済みのとき RegistrationNumberAlreadyTaken を返し永続化されない`() {
+            val bloodHorseRepository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(any()) } returns true
+                }
+            val horseInspectionRepository = mockk<HorseInspectionRepository>()
+            val useCase = RegisterInStudBookUseCase(bloodHorseRepository, horseInspectionRepository)
+
+            val result = useCase(actor, command(validPayload(UUID.randomUUID(), UUID.randomUUID())))
+
+            assert(
+                result.getError() ==
+                    RegisterInStudBookUseCaseError.RegistrationNumberAlreadyTaken("2023104567")
+            )
+            verify(exactly = 0) { bloodHorseRepository.save(any()) }
+        }
+
+        @Test
         fun `父が見つからないとき SireNotFound を返し永続化されない`() {
             val sireId = UUID.randomUUID()
             val damId = UUID.randomUUID()
             val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
             val repository =
                 mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(any()) } returns false
                     every { findAllById(setOf(BloodHorseId(sireId), BloodHorseId(damId))) } returns
                         mapOf(BloodHorseId(damId) to dam)
                 }
@@ -145,6 +168,7 @@ class RegisterInStudBookUseCaseTest {
             val sire = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
             val repository =
                 mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(any()) } returns false
                     every { findAllById(setOf(BloodHorseId(sireId), BloodHorseId(damId))) } returns
                         mapOf(BloodHorseId(sireId) to sire)
                 }
@@ -162,6 +186,7 @@ class RegisterInStudBookUseCaseTest {
             val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
             val repository =
                 mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(any()) } returns false
                     every { findAllById(setOf(sire.id, dam.id)) } returns
                         mapOf(sire.id to sire, dam.id to dam)
                 }
@@ -185,6 +210,7 @@ class RegisterInStudBookUseCaseTest {
             val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
             val bloodHorseRepository =
                 mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(any()) } returns false
                     every { findAllById(setOf(sire.id, dam.id)) } returns
                         mapOf(sire.id to sire, dam.id to dam)
                 }

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
@@ -14,6 +14,7 @@ import com.github.michaelbull.result.Ok
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import java.util.UUID
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -132,16 +133,23 @@ class BreedingRegistrationControllerTest(val mockMvc: MockMvc) {
                 )
             )
 
-        tester
-            .post()
-            .uri(uri)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(validBody)
-            .assertThat()
+        val result =
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .exchange()
+
+        assertThat(result)
             .hasStatus(HttpStatus.CONFLICT)
             .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
             .bodyJson()
             .extractingPath("$.error_code")
             .isEqualTo("breeding-registration-number-already-taken")
+        assertThat(result)
+            .bodyJson()
+            .extractingPath("$.registration_number")
+            .isEqualTo("B-2024-0001")
     }
 }

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
@@ -120,4 +120,28 @@ class BreedingRegistrationControllerTest(val mockMvc: MockMvc) {
             .extractingPath("$.blood_horse_id")
             .isEqualTo(id.toString())
     }
+
+    @Test
+    fun `RegistrationNumberAlreadyTaken で 409 と problem+json が返ること`() {
+        every {
+            registerBreedingRegistration(any(), any<Command<RegisterBreedingRegistrationCommand>>())
+        } returns
+            Err(
+                RegisterBreedingRegistrationUseCaseError.RegistrationNumberAlreadyTaken(
+                    "B-2024-0001"
+                )
+            )
+
+        tester
+            .post()
+            .uri(uri)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validBody)
+            .assertThat()
+            .hasStatus(HttpStatus.CONFLICT)
+            .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+            .bodyJson()
+            .extractingPath("$.error_code")
+            .isEqualTo("breeding-registration-number-already-taken")
+    }
 }

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -260,6 +260,24 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
                 .extractingPath("$.error_code")
                 .isEqualTo("breed-mismatch")
         }
+
+        @Test
+        fun `RegistrationNumberAlreadyTaken で 409 と problem+json が返ること`() {
+            every { registerInStudBook(any(), any<Command<RegisterInStudBookCommand>>()) } returns
+                Err(RegisterInStudBookUseCaseError.RegistrationNumberAlreadyTaken("2023104567"))
+
+            tester
+                .post()
+                .uri("/api/bloodHorses")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.CONFLICT)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.error_code")
+                .isEqualTo("registration-number-already-taken")
+        }
     }
 
     @Nested
@@ -469,6 +487,26 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
                 .bodyJson()
                 .extractingPath("$.error_code")
                 .isEqualTo("blank-origin-country")
+        }
+
+        @Test
+        fun `RegistrationNumberAlreadyTaken で 409 と problem+json が返ること`() {
+            every {
+                registerImportedHorse(any(), any<Command<RegisterImportedHorseCommand>>())
+            } returns
+                Err(RegisterImportedHorseUseCaseError.RegistrationNumberAlreadyTaken("2020900001"))
+
+            tester
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.CONFLICT)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.error_code")
+                .isEqualTo("registration-number-already-taken")
         }
     }
 }

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -266,17 +266,24 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
             every { registerInStudBook(any(), any<Command<RegisterInStudBookCommand>>()) } returns
                 Err(RegisterInStudBookUseCaseError.RegistrationNumberAlreadyTaken("2023104567"))
 
-            tester
-                .post()
-                .uri("/api/bloodHorses")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(validBody)
-                .assertThat()
+            val result =
+                tester
+                    .post()
+                    .uri("/api/bloodHorses")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(validBody)
+                    .exchange()
+
+            assertThat(result)
                 .hasStatus(HttpStatus.CONFLICT)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
                 .extractingPath("$.error_code")
                 .isEqualTo("registration-number-already-taken")
+            assertThat(result)
+                .bodyJson()
+                .extractingPath("$.registration_number")
+                .isEqualTo("2023104567")
         }
     }
 
@@ -496,17 +503,24 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
             } returns
                 Err(RegisterImportedHorseUseCaseError.RegistrationNumberAlreadyTaken("2020900001"))
 
-            tester
-                .post()
-                .uri(uri)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(validBody)
-                .assertThat()
+            val result =
+                tester
+                    .post()
+                    .uri(uri)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(validBody)
+                    .exchange()
+
+            assertThat(result)
                 .hasStatus(HttpStatus.CONFLICT)
                 .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
                 .bodyJson()
                 .extractingPath("$.error_code")
                 .isEqualTo("registration-number-already-taken")
+            assertThat(result)
+                .bodyJson()
+                .extractingPath("$.registration_number")
+                .isEqualTo("2020900001")
         }
     }
 }

--- a/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseFixture.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseFixture.kt
@@ -58,11 +58,15 @@ object BloodHorseFixture {
      * テストで父・母や種牡馬・繁殖牝馬として使う「既に登録済みの馬」を、前提条件検証を経ずに用意するためのもの。 検証を持たない [BloodHorse.createImported]
      * を経由するため、性・品種・ID は自由に指定できる。
      */
-    fun bloodHorse(sex: Sex = Sex.MALE, breedType: BreedType = BreedType.THOROUGHBRED): BloodHorse =
+    fun bloodHorse(
+        sex: Sex = Sex.MALE,
+        breedType: BreedType = BreedType.THOROUGHBRED,
+        registrationNumber: String = "2023104567",
+    ): BloodHorse =
         BloodHorse.createImported(
             entry = importedHorseEntry(sex = sex, breedType = breedType),
             inspection = inspection(parentage = ParentageDetermination.NotApplicable),
-            registrationNumber = PedigreeRegistrationNumber.create("2023104567").unwrap(),
+            registrationNumber = PedigreeRegistrationNumber.create(registrationNumber).unwrap(),
         )
 
     /** 既定値を持つ [ImportedHorseEntry]（輸入馬）を生成する。必要な属性のみ上書きする。 */

--- a/src/test/kotlin/com/example/api/domain/studbook/service/breeding/EnsureBreedingRegistrationNumberAvailableTest.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/service/breeding/EnsureBreedingRegistrationNumberAvailableTest.kt
@@ -1,0 +1,37 @@
+package com.example.api.domain.studbook.service.breeding
+
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationNumber
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationNumberAlreadyTaken
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+class EnsureBreedingRegistrationNumberAvailableTest {
+
+    private val number = BreedingRegistrationNumber.create("B-2024-0001").unwrap()
+
+    @Test
+    fun `未使用の繁殖登録番号なら Ok を返す`() {
+        val repository =
+            mockk<BreedingRegistrationRepository> {
+                every { existsByRegistrationNumber(number) } returns false
+            }
+
+        assert(ensureBreedingRegistrationNumberAvailable(number, repository).isOk)
+    }
+
+    @Test
+    fun `使用済みの繁殖登録番号なら BreedingRegistrationNumberAlreadyTaken を返す`() {
+        val repository =
+            mockk<BreedingRegistrationRepository> {
+                every { existsByRegistrationNumber(number) } returns true
+            }
+
+        val error = ensureBreedingRegistrationNumberAvailable(number, repository).getError()
+
+        assert(error == BreedingRegistrationNumberAlreadyTaken(number))
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/studbook/service/horse/EnsurePedigreeRegistrationNumberAvailableTest.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/service/horse/EnsurePedigreeRegistrationNumberAvailableTest.kt
@@ -1,0 +1,39 @@
+package com.example.api.domain.studbook.service.horse
+
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
+import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumberAlreadyTaken
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+class EnsurePedigreeRegistrationNumberAvailableTest {
+
+    private val number = PedigreeRegistrationNumber.create("2023104567").unwrap()
+
+    @Test
+    fun `未使用の血統登録番号なら Ok を返す`() {
+        val repository =
+            mockk<BloodHorseRepository> {
+                every { existsByRegistrationNumber(number) } returns false
+            }
+
+        val result = ensurePedigreeRegistrationNumberAvailable(number, repository)
+
+        assert(result.isOk)
+    }
+
+    @Test
+    fun `使用済みの血統登録番号なら PedigreeRegistrationNumberAlreadyTaken を返す`() {
+        val repository =
+            mockk<BloodHorseRepository> {
+                every { existsByRegistrationNumber(number) } returns true
+            }
+
+        val error = ensurePedigreeRegistrationNumberAvailable(number, repository).getError()
+
+        assert(error == PedigreeRegistrationNumberAlreadyTaken(number))
+    }
+}

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/StudbookSeeder.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/StudbookSeeder.kt
@@ -55,11 +55,15 @@ class StudbookSeeder(
     }
 
     /** 任意 ID の馬行（輸入馬の最小構成）を審査行ごと作り ID を返す（生 Row の sire/dam・種牡馬用）。 */
-    fun seedHorseRow(id: UUID = generateId(), sex: String = "MALE"): UUID {
+    fun seedHorseRow(
+        id: UUID = generateId(),
+        sex: String = "MALE",
+        registrationNumber: String = "SEED-$id",
+    ): UUID {
         horseRows.save(
             BloodHorseRow(
                 id = id,
-                registrationNumber = "2020900001",
+                registrationNumber = registrationNumber,
                 sex = sex,
                 coatColor = "BAY",
                 breedType = "THOROUGHBRED",
@@ -75,11 +79,15 @@ class StudbookSeeder(
     }
 
     /** 任意 ID の繁殖登録行を対象馬・審査行ごと作り ID を返す（生 Row の breeding_registration_id 用）。 */
-    fun seedRegistrationRow(id: UUID = generateId(), role: String = "BROODMARE"): UUID {
+    fun seedRegistrationRow(
+        id: UUID = generateId(),
+        role: String = "BROODMARE",
+        registrationNumber: String = "SEED-REG-$id",
+    ): UUID {
         registrationRows.save(
             BreedingRegistrationRow(
                 id = id,
-                registrationNumber = "B-0001",
+                registrationNumber = registrationNumber,
                 registeredHorseId =
                     seedHorseRow(sex = if (role == "STALLION") "MALE" else "FEMALE"),
                 breedingRole = role,

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepositoryContractTest.kt
@@ -227,4 +227,32 @@ class JdbcBreedingRegistrationRepositoryContractTest(
 
         assertThrows<DataIntegrityViolationException> { rows.save(inconsistent) }
     }
+
+    @Test
+    fun `既に保存済みの繁殖登録番号は existsByRegistrationNumber が true を返す`() {
+        val mare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+        val number = BreedingRegistrationNumber.create("B-2024-0001").unwrap()
+        repository.save(BreedingRegistration.create(number, mare)).unwrap()
+
+        assert(repository.existsByRegistrationNumber(number))
+    }
+
+    @Test
+    fun `未使用の繁殖登録番号は existsByRegistrationNumber が false を返す`() {
+        val mare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+        repository
+            .save(
+                BreedingRegistration.create(
+                    BreedingRegistrationNumber.create("B-2024-0001").unwrap(),
+                    mare,
+                )
+            )
+            .unwrap()
+
+        assert(
+            !repository.existsByRegistrationNumber(
+                BreedingRegistrationNumber.create("B-9999-9999").unwrap()
+            )
+        )
+    }
 }

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepositoryContractTest.kt
@@ -45,6 +45,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode
  * 7. 古い version での save が UpdateConflict を返し先行の書き込みを保つこと（楽観ロック）
  * 8. 供用停止の共在不変条件が CHECK 制約でスキーマ側にも強制されること
  * 9. 並行削除された集約への save が UpdateConflict を返すこと
+ * 10. 繁殖登録番号の一意性が UNIQUE 制約でスキーマ側にも強制されること（read-then-insert 競合の backstop）
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)
@@ -254,5 +255,22 @@ class JdbcBreedingRegistrationRepositoryContractTest(
                 BreedingRegistrationNumber.create("B-9999-9999").unwrap()
             )
         )
+    }
+
+    @Test
+    fun `同一繁殖登録番号の二重insertはUNIQUE制約で拒否される`() {
+        val number = BreedingRegistrationNumber.create("DUP-B-0001").unwrap()
+        val mare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+        repository.save(BreedingRegistration.create(number, mare)).unwrap()
+
+        // 別個体・同じ繁殖登録番号
+        val other =
+            seeder.seedHorse(
+                BloodHorseFixture.bloodHorse(sex = Sex.MALE, registrationNumber = "OTHER-2024-0001")
+            )
+
+        assertThrows<DataIntegrityViolationException> {
+            repository.save(BreedingRegistration.create(number, other))
+        }
     }
 }

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepositoryContractTest.kt
@@ -70,11 +70,23 @@ class JdbcBreedingResultRepositoryContractTest(
     private fun seededBreedingResult(): BreedingResult {
         val broodmareRegistration =
             BreedingFixture.breedingRegistration(
-                broodmare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+                broodmare =
+                    seeder.seedHorse(
+                        BloodHorseFixture.bloodHorse(
+                            sex = Sex.FEMALE,
+                            registrationNumber = "MARE-${generateId()}",
+                        )
+                    )
             )
         val stallionRegistration =
             BreedingFixture.stallionRegistration(
-                stallion = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.MALE))
+                stallion =
+                    seeder.seedHorse(
+                        BloodHorseFixture.bloodHorse(
+                            sex = Sex.MALE,
+                            registrationNumber = "STALLION-${generateId()}",
+                        )
+                    )
             )
         seeder.seedRegistration(broodmareRegistration)
         seeder.seedRegistration(stallionRegistration)

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
@@ -46,6 +46,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode
  * 9. 古い version での save が UpdateConflict を返し先行の書き込みを保つこと（楽観ロック）
  * 10. 並行削除された集約への save が UpdateConflict を返すこと
  * 11. 馬名の一意性が UNIQUE 制約でスキーマ側にも強制されること（read-then-insert 競合の backstop）
+ * 12. 血統登録番号の一意性が UNIQUE 制約でスキーマ側にも強制されること（read-then-insert 競合の backstop）
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)
@@ -314,5 +315,19 @@ class JdbcBloodHorseRepositoryContractTest(
                 PedigreeRegistrationNumber.create("9999999999").unwrap()
             )
         )
+    }
+
+    @Test
+    fun `同一血統登録番号の二重insertはUNIQUE制約で拒否される`() {
+        // ドメインサービス ensurePedigreeRegistrationNumberAvailable の検証をすり抜ける
+        // read-then-insert 並行競合（#532）の backstop。
+        val first = BloodHorseFixture.bloodHorse(registrationNumber = "DUP-2024-0001")
+        seeder.seedInspectionFor(first)
+        repository.save(first).unwrap()
+
+        val duplicate = BloodHorseFixture.bloodHorse(registrationNumber = "DUP-2024-0001")
+        seeder.seedInspectionFor(duplicate)
+
+        assertThrows<DataIntegrityViolationException> { repository.save(duplicate) }
     }
 }

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
@@ -81,15 +81,28 @@ class JdbcBloodHorseRepositoryContractTest(
 
     /** 内国産の父母を持つ命名済みの軽種馬を組み立てる（前提条件を満たす父=雄・母=雌・品種/ DNA 整合）。父母・仔馬自身の審査行は seed 済み。 */
     private fun namedDomesticFoal(): BloodHorse {
-        val sire = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.MALE))
-        val dam = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+        val sire =
+            seeder.seedHorse(
+                BloodHorseFixture.bloodHorse(
+                    sex = Sex.MALE,
+                    registrationNumber = "SIRE-${generateId()}",
+                )
+            )
+        val dam =
+            seeder.seedHorse(
+                BloodHorseFixture.bloodHorse(
+                    sex = Sex.FEMALE,
+                    registrationNumber = "DAM-${generateId()}",
+                )
+            )
         val foal =
             BloodHorse.create(
                     sire = sire,
                     dam = dam,
                     entry = BloodHorseFixture.studBookEntry(sex = Sex.MALE),
                     inspection = BloodHorseFixture.inspection(),
-                    registrationNumber = PedigreeRegistrationNumber.create("2023109999").unwrap(),
+                    registrationNumber =
+                        PedigreeRegistrationNumber.create("FOAL-${generateId()}").unwrap(),
                 )
                 .unwrap()
         seeder.seedInspectionFor(foal)

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
@@ -276,4 +276,30 @@ class JdbcBloodHorseRepositoryContractTest(
 
         assert(conflicted.getError() == UpdateConflict)
     }
+
+    @Test
+    fun `既に保存済みの登録番号は existsByRegistrationNumber が true を返す`() {
+        val horse = BloodHorseFixture.bloodHorse() // registrationNumber = "2023104567"
+        seeder.seedInspectionFor(horse)
+        repository.save(horse).unwrap()
+
+        assert(
+            repository.existsByRegistrationNumber(
+                PedigreeRegistrationNumber.create("2023104567").unwrap()
+            )
+        )
+    }
+
+    @Test
+    fun `未使用の登録番号は existsByRegistrationNumber が false を返す`() {
+        val horse = BloodHorseFixture.bloodHorse() // registrationNumber = "2023104567"
+        seeder.seedInspectionFor(horse)
+        repository.save(horse).unwrap()
+
+        assert(
+            !repository.existsByRegistrationNumber(
+                PedigreeRegistrationNumber.create("9999999999").unwrap()
+            )
+        )
+    }
 }


### PR DESCRIPTION
## 概要

血統登録番号（`blood_horse.registration_number`）と繁殖登録番号（`breeding_registration.registration_number`）に一意性を敷く（#652）。方式は馬名一意性（ADR-0022 / V14）と同じ**二層防御**。

- **第1層（ドメイン検証）**: 集合制約なので、ドメインサービス `ensurePedigreeRegistrationNumberAvailable` / `ensureBreedingRegistrationNumberAvailable` がリポジトリポートを読み取り引数で受けて既存の採番を照合する（ADR-0022）。書き込みユースケースがファクトリ呼び出し前に検証し、衝突は `Result` の `Err` として返す（`throw` しない）。
- **第2層（DB UNIQUE backstop）**: `V16` が `uq_blood_horse_registration_number` / `uq_breeding_registration_registration_number` を独立に張り、READ COMMITTED 下の read-then-insert 並行競合（#532）の敗者 insert を DB で拒否する。

## 典拠（原典で確認・登録規程本体 tourokukitei.pdf / 実施基準）

- 登録規程 第3条: 登録は血統登録（＝血統及び**個体識別**を明らかにする登録）と繁殖登録（＝繁殖成績を明らかにする登録）に区分。
- 第4条・第5条: 各登録原簿に**登録番号**を記載。血統登録原簿（様式1号）と繁殖登録原簿（様式2/3号）は別の原簿＝**別の採番空間**。繁殖登録個体は両番号を併せ持つ（様式2号が併記）。

→ 一意性は「個体識別を明らかにする登録」に内在する不変条件。血統・繁殖は別スコープとして独立に一意制約を張る。

## 変更点

**血統スコープ**（内国産 `RegisterInStudBook` / 輸入 `RegisterImportedHorse` / 生産 `RegisterFoal` の3経路）
- `BloodHorseRepository.existsByRegistrationNumber` ＋ Jdbc/Spring Data 実装
- ドメインサービス `ensurePedigreeRegistrationNumberAvailable` ＋ 失敗型 `PedigreeRegistrationNumberAlreadyTaken`
- 3ユースケースに配線＋app エラー `RegistrationNumberAlreadyTaken`、409 描画（`registration-number-already-taken`）

**繁殖スコープ**（`RegisterBreedingRegistration`）
- 上記の繁殖版ミラー（`existsByRegistrationNumber` / `ensureBreedingRegistrationNumberAvailable` / 409 `breeding-registration-number-already-taken`）

**DB・その他**
- `V16__add_registration_number_unique_backstop.sql`（両テーブルの UNIQUE、V14 と同型）
- テスト Fixture/Seeder を一意採番化（UNIQUE 追加で複数個体 seed が衝突しないよう）
- 用語集に一意性・2採番空間を追記

## テスト

- ドメインサービス単体（mockk）／ユースケース slice／controller slice（409＋problem+json＋`registration_number` 拡張プロパティ）／永続化契約テスト（`existsByRegistrationNumber` の true/false ＋ 二重 insert が `DataIntegrityViolationException`）
- `./gradlew check` BUILD SUCCESSFUL、`./gradlew replay` green（再利用牝馬 04/06 は一意性で登録段階停止＝不変条件が働いた結果）

## 補足

- `RegisterFoal` は現状 HTTP/MCP 未配線（replay 専用）のためドメインガードのみ持つ（controller 配線時に 409 描画を追加）。
- 並行競合で DB backstop が発火した敗者は 409 でなく 500（既存の馬名 backstop と同一挙動。稀な競合の最終防壁という設計意図どおり）。
- ADR は起こさない（既存 ADR-0022 / 0062 / 0052 の適用）。

## スタック

本 PR は #606（PR #653、認可 RBAC）の上にスタックしている。base を `feat/606-authz-rbac-actor` にしており、#606 マージ後に main へ retarget する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
