### PR TITLE
refactor: #621 分娩区分名の写像を compile-time exhaustive 化する

### DIFF
--- a/src/replay/kotlin/com/example/api/replay/FixtureMappers.kt
+++ b/src/replay/kotlin/com/example/api/replay/FixtureMappers.kt
@@ -20,30 +20,68 @@ import java.time.ZoneOffset
 private val TOKYO: ZoneId = ZoneId.of("Asia/Tokyo")
 
 /**
+ * フィクスチャの分娩区分名。[FoalingOutcome] の各 variant と 1:1 に対応する。
+ *
+ * 種付せず（[FoalingOutcome.NotCovered]）は分娩結果としてフィクスチャに現れないため持たない（理由は [toOutcome] の KDoc）。variant
+ * との対応の閉じ（増減の追従）は [toFixtureName] の網羅 when が compile 時に強制する。
+ */
+enum class FoalingOutcomeName {
+    LiveFoal,
+    NotConceived,
+    Abortion,
+    TwinAbortion,
+    Stillbirth,
+    TwinStillbirth,
+    NeonatalDeath,
+    TwinNeonatalDeath,
+}
+
+/**
  * フィクスチャの分娩区分名を [FoalingOutcome] に写す。未知の区分名は前提エラーとして例外にする（フィクスチャの記述ミス）。
  *
  * 種付せず（[FoalingOutcome.NotCovered]）はここに現れない。種付を行わなかった年は分娩結果の区分ではなく フィクスチャの
  * kind（UncoveredSeasonFixture）で表し、
  * [com.example.api.application.studbook.breeding.RecordUncoveredUseCase] が
  * 起こす終端の繁殖成績として実体化する。分娩結果として NotCovered を渡すと BreedingResult.recordFoaling が require で弾く（Err
- * ではなく例外）ため、写像の入口で塞ぐ。
+ * ではなく例外）ため、写像の入口（[FoalingOutcomeName] に持たせない）で塞ぐ。
  */
-fun FoalingFixture.toOutcome(): FoalingOutcome =
-    when (outcome) {
-        "LiveFoal" ->
+fun FoalingFixture.toOutcome(): FoalingOutcome {
+    val name = FoalingOutcomeName.entries.find { it.name == outcome } ?: error("未知の分娩区分名: $outcome")
+    return when (name) {
+        FoalingOutcomeName.LiveFoal ->
             FoalingOutcome.LiveFoal(
                 LocalDate.parse(
                     requireNotNull(foalingDate) { "LiveFoal には foalingDate が必要: $this" }
                 )
             )
-        "NotConceived" -> FoalingOutcome.NotConceived
-        "Abortion" -> FoalingOutcome.Abortion
-        "TwinAbortion" -> FoalingOutcome.TwinAbortion
-        "Stillbirth" -> FoalingOutcome.Stillbirth
-        "TwinStillbirth" -> FoalingOutcome.TwinStillbirth
-        "NeonatalDeath" -> FoalingOutcome.NeonatalDeath
-        "TwinNeonatalDeath" -> FoalingOutcome.TwinNeonatalDeath
-        else -> error("未知の分娩区分名: $outcome")
+        FoalingOutcomeName.NotConceived -> FoalingOutcome.NotConceived
+        FoalingOutcomeName.Abortion -> FoalingOutcome.Abortion
+        FoalingOutcomeName.TwinAbortion -> FoalingOutcome.TwinAbortion
+        FoalingOutcomeName.Stillbirth -> FoalingOutcome.Stillbirth
+        FoalingOutcomeName.TwinStillbirth -> FoalingOutcome.TwinStillbirth
+        FoalingOutcomeName.NeonatalDeath -> FoalingOutcome.NeonatalDeath
+        FoalingOutcomeName.TwinNeonatalDeath -> FoalingOutcome.TwinNeonatalDeath
+    }
+}
+
+/**
+ * [FoalingOutcome] の variant をフィクスチャの分娩区分名へ写す。
+ *
+ * sealed の網羅 when により、variant の増減を compile error として [FoalingOutcomeName]（ひいては [toOutcome]）へ
+ * 伝えるトリップワイヤ。種付せず（[FoalingOutcome.NotCovered]）だけは分娩結果の区分名を持たないため null （フィクスチャでは kind＝uncovered
+ * で表す）。
+ */
+fun FoalingOutcome.toFixtureName(): FoalingOutcomeName? =
+    when (this) {
+        is FoalingOutcome.LiveFoal -> FoalingOutcomeName.LiveFoal
+        FoalingOutcome.NotConceived -> FoalingOutcomeName.NotConceived
+        FoalingOutcome.Abortion -> FoalingOutcomeName.Abortion
+        FoalingOutcome.TwinAbortion -> FoalingOutcomeName.TwinAbortion
+        FoalingOutcome.Stillbirth -> FoalingOutcomeName.Stillbirth
+        FoalingOutcome.TwinStillbirth -> FoalingOutcomeName.TwinStillbirth
+        FoalingOutcome.NeonatalDeath -> FoalingOutcomeName.NeonatalDeath
+        FoalingOutcome.TwinNeonatalDeath -> FoalingOutcomeName.TwinNeonatalDeath
+        FoalingOutcome.NotCovered -> null
     }
 
 /** フィクスチャの出典をラベル付きの一覧に写す（レポートに全件出し、典拠を辿れるようにする）。 */

--- a/src/replay/kotlin/com/example/api/replay/fixture/FixtureMappersTest.kt
+++ b/src/replay/kotlin/com/example/api/replay/fixture/FixtureMappersTest.kt
@@ -1,7 +1,9 @@
 package com.example.api.replay.fixture
 
 import com.example.api.domain.studbook.model.breeding.FoalingOutcome
+import com.example.api.replay.FoalingOutcomeName
 import com.example.api.replay.submissionInstant
+import com.example.api.replay.toFixtureName
 import com.example.api.replay.toInput
 import com.example.api.replay.toOutcome
 import java.time.LocalDate
@@ -40,6 +42,21 @@ class FixtureMappersTest {
             LocalDate.of(2001, 9, 30).atTime(12, 0).atZone(ZoneId.of("Asia/Tokyo")).toInstant()
 
         assert(instant == expected)
+    }
+
+    @Test
+    fun `全区分名が写像をラウンドトリップして自身へ戻る`() {
+        // FoalingOutcome の variant 追加は toFixtureName() の網羅 when が compile error で検知する。
+        // 本テストは残りの追従漏れ（enum に足したのに toOutcome() の対応が誤っている等）を検知する。
+        for (name in FoalingOutcomeName.entries) {
+            val fixture =
+                when (name) {
+                    FoalingOutcomeName.LiveFoal -> FoalingFixture(name.name, "2002-03-25")
+                    else -> FoalingFixture(name.name)
+                }
+
+            assert(fixture.toOutcome().toFixtureName() == name)
+        }
     }
 
     @Test


### PR DESCRIPTION
## 概要

replay ハーネスの `FixtureMappers.toOutcome()` は文字列キーの when で `FoalingOutcome` へ写しており、sealed の網羅性がコンパイル時に検査されなかった（`else -> error()` はフィクスチャの typo を守るのみ）。将来 10 個目の variant を追加しても compile error にならず、その variant のフィクスチャ文字列が黙って弾かれる穴を塞ぐ。

Closes #621

## 変更内容

controller 層の既存パターン（`FoalingOutcomeDto` の網羅 when 往復）を fixture 側に適用した。

- **`FoalingOutcomeName` enum を追加**: フィクスチャの分娩区分名。`FoalingOutcome` の各 variant と 1:1 に対応する。種付せず（`NotCovered`）は分娩結果としてフィクスチャに現れないため持たない（kind＝uncovered で表す既存方針のまま）。
- **`toOutcome()` を「文字列→enum 引き当て→enum の網羅 when」に変更**: 未知の区分名を `error()` で弾く従来挙動（メッセージ含む）は維持。
- **`FoalingOutcome.toFixtureName()` を追加（トリップワイヤ）**: sealed の網羅 when。variant を追加するとここが compile error になり、`FoalingOutcomeName`（ひいては `toOutcome()`）への追従を強制する。`NotCovered` のみ区分名を持たないため null。
- **ラウンドトリップテストを追加**: 全区分名について `fixture → toOutcome() → toFixtureName()` が自身へ戻ることを検証（enum に追加したのに `toOutcome()` の対応が誤っているケースを検知）。

## 検証

- トリップワイヤの実効性をミューテーションで確認: `toFixtureName()` の `NotCovered` 分岐を一時除去すると `'when' expression must be exhaustive` の compile error になることを実測（確認後復元）。
- `./gradlew replay check` BUILD SUCCESSFUL。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
