### PR TITLE
feat: GCP Identity Platform を Terraform で管理する（email/password 有効化）

### DIFF
--- a/docs/adr/0064-authn-via-identity-platform-authz-in-app.md
+++ b/docs/adr/0064-authn-via-identity-platform-authz-in-app.md
@@ -56,6 +56,13 @@
 `terraform destroy` しても state から外れるだけで GCP 側の設定はそのまま残る）。`deletion_policy` 引数は
 このリソースには存在しない（provider 7.39/7.40 の実装で確認済み）ため付けない。
 
+**Terraform が config の source of truth になる点に注意**: `authorized_domains` と `sign_in` は
+full-replace で書き込まれるため、Console で手動追加したドメインやサインイン方式は apply のたびに
+上書き・削除される（現スコープは email/password + `localhost` に収束する）。既に手動で config が
+初期化済みの環境では、初回 apply が create ではなく既存リソースの diff として扱われないことがあり、
+その場合は `terraform import google_identity_platform_config.default projects/ptiringo-toy-box/config`
+を検討する（HCP の speculative plan で create と出たら import すべきサイン）。
+
 **今回スコープ外（手動 or 段階 B）**:
 - **Web config の `apiKey` / `authDomain`** は当面 Console の「Application setup details」で手動取得し、
   フロントの `frontend/.env.local` に入れる。Terraform 取得（`google-beta` + `google_firebase_web_app`

--- a/docs/adr/0064-authn-via-identity-platform-authz-in-app.md
+++ b/docs/adr/0064-authn-via-identity-platform-authz-in-app.md
@@ -44,3 +44,20 @@
 - MCP エンドポイントは `permitAll` のまま残る。MCP クライアントへの認証の載せ方（[ADR-0035](0035-mcp-interface-adapter.md) の adapter）は別途決める必要がある。
 - 本番（Cloud Run）は `GCP_PROJECT_ID` を環境変数で受け取る。プロジェクト ID は秘密ではないため Secret Manager には置かない。この値が注入されないと issuer が既定値に落ち、全トークンが 401 になる。
 - 結論は指示ファイル側に置き、経緯は本 ADR に残す（`permitAll` の範囲は CLAUDE.md「認証」、slice テストの方針は `.claude/rules/testing.md`）。
+
+## 追補（2026-07-20）: Identity Platform を Terraform 化
+
+本 ADR が「Terraform 管理の射程に入る」とした点を実装した。`infra/modules/identity-platform/`
+（`google_identity_platform_config`）で **email/password サインインの有効化と `authorized_domains`
+（ローカル E2E 用に `localhost` を含む）を宣言的に管理**する。`identitytoolkit` API 有効化も
+`google_project_service` に含める。
+
+`google_identity_platform_config` は API 上削除できない（provider の Delete は恒久的な no-op で、
+`terraform destroy` しても state から外れるだけで GCP 側の設定はそのまま残る）。`deletion_policy` 引数は
+このリソースには存在しない（provider 7.39/7.40 の実装で確認済み）ため付けない。
+
+**今回スコープ外（手動 or 段階 B）**:
+- **Web config の `apiKey` / `authDomain`** は当面 Console の「Application setup details」で手動取得し、
+  フロントの `frontend/.env.local` に入れる。Terraform 取得（`google-beta` + `google_firebase_web_app`
+  + `data.google_firebase_web_app_config`）は GCP プロジェクトの Firebase 化を伴うため段階 B として分けた。
+- **テストユーザー**は Terraform にリソースが無いため Console / gcloud で手動作成する。

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -3,6 +3,7 @@ resource "google_project_service" "project" {
     "artifactregistry",
     "iam",
     "iamcredentials",
+    "identitytoolkit",
     "orgpolicy",
     "run",
     "secretmanager",
@@ -46,6 +47,16 @@ module "prisma_postgres" {
 
   api_runner_email = module.cloudrun.api_runner_email
   project_name     = var.prisma_project_name
+
+  depends_on = [google_project_service.project]
+}
+
+# Identity Platform（認証委譲先。email/password + authorized_domains）。ADR-0064 / #612。
+# identitytoolkit API 有効化に依存させ、初回 apply の順序レースを避ける。
+module "identity_platform" {
+  source = "./modules/identity-platform"
+
+  project_id = "ptiringo-toy-box"
 
   depends_on = [google_project_service.project]
 }

--- a/infra/modules/identity-platform/main.tf
+++ b/infra/modules/identity-platform/main.tf
@@ -18,4 +18,9 @@ resource "google_identity_platform_config" "default" {
   # no-op に固定されているため、そもそも実削除が起きない＝ABANDON 相当が常時の挙動）。
   # google 7.39.0 / 7.40.0（GA・beta とも）で deletion_policy を指定すると
   # `terraform validate` が Unsupported argument で落ちることを実機確認済み。
+  # registry docs（terraform.io の resource ページ）には deletion_policy が記載されているが、
+  # これは magic-modules の doc テンプレートが持つ boilerplate であり、実際に生成された
+  # provider の resource schema（resource_identity_platform_config.go の Schema map）には
+  # 該当 field が存在しない。docs と実 schema が食い違うケースなので、docs だけを見て
+  # 「引数を足すべき」と早合点しないこと（実測で Unsupported argument になることを確認済み）。
 }

--- a/infra/modules/identity-platform/main.tf
+++ b/infra/modules/identity-platform/main.tf
@@ -1,0 +1,21 @@
+# GCP Identity Platform の設定（認証は Identity Platform に委譲・ADR-0064 / #612）。
+# email/password サインインを有効化し、ローカル E2E 用に localhost を authorized_domains へ入れる。
+# config は API 上一度作ると削除できない（個別プロバイダの disable のみ）。billing 有効なプロジェクトが前提。
+resource "google_identity_platform_config" "default" {
+  project = var.project_id
+
+  sign_in {
+    email {
+      enabled           = true
+      password_required = true
+    }
+  }
+
+  authorized_domains = var.authorized_domains
+
+  # 注: この resource は deletion_policy 引数を持たない（provider の magic-modules 定義で
+  # exclude_delete: true。生成される Delete 実装は GCP API を呼ばず state から外すだけの
+  # no-op に固定されているため、そもそも実削除が起きない＝ABANDON 相当が常時の挙動）。
+  # google 7.39.0 / 7.40.0（GA・beta とも）で deletion_policy を指定すると
+  # `terraform validate` が Unsupported argument で落ちることを実機確認済み。
+}

--- a/infra/modules/identity-platform/outputs.tf
+++ b/infra/modules/identity-platform/outputs.tf
@@ -1,0 +1,4 @@
+output "issuer_uri" {
+  description = "バックエンド（OAuth2 リソースサーバ）が JWT 検証に使う issuer。GCP_PROJECT_ID から組み立てる値と一致する（ADR-0064）"
+  value       = "https://securetoken.google.com/${var.project_id}"
+}

--- a/infra/modules/identity-platform/variables.tf
+++ b/infra/modules/identity-platform/variables.tf
@@ -1,0 +1,14 @@
+variable "project_id" {
+  description = "Identity Platform を有効化する GCP プロジェクト ID"
+  type        = string
+}
+
+variable "authorized_domains" {
+  description = "OAuth redirect を許可するドメイン。ローカル E2E で localhost:5173 から認証するため localhost を含める"
+  type        = list(string)
+  default = [
+    "localhost",
+    "ptiringo-toy-box.firebaseapp.com",
+    "ptiringo-toy-box.web.app",
+  ]
+}

--- a/infra/modules/identity-platform/versions.tf
+++ b/infra/modules/identity-platform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.15"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 7.36.0"
+    }
+  }
+}


### PR DESCRIPTION
## 概要

GCP Identity Platform を Terraform（`infra/`、HCP バックエンド）で宣言的に管理する。#612 の軽量フロント（PR #657）の手動 E2E が前提とする「実 Identity Platform テナント」を再現可能な infra にし、ADR-0064 が予告した Terraform 化を実装する。

## 変更内容

- **`infra/modules/identity-platform/`**（新モジュール・google GA）: `google_identity_platform_config` で **email/password サインイン**（`password_required = true`）と **`authorized_domains`**（ローカル E2E 用に `localhost` を含む）を宣言。
- **`infra/main.tf`**: `google_project_service` の for_each に `identitytoolkit` を追加し module を配線（`depends_on = [google_project_service.project]` で API 有効化を先行）。
- **ADR-0064 追補**: Terraform 化した事実、`deletion_policy` の扱い、source-of-truth 注意。

## スコープ（段階論 A）

- **今回**: Identity Platform config のみ（google GA・google-beta を足さない）。
- **手動 / 段階 B（今回スコープ外）**: Web config の `apiKey`（Console の Application setup details で取得）、テストユーザー（Console で作成）。README / run-frontend スキルの「Terraform 管理」更新は #657 マージ後に別途。

## 重要な注意（apply 前に）

- **`deletion_policy` は付けていない**。`google_identity_platform_config` にこの引数は**存在しない**（provider 7.39.0 で `terraform validate` が `Unsupported argument`。実測確認済み。registry docs には載るが magic-modules の doc boilerplate で実 schema に無い）。リソースの Delete は恒久 no-op（state から外すだけで GCP API を呼ばない）で、ABANDON 相当の挙動を常時持つ。
- **Terraform が config の source of truth になる**: `authorized_domains` / `sign_in` は full-replace。Console で手動設定したドメインやサインイン方式は apply で上書き・削除される（現スコープ = email/password + localhost に収束）。
- **既存 config があれば import**: config は singleton（`projects/ptiringo-toy-box/config`）。既に手動初期化済みなら初回 apply は create でなく `terraform import google_identity_platform_config.default projects/ptiringo-toy-box/config` が要る可能性がある（speculative plan が create として出たら import を検討）。

## 適用

apply は HCP Terraform run（PR の speculative plan で add/change を確認 → apply は HCP、承認後）。ローカルは `terraform fmt -check`（差分なし）/ `terraform validate`（Success）まで確認済み。

Refs #612 / ADR-0064

🤖 Generated with [Claude Code](https://claude.com/claude-code)
