### PR TITLE
chore: .env 系の秘密ファイルを Claude の Read から deny する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,10 @@
       "Bash(terraform apply *)",
       "Bash(terraform apply)",
       "Bash(terraform destroy *)",
-      "Bash(terraform destroy)"
+      "Bash(terraform destroy)",
+      "Read(**/.env)",
+      "Read(**/.env.local)",
+      "Read(**/.env.*.local)"
     ],
     "ask": [
       "Bash(gcloud * create *)",


### PR DESCRIPTION
## 概要

Claude が `.env` 系の秘密ファイル（実値）を Read できないよう、`.claude/settings.json` の `permissions.deny` に Read ルールを追加する。

## 変更

`permissions.deny` に3ルール追加:

- `Read(**/.env)` — ルート等の `.env`（実値）
- `Read(**/.env.local)` — `frontend/.env.local` など
- `Read(**/.env.*.local)` — `.env.production.local` 等

`.env.example` / `.env.sample`（秘密でないテンプレート）は完全一致しないため **読める**。deny は allow/ask より優先で、auto mode（bypassPermissions 含む）でもブロックされる。

## 実測

`frontend/.env.local` を Read しようとして `File is in a directory that is denied by your permission settings` でブロックされることを確認した（設定が即時反映・実効することを確認）。

## 背景

#612 のフロント手動 E2E で `frontend/.env.local` に実 Firebase Web config を置くため、Claude がそれを読まないようにする。apiKey 自体は公開前提の識別子だが、`.env.local` は環境依存の秘密置き場として一律 Claude の視界から外す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
