### PR TITLE
feat: フロントを「軽種馬登録原簿」デザインに reshape する

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>toy-box 軽種馬シミュレータ</title>
+    <title>軽種馬登録原簿 · toy-box</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Shippori+Mincho:wght@500;600;700&family=Space+Mono:wght@400;700&family=Zen+Kaku+Gothic+New:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/labels.ts
+++ b/frontend/src/labels.ts
@@ -1,0 +1,43 @@
+// バックの wire enum 値（英語定数名）を、表示用の日本語ラベルと毛色スウォッチ色へ写す。
+// 出所は controller/horse/BloodHorseWireEnums.kt（SexDto / CoatColorDto / BreedTypeDto）。
+
+export const sexLabels: Record<string, string> = {
+  MALE: "牡",
+  FEMALE: "牝",
+};
+
+export const breedLabels: Record<string, string> = {
+  THOROUGHBRED: "サラブレッド",
+  ARAB: "アラブ",
+  ANGLO_ARAB: "アングロアラブ",
+  THOROUGHBRED_TYPE: "サラブレッド系種",
+  ARAB_TYPE: "アラブ系種",
+};
+
+export const coatLabels: Record<string, string> = {
+  CHESTNUT: "栗毛",
+  DARK_CHESTNUT: "栃栗毛",
+  BAY: "鹿毛",
+  DARK_BAY: "黒鹿毛",
+  BROWN: "青鹿毛",
+  BLACK: "青毛",
+  GRAY: "芦毛",
+  WHITE: "白毛",
+};
+
+// styles.css の --coat-* と対応する実色近似（毛色スウォッチ用）。
+export const coatColors: Record<string, string> = {
+  CHESTNUT: "#9c5a2c",
+  DARK_CHESTNUT: "#6e3d1c",
+  BAY: "#6b4423",
+  DARK_BAY: "#4a2f1e",
+  BROWN: "#38291f",
+  BLACK: "#2b2724",
+  GRAY: "#ada9a0",
+  WHITE: "#ece8de",
+};
+
+// 未知の wire 値はそのまま表示する（契約に列挙子が増えても表示を壊さない）。
+export function label(map: Record<string, string>, value: string): string {
+  return map[value] ?? value;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import "./styles.css";
 
 // biome-ignore lint/style/noNonNullAssertion: index.html が #root を必ず持つ
 createRoot(document.getElementById("root")!).render(

--- a/frontend/src/pages/BloodHorseListPage.test.tsx
+++ b/frontend/src/pages/BloodHorseListPage.test.tsx
@@ -29,7 +29,7 @@ function renderPage() {
 }
 
 describe("BloodHorseListPage", () => {
-  it("フェッチ成功時はテーブルを表示し、エラー banner は出ずステータス200が可視化される", async () => {
+  it("成功時はテーブルを表示し、wire enum を日本語ラベルで描き、エラーは出ずステータス200が可視化される", async () => {
     apiGetMock.mockResolvedValue([
       {
         id: "h1",
@@ -48,13 +48,18 @@ describe("BloodHorseListPage", () => {
     await waitFor(() => {
       expect(screen.getByText("0000000001")).toBeInTheDocument();
     });
-    expect(screen.getByText(/直近レスポンス: 200/)).toBeInTheDocument();
+    // wire 値（FEMALE / BAY / THOROUGHBRED）ではなく日本語ラベルで描かれる。
+    expect(screen.getByText("牝")).toBeInTheDocument();
+    expect(screen.getByText("鹿毛")).toBeInTheDocument();
+    expect(screen.getByText("サラブレッド")).toBeInTheDocument();
+    // ステータス可視化（バッジに直近レスポンスが出る）
+    expect(screen.getByTitle("直近レスポンス")).toHaveTextContent("200");
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-    // name が null の行は「（未命名）」で描画される。
-    expect(screen.getByText("（未命名）")).toBeInTheDocument();
+    // name が null の行は「未命名」で描画される。
+    expect(screen.getByText("未命名")).toBeInTheDocument();
   });
 
-  it("フェッチ失敗時はエラー banner が出て、ステータスが可視化される", async () => {
+  it("失敗時はエラー banner が出て、ステータスが可視化される", async () => {
     apiGetMock.mockRejectedValue(new ApiError(401));
 
     renderPage();
@@ -62,6 +67,6 @@ describe("BloodHorseListPage", () => {
     await waitFor(() => {
       expect(screen.getByRole("alert")).toBeInTheDocument();
     });
-    expect(screen.getByText(/直近レスポンス: 401/)).toBeInTheDocument();
+    expect(screen.getByTitle("直近レスポンス")).toHaveTextContent("401");
   });
 });

--- a/frontend/src/pages/BloodHorseListPage.tsx
+++ b/frontend/src/pages/BloodHorseListPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { ApiError, apiGet } from "../api/client";
 import { useAuth } from "../auth/AuthContext";
+import { breedLabels, coatColors, coatLabels, label, sexLabels } from "../labels";
 
 // バックの BloodHorseSummaryResponse（snake_case）に対応する行の型。
 type BloodHorseSummary = {
@@ -37,7 +38,7 @@ export function BloodHorseListPage() {
           setStatus(e.status);
           setError(e.message);
         } else {
-          setError("不明なエラーが発生しました。");
+          setError("原簿を読み込めませんでした。");
         }
       }
     })();
@@ -47,42 +48,78 @@ export function BloodHorseListPage() {
   }, [getToken]);
 
   return (
-    <main>
-      <header>
-        <h1>軽種馬一覧</h1>
-        {/* 認証を目で見るための小さなステータス可視化 */}
-        <small>直近レスポンス: {status ?? "-"}</small>
-        <button type="button" onClick={() => signOutUser()}>
+    <div className="ledger">
+      <header className="ledger__head">
+        <h1 className="ledger__title">軽種馬登録原簿</h1>
+        <span className="ledger__count">{rows.length} 頭</span>
+        <div className="ledger__spacer" />
+        {/* 認証を目で見るためのステータス可視化（直近レスポンス） */}
+        <span className="status" data-ok={status === 200} title="直近レスポンス">
+          {status ?? "—"}
+        </span>
+        <button className="btn-ghost" type="button" onClick={() => signOutUser()}>
           ログアウト
         </button>
       </header>
-      {error && <p role="alert">{error}</p>}
-      <table>
-        <thead>
-          <tr>
-            <th>登録番号</th>
-            <th>馬名</th>
-            <th>性</th>
-            <th>毛色</th>
-            <th>品種</th>
-            <th>生年月日</th>
-            <th>生産者</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((h) => (
-            <tr key={h.id}>
-              <td>{h.registration_number}</td>
-              <td>{h.name ?? "（未命名）"}</td>
-              <td>{h.sex}</td>
-              <td>{h.coat_color}</td>
-              <td>{h.breed_type}</td>
-              <td>{h.date_of_birth}</td>
-              <td>{h.breeder}</td>
+
+      {error && (
+        <p className="alert" role="alert">
+          {error}
+        </p>
+      )}
+
+      {rows.length === 0 && !error ? (
+        <section className="empty">
+          <p className="empty__mark">白紙</p>
+          <p className="empty__lede">
+            まだ登録された軽種馬がいません。血統登録が行われると、この原簿に記帳されます。
+          </p>
+        </section>
+      ) : (
+        <table className="registry">
+          <thead>
+            <tr>
+              <th>登録番号</th>
+              <th>馬名</th>
+              <th>性</th>
+              <th>毛色</th>
+              <th>品種</th>
+              <th>生年月日</th>
+              <th>生産者</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
-    </main>
+          </thead>
+          <tbody>
+            {rows.map((h) => (
+              <tr key={h.id}>
+                <td data-label="登録番号">
+                  <span className="reg-no">{h.registration_number}</span>
+                </td>
+                <td data-label="馬名">
+                  <span className="horse-name" data-unnamed={h.name === null}>
+                    {h.name ?? "未命名"}
+                  </span>
+                </td>
+                <td data-label="性">{label(sexLabels, h.sex)}</td>
+                <td data-label="毛色">
+                  <span className="coat">
+                    <span
+                      className="coat__dot"
+                      style={{ background: coatColors[h.coat_color] ?? "var(--line)" }}
+                      aria-hidden="true"
+                    />
+                    {label(coatLabels, h.coat_color)}
+                  </span>
+                </td>
+                <td data-label="品種">{label(breedLabels, h.breed_type)}</td>
+                <td data-label="生年月日">
+                  <span className="dob">{h.date_of_birth}</span>
+                </td>
+                <td data-label="生産者">{h.breeder}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
   );
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -8,38 +8,75 @@ export function LoginPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
 
   const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
+    setSubmitting(true);
     try {
       await signIn(email, password);
       navigate("/bloodHorses", { replace: true });
     } catch {
-      setError("ログインに失敗しました。メールアドレスとパスワードを確認してください。");
+      setError("サインインできませんでした。メールアドレスとパスワードを確認してください。");
+      setSubmitting(false);
     }
   };
 
   return (
-    <main>
-      <h1>ログイン</h1>
-      <form onSubmit={onSubmit}>
-        <label>
-          メールアドレス
-          <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
-        </label>
-        <label>
-          パスワード
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-          />
-        </label>
-        <button type="submit">ログイン</button>
-      </form>
-      {error && <p role="alert">{error}</p>}
-    </main>
+    <div className="cover">
+      <aside className="cover__plate">
+        <p className="cover__eyebrow">JAIRS · Studbook</p>
+        <div>
+          <h1 className="cover__title">
+            軽種馬
+            <br />
+            登録原簿
+          </h1>
+          <p className="cover__lede">
+            血統登録された軽種馬の記録を閲覧する台帳です。登録担当のアカウントでサインインしてください。
+          </p>
+        </div>
+        <p className="cover__reg">REGISTRY ACCESS · ptiringo-toy-box</p>
+      </aside>
+
+      <main className="cover__form">
+        <form className="sheet" onSubmit={onSubmit}>
+          <h2 className="sheet__heading">記帳にサインイン</h2>
+          <p className="sheet__note">Identity Platform のアカウントで認証します。</p>
+
+          <label className="field">
+            <span>メールアドレス</span>
+            <input
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </label>
+          <label className="field">
+            <span>パスワード</span>
+            <input
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </label>
+
+          <button className="btn" type="submit" disabled={submitting}>
+            {submitting ? "確認中…" : "サインイン"}
+          </button>
+
+          {error && (
+            <p className="alert" role="alert">
+              {error}
+            </p>
+          )}
+        </form>
+      </main>
+    </div>
   );
 }

--- a/frontend/src/pages/RequireAuth.tsx
+++ b/frontend/src/pages/RequireAuth.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "../auth/AuthContext";
 export function RequireAuth() {
   const { user, loading } = useAuth();
   if (loading) {
-    return <p>認証状態を確認中…</p>;
+    return <div className="loading">認証状態を確認中…</div>;
   }
   return user ? <Outlet /> : <Navigate to="/login" replace />;
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,427 @@
+/* ============================================================
+   軽種馬登録原簿（Studbook Ledger）デザインシステム
+   コンセプト: JAIRS 血統登録原簿の端正な台帳 × 馬の毛色の実在感。
+   フォント（index.html で読み込み）:
+     見出し = Shippori Mincho（明朝・原簿の格式）
+     本文   = Zen Kaku Gothic New（和文ゴシック）
+     数値   = Space Mono（登録番号・年月日の等幅）
+   ============================================================ */
+
+/* ---- リセット ---- */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+* {
+  margin: 0;
+}
+html {
+  -webkit-text-size-adjust: 100%;
+}
+button,
+input {
+  font: inherit;
+  color: inherit;
+}
+button {
+  cursor: pointer;
+}
+
+/* ---- トークン ---- */
+:root {
+  --font-display: "Shippori Mincho", serif;
+  --font-body: "Zen Kaku Gothic New", system-ui, sans-serif;
+  --font-mono: "Space Mono", ui-monospace, "SFMono-Regular", monospace;
+
+  --paper: #f3f5f2;
+  --paper-raised: #ffffff;
+  --ink: #1a1d18;
+  --ink-soft: #565b4e;
+  --accent: #1f4a34;
+  --on-accent: #f3f5f2;
+  --accent-soft: #e6ede8;
+  --line: #d7dad2;
+  --danger: #8f2f1f;
+
+  /* 毛色スウォッチ（JAIRS 毛色区分の実色近似） */
+  --coat-chestnut: #9c5a2c;
+  --coat-dark-chestnut: #6e3d1c;
+  --coat-bay: #6b4423;
+  --coat-dark-bay: #4a2f1e;
+  --coat-brown: #38291f;
+  --coat-black: #2b2724;
+  --coat-gray: #ada9a0;
+  --coat-white: #ece8de;
+
+  --radius: 3px;
+  --shadow: 0 1px 2px rgba(26, 29, 24, 0.05), 0 10px 30px rgba(26, 29, 24, 0.07);
+}
+
+:root[data-theme="dark"],
+html:not([data-theme="light"]) {
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --paper: #13160f;
+    --paper-raised: #1b1f15;
+    --ink: #e9eae0;
+    --ink-soft: #9ba090;
+    --accent: #5e9c78;
+    --on-accent: #0e120a;
+    --accent-soft: #202b1c;
+    --line: #2b3022;
+    --danger: #d9836a;
+    color-scheme: dark;
+  }
+}
+
+body {
+  min-height: 100vh;
+  font-family: var(--font-body);
+  background: var(--paper);
+  color: var(--ink);
+  font-size: 15px;
+  line-height: 1.65;
+  font-feature-settings: "palt" 1;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ============================================================
+   ログイン: 台帳の表紙（左=標題ページ / 右=記帳フォーム）
+   ============================================================ */
+.cover {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+}
+
+.cover__plate {
+  background: var(--accent);
+  color: var(--on-accent);
+  padding: clamp(2rem, 5vw, 4.5rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 2rem;
+  position: relative;
+  overflow: hidden;
+}
+/* 台帳の綴じ穴を思わせる控えめな縦の刻み */
+.cover__plate::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 1.4rem;
+  width: 1px;
+  background: repeating-linear-gradient(
+    to bottom,
+    color-mix(in srgb, var(--on-accent) 30%, transparent) 0 6px,
+    transparent 6px 16px
+  );
+}
+.cover__eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+.cover__title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: clamp(2.6rem, 5.5vw, 4.4rem);
+  line-height: 1.1;
+  letter-spacing: 0.02em;
+}
+.cover__lede {
+  max-width: 34ch;
+  opacity: 0.85;
+}
+.cover__reg {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  opacity: 0.65;
+}
+
+.cover__form {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.sheet {
+  width: min(380px, 100%);
+}
+.sheet__heading {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+.sheet__note {
+  color: var(--ink-soft);
+  font-size: 0.86rem;
+  margin-bottom: 2rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.4rem;
+  margin-bottom: 1.15rem;
+}
+.field > span {
+  font-size: 0.78rem;
+  color: var(--ink-soft);
+  letter-spacing: 0.02em;
+}
+.field input {
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper-raised);
+  transition: border-color 0.15s ease;
+}
+.field input:hover {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
+}
+.field input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  border-color: var(--accent);
+}
+
+.btn {
+  width: 100%;
+  padding: 0.8rem 1rem;
+  margin-top: 0.5rem;
+  background: var(--accent);
+  color: var(--on-accent);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  transition: filter 0.15s ease;
+}
+.btn:hover {
+  filter: brightness(1.08);
+}
+.btn:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 2px;
+}
+
+.alert {
+  margin-top: 1.1rem;
+  padding: 0.65rem 0.8rem;
+  border-left: 3px solid var(--danger);
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
+  color: var(--danger);
+  font-size: 0.86rem;
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+/* ============================================================
+   一覧: 登録原簿
+   ============================================================ */
+.ledger {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: clamp(1.5rem, 4vw, 3rem) 1.5rem 5rem;
+}
+
+.ledger__head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.9rem;
+  padding-bottom: 0.9rem;
+  border-bottom: 2px solid var(--ink);
+  margin-bottom: 1.6rem;
+  flex-wrap: wrap;
+}
+.ledger__title {
+  font-family: var(--font-display);
+  font-size: clamp(1.4rem, 3vw, 1.9rem);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.ledger__count {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--ink-soft);
+}
+.ledger__spacer {
+  margin-left: auto;
+}
+
+.status {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  color: var(--ink-soft);
+}
+.status[data-ok="true"] {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+  background: var(--accent-soft);
+}
+.status[data-ok="false"] {
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 55%, var(--line));
+}
+
+.btn-ghost {
+  padding: 0.35rem 0.75rem;
+  background: transparent;
+  color: var(--ink-soft);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  font-size: 0.82rem;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.btn-ghost:hover {
+  color: var(--ink);
+  border-color: var(--ink-soft);
+}
+.btn-ghost:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.registry {
+  width: 100%;
+  border-collapse: collapse;
+}
+.registry thead th {
+  text-align: left;
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  padding: 0.5rem 0.7rem;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+}
+.registry tbody td {
+  padding: 0.75rem 0.7rem;
+  border-bottom: 1px solid var(--line);
+  vertical-align: middle;
+}
+.registry tbody tr {
+  transition: background 0.12s ease;
+}
+.registry tbody tr:hover td {
+  background: var(--accent-soft);
+}
+
+.reg-no {
+  font-family: var(--font-mono);
+  font-size: 0.86rem;
+  letter-spacing: 0.02em;
+}
+.horse-name {
+  font-family: var(--font-display);
+  font-size: 1.02rem;
+}
+.horse-name[data-unnamed="true"] {
+  font-family: var(--font-body);
+  color: var(--ink-soft);
+  font-style: italic;
+  font-size: 0.9rem;
+}
+.dob {
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  color: var(--ink-soft);
+}
+
+/* 署名要素: 毛色スウォッチ */
+.coat {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: nowrap;
+}
+.coat__dot {
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  border: 1px solid color-mix(in srgb, var(--ink) 22%, transparent);
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.25);
+  flex-shrink: 0;
+}
+
+/* 空状態: 白紙の記帳ページ */
+.empty {
+  text-align: center;
+  padding: clamp(2.5rem, 8vw, 5rem) 1.5rem;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius);
+  background: var(--paper-raised);
+}
+.empty__mark {
+  font-family: var(--font-display);
+  font-size: 2.2rem;
+  color: var(--ink);
+  margin-bottom: 0.6rem;
+}
+.empty__lede {
+  color: var(--ink-soft);
+  max-width: 40ch;
+  margin: 0 auto;
+}
+
+/* 認証状態の確認中 */
+.loading {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+}
+
+/* ---- レスポンシブ ---- */
+@media (max-width: 720px) {
+  .cover {
+    grid-template-columns: 1fr;
+  }
+  .cover__plate {
+    min-height: 38vh;
+  }
+  .registry thead {
+    display: none;
+  }
+  .registry tbody td {
+    display: block;
+    border: none;
+    padding: 0.15rem 0.7rem;
+  }
+  .registry tbody tr {
+    display: block;
+    padding: 0.9rem 0;
+    border-bottom: 1px solid var(--line);
+  }
+  .registry tbody td::before {
+    content: attr(data-label) "  ";
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-soft);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## 概要

#657 の軽量フロント（LoginPage / BloodHorseListPage）を、CSS ゼロのブラウザデフォルトから **「軽種馬登録原簿（Studbook Ledger）」** デザインへ reshape する。**base は feat/612**（#657 に重ねる）。

## デザイン方向

JAIRS 血統登録原簿の端正な台帳と、馬の毛色の実在感を両立させる。AI が量産しがちな見た目（クリーム地＋セリフ＋テラコッタ / 黒地＋アシッド色 / 新聞レイアウト）を避け、ドメイン固有の signature を主役にした。

- **Signature: 毛色スウォッチ** — 一覧の「毛色」列を、鹿毛・栗毛・芦毛…の**実色の小さな色見本**で示す。汎用の管理画面には出てこない要素。
- 見出し = 明朝（Shippori Mincho）/ 本文 = 和文ゴシック（Zen Kaku Gothic New）/ データ = 等幅（Space Mono）
- ログイン = 台帳の表紙（深緑の標題面 + 綴じ穴の破線 + 記帳フォーム）、一覧 = 登録原簿テーブル、空状態 = 「白紙」の記帳ページ
- ダーク/ライト両対応、キーボードフォーカス可視、reduced-motion 尊重、モバイルでテーブルをカード化

## 変更

- `frontend/src/styles.css`（新規）: デザインシステム（トークン・タイポ・レイアウト・コンポーネント）
- `frontend/src/labels.ts`（新規）: wire enum → 日本語ラベル + 毛色スウォッチ色
- `LoginPage` / `BloodHorseListPage` / `RequireAuth` を reshape、`index.html` にフォント読み込み
- `BloodHorseListPage.test` を日本語ラベル・ステータスバッジ表示に追従
- `LoginPage`: 送信中の二重クリック防止（最終レビューの Minor も同時にカバー）

## 副次的な解消

一覧の性・毛色・品種が **英語の wire 値（FEMALE / BAY / THOROUGHBRED）で生表示**されていた問題（#657 最終レビューの Important #1・follow-up 予定だった）を、`labels.ts` の日本語ラベルで同時に解消した。

## 検証

- Vitest 9/9、Biome clean、`tsc` + `vite build` 緑
- 静的プレビューを Chrome headless で screenshot し、ログイン・一覧（毛色スウォッチ）・空状態・ダーク/ライトを目視確認

Refs #612 / #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)
