### PR TITLE
fix: #678 ユビキタス言語カタログ再生成コマンドを :test に直す

### DIFF
--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -15,7 +15,7 @@
 > 落ちる。次でカタログを再生成し、併せて下の手書き用語集にも定義を足してからコミットする。
 >
 > ```bash
-> ./gradlew test --tests "*UbiquitousLanguageCatalogTest" -DubiquitousLanguage.update=true
+> ./gradlew :test --tests "*UbiquitousLanguageCatalogTest" -DubiquitousLanguage.update=true
 > ```
 
 ---

--- a/src/test/kotlin/com/example/api/architecture/UbiquitousLanguageCatalogTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/UbiquitousLanguageCatalogTest.kt
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test
  *
  * コードが唯一の出所であり、ビルディングブロックを足し引きするとカタログが乖離してこのテストが落ちる。 再生成するには次を実行してドキュメントを更新し、差分をコミットする:
  * ```
- * ./gradlew test --tests "*UbiquitousLanguageCatalogTest" -DubiquitousLanguage.update=true
+ * ./gradlew :test --tests "*UbiquitousLanguageCatalogTest" -DubiquitousLanguage.update=true
  * ```
  *
  * 定義・和名・別名・禁止語といった意味づけは手書きセクションが担い、本テストは型の一覧（どの用語が存在すべきか） だけをゲートする。KDoc はバイトコードに残らないため自動抽出の対象外。
@@ -45,7 +45,7 @@ class UbiquitousLanguageCatalogTest {
 
         assert(current.trim() == expected.trim()) {
             "ユビキタス言語カタログ（docs/ubiquitous-language.md の自動生成ブロック）がコードと乖離しています。" +
-                "次で再生成してコミットしてください: ./gradlew test " +
+                "次で再生成してコミットしてください: ./gradlew :test " +
                 "--tests \"*UbiquitousLanguageCatalogTest\" -DubiquitousLanguage.update=true"
         }
     }


### PR DESCRIPTION
Closes #678

## 背景

ユビキタス言語カタログの再生成コマンドが、**書かれたとおりに実行すると失敗する**状態になっていた。`--tests` をルートの `test` タスクに付けているため、ビルドに含まれる `:detekt-rules` の `test` にも同じフィルタが適用され `No tests found for given includes` でビルドが落ちる（`.claude/rules/testing.md:44` が定めるとおり `:test` に付ける必要がある）。

## 変更内容

Issue 記載の 2 箇所に加え、**アサートメッセージ内の 1 箇所**も直した（文字列連結で改行されており、Issue 起票時の grep では拾えていなかった）。

- `docs/ubiquitous-language.md:18` — メンテナンス方法に載せている再生成コマンド
- `src/test/.../UbiquitousLanguageCatalogTest.kt:28` — KDoc の再生成コマンド
- `src/test/.../UbiquitousLanguageCatalogTest.kt:48` — カタログ乖離時のアサートメッセージに埋め込まれた再生成コマンド

`.claude/rules/testing.md:44` の `./gradlew test --tests …` は「こう書くと失敗する」という**誤用例としての引用**なのでそのままにしている。

## 確認したこと

拡張子を問わず `--tests` の記述を全走査し、残る記述が上記の誤用例だけであることを確認した。

修正前後の挙動を実測で確認した（推論ではない）。

```console
$ ./gradlew test --tests "*UbiquitousLanguageCatalogTest"      # 修正前の形
> Task :detekt-rules:test FAILED
> No tests found for given includes: [*UbiquitousLanguageCatalogTest](--tests filter)
BUILD FAILED in 20s

$ ./gradlew :test --tests "*UbiquitousLanguageCatalogTest" -DubiquitousLanguage.update=true   # 修正後の形
BUILD SUCCESSFUL in 49s
```

再生成を実行しても `docs/ubiquitous-language.md` の自動生成ブロックに差分は出ず、カタログはコードと一致している。

`./gradlew check` は `BUILD SUCCESSFUL`（`koverVerifyMature` まで通過）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
