### PR TITLE
test: #683 馬一覧の契約テストを固定 UUID ベースへ書き直す

### DIFF
--- a/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseQueriesContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseQueriesContractTest.kt
@@ -1,12 +1,12 @@
 package com.example.api.infrastructure.studbook.horse
 
-import com.example.api.domain.shared.generateId
 import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
 import com.example.api.infrastructure.studbook.StudbookSeeder
 import com.example.api.infrastructure.studbook.breeding.BreedingRegistrationSpringDataRepository
 import com.example.api.infrastructure.studbook.inspection.HorseInspectionSpringDataRepository
 import com.example.api.support.PostgresContainerSupport
 import com.example.api.support.deleteAllStudbookTables
+import java.util.UUID
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
@@ -40,15 +40,16 @@ class JdbcBloodHorseQueriesContractTest(
 
     @Test
     fun `登録済みの馬を全件 id 昇順で返す`() {
-        // generateId() は UUIDv7 相当で単調増加するため、先に採った first が id 昇順で先頭になる。
-        val first = generateId()
-        val second = generateId()
-        seeder.seedHorseRow(id = first, registrationNumber = "REG-001")
-        seeder.seedHorseRow(id = second, registrationNumber = "REG-002")
+        // generateId() は同一ミリ秒内での単調増加を保証しない（ADR-0005 は「ほぼ単調」＝インデックス局所性が目的）
+        // ため、大小が自明な固定 ID を使う。さらに挿入順を id 昇順と逆にして、ORDER BY id が効いていることを検証する。
+        val smaller = UUID.fromString("00000000-0000-7000-8000-000000000001")
+        val larger = UUID.fromString("00000000-0000-7000-8000-000000000002")
+        seeder.seedHorseRow(id = larger, registrationNumber = "REG-002")
+        seeder.seedHorseRow(id = smaller, registrationNumber = "REG-001")
 
         val views = queries.findAll()
 
-        assert(views.map { it.id } == listOf(first, second))
+        assert(views.map { it.id } == listOf(smaller, larger))
         val head = views.first()
         assert(head.registrationNumber == "REG-001")
         // seedHorseRow のデフォルト（coat_color=BAY / breed_type=THOROUGHBRED / name 未設定）を写せていること


### PR DESCRIPTION
Closes #683

## 原因（実測で確定）

`登録済みの馬を全件 id 昇順で返す` は `generateId()` を連続 2 回呼んで `first` < `second` を仮定していたが、実体の `Generators.timeBasedEpochRandomGenerator()` は **同一ミリ秒内での単調増加を保証しない**。UUIDv7 の同一ミリ秒では `rand_a`（12bit）がランダムなため順序が入れ替わる。

10,000 回の連続生成で実測したところ、同一ミリ秒に入ったペアが 9,943、うち **4,967 ペア（49.9%）で順序が逆転**した。

```
sameMillisPairs=9943 inversions=4967
```

常に落ちないのは、通常 `first` と `second` の生成が別ミリ秒にまたがるため。同一ミリ秒に入ったときだけ 50% で落ちる（テスト導入の 9f41210 以降、main で 2 回の失敗実績）。

ADR-0005 が約束するのは「生成順に**ほぼ**単調増加」＝インデックス局所性であり、厳密な単調性ではない。したがって **プロダクションの `generateId()` は変更せず、テスト側の誤った前提を正す**。

## 変更内容

#683 の推奨案どおり、固定 UUID ベースへ書き直した。

- 大小が自明な固定 UUID（`...0001` / `...0002`）を使い、ID 生成の実装詳細への依存を断つ
- **挿入順を id 昇順と逆にした**。従来は挿入順＝id 昇順だったため、`ORDER BY id` を外しても通ってしまう弱いテストだった

## 横断確認（#683 備考への回答）

`generateId()` を連続で呼んで順序に依存している箇所を横断的に調べた。**同じ仮定を置いているテストは他に無い。**

- `ORDER BY` を使う読み取り実装は 2 つのみ
  - `JdbcBloodHorseQueries` — `ORDER BY id`（本 PR の対象）
  - `JdbcBreedingResultSummaryQueries` — `ORDER BY breeding_year`。テストも年で検証しており、`stallion` / `otherStallion` の ID は識別のみで順序に依存しない
- 他の `generateId()` 利用箇所は単発の ID 採番か `findById` の空振り確認で、複数 ID 間の大小関係を前提にしていない

## 検証

テストが実際に順序を検証していることをミューテーションで確認した。

```console
# ORDER BY id を一時的に削除して実行
JdbcBloodHorseQueriesContractTest > 登録済みの馬を全件 id 昇順で返す() FAILED
    java.lang.AssertionError at JdbcBloodHorseQueriesContractTest.kt:52
BUILD FAILED

# 復元後
./gradlew check
BUILD SUCCESSFUL in 4m 15s   # koverVerifyMature まで通過
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
