### PR TITLE
docs: ADR 一覧に抜けていた ADR-0066 の行を追加する

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -75,6 +75,7 @@
 | [0063](0063-dprint-config-file-formatting.md) | 設定ファイル（TOML/JSON/YAML）の整形に dprint を採用し lefthook / CI でゲートする | Accepted |
 | [0064](0064-authn-via-identity-platform-authz-in-app.md) | 認証は GCP Identity Platform に委譲し、認可の権限は自前 DB に持つ | Accepted |
 | [0065](0065-claude-code-on-the-web-support.md) | Claude Code on the web を軽量変更ワークフローとして最小サポートする | Accepted |
+| [0066](0066-gh-cli-via-gh-token-on-web.md) | Claude Code on the web で gh CLI を GH_TOKEN 認証で使う | Accepted |
 | [0068](0068-manual-infra-apply-with-notification.md) | infra の HCP Terraform apply を手動承認 + 通知にする（auto_apply 無効化） | Accepted |
 | [0069](0069-carried-over-registration-path.md) | 内国産既存馬はシステム境界の移行取り込み経路で血統登録する | Accepted |
 | [0070](0070-db-test-cleanup-via-truncate-not-transactional.md) | DB を触るテストの後始末は基底クラスの TRUNCATE に一元化し、@Transactional 分離は採らない | Accepted |


### PR DESCRIPTION
`docs/adr/0066-gh-cli-via-gh-token-on-web.md` はファイルが存在するのに、`docs/adr/README.md` の一覧が 0065 → 0068 と飛んでいた（0067 は欠番でファイル自体が無い）。#440（PR #689）の作業中に発見したもので、あちらのスコープ外だったため別 PR に切り出した。

## 変更

- `docs/adr/README.md` の 0065 と 0068 のあいだに 0066 の行を追加

## 検証

全 ADR ファイルと一覧を双方向で突合し、他に漏れも死にリンクも無いことを確認した。

```
# ファイル → 一覧（漏れ検出）
for f in docs/adr/[0-9]*.md; do n=$(basename "$f" | cut -c1-4); grep -q "\[$n\](" docs/adr/README.md || echo "README に無い: $f"; done
# 一覧 → ファイル（死にリンク検出）
grep -oE '^\| \[([0-9]{4})\]\(([^)]+)\)' docs/adr/README.md | sed -E 's/.*\((.*)\)/\1/' | while read p; do [ -f "docs/adr/$p" ] || echo "ファイル無し: $p"; done
```

いずれも修正後は出力なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WceBxhRyH2Kwv76yajaiFb