### PR TITLE
refactor: #688 読み取りユースケースの命名を AIP（Get / List）へ統一する

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -51,7 +51,7 @@ paths:
 
 ### 読み取り経路（軽量 CQRS / L2）
 
-読み取り（クエリ）系は、書き込み側の集約を**経由しない**独立経路として実装する（軽量 CQRS = L2。ストア分離・結果整合・イベントソーシング = L3 は採らない）。決定経緯は [ADR-0031](../../docs/adr/0031-lightweight-cqrs-read-model.md)、リファレンス実装は `racing/jockey`（`FindJockeyUseCase`）。
+読み取り（クエリ）系は、書き込み側の集約を**経由しない**独立経路として実装する（軽量 CQRS = L2。ストア分離・結果整合・イベントソーシング = L3 は採らない）。決定経緯は [ADR-0031](../../docs/adr/0031-lightweight-cqrs-read-model.md)、リファレンス実装は `racing/jockey`（`GetJockeyUseCase`）。
 
 - **Read Model（View）とクエリポートは `application` に置く**（ドメインを汚さない）。書き込みの「集約 + Repository ポートは `domain.*.model`」と非対称だが、これは意図したもの。読みモデルは集約のライフサイクル（生成・状態遷移・整合性境界）を持たないため domain には置かない
 - **View には jMolecules の `@QueryModel`（`org.jmolecules.architecture.cqrs`）を付ける**。不変条件を持たないフラットな DTO で、値の等価性が自然なため `data class` でよい。`@QueryModel` が `application` に居ることは ArchUnit [`queryModelsResideInApplication`] で強制する（DDD ビルディングブロックを `domain.*.model` に縛る [`dddBuildingBlocksResideInDomainModel`] と対称）
@@ -59,6 +59,7 @@ paths:
 - **infrastructure の実装は集約を組まずストアから直接 View へ詰める**（例: `JdbcJockeyQueries` が `JdbcClient` で `jockey` を直 SELECT し、書き込みの `JockeyRow`／集約を経由しない）。同じテーブルを読んでも、経路（write=集約復元 / read=View 直組み）とモデルを分離するのが L2 の価値であり、「write ポートに finder を生やす」誘惑には乗らない
 - **読み取りも write と対称に `application` を必ず通す**（現行オニオンの依存方向を維持。infrastructure → application のポート実装はアダプターの依存として onion ルールが許容する）
 - クエリ入力 DTO は `〜Query` サフィックス。書き込み系の `Command<T>` 封筒（発生時刻メタデータ）は読み取りでは**使わない**（発生時刻は書き込みイベントの概念）
+- **ユースケース名は Google AIP の標準メソッド名に寄せる**。by-id の単数照会は `Get〜UseCase`、コレクション照会は `List〜sUseCase`（**必ず複数形**にし、単数形の名前で `List` を返さない）。入力 DTO も `Get〜Query` / `List〜Query` と対応させる。adapter 側（`operationId`・Controller のハンドラ名）が既に Get / List で揃っているため、application 層をこれに合わせて語彙を一本化する。一方 **クエリポート（`〜Queries`）のメソッド名は `findById` / `findAll` / `findBy〜` のままにする**。ポートは「無いかもしれないものを探す」意味論で `find` が正しく、ユースケース名（何をする操作か）とポート名（どう引くか）は別の語彙（[#688](https://github.com/ptiringo/toy-box/issues/688)）
 
 ## パッケージ構造
 

--- a/src/main/kotlin/com/example/api/application/racing/jockey/GetJockeyUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/racing/jockey/GetJockeyUseCase.kt
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service
  *
  * @property id 照会対象ジョッキーの生 UUID
  */
-data class FindJockeyQuery(val id: UUID)
+data class GetJockeyQuery(val id: UUID)
 
 /** 照会対象のジョッキーが存在しない。URL パス上の操作対象の不在として Controller 境界で 404 に写す（api-design.md）。 */
 data class JockeyNotFound(val id: UUID)
@@ -28,7 +28,7 @@ data class JockeyNotFound(val id: UUID)
  * @return 照会できた [JockeyView]、または対象不在を表す [JockeyNotFound]
  */
 @Service
-class FindJockeyUseCase(private val jockeyQueries: JockeyQueries) {
-    operator fun invoke(query: FindJockeyQuery): Result<JockeyView, JockeyNotFound> =
+class GetJockeyUseCase(private val jockeyQueries: JockeyQueries) {
+    operator fun invoke(query: GetJockeyQuery): Result<JockeyView, JockeyNotFound> =
         jockeyQueries.findById(JockeyId(query.id)).toResultOr { JockeyNotFound(query.id) }
 }

--- a/src/main/kotlin/com/example/api/application/studbook/breeding/ListBreedingResultSummariesUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/ListBreedingResultSummariesUseCase.kt
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service
  *
  * @property stallionId 照会対象の種牡馬の `BloodHorseId`
  */
-data class FindBreedingResultSummaryQuery(val stallionId: BloodHorseId)
+data class ListBreedingResultSummariesQuery(val stallionId: BloodHorseId)
 
 /**
  * 繁殖成績の年次集計を照会するユースケース（軽量 CQRS / L2 の読み取り側。ADR-0031）。
@@ -19,9 +19,9 @@ data class FindBreedingResultSummaryQuery(val stallionId: BloodHorseId)
  * コレクション照会のため失敗バリアントは設けない（該当なし＝空リスト）。
  */
 @Service
-class FindBreedingResultSummaryUseCase(
+class ListBreedingResultSummariesUseCase(
     private val breedingResultSummaryQueries: BreedingResultSummaryQueries
 ) {
-    operator fun invoke(query: FindBreedingResultSummaryQuery): List<BreedingResultSummaryView> =
+    operator fun invoke(query: ListBreedingResultSummariesQuery): List<BreedingResultSummaryView> =
         breedingResultSummaryQueries.findByStallion(query.stallionId)
 }

--- a/src/main/kotlin/com/example/api/application/studbook/horse/GetBloodHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/GetBloodHorseUseCase.kt
@@ -22,8 +22,8 @@ data class BloodHorseNotFound(val id: UUID)
 /**
  * 軽種馬照会ユースケース（軽量 CQRS（L2）の読み取り側。ADR-0031）。
  *
- * 一覧の [FindBloodHorsesUseCase] と対になる by-id 照会。名前は AIP の標準メソッド名（List / Get）に寄せ、
- * 一覧（`FindBloodHorses〜`）との差が末尾の `s` 一文字だけになるのを避ける。
+ * 一覧の [ListBloodHorsesUseCase] と対になる by-id 照会。読み取りユースケースの名前は AIP の標準メソッド名 （Get /
+ * List）に寄せる（`.claude/rules/architecture.md`「読み取り経路（軽量 CQRS / L2）」）。
  *
  * 書き込みユースケース（[RegisterInStudBookUseCase] 等）と同列に `@Service` で公開するが、依存するのは 書き込みポートではなく読み取りポート
  * [BloodHorseQueries]。集約を組まず [BloodHorseDetailView] を返す。

--- a/src/main/kotlin/com/example/api/application/studbook/horse/ListBloodHorsesUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/ListBloodHorsesUseCase.kt
@@ -9,6 +9,6 @@ import org.springframework.stereotype.Service
  * を取らず、`Command` 封筒も使わない。
  */
 @Service
-class FindBloodHorsesUseCase(private val bloodHorseQueries: BloodHorseQueries) {
+class ListBloodHorsesUseCase(private val bloodHorseQueries: BloodHorseQueries) {
     operator fun invoke(): List<BloodHorseView> = bloodHorseQueries.findAll()
 }

--- a/src/main/kotlin/com/example/api/application/studbook/inspection/GetHorseInspectionUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/inspection/GetHorseInspectionUseCase.kt
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service
  *
  * @property id 照会対象審査の生 UUID
  */
-data class FindHorseInspectionQuery(val id: UUID)
+data class GetHorseInspectionQuery(val id: UUID)
 
 /** 照会対象の審査が存在しない。URL パス上の操作対象の不在として Controller 境界で 404 に写す（api-design.md）。 */
 data class HorseInspectionNotFound(val id: UUID)
@@ -28,9 +28,9 @@ data class HorseInspectionNotFound(val id: UUID)
  * @return 照会できた [HorseInspectionView]、または対象不在を表す [HorseInspectionNotFound]
  */
 @Service
-class FindHorseInspectionUseCase(private val horseInspectionQueries: HorseInspectionQueries) {
+class GetHorseInspectionUseCase(private val horseInspectionQueries: HorseInspectionQueries) {
     operator fun invoke(
-        query: FindHorseInspectionQuery
+        query: GetHorseInspectionQuery
     ): Result<HorseInspectionView, HorseInspectionNotFound> =
         horseInspectionQueries.findById(HorseInspectionId(query.id)).toResultOr {
             HorseInspectionNotFound(query.id)

--- a/src/main/kotlin/com/example/api/controller/breeding/BreedingResultSummaryController.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/BreedingResultSummaryController.kt
@@ -1,7 +1,7 @@
 package com.example.api.controller.breeding
 
-import com.example.api.application.studbook.breeding.FindBreedingResultSummaryQuery
-import com.example.api.application.studbook.breeding.FindBreedingResultSummaryUseCase
+import com.example.api.application.studbook.breeding.ListBreedingResultSummariesQuery
+import com.example.api.application.studbook.breeding.ListBreedingResultSummariesUseCase
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -19,12 +19,12 @@ import org.springframework.web.bind.annotation.RestController
  * 繁殖成績の年次集計リソースの HTTP アダプター（軽量 CQRS / L2 の読み取り側。ADR-0031）。
  *
  * JAIRS 様式第2号（繁殖登録原簿〈雄〉）に対応し、ある種牡馬の (種付年) ごとの繁殖成績（種付雌馬数・受胎率・ 生産率）を List で返す。読み取り経路は書き込み集約を一切経由せず
- * [FindBreedingResultSummaryUseCase] が
+ * [ListBreedingResultSummariesUseCase] が
  * [com.example.api.application.studbook.breeding.BreedingResultSummaryQueries] 経由でストアから直接組む。
  */
 @RestController
 class BreedingResultSummaryController(
-    private val findBreedingResultSummary: FindBreedingResultSummaryUseCase
+    private val listBreedingResultSummaries: ListBreedingResultSummariesUseCase
 ) {
     @Operation(
         summary = "種牡馬の繁殖成績の年次集計を取得する",
@@ -59,7 +59,6 @@ class BreedingResultSummaryController(
     fun list(
         @Parameter(description = "集計対象の種牡馬の生 UUID") @RequestParam stallionId: UUID
     ): List<BreedingResultSummaryResponse> =
-        findBreedingResultSummary(FindBreedingResultSummaryQuery(BloodHorseId(stallionId))).map {
-            it.toResponse()
-        }
+        listBreedingResultSummaries(ListBreedingResultSummariesQuery(BloodHorseId(stallionId)))
+            .map { it.toResponse() }
 }

--- a/src/main/kotlin/com/example/api/controller/horse/BloodHorseController.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/BloodHorseController.kt
@@ -1,8 +1,8 @@
 package com.example.api.controller.horse
 
-import com.example.api.application.studbook.horse.FindBloodHorsesUseCase
 import com.example.api.application.studbook.horse.GetBloodHorseQuery
 import com.example.api.application.studbook.horse.GetBloodHorseUseCase
+import com.example.api.application.studbook.horse.ListBloodHorsesUseCase
 import com.example.api.application.studbook.horse.NameHorseUseCase
 import com.example.api.application.studbook.horse.RegisterCarriedOverHorseUseCase
 import com.example.api.application.studbook.horse.RegisterImportedHorseUseCase
@@ -51,7 +51,7 @@ class BloodHorseController(
     private val registerImportedHorse: RegisterImportedHorseUseCase,
     private val registerCarriedOverHorse: RegisterCarriedOverHorseUseCase,
     private val nameHorse: NameHorseUseCase,
-    private val findBloodHorses: FindBloodHorsesUseCase,
+    private val listBloodHorses: ListBloodHorsesUseCase,
     private val getBloodHorse: GetBloodHorseUseCase,
     private val clock: Clock,
 ) {
@@ -82,7 +82,7 @@ class BloodHorseController(
             ],
     )
     @GetMapping("/api/bloodHorses")
-    fun list(): List<BloodHorseSummaryResponse> = findBloodHorses().map { it.toSummaryResponse() }
+    fun list(): List<BloodHorseSummaryResponse> = listBloodHorses().map { it.toSummaryResponse() }
 
     @Operation(
         operationId = "getBloodHorse",

--- a/src/main/kotlin/com/example/api/controller/inspection/HorseInspectionController.kt
+++ b/src/main/kotlin/com/example/api/controller/inspection/HorseInspectionController.kt
@@ -1,7 +1,7 @@
 package com.example.api.controller.inspection
 
-import com.example.api.application.studbook.inspection.FindHorseInspectionQuery
-import com.example.api.application.studbook.inspection.FindHorseInspectionUseCase
+import com.example.api.application.studbook.inspection.GetHorseInspectionQuery
+import com.example.api.application.studbook.inspection.GetHorseInspectionUseCase
 import com.example.api.application.studbook.inspection.RecordHorseInspectionUseCase
 import com.example.api.controller.inspection.problem.toProblemDetail
 import com.example.api.controller.inspection.request.RecordHorseInspectionRequest
@@ -37,7 +37,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class HorseInspectionController(
     private val recordHorseInspection: RecordHorseInspectionUseCase,
-    private val findHorseInspection: FindHorseInspectionUseCase,
+    private val getHorseInspection: GetHorseInspectionUseCase,
     private val clock: Clock,
 ) {
     @Operation(
@@ -118,7 +118,7 @@ class HorseInspectionController(
     fun get(
         @Parameter(description = "取得する審査の生 UUID") @PathVariable id: UUID
     ): HorseInspectionResponse =
-        findHorseInspection(FindHorseInspectionQuery(id))
+        getHorseInspection(GetHorseInspectionQuery(id))
             .mapError { it.toProblemDetail() }
             .orThrowProblem()
             .toResponse()

--- a/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
+++ b/src/main/kotlin/com/example/api/controller/jockey/JockeyController.kt
@@ -1,7 +1,7 @@
 package com.example.api.controller.jockey
 
-import com.example.api.application.racing.jockey.FindJockeyQuery
-import com.example.api.application.racing.jockey.FindJockeyUseCase
+import com.example.api.application.racing.jockey.GetJockeyQuery
+import com.example.api.application.racing.jockey.GetJockeyUseCase
 import com.example.api.application.racing.jockey.JockeyRegistrationUseCase
 import com.example.api.application.racing.jockey.RegisterJockeyCommand
 import com.example.api.controller.jockey.problem.toProblemDetail
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class JockeyController(
     private val registerJockey: JockeyRegistrationUseCase,
-    private val findJockey: FindJockeyUseCase,
+    private val getJockey: GetJockeyUseCase,
     private val clock: Clock,
 ) {
     @Operation(
@@ -126,8 +126,7 @@ class JockeyController(
     )
     @GetMapping("/api/jockeys/{id}")
     fun get(@Parameter(description = "取得するジョッキーの生 UUID") @PathVariable id: UUID): JockeyResponse {
-        val view =
-            findJockey(FindJockeyQuery(id)).mapError { it.toProblemDetail() }.orThrowProblem()
+        val view = getJockey(GetJockeyQuery(id)).mapError { it.toProblemDetail() }.orThrowProblem()
         return view.toResponse()
     }
 }

--- a/src/main/kotlin/com/example/api/mcp/racing/jockey/JockeyMcpResult.kt
+++ b/src/main/kotlin/com/example/api/mcp/racing/jockey/JockeyMcpResult.kt
@@ -1,7 +1,7 @@
 package com.example.api.mcp.racing.jockey
 
 /**
- * MCP ツール `find_jockey` の結果表現（adapter 所有のワイヤ DTO）。
+ * MCP ツール `get_jockey` の結果表現（adapter 所有のワイヤ DTO）。
  *
  * application の読みモデル [com.example.api.application.racing.jockey.JockeyView]（`@QueryModel`）を
  * アダプタ境界の外へ漏らさないため、ここで素の DTO へ写す（controller の `JockeyResponse` と同じ役割）。 id はワイヤ上は文字列で扱う。

--- a/src/main/kotlin/com/example/api/mcp/racing/jockey/JockeyMcpTools.kt
+++ b/src/main/kotlin/com/example/api/mcp/racing/jockey/JockeyMcpTools.kt
@@ -1,7 +1,7 @@
 package com.example.api.mcp.racing.jockey
 
-import com.example.api.application.racing.jockey.FindJockeyQuery
-import com.example.api.application.racing.jockey.FindJockeyUseCase
+import com.example.api.application.racing.jockey.GetJockeyQuery
+import com.example.api.application.racing.jockey.GetJockeyUseCase
 import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.map
 import java.util.UUID
@@ -10,19 +10,19 @@ import org.springframework.stereotype.Component
 
 /**
  * ジョッキー照会を MCP ツールとして公開する adapter（REST の [com.example.api.controller.jockey.JockeyController] と対になる
- * MCP アダプタ）。application の [FindJockeyUseCase] を再利用し、`Result` を MCP ツール結果へ写す。
+ * MCP アダプタ）。application の [GetJockeyUseCase] を再利用し、`Result` を MCP ツール結果へ写す。
  *
  * `@McpTool` を application 層に直付けすると MCP 関心がドメイン側へ漏れる（オニオン違反）ため、変換責務は
  * 必ずこのアダプタが持つ。失敗（不在・不正入力）は例外として送出し、Spring AI が MCP の `isError` ツール 結果へ写す（controller の
  * `orThrowProblem()` と同様、境界での throw は adapter に許される）。
  */
 @Component
-class JockeyMcpTools(private val findJockeyUseCase: FindJockeyUseCase) {
+class JockeyMcpTools(private val getJockeyUseCase: GetJockeyUseCase) {
 
-    @McpTool(name = "find_jockey", description = "ジョッキーIDで登録済みジョッキーを照会する")
-    fun findJockey(jockeyId: String): JockeyMcpResult {
+    @McpTool(name = "get_jockey", description = "ジョッキーIDで登録済みジョッキーを照会する")
+    fun getJockey(jockeyId: String): JockeyMcpResult {
         val id = UUID.fromString(jockeyId)
-        return findJockeyUseCase(FindJockeyQuery(id))
+        return getJockeyUseCase(GetJockeyQuery(id))
             .map { view ->
                 JockeyMcpResult(
                     id = view.id.toString(),

--- a/src/test/kotlin/com/example/api/application/racing/jockey/GetJockeyUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/racing/jockey/GetJockeyUseCaseTest.kt
@@ -9,14 +9,14 @@ import io.mockk.mockk
 import org.junit.jupiter.api.Test
 
 /**
- * 照会ユースケース [FindJockeyUseCase] の単体テスト（軽量 CQRS（L2）の読み取り側。ADR-0031）。
+ * 照会ユースケース [GetJockeyUseCase] の単体テスト（軽量 CQRS（L2）の読み取り側。ADR-0031）。
  *
  * 読み取りポート [JockeyQueries] を mockk でスタブし、ヒット時は [JockeyView] を、不在時は [JockeyNotFound] を
  * 返す分岐を検証する（testing.md: applicationService は Repository / Query ポート境界をモックする）。
  */
-class FindJockeyUseCaseTest {
+class GetJockeyUseCaseTest {
     private val jockeyQueries = mockk<JockeyQueries>()
-    private val findJockey = FindJockeyUseCase(jockeyQueries)
+    private val getJockey = GetJockeyUseCase(jockeyQueries)
 
     @Test
     fun `存在するIDなら対応するJockeyViewをOkで返す`() {
@@ -24,7 +24,7 @@ class FindJockeyUseCaseTest {
         val view = JockeyView(id = id, firstName = "武", lastName = "豊")
         every { jockeyQueries.findById(JockeyId(id)) } returns view
 
-        val result = findJockey(FindJockeyQuery(id))
+        val result = getJockey(GetJockeyQuery(id))
 
         assert(result.get() == view)
     }
@@ -34,7 +34,7 @@ class FindJockeyUseCaseTest {
         val id = generateId()
         every { jockeyQueries.findById(JockeyId(id)) } returns null
 
-        val result = findJockey(FindJockeyQuery(id))
+        val result = getJockey(GetJockeyQuery(id))
 
         assert(result.getError() == JockeyNotFound(id))
     }

--- a/src/test/kotlin/com/example/api/application/studbook/breeding/ListBreedingResultSummariesUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/breeding/ListBreedingResultSummariesUseCaseTest.kt
@@ -6,10 +6,10 @@ import io.mockk.mockk
 import java.util.UUID
 import org.junit.jupiter.api.Test
 
-class FindBreedingResultSummaryUseCaseTest {
+class ListBreedingResultSummariesUseCaseTest {
 
     private val queries = mockk<BreedingResultSummaryQueries>()
-    private val useCase = FindBreedingResultSummaryUseCase(queries)
+    private val useCase = ListBreedingResultSummariesUseCase(queries)
 
     private val stallionId = BloodHorseId(UUID.fromString("11111111-1111-1111-1111-111111111111"))
 
@@ -22,7 +22,7 @@ class FindBreedingResultSummaryUseCaseTest {
             )
         every { queries.findByStallion(stallionId) } returns rows
 
-        val result = useCase(FindBreedingResultSummaryQuery(stallionId))
+        val result = useCase(ListBreedingResultSummariesQuery(stallionId))
 
         assert(result == rows)
     }
@@ -31,7 +31,7 @@ class FindBreedingResultSummaryUseCaseTest {
     fun `該当する成績が無ければ空リストを返す`() {
         every { queries.findByStallion(stallionId) } returns emptyList()
 
-        val result = useCase(FindBreedingResultSummaryQuery(stallionId))
+        val result = useCase(ListBreedingResultSummariesQuery(stallionId))
 
         assert(result.isEmpty())
     }

--- a/src/test/kotlin/com/example/api/application/studbook/inspection/GetHorseInspectionUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/inspection/GetHorseInspectionUseCaseTest.kt
@@ -11,14 +11,14 @@ import io.mockk.mockk
 import org.junit.jupiter.api.Test
 
 /**
- * 照会ユースケース [FindHorseInspectionUseCase] の単体テスト（軽量 CQRS（L2）の読み取り側。ADR-0031）。
+ * 照会ユースケース [GetHorseInspectionUseCase] の単体テスト（軽量 CQRS（L2）の読み取り側。ADR-0031）。
  *
  * 読み取りポート [HorseInspectionQueries] を mockk でスタブし、ヒット時は [HorseInspectionView] を、不在時は
  * [HorseInspectionNotFound] を返す分岐を検証する（testing.md: applicationService はポート境界をモックする）。
  */
-class FindHorseInspectionUseCaseTest {
+class GetHorseInspectionUseCaseTest {
     private val horseInspectionQueries = mockk<HorseInspectionQueries>()
-    private val findHorseInspection = FindHorseInspectionUseCase(horseInspectionQueries)
+    private val getHorseInspection = GetHorseInspectionUseCase(horseInspectionQueries)
 
     @Test
     fun `存在するIDなら対応するHorseInspectionViewをOkで返す`() {
@@ -32,7 +32,7 @@ class FindHorseInspectionUseCaseTest {
             )
         every { horseInspectionQueries.findById(HorseInspectionId(id)) } returns view
 
-        val result = findHorseInspection(FindHorseInspectionQuery(id))
+        val result = getHorseInspection(GetHorseInspectionQuery(id))
 
         assert(result.get() == view)
     }
@@ -42,7 +42,7 @@ class FindHorseInspectionUseCaseTest {
         val id = generateId()
         every { horseInspectionQueries.findById(HorseInspectionId(id)) } returns null
 
-        val result = findHorseInspection(FindHorseInspectionQuery(id))
+        val result = getHorseInspection(GetHorseInspectionQuery(id))
 
         assert(result.getError() == HorseInspectionNotFound(id))
     }

--- a/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
@@ -1,6 +1,6 @@
 package com.example.api.controller
 
-import com.example.api.application.racing.jockey.FindJockeyUseCase
+import com.example.api.application.racing.jockey.GetJockeyUseCase
 import com.example.api.application.racing.jockey.JockeyRegistrationError
 import com.example.api.application.racing.jockey.JockeyRegistrationUseCase
 import com.example.api.application.racing.jockey.RegisterJockeyCommand
@@ -35,7 +35,7 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester
 class GlobalExceptionHandlerTest(val mockMvc: MockMvc) {
     @MockkBean private lateinit var registerJockey: JockeyRegistrationUseCase
 
-    @MockkBean private lateinit var findJockey: FindJockeyUseCase
+    @MockkBean private lateinit var getJockey: GetJockeyUseCase
 
     private val tester = MockMvcTester.create(mockMvc)
 

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultSummaryControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultSummaryControllerTest.kt
@@ -1,8 +1,8 @@
 package com.example.api.controller.breeding
 
 import com.example.api.application.studbook.breeding.BreedingResultSummaryView
-import com.example.api.application.studbook.breeding.FindBreedingResultSummaryQuery
-import com.example.api.application.studbook.breeding.FindBreedingResultSummaryUseCase
+import com.example.api.application.studbook.breeding.ListBreedingResultSummariesQuery
+import com.example.api.application.studbook.breeding.ListBreedingResultSummariesUseCase
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import java.util.UUID
@@ -19,7 +19,7 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester
 @AutoConfigureMockMvc(addFilters = false)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class BreedingResultSummaryControllerTest(val mockMvc: MockMvc) {
-    @MockkBean private lateinit var findBreedingResultSummary: FindBreedingResultSummaryUseCase
+    @MockkBean private lateinit var listBreedingResultSummaries: ListBreedingResultSummariesUseCase
 
     private val tester = MockMvcTester.create(mockMvc)
 
@@ -28,7 +28,7 @@ class BreedingResultSummaryControllerTest(val mockMvc: MockMvc) {
     @Test
     fun `種牡馬IDの集計一覧が200で件数と率つきの配列で返ること`() {
         // BreedingResultSummaryView.of(stallionId, 2024, 6, 4, 1) → 受胎率 4/6=66.7%
-        every { findBreedingResultSummary(any<FindBreedingResultSummaryQuery>()) } returns
+        every { listBreedingResultSummaries(any<ListBreedingResultSummariesQuery>()) } returns
             listOf(BreedingResultSummaryView.of(stallionId, 2024, 6, 4, 1))
 
         val body =
@@ -46,7 +46,7 @@ class BreedingResultSummaryControllerTest(val mockMvc: MockMvc) {
 
     @Test
     fun `集計の件数フィールドが snake_case で公開されること`() {
-        every { findBreedingResultSummary(any<FindBreedingResultSummaryQuery>()) } returns
+        every { listBreedingResultSummaries(any<ListBreedingResultSummariesQuery>()) } returns
             listOf(BreedingResultSummaryView.of(stallionId, 2024, 6, 4, 1))
 
         tester
@@ -61,7 +61,7 @@ class BreedingResultSummaryControllerTest(val mockMvc: MockMvc) {
 
     @Test
     fun `該当なしは200で空配列を返すこと`() {
-        every { findBreedingResultSummary(any<FindBreedingResultSummaryQuery>()) } returns
+        every { listBreedingResultSummaries(any<ListBreedingResultSummariesQuery>()) } returns
             emptyList()
 
         tester

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -3,9 +3,9 @@ package com.example.api.controller.horse
 import com.example.api.application.studbook.horse.BloodHorseDetailView
 import com.example.api.application.studbook.horse.BloodHorseNotFound
 import com.example.api.application.studbook.horse.BloodHorseView
-import com.example.api.application.studbook.horse.FindBloodHorsesUseCase
 import com.example.api.application.studbook.horse.GetBloodHorseQuery
 import com.example.api.application.studbook.horse.GetBloodHorseUseCase
+import com.example.api.application.studbook.horse.ListBloodHorsesUseCase
 import com.example.api.application.studbook.horse.NameHorseCommand
 import com.example.api.application.studbook.horse.NameHorseUseCase
 import com.example.api.application.studbook.horse.NameHorseUseCaseError
@@ -62,7 +62,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
     @MockkBean private lateinit var registerImportedHorse: RegisterImportedHorseUseCase
     @MockkBean private lateinit var nameHorse: NameHorseUseCase
     @MockkBean private lateinit var registerCarriedOverHorse: RegisterCarriedOverHorseUseCase
-    @MockkBean private lateinit var findBloodHorses: FindBloodHorsesUseCase
+    @MockkBean private lateinit var listBloodHorses: ListBloodHorsesUseCase
     @MockkBean private lateinit var getBloodHorse: GetBloodHorseUseCase
 
     private val tester = MockMvcTester.create(mockMvc)
@@ -94,7 +94,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
         @Test
         fun `軽種馬一覧が200で snake_case のサマリ配列として返ること`() {
             val id = UUID.fromString("22222222-2222-2222-2222-222222222222")
-            every { findBloodHorses() } returns
+            every { listBloodHorses() } returns
                 listOf(
                     BloodHorseView(
                         id = id,
@@ -122,7 +122,7 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
 
         @Test
         fun `登録が無ければ200で空配列を返すこと`() {
-            every { findBloodHorses() } returns emptyList()
+            every { listBloodHorses() } returns emptyList()
 
             tester
                 .get()

--- a/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
@@ -1,7 +1,7 @@
 package com.example.api.controller.inspection
 
-import com.example.api.application.studbook.inspection.FindHorseInspectionQuery
-import com.example.api.application.studbook.inspection.FindHorseInspectionUseCase
+import com.example.api.application.studbook.inspection.GetHorseInspectionQuery
+import com.example.api.application.studbook.inspection.GetHorseInspectionUseCase
 import com.example.api.application.studbook.inspection.HorseInspectionNotFound
 import com.example.api.application.studbook.inspection.HorseInspectionView
 import com.example.api.application.studbook.inspection.RecordHorseInspectionCommand
@@ -44,7 +44,7 @@ import tools.jackson.databind.json.JsonMapper
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class HorseInspectionControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper) {
     @MockkBean private lateinit var recordHorseInspection: RecordHorseInspectionUseCase
-    @MockkBean private lateinit var findHorseInspection: FindHorseInspectionUseCase
+    @MockkBean private lateinit var getHorseInspection: GetHorseInspectionUseCase
 
     private val tester = MockMvcTester.create(mockMvc)
 
@@ -201,7 +201,7 @@ class HorseInspectionControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMa
                     parentage = ParentageDetermination.ByDna(DnaParentageResult.CONSISTENT),
                     features = IdentificationFeatures("頭部正中", null, null),
                 )
-            every { findHorseInspection(FindHorseInspectionQuery(id)) } returns Ok(view)
+            every { getHorseInspection(GetHorseInspectionQuery(id)) } returns Ok(view)
 
             tester
                 .get()
@@ -216,7 +216,7 @@ class HorseInspectionControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMa
         @Test
         fun `存在しない ID で 404 と inspection_id 付きの problem+json が返ること`() {
             val id = UUID.fromString("44444444-4444-4444-4444-444444444444")
-            every { findHorseInspection(FindHorseInspectionQuery(id)) } returns
+            every { getHorseInspection(GetHorseInspectionQuery(id)) } returns
                 Err(HorseInspectionNotFound(id))
 
             val result = tester.get().uri("/api/horseInspections/$id").exchange()

--- a/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
@@ -1,7 +1,7 @@
 package com.example.api.controller.jockey
 
-import com.example.api.application.racing.jockey.FindJockeyQuery
-import com.example.api.application.racing.jockey.FindJockeyUseCase
+import com.example.api.application.racing.jockey.GetJockeyQuery
+import com.example.api.application.racing.jockey.GetJockeyUseCase
 import com.example.api.application.racing.jockey.JockeyNotFound
 import com.example.api.application.racing.jockey.JockeyRegistrationError
 import com.example.api.application.racing.jockey.JockeyRegistrationUseCase
@@ -36,7 +36,7 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester
 class JockeyControllerTest(val mockMvc: MockMvc) {
     @MockkBean private lateinit var registerJockey: JockeyRegistrationUseCase
 
-    @MockkBean private lateinit var findJockey: FindJockeyUseCase
+    @MockkBean private lateinit var getJockey: GetJockeyUseCase
 
     private val tester = MockMvcTester.create(mockMvc)
 
@@ -127,7 +127,7 @@ class JockeyControllerTest(val mockMvc: MockMvc) {
         @Test
         fun `存在するIDで 200 OK とリソース表現が返ること`() {
             val id = generateId()
-            every { findJockey(FindJockeyQuery(id)) } returns
+            every { getJockey(GetJockeyQuery(id)) } returns
                 Ok(JockeyView(id = id, firstName = "武", lastName = "豊"))
 
             val response =
@@ -142,7 +142,7 @@ class JockeyControllerTest(val mockMvc: MockMvc) {
         @Test
         fun `存在しないIDで 404 と jockey_id 付きの problem+json が返ること`() {
             val id = generateId()
-            every { findJockey(FindJockeyQuery(id)) } returns Err(JockeyNotFound(id))
+            every { getJockey(GetJockeyQuery(id)) } returns Err(JockeyNotFound(id))
 
             tester
                 .get()

--- a/src/test/kotlin/com/example/api/mcp/racing/jockey/JockeyMcpToolsTest.kt
+++ b/src/test/kotlin/com/example/api/mcp/racing/jockey/JockeyMcpToolsTest.kt
@@ -1,7 +1,7 @@
 package com.example.api.mcp.racing.jockey
 
-import com.example.api.application.racing.jockey.FindJockeyQuery
-import com.example.api.application.racing.jockey.FindJockeyUseCase
+import com.example.api.application.racing.jockey.GetJockeyQuery
+import com.example.api.application.racing.jockey.GetJockeyUseCase
 import com.example.api.application.racing.jockey.JockeyNotFound
 import com.example.api.application.racing.jockey.JockeyView
 import com.example.api.domain.shared.generateId
@@ -15,20 +15,20 @@ import org.junit.jupiter.api.assertThrows
 /**
  * MCP アダプタ [JockeyMcpTools] の slice 相当ユニットテスト。
  *
- * adapter リングのため [FindJockeyUseCase] を mockk でスタブし、Result → MCP ツール結果（成功 DTO /
+ * adapter リングのため [GetJockeyUseCase] を mockk でスタブし、Result → MCP ツール結果（成功 DTO /
  * 失敗時の例外送出）への変換のみを検証する（testing.md: adapter は slice 相当で入出力変換を検証）。
  */
 class JockeyMcpToolsTest {
-    private val findJockeyUseCase = mockk<FindJockeyUseCase>()
-    private val tools = JockeyMcpTools(findJockeyUseCase)
+    private val getJockeyUseCase = mockk<GetJockeyUseCase>()
+    private val tools = JockeyMcpTools(getJockeyUseCase)
 
     @Test
     fun `存在するIDならJockeyMcpResultを返す`() {
         val id = generateId()
-        every { findJockeyUseCase(FindJockeyQuery(id)) } returns
+        every { getJockeyUseCase(GetJockeyQuery(id)) } returns
             Ok(JockeyView(id = id, firstName = "武", lastName = "豊"))
 
-        val result = tools.findJockey(id.toString())
+        val result = tools.getJockey(id.toString())
 
         assert(result == JockeyMcpResult(id = id.toString(), firstName = "武", lastName = "豊"))
     }
@@ -36,14 +36,14 @@ class JockeyMcpToolsTest {
     @Test
     fun `存在しないIDなら例外を送出する（MCPのisErrorへ写す）`() {
         val id = generateId()
-        every { findJockeyUseCase(FindJockeyQuery(id)) } returns Err(JockeyNotFound(id))
+        every { getJockeyUseCase(GetJockeyQuery(id)) } returns Err(JockeyNotFound(id))
 
-        val ex = assertThrows<NoSuchElementException> { tools.findJockey(id.toString()) }
+        val ex = assertThrows<NoSuchElementException> { tools.getJockey(id.toString()) }
         assert(ex.message == "jockey not found: $id")
     }
 
     @Test
     fun `不正なUUID文字列なら例外を送出する`() {
-        assertThrows<IllegalArgumentException> { tools.findJockey("not-a-uuid") }
+        assertThrows<IllegalArgumentException> { tools.getJockey("not-a-uuid") }
     }
 }


### PR DESCRIPTION
Closes #688

## 背景

#495（PR #686）で軽種馬の by-id 照会を追加した際、一覧の `FindBloodHorsesUseCase` と差が末尾の `s` 一文字だけになるのを避けるため `GetBloodHorseUseCase` と命名した。その結果、単数 by-id 照会に `Find〜` と `Get〜` の 2 系統が併存していた。

着手時に読み取り系ユースケースを棚卸ししたところ、プロジェクト全体で 5 本しかなく、2 つの事実が確定した。

1. **HTTP の外部契約はすでに AIP（Get / List）に揃っている**。`operationId` も Controller のハンドラ名（`get` / `list`）も Get / List で、`Find〜` が残っていたのは application 層の内部名だけだった。
2. **`FindBreedingResultSummaryUseCase` は単数形の名前で `List` を返していた**。`Find〜`（単数）が by-id を指すのか絞り込み一覧を指すのかが名前から判別できず、末尾 `s` の有無より深い紛らわしさが既にあった。

#495 が一覧の改名を見送った理由は「他コンテキストの `Find〜` 群と不揃いになる」だったが、その `Find〜` 群は実在しなかった。よって全体を一度に揃えた。

## 変更内容

**単数 by-id → `Get〜UseCase`**

| 変更前 | 変更後 |
|---|---|
| `FindJockeyUseCase` / `FindJockeyQuery` | `GetJockeyUseCase` / `GetJockeyQuery` |
| `FindHorseInspectionUseCase` / `FindHorseInspectionQuery` | `GetHorseInspectionUseCase` / `GetHorseInspectionQuery` |
| `GetBloodHorseUseCase` | 変更なし（すでに準拠） |

**コレクション → `List〜sUseCase`（必ず複数形）**

| 変更前 | 変更後 |
|---|---|
| `FindBloodHorsesUseCase` | `ListBloodHorsesUseCase` |
| `FindBreedingResultSummaryUseCase` / `FindBreedingResultSummaryQuery` | `ListBreedingResultSummariesUseCase` / `ListBreedingResultSummariesQuery` |

あわせて Controller の DI プロパティ名、テストのファイル名・クラス名、KDoc の相互参照を追随させ、規約を `.claude/rules/architecture.md` の「読み取り経路（軽量 CQRS / L2）」節に明文化した。

## 外部契約への影響

**HTTP は変更ゼロ**。`operationId`・パス・レスポンス型・ステータスはいずれも動いていない。Controller の diff に含まれる変更行は import・DI プロパティ名・呼び出し式だけで、`operationId` や `@GetMapping` の行は 1 行も現れない（＝ OpenAPI に差分が出ない）。

**MCP ツール名だけ変わる**: `find_jockey` → `get_jockey`。MCP アダプタは ADR-0035 の walking skeleton で実運用クライアントが無く、互換破壊の実害なく内外の語彙を一本化できると判断した。今後 MCP ツールを増やすときの命名基準もここで確定する。

## スコープ外にしたもの

- **クエリポート `〜Queries` のメソッド名**（`findById` / `findAll` / `findByStallion`）は据え置き。ポートは「無いかもしれないものを探す」意味論で `find` が正しく、ユースケース名（何をする操作か）とポート名（どう引くか）は別の語彙。#687 で追加する `Jdbc〜Queries` もこの形を引き継ぐ。
- **View 型名**（`〜View` と `〜DetailView` の呼び分け）。別軸の論点。
- **ADR-0031 / ADR-0035 の本文**。`FindJockeyUseCase` への言及が残るが、ADR は決定時点の記録として改変しない。

## 検証

- `./gradlew check` 緑（ktfmt + detekt + 全テスト + ArchUnit + `koverVerifyMature`）
- 対象シンボルの残存がリポジトリ全体でゼロ（ADR を除く）
- Controller の diff に外部契約の追加/削除行がゼロ

挙動を一切変えない改名のため、既存テストが緑のままであることが検証そのもの。テストの期待値・アサーションは変更していない。

## 関連

#687（breeding 系の GET-by-id 整備）では、この規約に従って `Get〜UseCase` を 3 つ追加する。
