### PR TITLE
chore: mise.lock に gh の platform エントリを追加する

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -84,6 +84,48 @@ provenance = "cosign"
 version = "2.96.0"
 backend = "aqua:cli/cli"
 
+[tools."aqua:cli/cli"."platforms.linux-arm64"]
+checksum = "sha256:06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909"
+url = "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/464728549"
+provenance = "github-attestations"
+
+[tools."aqua:cli/cli"."platforms.linux-arm64-musl"]
+checksum = "sha256:06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909"
+url = "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/464728549"
+provenance = "github-attestations"
+
+[tools."aqua:cli/cli"."platforms.linux-x64"]
+checksum = "sha256:83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60"
+url = "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/464728543"
+provenance = "github-attestations"
+
+[tools."aqua:cli/cli"."platforms.linux-x64-musl"]
+checksum = "sha256:83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60"
+url = "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/464728543"
+provenance = "github-attestations"
+
+[tools."aqua:cli/cli"."platforms.macos-arm64"]
+checksum = "sha256:f23a0c37d963aacc3bed703ccbd59b41c5ca22101fab7f00eb2b7cad23aba463"
+url = "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_macOS_arm64.zip"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/464728562"
+provenance = "github-attestations"
+
+[tools."aqua:cli/cli"."platforms.macos-x64"]
+checksum = "sha256:4bd449df9ad639391bc62b8032546f0fe9edcd8526e06682a4f88abd8c5d163c"
+url = "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_macOS_amd64.zip"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/464728560"
+provenance = "github-attestations"
+
+[tools."aqua:cli/cli"."platforms.windows-x64"]
+checksum = "sha256:c2d6acc935cd2f00e2144d7e036d5cd82e6b6bd5594e8c75aa75ef2a4ed6aac3"
+url = "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_windows_amd64.zip"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/464728577"
+provenance = "github-attestations"
+
 [[tools."aqua:dprint/dprint"]]
 version = "0.55.1"
 backend = "aqua:dprint/dprint"


### PR DESCRIPTION
## 概要

`aqua:cli/cli`（gh）は `mise.toml` の 20 ツール中で**唯一 `mise.lock` に platform エントリを持たず**、`version` と `backend` だけの状態でした。

今は実害が出ていません。CI は各ワークフローが `install_args` で必要なツールだけを入れる構成で、gh はどこにも列挙されていない（runner 標準の `gh` を使う）ためです。ただし `mise-action` は `--locked` で install するので、#332（devcontainer で gh コマンドを使えるようにする）等で `install_args` に載せた瞬間に lock エントリを引けず落ちます。CLAUDE.md「ツール管理」が「必要な platform のエントリを揃える」と定めている対象そのものなので、先に埋めておきます。

## 変更内容

- `mise.lock`: `mise lock aqua:cli/cli --platform linux-x64,linux-arm64,linux-x64-musl,linux-arm64-musl,macos-x64,macos-arm64,windows-x64` で 7 platform 分を生成（+42 行、削除なし）。
  - platform の顔ぶれは、同じ aqua backend の既存ツール（dprint / shellcheck 等）が持つ 7 種に揃えました。
  - musl 系が glibc と同一アセットを指すのは、上流が musl 専用ビルドを配布しておらず aqua が同じ資産へ写すためです（既存ツールの記録と同型）。
  - `linux-x64` の `provenance` 行のみ手で補いました。生成時に sigstore へ到達できず lock 時の provenance 検証が落ちて欠落したもので、gh は attestation を publish している側なので他 6 platform と揃うのが正です。

## 動作確認

- [x] **checksum を公式と突き合わせ**: 生成された 5 種の実チェックサムが [`gh_2.96.0_checksums.txt`](https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_checksums.txt) と完全一致することを確認。
- [x] **差分が gh に限定されていること**: 追加セクションは `[tools."aqua:cli/cli"."platforms.*"]` の 7 つのみで、他ツールのエントリに変更なし（+42/-0）。
- [x] `editorconfig-checker` 通過。
- [x] `gitleaks`（staged）通過。

### この PR で確認できていないこと

- **`mise install --locked` の実地検証はできていません**。このセッションのプロキシが `api.github.com/repos/cli/cli/*` と sigstore CDN を遮断しており、gh の install 自体が attestation 検証で落ちるためです（生成された checksum / URL の正しさは上記の公式突き合わせで担保しています）。
- `dprint` は未実行です（`plugins.dprint.dev` へのプラグイン取得がプロキシに遮断されるため）。`mise.lock` は ADR-0063 で dprint の対象外なので、`dprint-check.yml` の判定には影響しません。

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3ZszHAjUBoAYtaY71gFdK)_