### PR TITLE
fix: Identity Platform 設定の永久差分を止める

### DIFF
--- a/infra/modules/identity-platform/main.tf
+++ b/infra/modules/identity-platform/main.tf
@@ -9,6 +9,15 @@ resource "google_identity_platform_config" "default" {
       enabled           = true
       password_required = true
     }
+
+    # 電話番号認証は使わないが、API は無効時も phone_number を
+    # `{enabled: false, testPhoneNumbers: {}}` として必ず返す。HCL 側でブロックを省くと
+    # Terraform が「[{enabled=false}] → []」を毎回 update として計画し、apply しても
+    # サーバ値が state に書き戻されるため収束しない（永久差分）。既定値をそのまま明示して止める。
+    phone_number {
+      enabled            = false
+      test_phone_numbers = {}
+    }
   }
 
   authorized_domains = var.authorized_domains


### PR DESCRIPTION
## 問題

`terraform plan` が毎回 `Plan: 0 to add, 1 to change, 0 to destroy.` を返し、`module.identity_platform.google_identity_platform_config.default` の update が永久に消えない状態だった。apply 済みの run の直後でも同じ差分が再出現する。

## 原因

plan の JSON 出力（ `GET /plans/:id/json-output` ）で before/after を突き合わせたところ、差分は `sign_in.phone_number` の 1 箇所だけだった。

| | 値 |
|---|---|
| before（state ＝ API の実状態） | `[{ enabled = false, test_phone_numbers = {} }]` |
| after（設定） | `[]` |

Identity Platform API は電話番号認証が無効でも `phone_number` を既定値付きで必ず返す。HCL 側でブロックを書いていないと Terraform は「ブロックを消す」更新を計画するが、apply 後の read でサーバ値が state に書き戻されるため収束しない（典型的な perpetual diff）。

## 対応

`sign_in` に `phone_number` ブロックを API 既定値のまま明示し、設定と実状態を一致させた。省略すると永久差分になる理由はコード内コメントに残している。

## 検証

修正後の構成で HCP の speculative plan を実行し、以下を確認済み。

```
No changes. Your infrastructure matches the configuration.
```

## 対応しないもの

同じログに出る `google_artifact_registry_repository.api: Drift detected (update)` は、差分が `update_time`（イメージ push のたびにサーバが更新する読み取り専用属性）のみで、plan の変更数には計上されない。設定で抑止できる類のものではないため、そのままにしている。
