### PR TITLE
docs: hcp-run-inspect に plan の属性レベル差分の追い方を追記する

### DIFF
--- a/.claude/skills/hcp-run-inspect/SKILL.md
+++ b/.claude/skills/hcp-run-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hcp-run-inspect
-description: Use when checking a Terraform plan/run in HCP Terraform via tfctl — especially the speculative plan that ran for a PR（「PR の plan を確認」「HCP の run を見る」「terraform plan が通ったか」plan の add/change/destroy 数）。PR の run が既定の run 一覧に見当たらないときも。
+description: Use when checking a Terraform plan/run in HCP Terraform via tfctl — especially the speculative plan that ran for a PR（「PR の plan を確認」「HCP の run を見る」「terraform plan が通ったか」plan の add/change/destroy 数）。PR の run が既定の run 一覧に見当たらないときも。plan の差分の中身（どのリソースのどの属性か）を属性レベルで突き止めたいとき、とくに「毎回同じ差分が出る」「apply しても消えない」永久差分を調べるときにも使う。
 ---
 
 # HCP Terraform の run/plan を tfctl で確認する
@@ -39,6 +39,27 @@ tfctl api "/plans/$plan" --jq '{add:.data.attributes."resource-additions", chang
 
 `planned_and_finished` + 期待どおりの add/change/destroy なら plan は健全。作成/変更されるリソース名の一覧が要るときは HCP UI の run ページ（`run status` の link）か run のログを見る。
 
+## 手順: 差分の中身（どの属性が変わるのか）を見る
+
+`resource-changes` は件数、run のログ（`type: planned_change`）はリソース名までしか出ない。**どの属性が差分なのかは plan の JSON 出力で before/after を突き合わせる**。「毎回同じリソースが update される」の原因究明はここまで落とさないと分からない。
+
+```bash
+plan=$(tfctl api "/runs/<run-id>" --jq '.data.relationships.plan.data.id')
+tfctl api "/plans/$plan/json-output" > plan.json   # ← 変数値が平文で入る。scratchpad に置き、用が済んだら消す
+
+# no-op 以外のリソース（＝実際に変更が計画されているもの）
+jq '[.resource_changes[] | select(.change.actions != ["no-op"]) | {addr:.address, actions:.change.actions}]' plan.json
+
+# 対象リソースの before/after のうち、実際に食い違うトップレベルのキーだけを出す
+jq -r '.resource_changes[] | select(.address=="<addr>") | .change | {before,after}' plan.json > d.json
+jq -n --slurpfile d d.json '$d[0].before as $b | $d[0].after as $a
+  | [($b|keys[]) | select(($b[.]|tojson) != ($a[.]|tojson)) | {key:., before:$b[.], after:$a[.]}]'
+```
+
+`resource_drift[]` も同じ構造で、refresh で検出されたサーバ側の変化（ログの `Drift detected`）が入る。**drift は plan の変更数には計上されない**ので、`update_time` のような読み取り専用属性だけが動いていれば実害はなく、設定で抑止する手段も基本ない。
+
+**注意: `json-output` には workspace の変数値が平文で含まれる**（sensitive 指定のトークン類も `.variables` に入る）。貼り付け・共有はせず、scratchpad に落として読み終えたら削除する。
+
 ## Quick Reference
 
 | 目的 | コマンド |
@@ -48,6 +69,7 @@ tfctl api "/plans/$plan" --jq '{add:.data.attributes."resource-additions", chang
 | commit → run | `tfctl api "/workspaces/<ws>/runs?search%5Bcommit%5D=<sha>"` |
 | run の状態（要約） | `tfctl run status <run-id>` |
 | plan の変更数 | `tfctl api "/plans/<plan-id>"`（`resource-additions` / `-changes` / `-destructions`） |
+| 差分の属性まで | `tfctl api "/plans/<plan-id>/json-output"` → `.resource_changes[].change.before/after`（変数値が平文で入る点に注意） |
 
 ## Common Mistakes
 
@@ -55,3 +77,4 @@ tfctl api "/plans/$plan" --jq '{add:.data.attributes."resource-additions", chang
 - GitHub のコミットステータスの target_url は集約ステータス（`acs-...`）止まりで run-id は出ない → head SHA 経由で引く。
 - `search[commit]` / `page[size]` の `[` `]` を URL エンコードし忘れる（`%5B` / `%5D`）。
 - TLS エラー `OSStatus -26276` → tfctl が sandbox 外で実行されていない。`X Unauthorized for app.terraform.io` → `tfctl auth login` 未実施。
+- 「毎回 `1 to change` が消えない」を件数とリソース名だけ見て原因不明のままにする → `json-output` で属性まで落とす。設定に書いていない block を API が既定値付きで返しているだけ（apply しても state に書き戻されて収束しない永久差分）というのが典型で、既定値をそのまま HCL に明示すれば止まる。


### PR DESCRIPTION
## 背景

#708（Identity Platform 設定の永久差分）を追ったとき、既存の `/hcp-run-inspect` の手順では詰まった。plan の `resource-changes` は件数だけ、run のログ（`type: planned_change`）はリソース名までで、**どの属性が毎回変わっているのか**が分からない。原因（`sign_in.phone_number` の 1 属性）にたどり着けたのは plan の JSON 出力まで落としたからだった。

同じ調べ方を次回すぐ再現できるよう、手順としてスキルに残す。

## 追記内容

`.claude/skills/hcp-run-inspect/SKILL.md`

- **「差分の中身（どの属性が変わるのか）を見る」節を追加**: `tfctl api "/plans/<id>/json-output"` を取得し、`resource_changes` の no-op 以外を抽出 → 対象リソースの `before` / `after` で食い違うキーだけを jq で出す、という手順
- `resource_drift[]` も同じ構造で、**drift は plan の変更数に計上されない**こと（`update_time` のような読み取り専用属性だけなら実害なし・設定での抑止手段もない）を明記
- **`json-output` には workspace の変数値が sensitive 指定のものも含めて平文で入る**ため、貼り付けず scratchpad に落として消す、という注意を追加
- Quick Reference に `json-output` の行を追加
- Common Mistakes に「毎回の `1 to change` を件数だけ見て原因不明のままにする」を追加。設定に書いていない block を API が既定値付きで返している永久差分が典型で、既定値を HCL に明示すれば止まる、と対処まで併記
- frontmatter の `description` に「属性レベルの差分」「永久差分の調査」を発火条件として追加

ドキュメントのみの変更で、コード・インフラへの影響はない。
