### PR TITLE
chore: frontend の npm を Dependabot 対象にし react-router の脆弱性を解消する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,31 @@ updates:
         patterns:
           - "*"
 
+  # Enable updates for frontend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      # React 本体と型定義はバージョン系列を揃える必要がある（react 19 に上げて @types/react が
+      # 18 のままだと型エラーになる）。react / react-dom / それぞれの @types を major も含め
+      # 常に 1 PR へ束ね、片側だけ進む状態を作らない。
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      # 残りの minor / patch を集約。react 系（上のグループ）はグループ定義順で先勝ちのため
+      # ここには入らない。major は個別 PR に残る。
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+
   # Enable updates for Terraform providers
   - package-ecosystem: "terraform"
     directory: "/infra"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "firebase": "^12.16.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^7.0.0"
+        "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.0",
@@ -1233,9 +1233,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1253,9 +1250,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1273,9 +1267,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1293,9 +1284,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1313,9 +1301,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1333,9 +1318,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1534,12 +1516,6 @@
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
       }
-    },
-    "node_modules/@types/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "license": "MIT"
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -2628,9 +2604,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2652,9 +2625,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2676,9 +2646,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2700,9 +2667,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2854,9 +2818,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -2934,9 +2898,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2954,7 +2918,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3051,15 +3015,13 @@
       "peer": true
     },
     "node_modules/react-router": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.0.0.tgz",
-      "integrity": "sha512-1xf+yMVhUjAzZGY90ZnYJ9KVe1R8FggpugzRBkh+p6vl4cC1sHDe3nO+r5rxWTAgCMf8uN5hfoV2M7rLVTWPUA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "@types/cookie": "^0.6.0",
         "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0",
-        "turbo-stream": "2.4.0"
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3075,12 +3037,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.0.0.tgz",
-      "integrity": "sha512-2QAxXpwgQuh423C64oZiV2cCKPCNUgZxcvZaS8O0PAHPZ/z8kTq7YbGD4KTNZm6Yj66d+HAfGkWPp8MCpdtD+Q==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.0.0"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3381,12 +3343,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/turbo-stream": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
-      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
-      "license": "ISC"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "firebase": "^12.16.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.0.0"
+    "react-router-dom": "^7.18.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",


### PR DESCRIPTION
## 概要

Closes #693

`frontend/` の npm 依存は #612 で追加されて以降、**一度も Dependabot の対象になっていなかった**。
`.github/dependabot.yml` に npm エコシステムの宣言が無かったためで、その結果 `react-router` が
導入時の 7.0.0 のまま取り残され、以後に公表された脆弱性が積み上がる構造になっていた。

エコシステムの宣言（再発防止）と版上げ（現状の解消）の両方を入れる。

## 変更内容

### `.github/dependabot.yml`

npm エコシステム（`directory: "/frontend"`）を追加。既存エントリに倣い `weekly` /
`open-pull-requests-limit: 5`、グルーピングは #381 の方針（minor / patch は集約、major は個別 PR）を踏襲した。

加えて **`react` / `react-dom` と対応する `@types/*` を major も含め 1 グループへ束ねる専用グループ**を置いた。
`react` を 19 に上げて `@types/react` が 18 のまま残ると型エラーになるため、片側だけ進む状態を構造的に防ぐ
（codeql-action グループと同じ考え方）。

### `frontend/package.json` / `package-lock.json`

- `react-router-dom` の range を `^7.0.0` → `^7.18.2`、解決バージョンを **7.18.2** へ。
- `turbo-stream` は react-router の依存から外れたため lockfile から消える（GHSA-rxv8-25v2-qmq8 も解消）。
- あわせて `postcss` を `npm audit fix` で引き上げ、GHSA-fxqj-rqcc-2cmp（moderate、vite の推移的依存）を解消。

## 検証

`.github/workflows/frontend.yml` と同じ 3 ステップをローカルで実行し、いずれも緑:

```
npm run lint   → Checked 22 files. No fixes applied.
npm run build  → tsc + vite build 成功（built in 874ms）
npm run test   → Test Files 4 passed (4) / Tests 9 passed (9)
```

ルーティングの退行については、`RequireAuth.test.tsx`（`MemoryRouter` + `Routes` + `Navigate` による
未認証リダイレクト）と `BloodHorseListPage.test.tsx` が通っていることで確認した。使っている API は
declarative mode の `BrowserRouter` / `Routes` / `Route` / `Navigate` / `Outlet` / `useNavigate` のみで、
7.0 → 7.18 は minor 内の更新。

**実ブラウザでのログイン → 馬一覧の E2E は未実施**（実 Identity Platform テナントと bootRun + local Postgres が要るため）。

## 残る脆弱性（この PR のスコープ外）

`npm audit` に **GHSA-qwww-vcr4-c8h2**（high / react-router `>=7.12.0 <8.3.0`）が残る。Issue 起票後に
公表されたもので、**修正版は 8.3.0 のみ**（7.x 系にバックポートが無い）。react-router 8.3.0 は
`react >= 19.2.7` を要求するため、解消には **React 18 → 19 の major upgrade** が必要になり、この PR の
スコープを超える。内容も RSC mode 前提の CSRF bypass で、SSR を持たない SPA（declarative mode）の
この構成では成立しない。**#699（frontend を React 19 + react-router v8 へ移行する）** が既に立っており、そちらの担当。

## この PR で扱わないこと

Dependabot の `cooldown`（リリースから N 日待ってから PR を作る）はエコシステム横断の運用方針のため、
**#716** に切り出した。設定しなくても version update には既定で 3 日の cooldown がかかっており
（security update は対象外）、この PR に含めないことによる無防備な状態は生じない。

## 完了条件

- [x] `.github/dependabot.yml` が `frontend/` の npm を対象に含む
- [x] `react-router` の解決バージョンが 7.18.0 以上になる（7.18.2）
- [ ] npm の Dependabot アラート 11 件がすべて自動クローズされる（マージ後に確認）
- [x] `.github/workflows/frontend.yml` の CI が通る（ローカルで同等の 3 ステップが緑。CI は本 PR で実行）
- [x] ルーティング（ログイン → 馬一覧）が退行していない（vitest で確認。実ブラウザ E2E は未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WceBxhRyH2Kwv76yajaiFb
