### PR TITLE
chore: #694 postgresql JDBC ドライバの脆弱性 (GHSA-j92g-9f8w-j867) を解消する

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,12 @@ springmockk = "5.0.1"
 archunit = "1.4.2"
 jmolecules-bom = "2025.0.2"
 junit = "6.1.2"
+# PostgreSQL JDBC ドライバ。通常は他の Spring 管理依存と同じく BOM に委ねるが、Spring Boot 4.1.0 の
+# managed version（42.7.11）が GHSA-j92g-9f8w-j867（high。未対応の証明書アルゴリズム経由で
+# channel binding 認証がサイレントにダウングレードされる）の脆弱範囲に入るため、修正版 42.7.12 を
+# 暫定で上書きする（#694）。Spring Boot の検証済み組み合わせから外れる暫定対処なので、
+# managed version が 42.7.12 以上になった Spring Boot へ更新したらこの上書きを外して BOM に戻す。
+postgresql = "42.7.12"
 
 [libraries]
 # Spring AI（MCP server。WebMVC SSE/Streamable トランスポート）
@@ -32,10 +38,11 @@ springdoc-openapi-starter-webmvc-ui = { module = "org.springdoc:springdoc-openap
 
 # 永続化（Spring Data JDBC + Flyway + PostgreSQL。ADR-0027 / ADR-0044）。
 # バージョンは Spring Boot の依存管理（BOM）に委ねるため version は指定しない
+# （postgresql だけは脆弱性回避で暫定上書き中。理由と外す条件は [versions] のコメント参照）
 spring-boot-starter-data-jdbc = { module = "org.springframework.boot:spring-boot-starter-data-jdbc" }
 spring-boot-starter-flyway = { module = "org.springframework.boot:spring-boot-starter-flyway" }
 spring-boot-docker-compose = { module = "org.springframework.boot:spring-boot-docker-compose" }
-postgresql = { module = "org.postgresql:postgresql" }
+postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 flyway-database-postgresql = { module = "org.flywaydb:flyway-database-postgresql" }
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql" }
 


### PR DESCRIPTION
Closes #694

## 何をしたか

`org.postgresql:postgresql` の解決バージョンを **42.7.11 → 42.7.12** に引き上げ、Dependabot アラート #19（**high**、[GHSA-j92g-9f8w-j867](https://github.com/advisories/GHSA-j92g-9f8w-j867) ）を解消する。

脆弱性の内容は「未対応の証明書アルゴリズムを介した **channel-binding 認証のサイレントなダウングレード**」で、脆弱範囲は `>= 42.7.4, < 42.7.12`、修正版が `42.7.12`。本番 DB は Prisma Postgres へ TLS 接続する（ADR-0044）ため、この認証経路に直接効く。

## 実装

Issue に挙がっていた 2 案（1. Spring Boot のパッチ更新を待つ / 2. バージョンを明示指定して即時解消）のうち、**2 を採った**。high であること、パッチバージョンの引き上げでリスクが小さいことが理由で、Spring Boot が追随したら上書きを外して 1 に戻す。

`gradle/libs.versions.toml` の 1 箇所（`[versions]` にバージョン追加 + `[libraries]` に `version.ref`）のみ。

- **`build.gradle.kts` 側の手当ては要らなかった**。`io.spring.dependency-management` は BOM の managed version で明示バージョンを上書きすることがあるため `extra["postgresql.version"]` が必要かと見たが、実測では catalog の明示だけで解決が変わった（下記）。設定を増やさない形に留めている。
- 上書きする理由と**外す条件**（managed version が 42.7.12 以上の Spring Boot へ更新したら BOM に戻す）を `[versions]` のコメントに明記した。`[libraries]` 側の「バージョンは BOM に委ねる」コメントにも、postgresql だけが暫定的な例外である旨を補記している。
- 最新は 42.7.13 だが、**Spring Boot の検証済み組み合わせから外れる暫定対処なので、脆弱性の修正版ちょうど（42.7.12）に留めて外れ幅を最小にした**。

## 検証

解決バージョン（本番 jar に載る runtime と、Testcontainers 契約テストが使う test runtime の両方）:

```
$ ./gradlew -q dependencyInsight --dependency org.postgresql:postgresql --configuration runtimeClasspath
org.postgresql:postgresql:42.7.12 (selected by rule)

$ ./gradlew -q dependencyInsight --dependency org.postgresql:postgresql --configuration testRuntimeClasspath
org.postgresql:postgresql:42.7.12 (selected by rule)
```

`./gradlew check` 緑（Testcontainers の永続化契約テスト込み、4m36s）。実 42.7.12 ドライバで PostgreSQL に接続してのテストが通っている。

## 完了条件

- [x] `org.postgresql:postgresql` の解決バージョンが 42.7.12 以上になる
- [ ] Dependabot アラート #19 が解消（自動クローズ）される ← マージ後に確認
- [x] `./gradlew check` が通る（Testcontainers の契約テスト込み）
- [x] 暫定上書きの理由と外す条件をコメントで明記する

## 関連

- #477 jackson-databind の脆弱性（同じく Spring Boot BOM 経由の推移的依存。medium のため Parked のまま）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
