### PR TITLE
chore: #383 テスト JVM の CDS を切って Kover agent 由来の VM 警告を消す

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,6 +95,14 @@ kotlin {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    // テスト JVM の CDS（Class Data Sharing）を明示的に切る。
+    // Kover の JVM agent は MANIFEST の `Boot-Class-Path` で自分自身をブートストラップクラスパスへ
+    // 追記するため、JDK 既定の CDS アーカイブ（lib/server/classes.jsa）が存在する環境では
+    // 「Sharing is only supported for boot loader classes because bootstrap classpath has been
+    // appended」という VM 警告がテスト起動のたびに出る（CI の Linux ランナーで再現。macOS の
+    // Temurin は classes.jsa を同梱しないため CDS 自体が無効でローカルには現れない）。
+    // テストで CDS の起動短縮は活用していないので、切って警告ごと消す（#383）。
+    jvmArgs("-Xshare:off")
     // maxParallelForks（テスト JVM の並列フォーク）は意図的に既定（1）のまま据え置く。
     // 計測上、単一モジュール・小規模スイートの本プロジェクトでは forks を増やすと逆に遅くなる
     // （42s→97s @ forks=4）。コンテキストキャッシュ統計の実測では distinct な ApplicationContext は


### PR DESCRIPTION
Closes #383

## 何をしたか

`build.gradle.kts` の `tasks.withType<Test>` に `jvmArgs("-Xshare:off")` を足し、テスト JVM の CDS（Class Data Sharing）を明示的に無効化した。

## なぜ

Kover の JVM agent は MANIFEST に `Boot-Class-Path: kover-jvm-agent-<version>.jar` を持ち、自分自身をブートストラップクラスパスへ追記する。JDK 既定の CDS アーカイブ（`lib/server/classes.jsa`）が存在する環境ではこれが CDS を無効化し、テスト JVM の起動ごとに次の警告が出る。

```
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
```

挙動には影響しない（テスト結果・カバレッジ計測とも正常）が、ログのノイズになる。テストで CDS の起動短縮は活用していないため、切って警告ごと消すのが費用対効果に優る（Issue の対応案 1）。

## 事実確認

- **警告は現存する**。最新 main の CI run（Linux ランナー）で `> Task :test` の直前に 2 件出ている。`:detekt-rules:test` は FROM-CACHE なので root の `:test` worker 由来。
- **原因は Kover agent のまま**。Issue 起票時の 0.9.8 から 0.9.9 に上がった今も `Boot-Class-Path` は健在（`unzip -p build/kover/kover-jvm-agent-0.9.9.jar META-INF/MANIFEST.MF` で確認）。
- **ローカル（macOS）で再現しないのは環境差であって解消ではない**。mise が供給する Temurin 25 の macOS 版は `lib/server/classes.jsa` を同梱しておらず、CDS 自体が無効になっている（`-Xlog:cds` で `Specified shared archive file not found` を確認）。したがって「ローカルで警告が出ない = 直った」とは言えない。
- `--debug` で test worker のコマンドラインに `-Xshare:off` が実際に渡ることを確認した。
- `./gradlew check` 緑（Testcontainers の永続化契約テスト込み）。

## 未確認事項

**警告が消えたことの確認はローカルでは原理的にできない**（CDS が無い環境なので変化を観測できない）。この PR の CI ログを grep して確認する。

## 影響範囲

`tasks.withType<Test>` は Test 型のタスク全部に効くため、`test` に加えて `e2eTest` / `replay` にも適用される。いずれも CDS を活用していないので実害はない。
