### PR TITLE
fix: issue-followup の工程 4 に相互参照があるときの実行順序を足す

### DIFF
--- a/.claude/skills/issue-followup/SKILL.md
+++ b/.claude/skills/issue-followup/SKILL.md
@@ -45,8 +45,12 @@ PR をマージした直後に 1 回走らせる。気づいた都度ではな�
 
 ## 工程 4: 実行と確認
 
-- 既存 Issue へのコメント: `gh issue comment <n> --body-file <file>`（本文が長いときは `--body` を使わない）
+**相互参照があるときは起票を先に行う**。Issue 番号は起票して初めて確定するため、既存 Issue へのコメントで
+新規 Issue を参照するなら、番号を得てからコメント本文を書く。逆順にすると存在しない番号を当て推量で書く
+ことになる（実際に踏んだ）。
+
 - 新規 Issue: **issue-ops の B に従う**（作成 → Project #4 に追加 → Priority 設定を 1 セットで行う）
+- 既存 Issue へのコメント: `gh issue comment <n> --body-file <file>`（本文が長いときは `--body` を使わない）
 - 締める前に、起票した Issue が Project #4 に乗り Priority が付いていることを確認する
 
 ## よくある失敗


### PR DESCRIPTION
## 背景

#729 で追加した `issue-followup` スキルを、直後に #694（postgresql の脆弱性解消）の締めへ**実地適用したところ、工程 4 の実行順序に穴があった**。

実際に踏んだ内容:

1. 反映案として「#477 へコメント」「新規 Issue を起票」の 2 件が決まった
2. スキルの工程 4 が「既存へのコメント → 新規起票」の順で書かれていたため、その順に着手した
3. #477 のコメント本文で新規 Issue を参照する必要があったが、**まだ起票していないので番号が無い**。当て推量で `#730` と書いてしまった
4. 起票して実際に付いたのは **#731**。投稿前に気づいて直したので実害はないが、順序が逆なら毎回この穴を踏む

## 変更

`.claude/skills/issue-followup/SKILL.md` の工程 4 のみ。

- 冒頭に **「相互参照があるときは起票を先に行う」** と、逆順にすると存在しない番号を当て推量で書くことになる理由を明記した
- 箇条書きの順序を実行順どおり **「新規 Issue の起票 → 既存 Issue へのコメント」** に入れ替えた。従来は逆順に並んでおり、素直に読むと穴を踏む並びだった

## 補足

#729 の PR 本文に書いたとおり、このスキルはサブエージェントでの pressure scenario 検証を行っていない（このセッションではサブエージェント起動が禁止されているため）。代わりに実地適用で穴を洗い出す方針を採っており、**本 PR はその 1 回目の結果**にあたる。失敗を観測してから直しているという意味では、順序としては TDD の RED → GREEN に沿っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
