### PR TITLE
chore: tennis を Kover 成熟ゲートの対象へ昇格する

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -106,7 +106,7 @@ Kover 0.9 の検証ルールはパッケージ単位のフィルタを持てな�
 - **自動ラチェット機構は持たない**（YAGNI）。手動で引き上げる。
 
 探索除外パッケージ（`build.gradle.kts` の `variant("mature")` の `excludes` が唯一の出所。ここは要約）:
-`domain.racing.model.race` / `domain.racing.service` / `domain.tennis` / `e2e`（E2E テスト基盤）/ `dbdoc`（tbls ドキュメント生成基盤）/ `replay`（帰納的検証ハーネス）。
+`domain.racing.model.race` / `domain.racing.service` / `e2e`（E2E テスト基盤）/ `dbdoc`（tbls ドキュメント生成基盤）/ `replay`（帰納的検証ハーネス）。
 
 - **ゲート外のソースセットを新設したら、そのパッケージを `variant("mature")` の `excludes` に加える**。Kover は main 以外のソースセットも計測対象に取り込むため、加えないとテスト基盤・ツール基盤のコードが未カバレッジのままゲート母集団に乗り、成熟ゲートを割る（`e2e` / `dbdoc` / `replay` はいずれもこの理由で除外している）。
 
@@ -146,6 +146,6 @@ CI（`api-tests.yml`）は test 後に `koverVerifyMature` でゲートを掛け
 
 - `infrastructure.*`（JDBC リポジトリ）: `Jockey` は Testcontainers 契約テスト済み。残り集約（`BloodHorse` / `BreedingRegistration` / `BreedingResult`）は JDBC 実装＋契約テストが未整備で、移行に伴い InMemory を廃止する（JDBC 一本化。[ADR-0030](../../docs/adr/0030-jdbc-only-persistence-retire-inmemory.md) / #435）。なお `infrastructure.*` は `excludes` に入れておらず**既にゲート母集団内**。未テスト分は集計に乗るが現状の LINE 90% / BRANCH 80% を満たしている（割り込んだらテストを添えること）。
 - `domain.racing.service`（`confirmRaceResult`）: サービスだがテスト無し。`excludes` 在籍。
-- `domain.racing.model`（`race`）・`tennis`: 探索段階のモデル。`excludes` 在籍（`sakamichi` は #367 でテストが揃いゲート対象へ昇格済み）。
+- `domain.racing.model`（`race`）: 探索段階のモデル。`excludes` 在籍（`sakamichi` は #367、`tennis` は #677 でテストが揃いゲート対象へ昇格済み）。
 
-このうち `excludes` に在籍している探索領域（`racing.model.race` / `racing.service` / `tennis`）は、テストが揃った時点で `variant("mature")` の `excludes` から外してゲート対象へ昇格させる（`infrastructure.*` は既にゲート対象なので対象外）。
+このうち `excludes` に在籍している探索領域（`racing.model.race` / `racing.service`）は、テストが揃った時点で `variant("mature")` の `excludes` から外してゲート対象へ昇格させる（`infrastructure.*` は既にゲート対象なので対象外）。

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -210,7 +210,6 @@ kover {
                         // 探索段階（レイヤーごとのテスト未整備）。成熟したらこの行を外す＝ゲート対象へ昇格。
                         "com.example.api.domain.racing.model.race",
                         "com.example.api.domain.racing.service",
-                        "com.example.api.domain.tennis",
                         // e2eTest ソースセットのクラス（E2E テスト本体）を除外。
                         // アプリケーションロジックではなくテスト基盤コードのため。
                         "com.example.api.e2e",


### PR DESCRIPTION
## 概要

#677。`domain.tennis` を Kover 成熟ゲート（`koverVerifyMature`: LINE 90% / BRANCH 80%）の対象へ昇格する。

#365（PR #676）で `Player` 集約と値オブジェクト群、3 つのユニットテストクラス（`PlayerNameTest` / `CountryTest` / `PlayerTest`）が揃ったが、当時は作業環境の Docker 不調で `koverVerifyMature` をローカル実行できず、**推論で excludes を外すと CI を壊すため見送っていた**。今回 Docker が使える環境で実測した。

## 実測

`variant("mature")` の `excludes` から `"com.example.api.domain.tennis"` を外した状態で計測（出所は `build/reports/kover/reportMature.xml`）。

| 対象 | LINE | BRANCH |
| --- | --- | --- |
| mature 母集団 全体 | **96.71%** (3001/3103) | **89.27%** (591/662) |
| `domain.tennis.model.player` | **100%** (39/39) | **100%** (14/14) |

下限（LINE 90% / BRANCH 80%）に対していずれも余裕がある。tennis 自体が 100% なので、母集団に加えても全体水準は下がらない。

```
> Task :koverPrintCoverageMature
成熟ゲート対象の行カバレッジ（分岐も別途ゲート）: 96.7129%

BUILD SUCCESSFUL
```

- `./gradlew koverVerifyMature koverLogMature` → BUILD SUCCESSFUL
- `./gradlew check` → BUILD SUCCESSFUL

補足: 母集団に乗るのは `model/player` パッケージのみで、`DateOfBirth` / `Handedness` / `TurnedProDate` には専用テストクラスが無いが、`PlayerTest` 経由の間接カバーで BRANCH まで 100% に届いている。

## 変更

### `build.gradle.kts`

- `variant("mature")` の `excludes` から `"com.example.api.domain.tennis"` を削除。

以降 #366（テニス大会の開催）等で tennis のコードが増えたとき、テスト不足はその時点でゲートに引っかかる（望ましいラチェット）。昇格を先送りするとこの効果が得られない、というのが #677 の動機でもある。

### `.claude/rules/testing.md`

`build.gradle.kts` が唯一の出所で testing.md はその要約なので、3 箇所を追従させた。

- 探索除外パッケージの要約リストから `domain.tennis` を削除。
- 「当面の宿題」の探索段階モデルの記述から `tennis` を外し、昇格済みである旨を `sakamichi`（#367）と並べて #677 として記録。
- 昇格待ちの列挙（`racing.model.race` / `racing.service`）から `tennis` を落とす。

## 注意

Kotlin のソース変更はゼロ（Kover のフィルタ設定のみ）なので、ローカルの `:test` はキャッシュヒットで再実行されていない。テスト本体の再走は CI（`api-tests.yml`）が担う。

Closes #677
