### PR TITLE
fix: #713 provision の並行実行が 500 になる穴を UNIQUE 裁定で塞ぐ

### DIFF
--- a/docs/adr/0067-per-player-world-tenant-isolation.md
+++ b/docs/adr/0067-per-player-world-tenant-isolation.md
@@ -136,6 +136,20 @@ Issue #703（IAM: アカウントと世界）で、フロントエンドをシ�
   `.claude/rules/architecture.md` の「ArchUnit で Kotlin の呼び出しを縛るときの空振り」に記載されて
   いる value class のメソッド名マングリングと同根の事情であり、value class を Spring MVC のような
   フレームワークへ渡す箇所全般で再発しうる。
+- **追補（#713 で解消）**: 上記の「`:provision` は冪等に作る」は、当初は**逐次実行に限った冪等**
+  だった。実装は事前照会（`findBySubjectId` / `existsByAccountId`）→ insert の 2 手で、そのあいだに
+  別リクエストが同じ subject を insert すると UNIQUE 制約違反（`uq_account_subject_id` /
+  `uq_world_account_id_name`）が未捕捉のまま伝播して 500 になっていた。サインイン直後にフロント
+  エンドが必ず 1 回叩く経路であり、StrictMode の二重発火・複数タブ・リロードで現実に踏む。
+  `DuplicateKeyException` を捕まえて読み直す素直な対処は、PostgreSQL が UNIQUE 違反の時点で
+  トランザクションを abort 済みのため同一トランザクション内では成立せず、別トランザクション境界の
+  手当てを要した。#713 では**そもそも UNIQUE 違反を例外にしない**方針を採り、`INSERT ... ON CONFLICT
+  DO NOTHING` ＋読み直しの専用ポート（`AccountRepository.saveIfAbsent` /
+  `WorldRepository.saveIfAbsent`）へ寄せた。DB の UNIQUE を唯一の裁定者にすることで TOCTOU が結果に
+  影響しなくなり、`:provision` は並行実行下でも冪等になった（事前照会は 2 回目以降の書き込みを避ける
+  高速経路として残るだけで、正しさはこれに依存しない）。なお**利用者が名前を指定する世界の作成・改名
+  は対象外**で、同名衝突を 409 として見せる必要があるため事前照会と `save` を使い続ける（そちらの
+  TOCTOU は未解消のまま）。
 - **次段階（本 ADR のスコープ外）**: 既存ドメイン（studbook / racing / sakamichi / tennis 全コンテキ
   スト）への `world_id` 列の追加・複合 FK の導入、既存 API の `/api/worlds/{worldId}/...` への移設は
   Issue #704 / #705 / #706 で扱う。本 ADR は「テナント分離の設計判断」を確定させるものであり、

--- a/src/main/kotlin/com/example/api/application/iam/me/ProvisionMeUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/iam/me/ProvisionMeUseCase.kt
@@ -9,7 +9,6 @@ import com.example.api.domain.iam.model.world.WorldNameValidationError
 import com.example.api.domain.iam.model.world.WorldRepository
 import com.example.api.domain.shared.AccountId
 import com.example.api.domain.shared.Command
-import com.example.api.domain.shared.UpdateConflict
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.mapError
@@ -30,21 +29,6 @@ sealed interface ProvisionMeError {
 
     /** 既定の世界名が不変条件を満たさなかった（定数の設定ミスでしか起きない）。 */
     data class InvalidDefaultWorldName(val cause: WorldNameValidationError) : ProvisionMeError
-
-    /**
-     * 並行する同一 subject のブートストラップと競合した。クライアントは再試行できる（冪等操作のため）。
-     *
-     * **既知の限界**: 事前照会（`findBySubjectId` / `existsByAccountId`）と insert の間には TOCTOU の レース窓が残る。真に同時な
-     * 2 リクエストが両方とも「未登録」を見て両方 insert を試みると、2 回目は DB の UNIQUE 制約（`uq_account_subject_id` /
-     * `uq_world_account_id_name`）に弾かれ、この `Conflict` ではなく未捕捉の `DuplicateKeyException`（500）として伝播する。
-     *
-     * このバリアントが実際に返るのは、事前照会が通った後・insert 前の別経路（例: 楽観ロック起因）に限られ、 通常の同時 provision レースでは 500
-     * になる。read-your-conflict 化（`DuplicateKeyException` を捕まえて `findBySubjectId`
-     * を引き直す）は当面見送る。PostgreSQL は UNIQUE 違反時点でトランザクションを abort
-     * 済みのため、同一トランザクション内でのリトライは効かず、別トランザクション境界の手当てが要る。 `:provision` はサインイン直後にフロントが必ず 1
-     * 回叩く設計で、レースの窓は実用上ごく短く、 かつ呼び出し側は 500 を含めて再試行してよい（冪等）ため、複雑さに見合わないと判断した。
-     */
-    data object Conflict : ProvisionMeError
 }
 
 /**
@@ -56,9 +40,11 @@ sealed interface ProvisionMeError {
  *
  * `Actor` を引数に取らないのは、この時点ではまだ「どの世界で操作しているか」が決まっていないため。 世界の所有確認を伴う操作は次の段階（世界スコープ化）で `Actor` を受ける。
  *
- * **並行実行の既知の限界**: 事前照会（`findBySubjectId` / `existsByAccountId`）と実際の insert の間に TOCTOU
- * のレースが残っており、真に同時な 2 リクエストが競合すると `Conflict`（409）ではなく DB の UNIQUE 制約違反に由来する未捕捉の例外（500）になる。詳細と判断理由は
- * [ProvisionMeError.Conflict] を参照。
+ * **並行実行**: サインイン直後・StrictMode の二重発火・複数タブなどで同時に呼ばれる前提の経路なので、 書き込みは事前照会に頼らず
+ * [AccountRepository.saveIfAbsent] / [WorldRepository.saveIfAbsent]（`INSERT ... ON CONFLICT DO
+ * NOTHING` ＋読み直し）で行う。DB の UNIQUE 制約を唯一の裁定者にすることで、事前照会と insert のあいだの TOCTOU
+ * が結果に影響しない（アカウントも世界も増えず、UNIQUE 違反の例外も出ない）。 事前照会（`findBySubjectId` / `existsByAccountId`）は 2
+ * 回目以降の呼び出しで書き込みを避けるための 高速経路として残しているだけで、正しさはこれに依存しない（#713）。
  */
 @Service
 class ProvisionMeUseCase(
@@ -78,19 +64,15 @@ class ProvisionMeUseCase(
                         Account.create(command.payload.subjectId)
                             .mapError { _: BlankSubjectId -> ProvisionMeError.InvalidSubject }
                             .bind()
-                    accounts
-                        .save(created)
-                        .mapError { _: UpdateConflict -> ProvisionMeError.Conflict }
-                        .bind()
+                    // 並行して同じ subject を作りにいっても、先着の行がそのまま返る（増えない）。
+                    accounts.saveIfAbsent(created)
                 }
 
             if (!worlds.existsByAccountId(account.id)) {
                 World.create(account.id, DEFAULT_WORLD_NAME)
                     .mapError { ProvisionMeError.InvalidDefaultWorldName(it) }
                     .bind()
-                    .let { worlds.save(it) }
-                    .mapError { _: UpdateConflict -> ProvisionMeError.Conflict }
-                    .bind()
+                    .let { worlds.saveIfAbsent(it) }
             }
 
             account.id

--- a/src/main/kotlin/com/example/api/controller/me/problem/MeProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/me/problem/MeProblem.kt
@@ -10,6 +10,8 @@ import org.springframework.http.ProblemDetail
  *
  * [ProvisionMeError.InvalidSubject] と [ProvisionMeError.InvalidDefaultWorldName] は、トークン検証を
  * 通っていれば／定数を正しく設定していれば起きない防御的分岐。クライアントに直せることが無いので 500 とし、 400 系で「あなたの入力が悪い」と誤って伝えない。
+ *
+ * 競合（409）のバリアントは持たない。並行するセットアップは DB の UNIQUE を裁定者にして吸収され、 呼び出し側に競合として見えないため（#713）。
  */
 fun ProvisionMeError.toProblemDetail(): ProblemDetail =
     when (this) {
@@ -26,14 +28,5 @@ fun ProvisionMeError.toProblemDetail(): ProblemDetail =
                 code = "invalid-default-world-name",
                 title = "Invalid default world name",
                 detail = "既定の世界名がサーバ側の不変条件を満たしていません。",
-            )
-        // 実際に同時リクエストが競合すると多くは DB の UNIQUE 制約違反（500）になり、このバリアントには
-        // 到達しないことが多い（既知の限界。詳細は ProvisionMeError.Conflict の KDoc）。
-        is ProvisionMeError.Conflict ->
-            problem(
-                status = HttpStatus.CONFLICT,
-                code = "provisioning-conflict",
-                title = "Provisioning conflict",
-                detail = "初回セットアップが別のリクエストと競合しました。やり直してください。",
             )
     }

--- a/src/main/kotlin/com/example/api/domain/iam/model/account/AccountRepository.kt
+++ b/src/main/kotlin/com/example/api/domain/iam/model/account/AccountRepository.kt
@@ -18,6 +18,20 @@ interface AccountRepository {
      * アカウントを永続化する。
      *
      * 集約の [Account.version] が null なら insert、非 null なら楽観ロック付き update になる。
+     *
+     * **同一 subject の重複（DB の `UNIQUE (subject_id)`）はここでは検知しない**。UNIQUE 違反は `DuplicateKeyException`
+     * として未捕捉のまま伝播する。初回ログインのブートストラップのように 並行実行が前提の経路では、この `save` ではなく [saveIfAbsent] を使うこと。
      */
     fun save(account: Account): Result<Account, UpdateConflict>
+
+    /**
+     * 同じ subject のアカウントが無ければ保存し、既にあればそれを返す（原子的な get-or-create）。
+     *
+     * 事前照会（[findBySubjectId]）→ insert という手順は、その 2 手のあいだに別のリクエストが同じ subject を insert しうる TOCTOU
+     * のレースを残す。この口は「先に照会してから書く」のではなく **DB の UNIQUE 制約を 唯一の裁定者にする**（`INSERT ... ON CONFLICT DO
+     * NOTHING` ＋衝突時の読み直し）ため、並行実行しても アカウントは増えず、UNIQUE 違反の例外も出ない。
+     *
+     * 渡した [account] の ID は、衝突したときは採用されない（先着の行がそのまま返る）。
+     */
+    fun saveIfAbsent(account: Account): Account
 }

--- a/src/main/kotlin/com/example/api/domain/iam/model/world/WorldRepository.kt
+++ b/src/main/kotlin/com/example/api/domain/iam/model/world/WorldRepository.kt
@@ -34,6 +34,18 @@ interface WorldRepository {
      */
     fun save(world: World): Result<World, UpdateConflict>
 
+    /**
+     * 同一アカウント内に同名の世界が無ければ保存し、既にあればそれを返す（原子的な get-or-create）。
+     *
+     * [existsByAccountIdAndName] による事前照会 → [save] は、その 2 手のあいだに別のリクエストが同名の世界を insert しうる TOCTOU
+     * のレースを残す。この口は **DB の `UNIQUE (account_id, name)` を唯一の裁定者にする** （`INSERT ... ON CONFLICT DO
+     * NOTHING` ＋衝突時の読み直し）ため、並行実行しても世界は増えず、UNIQUE 違反の 例外も出ない。
+     *
+     * 用途は**衝突を利用者に見せる必要が無い経路**（初回ログインで既定名の世界を用意する場合）に限る。 利用者が名前を指定する作成・改名は「同名が既にある」ことを 409
+     * で返す必要があるため、事前照会と [save] を 使い続ける。
+     */
+    fun saveIfAbsent(world: World): World
+
     /** 世界を削除する。配下のデータは DB の ON DELETE CASCADE で連鎖削除される。 */
     fun deleteById(id: WorldId)
 

--- a/src/main/kotlin/com/example/api/infrastructure/iam/account/JdbcAccountRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/iam/account/JdbcAccountRepository.kt
@@ -41,17 +41,20 @@ class JdbcAccountRepository(
      * 回増えるが、この口を通るのは初回ログインだけで割に合う。
      */
     override fun saveIfAbsent(account: Account): Account {
+        val subjectId = account.subjectId
         jdbcClient
-            .sql(INSERT_IF_ABSENT)
+            .sql(
+                "INSERT INTO iam.account (id, subject_id, version) " +
+                    "VALUES (:id, :subjectId, :version) " +
+                    "ON CONFLICT (subject_id) DO NOTHING"
+            )
             .param("id", account.id.value)
-            .param("subjectId", account.subjectId.value)
+            .param("subjectId", subjectId.value)
             .param("version", INITIAL_VERSION)
             .update()
         // insert したなら自分の行、衝突したなら先着の行。DO NOTHING は先行トランザクションの
         // 確定を待ってから効くため、この時点で行は必ず存在する（READ COMMITTED 前提）。
-        return checkNotNull(findBySubjectId(account.subjectId)) {
-            "saveIfAbsent の直後にアカウントを引けなかった: ${account.subjectId.value}"
-        }
+        return checkNotNull(findBySubjectId(subjectId)) { "insert 直後に引けない: ${subjectId.value}" }
     }
 
     private fun AccountRow.toDomain(): Account =
@@ -65,13 +68,5 @@ class JdbcAccountRepository(
          * 食い違うため、契約テスト（`saveIfAbsent の初回保存は save と同じ version を採番する`）で縛っている。
          */
         const val INITIAL_VERSION = 0L
-
-        val INSERT_IF_ABSENT =
-            """
-            INSERT INTO iam.account (id, subject_id, version)
-            VALUES (:id, :subjectId, :version)
-            ON CONFLICT (subject_id) DO NOTHING
-            """
-                .trimIndent()
     }
 }

--- a/src/main/kotlin/com/example/api/infrastructure/iam/account/JdbcAccountRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/iam/account/JdbcAccountRepository.kt
@@ -9,11 +9,15 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import org.springframework.dao.OptimisticLockingFailureException
+import org.springframework.jdbc.core.simple.JdbcClient
 import org.springframework.stereotype.Repository
 
 /** ドメインポート [AccountRepository] の唯一の実装。Spring Data JDBC で永続化する（ADR-0027 / ADR-0030）。 */
 @Repository
-class JdbcAccountRepository(private val rows: AccountSpringDataRepository) : AccountRepository {
+class JdbcAccountRepository(
+    private val rows: AccountSpringDataRepository,
+    private val jdbcClient: JdbcClient,
+) : AccountRepository {
 
     override fun findBySubjectId(subjectId: SubjectId): Account? =
         rows.findBySubjectId(subjectId.value)?.toDomain()
@@ -26,8 +30,48 @@ class JdbcAccountRepository(private val rows: AccountSpringDataRepository) : Acc
             Err(UpdateConflict)
         }
 
+    /**
+     * `ON CONFLICT DO NOTHING` で insert し、結果によらず DB の現状を読み直して返す。
+     *
+     * Spring Data JDBC の `save` は upsert を書けないため、ここだけ [JdbcClient] で SQL を直接書く。 **UNIQUE
+     * 違反を例外にしない**ことが要点で、これにより PostgreSQL がトランザクションを abort せず、 同一トランザクション内で読み直せる（例外を捕まえる方式では abort
+     * 済みのため別トランザクション境界が要る）。
+     *
+     * 衝突しなかった場合も読み直すのは、採番済みの `version` を含む DB の実状態を 1 か所のマッピング （[findBySubjectId]）で返すため。往復が 1
+     * 回増えるが、この口を通るのは初回ログインだけで割に合う。
+     */
+    override fun saveIfAbsent(account: Account): Account {
+        jdbcClient
+            .sql(INSERT_IF_ABSENT)
+            .param("id", account.id.value)
+            .param("subjectId", account.subjectId.value)
+            .param("version", INITIAL_VERSION)
+            .update()
+        // insert したなら自分の行、衝突したなら先着の行。DO NOTHING は先行トランザクションの
+        // 確定を待ってから効くため、この時点で行は必ず存在する（READ COMMITTED 前提）。
+        return checkNotNull(findBySubjectId(account.subjectId)) {
+            "saveIfAbsent の直後にアカウントを引けなかった: ${account.subjectId.value}"
+        }
+    }
+
     private fun AccountRow.toDomain(): Account =
         Account.reconstitute(AccountId(id), SubjectId(subjectId), version)
 
     private fun Account.toRow(): AccountRow = AccountRow(id.value, subjectId.value, version)
+
+    private companion object {
+        /**
+         * Spring Data JDBC が insert 時に採番する初期 version と揃える。ずれると経路によって楽観ロックの前提が
+         * 食い違うため、契約テスト（`saveIfAbsent の初回保存は save と同じ version を採番する`）で縛っている。
+         */
+        const val INITIAL_VERSION = 0L
+
+        val INSERT_IF_ABSENT =
+            """
+            INSERT INTO iam.account (id, subject_id, version)
+            VALUES (:id, :subjectId, :version)
+            ON CONFLICT (subject_id) DO NOTHING
+            """
+                .trimIndent()
+    }
 }

--- a/src/main/kotlin/com/example/api/infrastructure/iam/world/JdbcWorldRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/iam/world/JdbcWorldRepository.kt
@@ -10,11 +10,15 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import org.springframework.dao.OptimisticLockingFailureException
+import org.springframework.jdbc.core.simple.JdbcClient
 import org.springframework.stereotype.Repository
 
 /** ドメインポート [WorldRepository] の唯一の実装。Spring Data JDBC で永続化する（ADR-0027 / ADR-0030）。 */
 @Repository
-class JdbcWorldRepository(private val rows: WorldSpringDataRepository) : WorldRepository {
+class JdbcWorldRepository(
+    private val rows: WorldSpringDataRepository,
+    private val jdbcClient: JdbcClient,
+) : WorldRepository {
 
     override fun findOwnedBy(accountId: AccountId, id: WorldId): World? =
         rows.findByIdAndAccountId(id.value, accountId.value)?.toDomain()
@@ -25,6 +29,27 @@ class JdbcWorldRepository(private val rows: WorldSpringDataRepository) : WorldRe
         } catch (_: OptimisticLockingFailureException) {
             Err(UpdateConflict)
         }
+
+    /**
+     * `ON CONFLICT DO NOTHING` で insert し、結果によらず DB の現状を読み直して返す。
+     *
+     * 設計意図は `JdbcAccountRepository.saveIfAbsent` と同じで、UNIQUE 違反を例外にせず PostgreSQL の トランザクション abort
+     * を避ける（詳細はそちらの KDoc）。
+     */
+    override fun saveIfAbsent(world: World): World {
+        jdbcClient
+            .sql(INSERT_IF_ABSENT)
+            .param("id", world.id.value)
+            .param("accountId", world.accountId.value)
+            .param("name", world.name.value)
+            .param("version", INITIAL_VERSION)
+            .update()
+        return checkNotNull(
+            rows.findByAccountIdAndName(world.accountId.value, world.name.value)?.toDomain()
+        ) {
+            "saveIfAbsent の直後に世界を引けなかった: ${world.accountId.value} / ${world.name.value}"
+        }
+    }
 
     override fun deleteById(id: WorldId) = rows.deleteById(id.value)
 
@@ -38,4 +63,17 @@ class JdbcWorldRepository(private val rows: WorldSpringDataRepository) : WorldRe
         World.reconstitute(WorldId(id), AccountId(accountId), WorldName(name), version)
 
     private fun World.toRow(): WorldRow = WorldRow(id.value, accountId.value, name.value, version)
+
+    private companion object {
+        /** Spring Data JDBC が insert 時に採番する初期 version と揃える（契約テストで縛っている）。 */
+        const val INITIAL_VERSION = 0L
+
+        val INSERT_IF_ABSENT =
+            """
+            INSERT INTO iam.world (id, account_id, name, version)
+            VALUES (:id, :accountId, :name, :version)
+            ON CONFLICT (account_id, name) DO NOTHING
+            """
+                .trimIndent()
+    }
 }

--- a/src/main/kotlin/com/example/api/infrastructure/iam/world/JdbcWorldRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/iam/world/JdbcWorldRepository.kt
@@ -37,19 +37,25 @@ class JdbcWorldRepository(
      * を避ける（詳細はそちらの KDoc）。
      */
     override fun saveIfAbsent(world: World): World {
+        val accountId = world.accountId
+        val name = world.name
         jdbcClient
-            .sql(INSERT_IF_ABSENT)
+            .sql(
+                "INSERT INTO iam.world (id, account_id, name, version) " +
+                    "VALUES (:id, :accountId, :name, :version) " +
+                    "ON CONFLICT (account_id, name) DO NOTHING"
+            )
             .param("id", world.id.value)
-            .param("accountId", world.accountId.value)
-            .param("name", world.name.value)
+            .param("accountId", accountId.value)
+            .param("name", name.value)
             .param("version", INITIAL_VERSION)
             .update()
-        return checkNotNull(
-            rows.findByAccountIdAndName(world.accountId.value, world.name.value)?.toDomain()
-        ) {
-            "saveIfAbsent の直後に世界を引けなかった: ${world.accountId.value} / ${world.name.value}"
-        }
+        return checkNotNull(findByName(accountId, name)) { "insert 直後に引けない: ${name.value}" }
     }
+
+    /** 同一アカウント内の同名の世界を引く（[saveIfAbsent] が衝突後に先着を読み直すための口）。 */
+    private fun findByName(accountId: AccountId, name: WorldName): World? =
+        rows.findByAccountIdAndName(accountId.value, name.value)?.toDomain()
 
     override fun deleteById(id: WorldId) = rows.deleteById(id.value)
 
@@ -67,13 +73,5 @@ class JdbcWorldRepository(
     private companion object {
         /** Spring Data JDBC が insert 時に採番する初期 version と揃える（契約テストで縛っている）。 */
         const val INITIAL_VERSION = 0L
-
-        val INSERT_IF_ABSENT =
-            """
-            INSERT INTO iam.world (id, account_id, name, version)
-            VALUES (:id, :accountId, :name, :version)
-            ON CONFLICT (account_id, name) DO NOTHING
-            """
-                .trimIndent()
     }
 }

--- a/src/main/kotlin/com/example/api/infrastructure/iam/world/WorldSpringDataRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/iam/world/WorldSpringDataRepository.kt
@@ -13,4 +13,7 @@ interface WorldSpringDataRepository : CrudRepository<WorldRow, UUID> {
 
     /** 同一アカウント内に同名の世界が既にあるかを判定する。 */
     fun existsByAccountIdAndName(accountId: UUID, name: String): Boolean
+
+    /** 同一アカウント内の同名の世界を引く（UNIQUE (account_id, name) により高々 1 行）。 */
+    fun findByAccountIdAndName(accountId: UUID, name: String): WorldRow?
 }

--- a/src/test/kotlin/com/example/api/application/iam/me/ProvisionMeConcurrencyTest.kt
+++ b/src/test/kotlin/com/example/api/application/iam/me/ProvisionMeConcurrencyTest.kt
@@ -1,0 +1,107 @@
+package com.example.api.application.iam.me
+
+import com.example.api.domain.iam.model.account.Account
+import com.example.api.domain.iam.model.account.AccountRepository
+import com.example.api.domain.shared.AccountId
+import com.example.api.domain.shared.Command
+import com.example.api.support.PostgresContainerSupport
+import com.github.michaelbull.result.getOrThrow
+import java.time.Clock
+import java.util.concurrent.Callable
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.simple.JdbcClient
+
+/**
+ * `POST /api/me:provision` の並行実行が壊れないことを実 DB で検証する（#713）。
+ *
+ * この経路はサインイン直後にフロントエンドが必ず 1 回叩く設計で、StrictMode の二重発火・複数タブ・ ログイン直後のリロードで**現実に同時実行される**。事前照会と insert
+ * のあいだの TOCTOU を DB の UNIQUE 制約が 裁定するため、競合しても例外は飛ばず、アカウントも世界も増えない。
+ *
+ * レースは本質的に確率的なので、[CyclicBarrier] で全スレッドの発火点を揃えて窓に入りやすくしている。 タイミング次第で競合せずに終わる回もあるが、その場合も assert
+ * は成立する（レースを踏んだ回だけが 追加で意味を持つ「片側検出」のテスト）。実装を `saveIfAbsent` から `save` へ戻すと、このテストは未捕捉の
+ * `DuplicateKeyException` で落ちることを確認している。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class ProvisionMeConcurrencyTest : PostgresContainerSupport() {
+
+    @Autowired private lateinit var provisionMe: ProvisionMeUseCase
+    @Autowired private lateinit var accounts: AccountRepository
+    @Autowired private lateinit var jdbcClient: JdbcClient
+
+    /** 全スレッドの発火点を揃えて同時に `:provision` を叩き、各スレッドが得た [AccountId] を返す。 */
+    private fun provisionConcurrently(subjectId: String): List<AccountId> {
+        val barrier = CyclicBarrier(THREADS)
+        val executor = Executors.newFixedThreadPool(THREADS)
+        return try {
+            val tasks =
+                List(THREADS) {
+                    Callable {
+                        barrier.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                        provisionMe(Command.now(ProvisionMeCommand(subjectId), Clock.systemUTC()))
+                    }
+                }
+            // Future.get() は本体が投げた例外を ExecutionException で包んで再送出する。
+            // UNIQUE 制約違反が漏れていれば（＝本番なら 500）ここでテストが落ちる。
+            executor.invokeAll(tasks).map { future ->
+                future.get().getOrThrow { AssertionError(it.toString()) }
+            }
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    private fun countAccounts(subjectId: String): Long =
+        jdbcClient
+            .sql("SELECT count(*) FROM iam.account WHERE subject_id = :subjectId")
+            .param("subjectId", subjectId)
+            .query(Long::class.java)
+            .single()
+
+    private fun countWorlds(accountId: AccountId): Long =
+        jdbcClient
+            .sql("SELECT count(*) FROM iam.world WHERE account_id = :accountId")
+            .param("accountId", accountId.value)
+            .query(Long::class.java)
+            .single()
+
+    @Test
+    fun `未登録の subject を並行セットアップしてもアカウントと世界は 1 つずつ`() {
+        val subjectId = "sub-concurrent-provision"
+
+        val accountIds = provisionConcurrently(subjectId)
+
+        // 全スレッドが同じアカウントを見ている（先着の裁定に全員が従っている）。
+        assert(accountIds.toSet().size == 1)
+        assert(countAccounts(subjectId) == 1L)
+        assert(countWorlds(accountIds.first()) == 1L)
+    }
+
+    @Test
+    fun `アカウントだけある状態で並行セットアップしても世界は 1 つだけ`() {
+        // アカウントを先に作っておくと全スレッドが世界の insert まで到達し、
+        // UNIQUE (account_id, name) 側のレースを踏む（アカウント側で待たされないため）。
+        val subjectId = "sub-concurrent-first-world"
+        val account =
+            accounts
+                .save(Account.create(subjectId).getOrThrow { AssertionError(it.toString()) })
+                .getOrThrow { AssertionError(it.toString()) }
+
+        val accountIds = provisionConcurrently(subjectId)
+
+        assert(accountIds.toSet() == setOf(account.id))
+        assert(countWorlds(account.id) == 1L)
+    }
+
+    private companion object {
+        /** 同時に叩くスレッド数。Hikari の既定プール（10）に収まる範囲で窓に入りやすい数にする。 */
+        const val THREADS = 4
+
+        /** バリアで待ち合わせる上限。揃わないまま無言でハングさせないための保険。 */
+        const val TIMEOUT_SECONDS = 10L
+    }
+}

--- a/src/test/kotlin/com/example/api/application/iam/me/ProvisionMeUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/iam/me/ProvisionMeUseCaseTest.kt
@@ -7,7 +7,6 @@ import com.example.api.domain.iam.model.account.SubjectId
 import com.example.api.domain.iam.model.world.World
 import com.example.api.domain.iam.model.world.WorldRepository
 import com.example.api.domain.shared.Command
-import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.getError
 import com.github.michaelbull.result.getOrThrow
 import io.mockk.every
@@ -31,15 +30,30 @@ class ProvisionMeUseCaseTest {
     fun `未登録の subject ならアカウントと最初の世界を作る`() {
         val savedAccounts = mutableListOf<Account>()
         every { accounts.findBySubjectId(SubjectId("sub-new")) } returns null
-        every { accounts.save(capture(savedAccounts)) } answers { Ok(firstArg<Account>()) }
+        every { accounts.saveIfAbsent(capture(savedAccounts)) } answers { firstArg<Account>() }
         every { worlds.existsByAccountId(any()) } returns false
-        every { worlds.save(any()) } answers { Ok(firstArg<World>()) }
+        every { worlds.saveIfAbsent(any()) } answers { firstArg<World>() }
 
         val accountId = useCase(command("sub-new")).getOrThrow { AssertionError(it.toString()) }
 
-        verify(exactly = 1) { accounts.save(any()) }
-        verify(exactly = 1) { worlds.save(any()) }
+        verify(exactly = 1) { accounts.saveIfAbsent(any()) }
+        verify(exactly = 1) { worlds.saveIfAbsent(any()) }
         assert(accountId == savedAccounts.single().id)
+    }
+
+    @Test
+    fun `並行して先着に負けたら先着のアカウントIDを返す`() {
+        // saveIfAbsent は衝突時に「渡した集約」ではなく「先着の行」を返す。ユースケースが返すのは
+        // 自分が作った ID ではなく DB が裁定した ID であることを縛る。
+        val winner = AccountFixture.account(subjectId = "sub-raced", version = 0L)
+        every { accounts.findBySubjectId(SubjectId("sub-raced")) } returns null
+        every { accounts.saveIfAbsent(any()) } returns winner
+        every { worlds.existsByAccountId(winner.id) } returns false
+        every { worlds.saveIfAbsent(any()) } answers { firstArg<World>() }
+
+        val accountId = useCase(command("sub-raced")).getOrThrow { AssertionError(it.toString()) }
+
+        assert(accountId == winner.id)
     }
 
     @Test
@@ -52,7 +66,7 @@ class ProvisionMeUseCaseTest {
             useCase(command("sub-existing")).getOrThrow { AssertionError(it.toString()) }
 
         assert(accountId == existing.id)
-        verify(exactly = 0) { accounts.save(any()) }
+        verify(exactly = 0) { accounts.saveIfAbsent(any()) }
     }
 
     @Test
@@ -63,7 +77,7 @@ class ProvisionMeUseCaseTest {
 
         useCase(command("sub-has-world")).getOrThrow { AssertionError(it.toString()) }
 
-        verify(exactly = 0) { worlds.save(any()) }
+        verify(exactly = 0) { worlds.saveIfAbsent(any()) }
     }
 
     @Test
@@ -71,11 +85,11 @@ class ProvisionMeUseCaseTest {
         val existing = AccountFixture.account(subjectId = "sub-lost-worlds", version = 1L)
         every { accounts.findBySubjectId(SubjectId("sub-lost-worlds")) } returns existing
         every { worlds.existsByAccountId(existing.id) } returns false
-        every { worlds.save(any()) } answers { Ok(firstArg<World>()) }
+        every { worlds.saveIfAbsent(any()) } answers { firstArg<World>() }
 
         useCase(command("sub-lost-worlds")).getOrThrow { AssertionError(it.toString()) }
 
-        verify(exactly = 1) { worlds.save(any()) }
+        verify(exactly = 1) { worlds.saveIfAbsent(any()) }
     }
 
     @Test

--- a/src/test/kotlin/com/example/api/controller/me/MeControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/me/MeControllerTest.kt
@@ -8,9 +8,6 @@ import com.example.api.domain.iam.model.account.AccountRepository
 import com.example.api.domain.iam.model.account.SubjectId
 import com.example.api.domain.iam.model.world.World
 import com.example.api.domain.iam.model.world.WorldRepository
-import com.example.api.domain.shared.UpdateConflict
-import com.github.michaelbull.result.Err
-import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.getOrThrow
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
@@ -73,9 +70,9 @@ class MeControllerTest(val mockMvc: MockMvc) {
     fun `初回セットアップに成功すると 200 と account_id を返す`() {
         val subject = "me-controller-test-new-subject"
         every { accounts.findBySubjectId(SubjectId(subject)) } returns null
-        every { accounts.save(any()) } answers { Ok(firstArg<Account>()) }
+        every { accounts.saveIfAbsent(any()) } answers { firstArg<Account>() }
         every { worlds.existsByAccountId(any()) } returns false
-        every { worlds.save(any()) } answers { Ok(firstArg<World>()) }
+        every { worlds.saveIfAbsent(any()) } answers { firstArg<World>() }
 
         val created = Account.create(subject).getOrThrow { AssertionError(it.toString()) }
 
@@ -95,21 +92,21 @@ class MeControllerTest(val mockMvc: MockMvc) {
     }
 
     @Test
-    fun `並行するセットアップと競合すると 409 の problem を返す`() {
-        val subject = "me-controller-test-conflict-subject"
-        every { accounts.findBySubjectId(SubjectId(subject)) } returns null
-        every { accounts.save(any()) } returns Err(UpdateConflict)
+    fun `既にセットアップ済みでも 200 と account_id を返す`() {
+        val subject = "me-controller-test-existing-subject"
+        val existing = Account.create(subject).getOrThrow { AssertionError(it.toString()) }
+        every { accounts.findBySubjectId(SubjectId(subject)) } returns existing
+        every { worlds.existsByAccountId(existing.id) } returns true
 
         tester
             .post()
             .uri("/api/me:provision")
             .principal(jwtWithSubject(subject))
             .assertThat()
-            .hasStatus(HttpStatus.CONFLICT)
-            .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+            .hasStatusOk()
             .bodyJson()
-            .extractingPath("$.error_code")
-            .isEqualTo("provisioning-conflict")
+            .extractingPath("$.account_id")
+            .isEqualTo(existing.id.value.toString())
     }
 
     @Test

--- a/src/test/kotlin/com/example/api/controller/me/problem/MeProblemTest.kt
+++ b/src/test/kotlin/com/example/api/controller/me/problem/MeProblemTest.kt
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 
 /**
- * [ProvisionMeError] の 3 分岐すべてが RFC 9457 の problem+json へ正しく写ることを検証する。
+ * [ProvisionMeError] の 2 分岐すべてが RFC 9457 の problem+json へ正しく写ることを検証する。
  *
  * `ProvisionMeError.InvalidDefaultWorldName` は既定の世界名（定数）の設定ミスでしか起きない防御的分岐で、 現実的な HTTP
- * 入力からは再現できない（[MeControllerTest] の KDoc を参照）。ここでは変換関数を直接呼んで、 `MeProblem.kt` の 3 分岐すべてに `src/test`
+ * 入力からは再現できない（[MeControllerTest] の KDoc を参照）。ここでは変換関数を直接呼んで、 `MeProblem.kt` の 2 分岐すべてに `src/test`
  * 由来のカバレッジを行き渡らせる。
  */
 class MeProblemTest {
@@ -30,13 +30,5 @@ class MeProblemTest {
 
         assert(problem.status == HttpStatus.INTERNAL_SERVER_ERROR.value())
         assert(problem.properties?.get("error_code") == "invalid-default-world-name")
-    }
-
-    @Test
-    fun `Conflict は 409 の problem に写る`() {
-        val problem = ProvisionMeError.Conflict.toProblemDetail()
-
-        assert(problem.status == HttpStatus.CONFLICT.value())
-        assert(problem.properties?.get("error_code") == "provisioning-conflict")
     }
 }

--- a/src/test/kotlin/com/example/api/infrastructure/iam/account/JdbcAccountRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/iam/account/JdbcAccountRepositoryContractTest.kt
@@ -46,4 +46,37 @@ class JdbcAccountRepositoryContractTest : PostgresContainerSupport() {
 
         assert(saved.version != null)
     }
+
+    @Test
+    fun `未登録の subject なら saveIfAbsent がそのまま保存する`() {
+        val saved = repository.saveIfAbsent(newAccount("sub-if-absent-new"))
+
+        assert(repository.findBySubjectId(SubjectId("sub-if-absent-new"))?.id == saved.id)
+    }
+
+    @Test
+    fun `同じ subject を saveIfAbsent で二重に保存しても増えず先着が返る`() {
+        val first = repository.saveIfAbsent(newAccount("sub-if-absent-dup"))
+        // ID は Account.create() が採番するため、2 回目は先着とは別の ID を持つ集約を渡している。
+        // 返るのが先着の ID なら「insert せず既存を読み直した」ことの証拠になる。
+        val second = repository.saveIfAbsent(newAccount("sub-if-absent-dup"))
+
+        assert(second.id == first.id)
+        assert(second.subjectId == SubjectId("sub-if-absent-dup"))
+        assert(second.version == first.version)
+    }
+
+    @Test
+    fun `saveIfAbsent の初回保存は save と同じ version を採番する`() {
+        // saveIfAbsent は upsert のため Spring Data JDBC を通さず INSERT 文を手書きする。
+        // 初期 version が save（Spring Data JDBC 採番）とずれると、以後の楽観ロック更新の
+        // 前提が経路によって食い違うため、ここで縛る。
+        val bySave =
+            repository.save(newAccount("sub-version-save")).getOrThrow {
+                AssertionError(it.toString())
+            }
+        val byIfAbsent = repository.saveIfAbsent(newAccount("sub-version-if-absent"))
+
+        assert(byIfAbsent.version == bySave.version)
+    }
 }

--- a/src/test/kotlin/com/example/api/infrastructure/iam/world/JdbcWorldRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/iam/world/JdbcWorldRepositoryContractTest.kt
@@ -31,10 +31,11 @@ class JdbcWorldRepositoryContractTest : PostgresContainerSupport() {
             .getOrThrow { AssertionError(it.toString()) }
             .id
 
+    private fun newWorld(ownerId: AccountId, name: String): World =
+        World.create(ownerId, name).getOrThrow { AssertionError(it.toString()) }
+
     private fun saveWorld(ownerId: AccountId, name: String): World =
-        worlds
-            .save(World.create(ownerId, name).getOrThrow { AssertionError(it.toString()) })
-            .getOrThrow { AssertionError(it.toString()) }
+        worlds.save(newWorld(ownerId, name)).getOrThrow { AssertionError(it.toString()) }
 
     @Test
     fun `所有付き lookup で自分の世界を ID で引き当てられる`() {
@@ -116,6 +117,43 @@ class JdbcWorldRepositoryContractTest : PostgresContainerSupport() {
         val thrown = runCatching { worlds.save(duplicate) }.exceptionOrNull()
 
         assert(thrown is DuplicateKeyException)
+    }
+
+    @Test
+    fun `同名の世界を saveIfAbsent で二重に保存しても増えず先着が返る`() {
+        val ownerId = newOwner("sub-world-if-absent")
+
+        // ID は World.create() が採番するため、2 回目は先着とは別の ID を持つ集約を渡している。
+        // 返るのが先着の ID なら「insert せず既存を読み直した」ことの証拠になる。
+        val first = worlds.saveIfAbsent(newWorld(ownerId, "はじまりの世界"))
+        val second = worlds.saveIfAbsent(newWorld(ownerId, "はじまりの世界"))
+
+        assert(second.id == first.id)
+        assert(second.version == first.version)
+        assert(queries.findAllByAccountId(ownerId).size == 1)
+    }
+
+    @Test
+    fun `別名の世界なら saveIfAbsent はそのまま保存する`() {
+        val ownerId = newOwner("sub-world-if-absent-distinct")
+
+        worlds.saveIfAbsent(newWorld(ownerId, "1つ目"))
+        worlds.saveIfAbsent(newWorld(ownerId, "2つ目"))
+
+        assert(queries.findAllByAccountId(ownerId).size == 2)
+    }
+
+    @Test
+    fun `saveIfAbsent の初回保存は save と同じ version を採番する`() {
+        // saveIfAbsent は upsert のため Spring Data JDBC を通さず INSERT 文を手書きする。
+        // 初期 version が save（Spring Data JDBC 採番）とずれると、以後の楽観ロック更新の
+        // 前提が経路によって食い違うため、ここで縛る。
+        val ownerId = newOwner("sub-world-if-absent-version")
+        val bySave = saveWorld(ownerId, "save で作った世界")
+
+        val byIfAbsent = worlds.saveIfAbsent(newWorld(ownerId, "saveIfAbsent で作った世界"))
+
+        assert(byIfAbsent.version == bySave.version)
     }
 
     @Test


### PR DESCRIPTION
Closes #713

## 何を直したか

同一 subject の `POST /api/me:provision` を並行実行すると 500 が返っていた穴を塞ぎ、**並行実行下でも冪等**にした。

`ProvisionMeUseCase` は事前照会（`findBySubjectId` / `existsByAccountId`）→ insert の 2 手で書いており、そのあいだに別リクエストが同じ行を insert すると UNIQUE 制約違反（`uq_account_subject_id` / `uq_world_account_id_name`）が `DuplicateKeyException` として未捕捉のまま貫通していた。サインイン直後にフロントが必ず 1 回叩く経路なので、StrictMode の二重発火・複数タブ・リロードで現実に踏む。

## なぜこの方針か（Issue の案 2 を採用）

Issue には 3 案あった。**案 1（DuplicateKeyException を捕まえて読み直す）は、PostgreSQL が UNIQUE 違反の時点でトランザクションを abort 済みのため、同一トランザクション内では成立しない**（`REQUIRES_NEW` 等の別トランザクション境界の手当てが要る）。案 3（409 を返す）は冪等を謳う API としては後退。

採ったのは案 2 で、**そもそも UNIQUE 違反を例外にしない**。`INSERT ... ON CONFLICT DO NOTHING` は衝突してもエラーを上げないため、トランザクション abort が起きず、同一トランザクション内で先着の行を読み直せる。abort への手当て自体が不要になる。

## 変更の形

ポートに原子的な get-or-create を 1 本足した（`AccountRepository.saveIfAbsent` / `WorldRepository.saveIfAbsent`）。実装は Spring Data JDBC が upsert を書けないため、ここだけ `JdbcClient` で SQL を直接書く。

- 事前照会は**残す**が、これは 2 回目以降の呼び出しで書き込みを避けるための高速経路であって、正しさはこれに依存しない（DB の UNIQUE が唯一の裁定者）。
- 到達不能になった `ProvisionMeError.Conflict` と 409 マッピングを削除した。競合は呼び出し側に見えなくなったため。
- **世界の作成・改名（利用者が名前を指定する経路）は対象外**。同名衝突を 409 として見せる必要があるので事前照会と `save` を使い続ける。そちらの TOCTOU は未解消（#713 のスコープ外）。

## 検証

- `./gradlew check` 緑（`e2eTest` も緑）。
- 並行再現テスト（`ProvisionMeConcurrencyTest`）は `CyclicBarrier` で 4 スレッドの発火点を揃えて実 DB を叩く。アカウント側のレースと世界側のレース（アカウントを先に作っておく）を別ケースで踏む。
- **ミューテーションで空振りしていないことを確認済み**: 実装を `saveIfAbsent` から素の `save` へ戻すと、両ケースとも `DuplicateKeyException`（＝本番なら 500）で落ちた。
- 初期 version の一致もテストで縛った。手書き INSERT の `version` を 1 と書いたところ契約テストが落ち、Spring Data JDBC の採番は 0 だと判明したので 0 に揃えた（このテストが無ければ経路によって楽観ロックの前提が食い違っていた）。

## Issue の完了条件との差分

「ADR-0067 の『既知の限界』の記述を更新する」とあったが、**ADR-0067 にその記述は無かった**（限界は `ProvisionMeUseCase` の KDoc にだけ書かれていた）。ADR 側は「`:provision` は冪等に作る」と言い切っていたので、当初それが逐次実行限定の冪等だったことと今回の解消を追補として足した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
