### PR TITLE
feat: #714 フロントエンドに初回セットアップと世界の選択・作成を実装する

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,11 +1,8 @@
 # toy-box フロントエンド（軽種馬シミュレータ）
 
-ログインしたユーザーが実 Identity Platform にログインし、保護 API `GET /api/bloodHorses` を叩いて軽種馬一覧を見る軽量 SPA（Vite + React + TypeScript）。認証・認可を「目で見て触れる」ことが主眼の MVP（#612）。
-
-> **既知の破壊: 現状のフロントは動かない。** バックエンドは `#705` で `/api/bloodHorses` を含む全ドメイン API を
-> `/api/worlds/{worldId}/...` 配下へ移した（プレイヤーごとの世界＝テナント分離。ADR-0067）。
-> `BloodHorseListPage.tsx` はまだ旧パス `/api/bloodHorses` を叩いており、必ず失敗する。フロント側の追随は
-> `#714` で扱う。
+ログインしたユーザーが実 Identity Platform にログインし、自分の世界（セーブデータ）を選んで保護 API
+`GET /api/worlds/{worldId}/bloodHorses` を叩き、軽種馬一覧を見る軽量 SPA（Vite + React + TypeScript）。
+認証・テナント分離（ADR-0067）を「目で見て触れる」ことが主眼の MVP（#612 / #714）。
 
 ## 前提
 
@@ -51,7 +48,10 @@ Vite dev server が `/api/*` を `http://localhost:8080`（バックエンド）
    ```bash
    GCP_PROJECT_ID=<実テナントの projectId> ./gradlew bootRun   # :8080
    ```
-3. ブラウザで `http://localhost:5173` を開く → 未ログインなら `/login` へ。テストユーザーでログイン → `/bloodHorses` に遷移し一覧が表示される。画面右上に直近レスポンスのステータス（未ログイン `401` → ログイン後 `200`）が出る。
+3. ブラウザで `http://localhost:5173` を開く → 未ログインなら `/login` へ。テストユーザーでログインすると
+   初回セットアップ（`POST /api/me:provision`）が走り、`/worlds` に「はじまりの世界」が 1 つ見える。
+   世界を選ぶと `/worlds/{worldId}/bloodHorses` に遷移し、その世界の一覧が表示される。画面右上に
+   直近レスポンスのステータス（未ログイン `401` → ログイン後 `200`）が出る。
 
 ## スクリプト
 
@@ -70,14 +70,15 @@ CI（`.github/workflows/frontend.yml`）と lefthook の pre-commit が `fronten
 ```
 frontend/src/
 ├── auth/       # Firebase 初期化（firebase.ts）と認証 Context（AuthContext.tsx）
-├── api/        # fetch ラッパ（Bearer 付与・RFC 9457 problem+json 解釈・401 判定）
-├── pages/      # LoginPage / BloodHorseListPage / RequireAuth（認証ガード）
-├── App.tsx     # React Router（/login, /bloodHorses〈要認証〉）
+├── api/        # fetch ラッパ（Bearer 付与・RFC 9457 problem+json 解釈）/ 世界 API / :provision
+├── worlds/     # 世界一覧の state と変更操作（useWorlds.ts）
+├── pages/      # LoginPage / WorldsPage / BloodHorseListPage / RequireAuth / RequireProvisioned
+├── App.tsx     # React Router（/login, /worlds, /worlds/:worldId/bloodHorses〈要認証＋セットアップ済み〉）
 └── main.tsx    # エントリ
 ```
 
 ## 現状の割り切り（MVP）
 
 - **ローカルのみ**（Cloud Run デプロイ・イングレス公開/BFF・本番 CORS はスコープ外）。
-- 認証確認 + 馬一覧のみ。書き込み画面・認可 403 体験（#606 / #607）は後続。
+- 認証確認・世界の CRUD・馬一覧の閲覧のみ。**書き込み画面（血統登録など）は後続**。
 - 一覧の性・毛色・品種は現状 wire の英語定数名（`FEMALE` / `BAY` / `THOROUGHBRED`）を素で表示する（日本語ラベル化は follow-up）。

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@biomejs/biome": "^1.9.0",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.6.3",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "@vitejs/plugin-react": "^6.0.5",
@@ -1270,9 +1271,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1290,9 +1288,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1310,9 +1305,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1330,9 +1322,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1350,9 +1339,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1370,9 +1356,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1524,6 +1507,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.3.tgz",
+      "integrity": "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@biomejs/biome": "^1.9.0",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.6.3",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+// firebase の初期化を避けるため、認証まわりはすべてモックする。
+vi.mock("./auth/AuthContext", () => ({
+  AuthProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useAuth: () => ({
+    user: { uid: "u1" },
+    loading: false,
+    getToken: async () => "t",
+    signOutUser: vi.fn(),
+    signIn: vi.fn(),
+  }),
+}));
+
+vi.mock("./api/me", () => ({ provisionMe: vi.fn().mockResolvedValue({ account_id: "a1" }) }));
+
+vi.mock("./worlds/useWorlds", () => ({
+  useWorlds: () => ({
+    worlds: [{ id: "w1", name: "はじまりの世界" }],
+    loading: false,
+    error: null,
+    create: vi.fn(),
+    rename: vi.fn(),
+    remove: vi.fn(),
+  }),
+}));
+
+import { App } from "./App";
+
+describe("App のルーティング", () => {
+  it("未知のパスは /worlds へ送り、世界一覧を描く", async () => {
+    window.history.pushState({}, "", "/unknown");
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText("世界一覧")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,8 @@ import { AuthProvider } from "./auth/AuthContext";
 import { BloodHorseListPage } from "./pages/BloodHorseListPage";
 import { LoginPage } from "./pages/LoginPage";
 import { RequireAuth } from "./pages/RequireAuth";
+import { RequireProvisioned } from "./pages/RequireProvisioned";
+import { WorldsPage } from "./pages/WorldsPage";
 
 export function App() {
   return (
@@ -10,10 +12,14 @@ export function App() {
       <BrowserRouter>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
+          {/* 認証 → 初回セットアップの順に通す。:provision を通さないと他の API は 403 になる。 */}
           <Route element={<RequireAuth />}>
-            <Route path="/bloodHorses" element={<BloodHorseListPage />} />
+            <Route element={<RequireProvisioned />}>
+              <Route path="/worlds" element={<WorldsPage />} />
+              <Route path="/worlds/:worldId/bloodHorses" element={<BloodHorseListPage />} />
+            </Route>
           </Route>
-          <Route path="*" element={<Navigate to="/bloodHorses" replace />} />
+          <Route path="*" element={<Navigate to="/worlds" replace />} />
         </Routes>
       </BrowserRouter>
     </AuthProvider>

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { apiGet } from "./client";
+import { ApiError, apiDelete, apiGet, apiPatch, apiPost, errorMessage } from "./client";
 
 const token = async () => "id-token-123";
 
@@ -60,5 +60,95 @@ describe("apiGet", () => {
       status: 401,
     });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("apiPost / apiPatch / apiDelete", () => {
+  it("POST は Bearer と Content-Type を載せ、ボディを JSON 化して送る", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "w1", name: "はじまりの世界" }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const body = await apiPost<{ id: string }>("/api/worlds", token, { name: "はじまりの世界" });
+
+    expect(body).toEqual({ id: "w1", name: "はじまりの世界" });
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe("/api/worlds");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer id-token-123");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(init.body).toBe(JSON.stringify({ name: "はじまりの世界" }));
+  });
+
+  it("ボディなしの POST は Content-Type を付けない", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ account_id: "a1" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiPost("/api/me:provision", token);
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.body).toBeUndefined();
+    expect(init.headers["Content-Type"]).toBeUndefined();
+  });
+
+  it("PATCH はメソッドとボディを送る", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "w1", name: "2周目" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiPatch("/api/worlds/w1", token, { name: "2周目" });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe("PATCH");
+    expect(init.body).toBe(JSON.stringify({ name: "2周目" }));
+  });
+
+  it("DELETE の 204 は本文を読まずに解決する", async () => {
+    // 204 で json() を呼ぶと落ちるため、呼ばれていないことを保証する。
+    const response = new Response(null, { status: 204 });
+    const jsonSpy = vi.spyOn(response, "json");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response));
+
+    await expect(apiDelete("/api/worlds/w1", token)).resolves.toBeUndefined();
+    expect(jsonSpy).not.toHaveBeenCalled();
+  });
+
+  it("POST の problem+json は ApiError に写す", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error_code: "world-name-taken", status: 409 }), {
+          status: 409,
+          headers: { "Content-Type": "application/problem+json" },
+        }),
+      ),
+    );
+
+    await expect(apiPost("/api/worlds", token, { name: "重複" })).rejects.toMatchObject({
+      status: 409,
+      problem: { error_code: "world-name-taken" },
+    });
+  });
+});
+
+describe("errorMessage", () => {
+  it("ApiError は problem の文言、それ以外は既定文言に写す", () => {
+    expect(errorMessage(new ApiError(409, { error_code: "world-name-taken" }), "既定")).toBe(
+      "同じ名前の世界が既にあります。",
+    );
+    expect(errorMessage(new Error("network"), "既定")).toBe("既定");
   });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,7 @@
-import { type ProblemDetail, isProblemContentType } from "./problem";
+import { type ProblemDetail, isProblemContentType, problemMessage } from "./problem";
+
+/** ID トークンを取り出す関数。未ログインなら null を返す（AuthContext.getToken）。 */
+export type GetToken = () => Promise<string | null>;
 
 /** API 呼び出しの失敗。status===401 は未認証（ログインへ誘導する）。 */
 export class ApiError extends Error {
@@ -12,17 +15,29 @@ export class ApiError extends Error {
 }
 
 /**
- * 保護 API に GET する。ID トークンを Authorization: Bearer に載せ、problem+json を ApiError へ写す。
+ * 保護 API を叩く。ID トークンを Authorization: Bearer に載せ、problem+json を ApiError へ写す。
  * トークンが取れない（未ログイン）ときは fetch せず 401 相当の ApiError を投げる。
  */
-export async function apiGet<T>(path: string, getToken: () => Promise<string | null>): Promise<T> {
+async function request(
+  method: string,
+  path: string,
+  getToken: GetToken,
+  body?: unknown,
+): Promise<unknown> {
   const token = await getToken();
   if (token === null) {
     throw new ApiError(401);
   }
 
+  const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+  if (body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+
   const response = await fetch(path, {
-    headers: { Authorization: `Bearer ${token}` },
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
   });
 
   if (!response.ok) {
@@ -32,5 +47,30 @@ export async function apiGet<T>(path: string, getToken: () => Promise<string | n
     throw new ApiError(response.status, problem);
   }
 
-  return (await response.json()) as T;
+  // 204 No Content（DELETE）は本文が無い。json() を呼ぶと落ちる。
+  if (response.status === 204) {
+    return undefined;
+  }
+  return await response.json();
+}
+
+export async function apiGet<T>(path: string, getToken: GetToken): Promise<T> {
+  return (await request("GET", path, getToken)) as T;
+}
+
+export async function apiPost<T>(path: string, getToken: GetToken, body?: unknown): Promise<T> {
+  return (await request("POST", path, getToken, body)) as T;
+}
+
+export async function apiPatch<T>(path: string, getToken: GetToken, body: unknown): Promise<T> {
+  return (await request("PATCH", path, getToken, body)) as T;
+}
+
+export async function apiDelete(path: string, getToken: GetToken): Promise<void> {
+  await request("DELETE", path, getToken);
+}
+
+/** 例外を画面表示用の文言へ写す。ApiError 以外（ネットワーク断等）は既定文言にする。 */
+export function errorMessage(e: unknown, fallback: string): string {
+  return e instanceof ApiError ? problemMessage(e.problem, fallback) : fallback;
 }

--- a/frontend/src/api/me.test.ts
+++ b/frontend/src/api/me.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { provisionMe } from "./me";
+
+const token = async () => "id-token-123";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function okResponse(): Response {
+  return new Response(JSON.stringify({ account_id: "a1" }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("provisionMe", () => {
+  it("同一 uid の同時呼び出しは 1 リクエストに畳む", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const [a, b] = await Promise.all([provisionMe("uid-1", token), provisionMe("uid-1", token)]);
+
+    expect(a).toEqual({ account_id: "a1" });
+    expect(b).toEqual({ account_id: "a1" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("失敗は覚えず、次の呼び出しでやり直せる", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(provisionMe("uid-3", token)).rejects.toMatchObject({ status: 500 });
+    // リトライはしない（サーバが並行実行下でも冪等になったため。#713 / PR #738）。
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // 失敗をキャッシュしないので、再試行ボタン相当の呼び直しでもう一度リクエストが飛ぶ。
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(okResponse()));
+    await expect(provisionMe("uid-3", token)).resolves.toEqual({ account_id: "a1" });
+  });
+
+  it("成功は覚えるので、再マウント相当の呼び直しではリクエストしない", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await provisionMe("uid-4", token);
+    await provisionMe("uid-4", token);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uid が違えばそれぞれ実行する", async () => {
+    // 2 uid とも実際に fetch されるため、Response を毎回新規に作る
+    // （同一インスタンスを使い回すと 2 回目の .json() で body 読み取り済みエラーになる）。
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(okResponse()));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await Promise.all([provisionMe("uid-5", token), provisionMe("uid-6", token)]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/api/me.ts
+++ b/frontend/src/api/me.ts
@@ -1,0 +1,32 @@
+import { type GetToken, apiPost } from "./client";
+
+/** バックの MeResponse（accountId は wire 上 snake_case）。 */
+export type Me = {
+  account_id: string;
+};
+
+// uid ごとの実行中／成功済み Promise。StrictMode の二重発火と再マウントを 1 リクエストに畳む。
+// 失敗は覚えない（下の catch で消す）ので、再試行ボタンから引き直せる。
+const provisioning = new Map<string, Promise<Me>>();
+
+/**
+ * 初回セットアップ（POST /api/me:provision）を通す。これを通さないと他の API は 403
+ * account-not-provisioned を返す。
+ *
+ * サーバは並行実行下でも冪等（#713 / PR #738 で UNIQUE を裁定者にする形に変わった）なので、
+ * 競合を見越したリトライはしない。ここで畳むのは無駄なリクエスト（StrictMode の二重発火・
+ * 再マウント）だけ。
+ */
+export function provisionMe(uid: string, getToken: GetToken): Promise<Me> {
+  const running = provisioning.get(uid);
+  if (running !== undefined) {
+    return running;
+  }
+
+  const started = apiPost<Me>("/api/me:provision", getToken);
+  provisioning.set(uid, started);
+  started.catch(() => {
+    provisioning.delete(uid);
+  });
+  return started;
+}

--- a/frontend/src/api/problem.test.ts
+++ b/frontend/src/api/problem.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { problemMessage } from "./problem";
+
+describe("problemMessage", () => {
+  it("既知の error_code は画面用の日本語文言に写す", () => {
+    expect(problemMessage({ error_code: "world-name-taken" }, "既定")).toBe(
+      "同じ名前の世界が既にあります。",
+    );
+    expect(problemMessage({ error_code: "world-update-conflict" }, "既定")).toBe(
+      "同じ名前の世界があるか、別の更新と競合しました。やり直してください。",
+    );
+  });
+
+  it("未知の error_code は detail にフォールバックする", () => {
+    expect(problemMessage({ error_code: "unknown-code", detail: "サーバの説明" }, "既定")).toBe(
+      "サーバの説明",
+    );
+  });
+
+  it("detail が無ければ title、それも無ければ既定文言にフォールバックする", () => {
+    expect(problemMessage({ title: "Conflict" }, "既定")).toBe("Conflict");
+    expect(problemMessage(undefined, "既定")).toBe("既定");
+  });
+});

--- a/frontend/src/api/problem.ts
+++ b/frontend/src/api/problem.ts
@@ -1,12 +1,35 @@
-// RFC 9457 problem+json のうち本フロントが解釈する項目。拡張キー error_code は snake_case（バック規約）。
+// RFC 9457 problem+json のうち本フロントが解釈する項目。拡張キー error_code / world_id は snake_case（バック規約）。
 export type ProblemDetail = {
   type?: string;
   title?: string;
   status?: number;
   detail?: string;
   error_code?: string;
+  world_id?: string;
 };
 
 export function isProblemContentType(contentType: string | null): boolean {
   return contentType?.includes("application/problem+json") ?? false;
+}
+
+// error_code → 画面表示用の文言。出所は controller 配下の各 toProblemDetail()
+// （WorldProblem.kt / MeProblem.kt / GlobalExceptionHandler.kt）。
+const errorMessages: Record<string, string> = {
+  "account-not-provisioned": "セットアップが完了していません。再試行してください。",
+  "world-not-found": "この世界は見つかりません。",
+  "world-name-blank": "世界の名前を入力してください。",
+  "world-name-too-long": "世界の名前は 64 文字以内で入力してください。",
+  "world-name-taken": "同じ名前の世界が既にあります。",
+  "world-update-conflict": "同じ名前の世界があるか、別の更新と競合しました。やり直してください。",
+};
+
+/**
+ * problem+json を画面表示用の文言へ写す。
+ *
+ * 未知の error_code は detail → title → 既定文言の順にフォールバックする（バックが新しいコードを
+ * 足しても表示を壊さない）。
+ */
+export function problemMessage(problem: ProblemDetail | undefined, fallback: string): string {
+  const known = problem?.error_code === undefined ? undefined : errorMessages[problem.error_code];
+  return known ?? problem?.detail ?? problem?.title ?? fallback;
 }

--- a/frontend/src/api/worlds.test.ts
+++ b/frontend/src/api/worlds.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createWorld, deleteWorld, listWorlds, renameWorld } from "./worlds";
+
+const token = async () => "id-token-123";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function stubFetch(status: number, body: unknown): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(body === undefined ? null : JSON.stringify(body), {
+      status,
+      headers: body === undefined ? {} : { "Content-Type": "application/json" },
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("世界 API", () => {
+  it("一覧は GET /api/worlds を叩く", async () => {
+    const fetchMock = stubFetch(200, [{ id: "w1", name: "はじまりの世界" }]);
+
+    await expect(listWorlds(token)).resolves.toEqual([{ id: "w1", name: "はじまりの世界" }]);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/worlds");
+    expect(fetchMock.mock.calls[0][1].method).toBe("GET");
+  });
+
+  it("作成は POST /api/worlds に name を送る", async () => {
+    const fetchMock = stubFetch(201, { id: "w2", name: "2周目" });
+
+    await expect(createWorld(token, "2周目")).resolves.toEqual({ id: "w2", name: "2周目" });
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/worlds");
+    expect(fetchMock.mock.calls[0][1].body).toBe(JSON.stringify({ name: "2周目" }));
+  });
+
+  it("改名は PATCH /api/worlds/{id} に name を送る", async () => {
+    const fetchMock = stubFetch(200, { id: "w1", name: "改名後" });
+
+    await expect(renameWorld(token, "w1", "改名後")).resolves.toEqual({
+      id: "w1",
+      name: "改名後",
+    });
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/worlds/w1");
+    expect(fetchMock.mock.calls[0][1].method).toBe("PATCH");
+  });
+
+  it("削除は DELETE /api/worlds/{id} を叩く", async () => {
+    const fetchMock = stubFetch(204, undefined);
+
+    await expect(deleteWorld(token, "w1")).resolves.toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/worlds/w1");
+    expect(fetchMock.mock.calls[0][1].method).toBe("DELETE");
+  });
+});

--- a/frontend/src/api/worlds.ts
+++ b/frontend/src/api/worlds.ts
@@ -1,0 +1,23 @@
+import { type GetToken, apiDelete, apiGet, apiPatch, apiPost } from "./client";
+
+/** バックの WorldResponse（controller/world/WorldResponse.kt）に対応する世界（セーブデータ）。 */
+export type World = {
+  id: string;
+  name: string;
+};
+
+export function listWorlds(getToken: GetToken): Promise<World[]> {
+  return apiGet<World[]>("/api/worlds", getToken);
+}
+
+export function createWorld(getToken: GetToken, name: string): Promise<World> {
+  return apiPost<World>("/api/worlds", getToken, { name });
+}
+
+export function renameWorld(getToken: GetToken, worldId: string, name: string): Promise<World> {
+  return apiPatch<World>(`/api/worlds/${worldId}`, getToken, { name });
+}
+
+export function deleteWorld(getToken: GetToken, worldId: string): Promise<void> {
+  return apiDelete(`/api/worlds/${worldId}`, getToken);
+}

--- a/frontend/src/pages/BloodHorseListPage.test.tsx
+++ b/frontend/src/pages/BloodHorseListPage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { ApiError } from "../api/client";
 
@@ -9,6 +9,9 @@ vi.mock("../auth/AuthContext", () => ({
     signOutUser: vi.fn(),
   }),
 }));
+
+const useWorldsMock = vi.fn();
+vi.mock("../worlds/useWorlds", () => ({ useWorlds: () => useWorldsMock() }));
 
 vi.mock("../api/client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../api/client")>();
@@ -21,15 +24,26 @@ import { BloodHorseListPage } from "./BloodHorseListPage";
 const apiGetMock = vi.mocked(apiGet);
 
 function renderPage() {
+  useWorldsMock.mockReturnValue({
+    worlds: [{ id: "w1", name: "はじまりの世界" }],
+    loading: false,
+    error: null,
+    create: vi.fn(),
+    rename: vi.fn(),
+    remove: vi.fn(),
+  });
   return render(
-    <MemoryRouter>
-      <BloodHorseListPage />
+    <MemoryRouter initialEntries={["/worlds/w1/bloodHorses"]}>
+      <Routes>
+        <Route path="/worlds/:worldId/bloodHorses" element={<BloodHorseListPage />} />
+        <Route path="/worlds" element={<div>世界一覧ページ</div>} />
+      </Routes>
     </MemoryRouter>,
   );
 }
 
 describe("BloodHorseListPage", () => {
-  it("成功時はテーブルを表示し、wire enum を日本語ラベルで描き、エラーは出ずステータス200が可視化される", async () => {
+  it("世界スコープのパスを叩き、世界名とテーブルを描く", async () => {
     apiGetMock.mockResolvedValue([
       {
         id: "h1",
@@ -48,18 +62,31 @@ describe("BloodHorseListPage", () => {
     await waitFor(() => {
       expect(screen.getByText("0000000001")).toBeInTheDocument();
     });
-    // wire 値（FEMALE / BAY / THOROUGHBRED）ではなく日本語ラベルで描かれる。
+    expect(apiGetMock).toHaveBeenCalledWith("/api/worlds/w1/bloodHorses", expect.any(Function));
+    // どの世界を見ているかがヘッダに出る。
+    expect(screen.getByText("はじまりの世界")).toBeInTheDocument();
+    // wire 値ではなく日本語ラベルで描かれる。
     expect(screen.getByText("牝")).toBeInTheDocument();
     expect(screen.getByText("鹿毛")).toBeInTheDocument();
     expect(screen.getByText("サラブレッド")).toBeInTheDocument();
-    // ステータス可視化（バッジに直近レスポンスが出る）
     expect(screen.getByTitle("直近レスポンス")).toHaveTextContent("200");
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-    // name が null の行は「未命名」で描画される。
     expect(screen.getByText("未命名")).toBeInTheDocument();
   });
 
-  it("失敗時はエラー banner が出て、ステータスが可視化される", async () => {
+  it("404 world-not-found なら見つからない旨と世界一覧への導線を出す", async () => {
+    apiGetMock.mockRejectedValue(new ApiError(404, { error_code: "world-not-found" }));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("この世界は見つかりません。");
+    });
+    expect(screen.getByRole("link", { name: "世界一覧へ" })).toBeInTheDocument();
+    expect(screen.getByTitle("直近レスポンス")).toHaveTextContent("404");
+  });
+
+  it("失敗時はエラー banner とステータスを出す", async () => {
     apiGetMock.mockRejectedValue(new ApiError(401));
 
     renderPage();

--- a/frontend/src/pages/BloodHorseListPage.tsx
+++ b/frontend/src/pages/BloodHorseListPage.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
-import { ApiError, apiGet } from "../api/client";
+import { Link, useParams } from "react-router-dom";
+import { ApiError, apiGet, errorMessage } from "../api/client";
 import { useAuth } from "../auth/AuthContext";
 import { breedLabels, coatColors, coatLabels, label, sexLabels } from "../labels";
+import { useWorlds } from "../worlds/useWorlds";
 
 // バックの BloodHorseSummaryResponse（snake_case）に対応する行の型。
 type BloodHorseSummary = {
@@ -16,7 +18,12 @@ type BloodHorseSummary = {
 };
 
 export function BloodHorseListPage() {
+  const { worldId } = useParams<{ worldId: string }>();
   const { getToken, signOutUser } = useAuth();
+  // 世界名は表示専用。取得に失敗しても名前を出さないだけで、アクセス可否の判断はしない
+  // （それは API の 404 world-not-found が担う）。
+  const { worlds } = useWorlds();
+  const worldName = worlds.find((w) => w.id === worldId)?.name ?? null;
   const [rows, setRows] = useState<BloodHorseSummary[]>([]);
   const [status, setStatus] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -25,7 +32,10 @@ export function BloodHorseListPage() {
     let active = true;
     (async () => {
       try {
-        const data = await apiGet<BloodHorseSummary[]>("/api/bloodHorses", getToken);
+        const data = await apiGet<BloodHorseSummary[]>(
+          `/api/worlds/${worldId}/bloodHorses`,
+          getToken,
+        );
         if (active) {
           setRows(data);
           setStatus(200);
@@ -36,23 +46,25 @@ export function BloodHorseListPage() {
         if (!active) return;
         if (e instanceof ApiError) {
           setStatus(e.status);
-          setError(e.message);
-        } else {
-          setError("原簿を読み込めませんでした。");
         }
+        setError(errorMessage(e, "原簿を読み込めませんでした。"));
       }
     })();
     return () => {
       active = false;
     };
-  }, [getToken]);
+  }, [getToken, worldId]);
 
   return (
     <div className="ledger">
       <header className="ledger__head">
         <h1 className="ledger__title">軽種馬登録原簿</h1>
+        {worldName !== null && <span className="ledger__world">{worldName}</span>}
         <span className="ledger__count">{rows.length} 頭</span>
         <div className="ledger__spacer" />
+        <Link className="btn-ghost" to="/worlds">
+          世界一覧へ
+        </Link>
         {/* 認証を目で見るためのステータス可視化（直近レスポンス） */}
         <span className="status" data-ok={status === 200} title="直近レスポンス">
           {status ?? "—"}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -16,7 +16,7 @@ export function LoginPage() {
     setSubmitting(true);
     try {
       await signIn(email, password);
-      navigate("/bloodHorses", { replace: true });
+      navigate("/worlds", { replace: true });
     } catch {
       setError("サインインできませんでした。メールアドレスとパスワードを確認してください。");
       setSubmitting(false);

--- a/frontend/src/pages/RequireProvisioned.test.tsx
+++ b/frontend/src/pages/RequireProvisioned.test.tsx
@@ -4,8 +4,13 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { ApiError } from "../api/client";
 
+// getToken / signOutUser はモジュールスコープの安定した参照にする。実物の AuthContext（useMemo）と
+// 同じく、レンダーのたびに新しい関数を返すと RequireProvisioned の run（useCallback の依存に
+// getToken を含む）の参照が毎回変わり、useEffect が無限に再フェッチする事故が過去にあった。
+const getToken = async () => "t";
+const signOutUser = vi.fn();
 vi.mock("../auth/AuthContext", () => ({
-  useAuth: () => ({ user: { uid: "u1" }, getToken: async () => "t" }),
+  useAuth: () => ({ user: { uid: "u1" }, getToken, signOutUser }),
 }));
 
 vi.mock("../api/me", () => ({ provisionMe: vi.fn() }));
@@ -67,5 +72,21 @@ describe("RequireProvisioned", () => {
     await waitFor(() => {
       expect(screen.getByText("protected")).toBeInTheDocument();
     });
+  });
+
+  it("セットアップに失敗したらログアウトできる", async () => {
+    provisionMock.mockRejectedValueOnce(
+      new ApiError(401, { error_code: "account-not-provisioned" }),
+    );
+
+    renderGuard();
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "ログアウト" }));
+
+    expect(signOutUser).toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/RequireProvisioned.test.tsx
+++ b/frontend/src/pages/RequireProvisioned.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { ApiError } from "../api/client";
+
+vi.mock("../auth/AuthContext", () => ({
+  useAuth: () => ({ user: { uid: "u1" }, getToken: async () => "t" }),
+}));
+
+vi.mock("../api/me", () => ({ provisionMe: vi.fn() }));
+
+import { provisionMe } from "../api/me";
+import { RequireProvisioned } from "./RequireProvisioned";
+
+const provisionMock = vi.mocked(provisionMe);
+
+function renderGuard() {
+  return render(
+    <MemoryRouter initialEntries={["/worlds"]}>
+      <Routes>
+        <Route element={<RequireProvisioned />}>
+          <Route path="/worlds" element={<div>protected</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("RequireProvisioned", () => {
+  it("セットアップ完了までは子ルートを描かない", () => {
+    // 解決しない Promise を返して pending 状態に留める。
+    provisionMock.mockReturnValue(new Promise(() => {}));
+
+    renderGuard();
+
+    expect(screen.getByText("準備中…")).toBeInTheDocument();
+    expect(screen.queryByText("protected")).not.toBeInTheDocument();
+  });
+
+  it("成功したら子ルートを描く", async () => {
+    provisionMock.mockResolvedValue({ account_id: "a1" });
+
+    renderGuard();
+
+    await waitFor(() => {
+      expect(screen.getByText("protected")).toBeInTheDocument();
+    });
+  });
+
+  it("失敗したらエラーを出し、再試行でもう一度呼ぶ", async () => {
+    provisionMock.mockRejectedValueOnce(
+      new ApiError(403, { error_code: "account-not-provisioned" }),
+    );
+
+    renderGuard();
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "セットアップが完了していません。再試行してください。",
+      );
+    });
+
+    provisionMock.mockResolvedValue({ account_id: "a1" });
+    await userEvent.click(screen.getByRole("button", { name: "再試行" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("protected")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/RequireProvisioned.tsx
+++ b/frontend/src/pages/RequireProvisioned.tsx
@@ -12,7 +12,7 @@ const FALLBACK = "セットアップに失敗しました。時間をおいて�
  * 認証ガード（RequireAuth）と分けているのは、RequireAuth を「認証状態を見るだけ」に保つため。
  */
 export function RequireProvisioned() {
-  const { user, getToken } = useAuth();
+  const { user, getToken, signOutUser } = useAuth();
   const uid = user?.uid ?? null;
   const [state, setState] = useState<"pending" | "ready" | "error">("pending");
   const [message, setMessage] = useState("");
@@ -43,6 +43,9 @@ export function RequireProvisioned() {
         </p>
         <button className="btn" type="button" onClick={() => void run()}>
           再試行
+        </button>
+        <button className="btn-ghost" type="button" onClick={() => signOutUser()}>
+          ログアウト
         </button>
       </div>
     );

--- a/frontend/src/pages/RequireProvisioned.tsx
+++ b/frontend/src/pages/RequireProvisioned.tsx
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from "react";
+import { Outlet } from "react-router-dom";
+import { errorMessage } from "../api/client";
+import { provisionMe } from "../api/me";
+import { useAuth } from "../auth/AuthContext";
+
+const FALLBACK = "セットアップに失敗しました。時間をおいて再試行してください。";
+
+/**
+ * 初回セットアップ（:provision）が通るまで子ルートを描かないガード。
+ *
+ * 認証ガード（RequireAuth）と分けているのは、RequireAuth を「認証状態を見るだけ」に保つため。
+ */
+export function RequireProvisioned() {
+  const { user, getToken } = useAuth();
+  const uid = user?.uid ?? null;
+  const [state, setState] = useState<"pending" | "ready" | "error">("pending");
+  const [message, setMessage] = useState("");
+
+  const run = useCallback(async () => {
+    if (uid === null) {
+      return;
+    }
+    setState("pending");
+    try {
+      await provisionMe(uid, getToken);
+      setState("ready");
+    } catch (e) {
+      setMessage(errorMessage(e, FALLBACK));
+      setState("error");
+    }
+  }, [uid, getToken]);
+
+  useEffect(() => {
+    void run();
+  }, [run]);
+
+  if (state === "error") {
+    return (
+      <div className="loading">
+        <p className="alert" role="alert">
+          {message}
+        </p>
+        <button className="btn" type="button" onClick={() => void run()}>
+          再試行
+        </button>
+      </div>
+    );
+  }
+
+  if (state === "pending") {
+    return <div className="loading">準備中…</div>;
+  }
+
+  return <Outlet />;
+}

--- a/frontend/src/pages/WorldsPage.test.tsx
+++ b/frontend/src/pages/WorldsPage.test.tsx
@@ -118,4 +118,13 @@ describe("WorldsPage", () => {
       expect(screen.getByRole("alert")).toHaveTextContent("同じ名前の世界が既にあります。");
     });
   });
+
+  it("一覧の取得に失敗したら空状態を出さずエラーだけ出す", () => {
+    stubWorlds({ worlds: [], error: "世界の一覧を取得できませんでした。" });
+
+    renderPage();
+
+    expect(screen.queryByText("世界がありません")).toBeNull();
+    expect(screen.getByRole("alert")).toHaveTextContent("世界の一覧を取得できませんでした。");
+  });
 });

--- a/frontend/src/pages/WorldsPage.test.tsx
+++ b/frontend/src/pages/WorldsPage.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../auth/AuthContext", () => ({
+  useAuth: () => ({ signOutUser: vi.fn() }),
+}));
+
+const useWorldsMock = vi.fn();
+vi.mock("../worlds/useWorlds", () => ({ useWorlds: () => useWorldsMock() }));
+
+import { WorldsPage } from "./WorldsPage";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/worlds"]}>
+      <Routes>
+        <Route path="/worlds" element={<WorldsPage />} />
+        <Route path="/worlds/:worldId/bloodHorses" element={<div>馬一覧</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// テストコードも tsc の対象なので、ヘルパの戻り値に正確な型を付ける（Record<string, unknown> で
+// スプレッドすると create 等が unknown に落ちて npm run build が失敗する）。
+type WorldsStub = {
+  worlds: { id: string; name: string }[];
+  loading: boolean;
+  error: string | null;
+  create: ReturnType<typeof vi.fn>;
+  rename: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+};
+
+function stubWorlds(overrides: Partial<WorldsStub> = {}): WorldsStub {
+  const value: WorldsStub = {
+    worlds: [{ id: "w1", name: "はじまりの世界" }],
+    loading: false,
+    error: null,
+    create: vi.fn().mockResolvedValue(true),
+    rename: vi.fn().mockResolvedValue(true),
+    remove: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+  useWorldsMock.mockReturnValue(value);
+  return value;
+}
+
+describe("WorldsPage", () => {
+  it("世界を一覧し、選ぶと馬一覧へ遷移する", async () => {
+    stubWorlds();
+
+    renderPage();
+
+    await userEvent.click(screen.getByRole("button", { name: "はじまりの世界" }));
+    expect(screen.getByText("馬一覧")).toBeInTheDocument();
+  });
+
+  it("0 件なら空状態を出す", () => {
+    stubWorlds({ worlds: [] });
+
+    renderPage();
+
+    expect(screen.getByText("世界がありません")).toBeInTheDocument();
+  });
+
+  it("名前を入力して作成できる", async () => {
+    const value = stubWorlds();
+
+    renderPage();
+
+    await userEvent.type(screen.getByLabelText("新しい世界の名前"), "2周目");
+    await userEvent.click(screen.getByRole("button", { name: "作る" }));
+
+    expect(value.create).toHaveBeenCalledWith("2周目");
+  });
+
+  it("改名はインライン編集で行う", async () => {
+    const value = stubWorlds();
+
+    renderPage();
+
+    await userEvent.click(screen.getByRole("button", { name: "改名" }));
+    const input = screen.getByLabelText("変更後の名前");
+    await userEvent.clear(input);
+    await userEvent.type(input, "改名後");
+    await userEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    expect(value.rename).toHaveBeenCalledWith("w1", "改名後");
+  });
+
+  it("削除は確認してから実行し、取り消したら実行しない", async () => {
+    const value = stubWorlds();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    renderPage();
+
+    await userEvent.click(screen.getByRole("button", { name: "削除" }));
+    expect(value.remove).not.toHaveBeenCalled();
+
+    confirmSpy.mockReturnValue(true);
+    await userEvent.click(screen.getByRole("button", { name: "削除" }));
+    expect(value.remove).toHaveBeenCalledWith("w1");
+  });
+
+  it("エラーがあれば alert で表示する", async () => {
+    stubWorlds({ error: "同じ名前の世界が既にあります。" });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("同じ名前の世界が既にあります。");
+    });
+  });
+});

--- a/frontend/src/pages/WorldsPage.tsx
+++ b/frontend/src/pages/WorldsPage.tsx
@@ -1,0 +1,131 @@
+import { type FormEvent, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
+import { useWorlds } from "../worlds/useWorlds";
+
+/**
+ * 世界（セーブデータ）の一覧ハブ。
+ *
+ * 選択中の世界は URL（/worlds/:worldId/...）が唯一の出所なので、この画面は選択状態を持たない。
+ */
+export function WorldsPage() {
+  const { signOutUser } = useAuth();
+  const { worlds, loading, error, create, rename, remove } = useWorlds();
+  const navigate = useNavigate();
+  const [newName, setNewName] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState("");
+
+  // 失敗したときは入力・編集状態を保つ（打ち直しにさせない）。エラー文言は useWorlds が error に載せる。
+  const onCreate = async (e: FormEvent) => {
+    e.preventDefault();
+    if (await create(newName)) {
+      setNewName("");
+    }
+  };
+
+  const onSaveRename = async (worldId: string) => {
+    if (await rename(worldId, editingName)) {
+      setEditingId(null);
+    }
+  };
+
+  const onDelete = async (worldId: string, name: string) => {
+    if (!window.confirm(`「${name}」を削除します。よろしいですか？`)) {
+      return;
+    }
+    await remove(worldId);
+  };
+
+  return (
+    <div className="ledger">
+      <header className="ledger__head">
+        <h1 className="ledger__title">世界一覧</h1>
+        <span className="ledger__count">{worlds.length} 個</span>
+        <div className="ledger__spacer" />
+        <button className="btn-ghost" type="button" onClick={() => signOutUser()}>
+          ログアウト
+        </button>
+      </header>
+
+      {error && (
+        <p className="alert" role="alert">
+          {error}
+        </p>
+      )}
+
+      {loading ? (
+        <div className="loading">読み込み中…</div>
+      ) : worlds.length === 0 ? (
+        <section className="empty">
+          <p className="empty__mark">世界がありません</p>
+          <p className="empty__lede">最初の世界を作ると、その中で軽種馬の登録を始められます。</p>
+        </section>
+      ) : (
+        <ul className="worlds">
+          {worlds.map((world) => (
+            <li className="worlds__item" key={world.id}>
+              {editingId === world.id ? (
+                <>
+                  {/* 作成フォームの「新しい世界の名前」と紛れないラベルにする。 */}
+                  <label className="field worlds__field">
+                    <span>変更後の名前</span>
+                    <input
+                      value={editingName}
+                      onChange={(e) => setEditingName(e.target.value)}
+                      // biome-ignore lint/a11y/noAutofocus: 改名ボタンから開いた入力に即入力できるようにする
+                      autoFocus
+                    />
+                  </label>
+                  <button className="btn" type="button" onClick={() => void onSaveRename(world.id)}>
+                    保存
+                  </button>
+                  <button className="btn-ghost" type="button" onClick={() => setEditingId(null)}>
+                    やめる
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button
+                    className="worlds__name"
+                    type="button"
+                    onClick={() => navigate(`/worlds/${world.id}/bloodHorses`)}
+                  >
+                    {world.name}
+                  </button>
+                  <button
+                    className="btn-ghost"
+                    type="button"
+                    onClick={() => {
+                      setEditingId(world.id);
+                      setEditingName(world.name);
+                    }}
+                  >
+                    改名
+                  </button>
+                  <button
+                    className="btn-ghost"
+                    type="button"
+                    onClick={() => void onDelete(world.id, world.name)}
+                  >
+                    削除
+                  </button>
+                </>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <form className="sheet worlds__new" onSubmit={onCreate}>
+        <label className="field">
+          <span>新しい世界の名前</span>
+          <input value={newName} onChange={(e) => setNewName(e.target.value)} required />
+        </label>
+        <button className="btn" type="submit">
+          作る
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/WorldsPage.tsx
+++ b/frontend/src/pages/WorldsPage.tsx
@@ -56,7 +56,7 @@ export function WorldsPage() {
 
       {loading ? (
         <div className="loading">読み込み中…</div>
-      ) : worlds.length === 0 ? (
+      ) : worlds.length === 0 && !error ? (
         <section className="empty">
           <p className="empty__mark">世界がありません</p>
           <p className="empty__lede">最初の世界を作ると、その中で軽種馬の登録を始められます。</p>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -469,3 +469,10 @@ body {
   align-items: flex-end;
   gap: 0.75rem;
 }
+
+.ledger__world {
+  padding: 0.15rem 0.6rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  font-size: 0.85rem;
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -425,3 +425,47 @@ body {
     transition: none !important;
   }
 }
+
+/* 世界一覧（WorldsPage） */
+.worlds {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--line);
+}
+
+.worlds__item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 0.5rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.worlds__name {
+  flex: 1;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 1.05rem;
+  color: inherit;
+  cursor: pointer;
+}
+
+.worlds__name:hover {
+  text-decoration: underline;
+}
+
+.worlds__field {
+  flex: 1;
+  margin: 0;
+}
+
+.worlds__new {
+  margin-top: 1.5rem;
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+}

--- a/frontend/src/worlds/useWorlds.test.ts
+++ b/frontend/src/worlds/useWorlds.test.ts
@@ -17,12 +17,13 @@ vi.mock("../api/worlds", () => ({
   deleteWorld: vi.fn(),
 }));
 
-import { createWorld, deleteWorld, listWorlds } from "../api/worlds";
+import { createWorld, deleteWorld, listWorlds, renameWorld } from "../api/worlds";
 import { useWorlds } from "./useWorlds";
 
 const listMock = vi.mocked(listWorlds);
 const createMock = vi.mocked(createWorld);
 const deleteMock = vi.mocked(deleteWorld);
+const renameMock = vi.mocked(renameWorld);
 
 describe("useWorlds", () => {
   it("マウント時に一覧を読み込む", async () => {
@@ -74,6 +75,27 @@ describe("useWorlds", () => {
     expect(created).toBe(false);
     expect(result.current.error).toBe("同じ名前の世界が既にあります。");
     expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it("改名が成功したら一覧を引き直す", async () => {
+    listMock
+      .mockResolvedValueOnce([{ id: "w1", name: "はじまりの世界" }])
+      .mockResolvedValueOnce([{ id: "w1", name: "改名後" }]);
+    renameMock.mockResolvedValue({ id: "w1", name: "改名後" });
+
+    const { result } = renderHook(() => useWorlds());
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    let renamed = false;
+    await act(async () => {
+      renamed = await result.current.rename("w1", "改名後");
+    });
+
+    expect(renamed).toBe(true);
+    expect(renameMock).toHaveBeenCalledWith(expect.any(Function), "w1", "改名後");
+    expect(result.current.worlds).toEqual([{ id: "w1", name: "改名後" }]);
   });
 
   it("削除が成功したら一覧を引き直す", async () => {

--- a/frontend/src/worlds/useWorlds.test.ts
+++ b/frontend/src/worlds/useWorlds.test.ts
@@ -2,8 +2,12 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ApiError } from "../api/client";
 
+// getToken はモジュールスコープの安定した参照にする。実物の AuthContext（useMemo）と同じく、
+// レンダーのたびに新しい関数を返さない — そうしないと reload の依存配列（[getToken]）が
+// 呼び出しごとに変わったと誤検知し、useEffect が再フェッチを連鎖させてしまう。
+const getToken = async () => "t";
 vi.mock("../auth/AuthContext", () => ({
-  useAuth: () => ({ getToken: async () => "t" }),
+  useAuth: () => ({ getToken }),
 }));
 
 vi.mock("../api/worlds", () => ({

--- a/frontend/src/worlds/useWorlds.test.ts
+++ b/frontend/src/worlds/useWorlds.test.ts
@@ -1,0 +1,103 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ApiError } from "../api/client";
+
+vi.mock("../auth/AuthContext", () => ({
+  useAuth: () => ({ getToken: async () => "t" }),
+}));
+
+vi.mock("../api/worlds", () => ({
+  listWorlds: vi.fn(),
+  createWorld: vi.fn(),
+  renameWorld: vi.fn(),
+  deleteWorld: vi.fn(),
+}));
+
+import { createWorld, deleteWorld, listWorlds } from "../api/worlds";
+import { useWorlds } from "./useWorlds";
+
+const listMock = vi.mocked(listWorlds);
+const createMock = vi.mocked(createWorld);
+const deleteMock = vi.mocked(deleteWorld);
+
+describe("useWorlds", () => {
+  it("マウント時に一覧を読み込む", async () => {
+    listMock.mockResolvedValue([{ id: "w1", name: "はじまりの世界" }]);
+
+    const { result } = renderHook(() => useWorlds());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.worlds).toEqual([{ id: "w1", name: "はじまりの世界" }]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("作成が成功したら一覧を引き直す", async () => {
+    listMock.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: "w2", name: "2周目" }]);
+    createMock.mockResolvedValue({ id: "w2", name: "2周目" });
+
+    const { result } = renderHook(() => useWorlds());
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    let created = false;
+    await act(async () => {
+      created = await result.current.create("2周目");
+    });
+
+    expect(created).toBe(true);
+    expect(createMock).toHaveBeenCalledWith(expect.any(Function), "2周目");
+    expect(result.current.worlds).toEqual([{ id: "w2", name: "2周目" }]);
+  });
+
+  it("作成が 409 なら error に文言が入り、一覧は引き直さない", async () => {
+    listMock.mockResolvedValue([]);
+    createMock.mockRejectedValue(new ApiError(409, { error_code: "world-name-taken" }));
+
+    const { result } = renderHook(() => useWorlds());
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    listMock.mockClear();
+
+    let created = true;
+    await act(async () => {
+      created = await result.current.create("重複");
+    });
+
+    expect(created).toBe(false);
+    expect(result.current.error).toBe("同じ名前の世界が既にあります。");
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it("削除が成功したら一覧を引き直す", async () => {
+    listMock
+      .mockResolvedValueOnce([{ id: "w1", name: "はじまりの世界" }])
+      .mockResolvedValueOnce([]);
+    deleteMock.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useWorlds());
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.remove("w1");
+    });
+
+    expect(result.current.worlds).toEqual([]);
+  });
+
+  it("一覧の取得に失敗したら error に文言が入る", async () => {
+    listMock.mockRejectedValue(new ApiError(500));
+
+    const { result } = renderHook(() => useWorlds());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.error).toBe("世界の一覧を取得できませんでした。");
+  });
+});

--- a/frontend/src/worlds/useWorlds.ts
+++ b/frontend/src/worlds/useWorlds.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { errorMessage } from "../api/client";
 import { type World, createWorld, deleteWorld, listWorlds, renameWorld } from "../api/worlds";
 import { useAuth } from "../auth/AuthContext";
@@ -27,25 +27,16 @@ export function useWorlds(): UseWorlds {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // getToken は ref 越しに参照する。AuthContext の実装は認証状態が変わらない限り安定した参照を返すが、
-  // それを useCallback/useEffect の依存に直接入れると「毎回新しい関数を返す」呼び出し元（テストダブル等）
-  // まで暗黙に安定を仮定してしまい、マウント時 useEffect が再フェッチを連鎖させかねない。ref にすれば
-  // reload/mutate 系の参照が安定し、常に最新の getToken を使いつつ再フェッチはマウント時の 1 回に保てる。
-  const getTokenRef = useRef(getToken);
-  useEffect(() => {
-    getTokenRef.current = getToken;
-  }, [getToken]);
-
   const reload = useCallback(async () => {
     try {
-      setWorlds(await listWorlds(getTokenRef.current));
+      setWorlds(await listWorlds(getToken));
       setError(null);
     } catch (e) {
       setError(errorMessage(e, "世界の一覧を取得できませんでした。"));
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [getToken]);
 
   useEffect(() => {
     void reload();
@@ -67,24 +58,20 @@ export function useWorlds(): UseWorlds {
   );
 
   const create = useCallback(
-    (name: string) =>
-      mutate(() => createWorld(getTokenRef.current, name), "世界を作成できませんでした。"),
-    [mutate],
+    (name: string) => mutate(() => createWorld(getToken, name), "世界を作成できませんでした。"),
+    [mutate, getToken],
   );
 
   const rename = useCallback(
     (worldId: string, name: string) =>
-      mutate(
-        () => renameWorld(getTokenRef.current, worldId, name),
-        "世界の名前を変更できませんでした。",
-      ),
-    [mutate],
+      mutate(() => renameWorld(getToken, worldId, name), "世界の名前を変更できませんでした。"),
+    [mutate, getToken],
   );
 
   const remove = useCallback(
     (worldId: string) =>
-      mutate(() => deleteWorld(getTokenRef.current, worldId), "世界を削除できませんでした。"),
-    [mutate],
+      mutate(() => deleteWorld(getToken, worldId), "世界を削除できませんでした。"),
+    [mutate, getToken],
   );
 
   return { worlds, loading, error, create, rename, remove };

--- a/frontend/src/worlds/useWorlds.ts
+++ b/frontend/src/worlds/useWorlds.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { errorMessage } from "../api/client";
+import { type World, createWorld, deleteWorld, listWorlds, renameWorld } from "../api/worlds";
+import { useAuth } from "../auth/AuthContext";
+
+type UseWorlds = {
+  worlds: World[];
+  loading: boolean;
+  error: string | null;
+  create: (name: string) => Promise<boolean>;
+  rename: (worldId: string, name: string) => Promise<boolean>;
+  remove: (worldId: string) => Promise<boolean>;
+};
+
+/**
+ * 世界一覧の取得と変更操作。
+ *
+ * 変更が成功したら一覧を引き直して画面を API に合わせる（楽観更新はしない。世界の数は少なく、
+ * 取り直しのコストより整合の確かさを取る）。
+ *
+ * 変更操作は例外を投げず、失敗を error の文言と戻り値 false で表す。呼び出し側は成否だけを見て
+ * 入力欄や編集モードを閉じるか決める（失敗したのに入力を捨てるとユーザーが打ち直しになる）。
+ */
+export function useWorlds(): UseWorlds {
+  const { getToken } = useAuth();
+  const [worlds, setWorlds] = useState<World[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // getToken は ref 越しに参照する。AuthContext の実装は認証状態が変わらない限り安定した参照を返すが、
+  // それを useCallback/useEffect の依存に直接入れると「毎回新しい関数を返す」呼び出し元（テストダブル等）
+  // まで暗黙に安定を仮定してしまい、マウント時 useEffect が再フェッチを連鎖させかねない。ref にすれば
+  // reload/mutate 系の参照が安定し、常に最新の getToken を使いつつ再フェッチはマウント時の 1 回に保てる。
+  const getTokenRef = useRef(getToken);
+  useEffect(() => {
+    getTokenRef.current = getToken;
+  }, [getToken]);
+
+  const reload = useCallback(async () => {
+    try {
+      setWorlds(await listWorlds(getTokenRef.current));
+      setError(null);
+    } catch (e) {
+      setError(errorMessage(e, "世界の一覧を取得できませんでした。"));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const mutate = useCallback(
+    async (operation: () => Promise<unknown>, fallback: string): Promise<boolean> => {
+      try {
+        await operation();
+      } catch (e) {
+        setError(errorMessage(e, fallback));
+        return false;
+      }
+      setError(null);
+      await reload();
+      return true;
+    },
+    [reload],
+  );
+
+  const create = useCallback(
+    (name: string) =>
+      mutate(() => createWorld(getTokenRef.current, name), "世界を作成できませんでした。"),
+    [mutate],
+  );
+
+  const rename = useCallback(
+    (worldId: string, name: string) =>
+      mutate(
+        () => renameWorld(getTokenRef.current, worldId, name),
+        "世界の名前を変更できませんでした。",
+      ),
+    [mutate],
+  );
+
+  const remove = useCallback(
+    (worldId: string) =>
+      mutate(() => deleteWorld(getTokenRef.current, worldId), "世界を削除できませんでした。"),
+    [mutate],
+  );
+
+  return { worlds, loading, error, create, rename, remove };
+}


### PR DESCRIPTION
## 概要

フロントエンドに初回セットアップ（`POST /api/me:provision`）と世界（セーブデータ）の選択・作成を実装する（#714）。

`#705` で全ドメイン API が `/api/worlds/{worldId}/...` へ移った結果、`BloodHorseListPage.tsx` は旧パス `/api/bloodHorses` を叩き続けており、**現状のフロントは動かない**（`frontend/README.md` に既知の破壊として記載済み）。本 PR でその追随と、世界を選ぶ導線を入れる。

実装は全 10 タスク完了。`npm run lint` / `npm run test`（11 ファイル 45 ケース）/ `npm run build` はいずれも green。

## 設計の決定

| 論点 | 決定 | 理由 |
|---|---|---|
| 世界の選択 UI | 一覧ハブ `/worlds` を置き、選ぶと `/worlds/:worldId/bloodHorses` へ | 選択状態を URL が持つので、リロード・ブックマークで復元できる。ローカルストレージやコンテキストに隠し持たない |
| `worldId` の検証 | 事前検証せず、API の 404 `world-not-found` をそのまま使う | 権限判断の出所をサーバに一本化する（ADR-0067）。リクエストも 1 本で済む |
| `:provision` の並行競合 | in-flight dedupe のみ。**リトライはしない** | `#713`（PR #738）でサーバが並行実行下でも冪等になり、409 バリアント自体が削除された。競合を見越した再試行は意味を失っており、残すと別の障害を盲目的に再送してしまう。dedupe は StrictMode の二重発火・再マウントで無駄な POST を投げないために残す |
| 世界 0 個 | 空状態を出して作成を促す | DELETE を全件許す API の意図を尊重し、隠れた自動再生成を作らない |
| 馬一覧での世界名 | `GET /api/worlds` を引いて解決。**表示専用** | `GET /api/worlds/{id}` が無いため一覧から引くしかない。失敗しても名前を出さないだけで、アクセス可否は判断しない |
| データ層 | `api/*` の関数 ＋ `useWorlds` フックに薄く切り出す | 世界一覧の取得が `WorldsPage`（CRUD）と `BloodHorseListPage`（名前解決）で二重化するため。TanStack Query は現状 2 画面には過剰 |

## 進捗

| # | 内容 | 状態 |
|---|---|---|
| 1 | `problem.ts` に `error_code` → 画面文言の解決 | ✅ `c43853b` |
| 2 | `client.ts` に `apiPost` / `apiPatch` / `apiDelete` | ✅ `f2efc64` |
| 3 | `api/worlds.ts`（世界 API の 4 操作） | ✅ `19392e9` |
| 4 | `api/me.ts`（`:provision` の dedupe） | ✅ `629022b` |
| 5 | `RequireProvisioned`（セットアップ完了までのガード） | ✅ `d155367` |
| 6 | `useWorlds`（一覧の state と変更操作） | ✅ `898bde9` |
| 7 | `WorldsPage`（一覧ハブ・作成・改名・削除） | ✅ `902f6bc` |
| 8 | 馬一覧を世界スコープへ追随 | ✅ `0aea6bb` |
| 9 | ルーティング配線 | ✅ `5b17e04` |
| 10 | README 更新と全体ゲート | ✅ `bb91a5a` |

## エラー描画（バックの実装を読んで確認した対応表）

| `error_code` | HTTP | 出所 | 画面での扱い |
|---|---|---|---|
| `account-not-provisioned` | 403 | `GlobalExceptionHandler.kt` | セットアップ未完了。再試行を促す |
| `world-not-found` | 404 | `ActorArgumentResolver` / `WorldProblem.kt` | 「この世界は見つかりません」＋世界一覧へ戻る導線 |
| `world-name-blank` / `world-name-too-long` | 400 | `WorldProblem.kt` | 入力を直す |
| `world-name-taken` | 409 | `WorldProblem.kt`（**作成時**） | 同名の世界があります |
| `world-update-conflict` | 409 | `WorldProblem.kt`（**改名時**） | 同名か、別の更新と競合 |

**Issue #714 の記述とのずれ**: Issue の表は改名の 409 も `world-name-taken` としているが、実装は `PATCH` 経路が `world-update-conflict`（同名衝突と楽観ロック競合を 1 コードに束ねる）を返す。両方をハンドリングする。

## テスト

各コミットが TDD（RED → GREEN）で実装とテストを対にしている。現時点で frontend のテストは 10 ファイル / 40 ケースが green、`npm run lint` と `tsc` もエラーなし。

- `problem.test.ts` — 既知コード・未知コード・フォールバック
- `client.test.ts` — メソッド・ボディ・Content-Type・204 で `json()` を呼ばないこと・409 の problem 解釈
- `worlds.test.ts` — 4 操作のパス・メソッド・ボディ
- `me.test.ts` — dedupe・失敗を覚えない・成功はキャッシュする・uid 別実行
- `RequireProvisioned.test.tsx` — 完了まで子を描かない・成功・失敗からの再試行
- `useWorlds.test.ts` — 初回ロード・作成成功／409・削除・一覧失敗
- `WorldsPage.test.tsx` — 一覧と遷移・空状態・作成・改名・削除の確認と取り消し・エラー表示

### 最終レビュー（ブランチ全体）で直した点（`cd859d6`）

タスク単位のレビューでは見えず、11 コミットを横断して初めて出た指摘 3 件:

1. **`WorldsPage` が「一覧の取得失敗」を「世界が 0 件」として描いていた** — 既存の世界があるのに「世界がありません」と出るため、同名を作ろうとして 409 を踏む。姉妹画面の `BloodHorseListPage` は `rows.length === 0 && !error` とエラー時は空状態を出さない設計で、2 枚のページに別々の答えが並んでいた。条件を揃えた。
2. **`RequireProvisioned` のエラー画面が 401 で袋小路だった** — トークンが拒否される状況（`GCP_PROJECT_ID` / audience の不一致、ユーザー無効化）で「再試行」しか無く、何度押しても 401 のまま。全画面のうちここだけログアウト導線が無かったので追加した。
3. **`useWorlds.rename` の配線がどのテストにも通っていなかった** — ページ側はフックをモックし、API 側は関数を直接叩くため、その間の `mutate(() => renameWorld(getToken, worldId, name))` が無検証だった（引数順を取り違えても誰も落ちない）。create / remove は検証済みで rename だけ非対称だったので、引数順を検証するケースを足した。

### タスク単位のレビューで直した点（`898bde9`）

`useWorlds` の初回実装は、テストダブルの `getToken` が呼ばれるたび新しい関数を返すせいで無限再フェッチが起き、それを避けるため実装側を `useRef` 経由に変えていた。これは**本番コードをテストの欠陥に合わせて曲げた**もので、`getToken` は `user` をクロージャに捕捉しているため「認証ユーザーが変わったら一覧を引き直す」性質を落としていた。テストダブルを本番の `AuthContext`（`useMemo` で参照が安定）に合わせて直し、実装は素直な依存配列に戻した。`RequireProvisioned` とパターンも揃っている。

## 手動確認（実 Identity Platform が要るため自動化していない）

1. ローカル Postgres を用意し、`GCP_PROJECT_ID=<projectId> ./gradlew bootRun` でバックを起動
2. `cd frontend && npm run dev` で `http://localhost:5173` を開く
3. テストユーザーでログイン → `/worlds` に「はじまりの世界」が 1 件
4. 世界の作成・改名・削除が画面からできる
5. 世界を選んで `/worlds/{worldId}/bloodHorses` へ遷移し、リロードしても同じ画面に戻る
6. URL の `worldId` を適当な UUID に書き換えると「この世界は見つかりません。」が出る
7. 世界をすべて削除すると空状態になり、そこから作り直せる

## 依存の追加

`@testing-library/user-event`（devDependency）— Testing Library 公式の操作 API。`RequireProvisioned` の再試行ボタンと、後続の `WorldsPage` の入力・クリックのテストに使う。

Refs #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)
