### PR TITLE
chore: #711 tfctl を 0.4.0 へアップグレードする

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,7 @@
       "Bash(terraform apply)",
       "Bash(terraform destroy *)",
       "Bash(terraform destroy)",
+      "Bash(tfctl harness *)",
       "Read(**/.env)",
       "Read(**/.env.local)",
       "Read(**/.env.*.local)"

--- a/mise.lock
+++ b/mise.lock
@@ -396,32 +396,32 @@ checksum = "sha256:f3845ae9ee38c22ef5e436390d86a3d908f77073e9667fa643a5ae0957c19
 url = "https://download-cdn.jetbrains.com/language-server/kotlin-server/262.8190.0/kotlin-server-262.8190.0.sit"
 
 [[tools."http:tfctl"]]
-version = "0.3.0"
+version = "0.4.0"
 backend = "http:tfctl"
 
 [tools."http:tfctl"."platforms.linux-arm64"]
-checksum = "sha256:1060b2903cd8f9cb0af5c878cf89790e0f588b735b6715d2eeadd52c5a71f8c5"
-url = "https://releases.hashicorp.com/tfctl/0.3.0/tfctl_0.3.0_linux_arm64.zip"
+checksum = "sha256:5f2caf7900b8f43dd72f390b992bafceab4ae85bbc58b60325bb1888ef9a0e53"
+url = "https://releases.hashicorp.com/tfctl/0.4.0/tfctl_0.4.0_linux_arm64.zip"
 
 [tools."http:tfctl"."platforms.linux-arm64-musl"]
-checksum = "sha256:1060b2903cd8f9cb0af5c878cf89790e0f588b735b6715d2eeadd52c5a71f8c5"
-url = "https://releases.hashicorp.com/tfctl/0.3.0/tfctl_0.3.0_linux_arm64.zip"
+checksum = "sha256:5f2caf7900b8f43dd72f390b992bafceab4ae85bbc58b60325bb1888ef9a0e53"
+url = "https://releases.hashicorp.com/tfctl/0.4.0/tfctl_0.4.0_linux_arm64.zip"
 
 [tools."http:tfctl"."platforms.linux-x64"]
-checksum = "sha256:5526b438bb66c5bc872f55c4bbb7325bb3e9d162ddd392eed3d60f407598cf62"
-url = "https://releases.hashicorp.com/tfctl/0.3.0/tfctl_0.3.0_linux_amd64.zip"
+checksum = "sha256:055d365cf165708dd304747f27a7242c51ce61a0bf680bd83fd3abe7cbcaa356"
+url = "https://releases.hashicorp.com/tfctl/0.4.0/tfctl_0.4.0_linux_amd64.zip"
 
 [tools."http:tfctl"."platforms.linux-x64-musl"]
-checksum = "sha256:5526b438bb66c5bc872f55c4bbb7325bb3e9d162ddd392eed3d60f407598cf62"
-url = "https://releases.hashicorp.com/tfctl/0.3.0/tfctl_0.3.0_linux_amd64.zip"
+checksum = "sha256:055d365cf165708dd304747f27a7242c51ce61a0bf680bd83fd3abe7cbcaa356"
+url = "https://releases.hashicorp.com/tfctl/0.4.0/tfctl_0.4.0_linux_amd64.zip"
 
 [tools."http:tfctl"."platforms.macos-arm64"]
-checksum = "sha256:045a5d7ebf2913006213b485353acf7c832bbf28e1cf3a6a34313dd761d4f535"
-url = "https://releases.hashicorp.com/tfctl/0.3.0/tfctl_0.3.0_darwin_arm64.zip"
+checksum = "sha256:e53f2b965eec2435d5543ff4b6ff799b4beac0e0c233a3a355158abe4c524632"
+url = "https://releases.hashicorp.com/tfctl/0.4.0/tfctl_0.4.0_darwin_arm64.zip"
 
 [tools."http:tfctl"."platforms.macos-x64"]
-checksum = "blake3:e860c6cd3698a644712c5869ad6213603528d7e64e78b6921835c249e75f519f"
-url = "https://releases.hashicorp.com/tfctl/0.3.0/tfctl_0.3.0_darwin_amd64.zip"
+checksum = "sha256:19786ebddb3cbd922402d21577e85842385910a666e62b1f9b0de46520c527d7"
+url = "https://releases.hashicorp.com/tfctl/0.4.0/tfctl_0.4.0_darwin_amd64.zip"
 
 [[tools.java]]
 version = "temurin-25.0.3+9.0.LTS"

--- a/mise.toml
+++ b/mise.toml
@@ -30,27 +30,28 @@ zizmor = "1.26.1"
 # 直接指す。バージョン更新は version フィールド 1 箇所のみ（URL は {{version}} テンプレート）、整合性は
 # mise.lock（lockfile=true）が SHA256 で担保する。
 [tools."http:tfctl"]
-version = "0.3.0"
+version = "0.4.0"
 bin = "tfctl"
 
 # checksum は公式 SHA256SUMS（releases.hashicorp.com/tfctl/<version>/tfctl_<version>_SHA256SUMS）の値を固定する。
 # http バックエンドは aqua/ubi と異なり mise.lock に per-platform SHA を埋めないため、ここで明示して整合性を担保する。
-# バージョン更新時は version と 4 つの checksum を SHA256SUMS から更新すること。
+# バージョン更新時は version と 4 つの checksum を SHA256SUMS から更新すること。mise.lock 側は
+# `mise install` しても自ホスト分しか書き換わらないため、6 エントリ（linux の -musl 派生を含む）を手で揃える。
 [tools."http:tfctl".platforms.macos-x64]
 url = "https://releases.hashicorp.com/tfctl/{{version}}/tfctl_{{version}}_darwin_amd64.zip"
-checksum = "sha256:a12de01e640cb9dea6080b7e8a2cdb74c5efe466f3ff6ba19c520c03d383dac9"
+checksum = "sha256:19786ebddb3cbd922402d21577e85842385910a666e62b1f9b0de46520c527d7"
 
 [tools."http:tfctl".platforms.macos-arm64]
 url = "https://releases.hashicorp.com/tfctl/{{version}}/tfctl_{{version}}_darwin_arm64.zip"
-checksum = "sha256:045a5d7ebf2913006213b485353acf7c832bbf28e1cf3a6a34313dd761d4f535"
+checksum = "sha256:e53f2b965eec2435d5543ff4b6ff799b4beac0e0c233a3a355158abe4c524632"
 
 [tools."http:tfctl".platforms.linux-x64]
 url = "https://releases.hashicorp.com/tfctl/{{version}}/tfctl_{{version}}_linux_amd64.zip"
-checksum = "sha256:5526b438bb66c5bc872f55c4bbb7325bb3e9d162ddd392eed3d60f407598cf62"
+checksum = "sha256:055d365cf165708dd304747f27a7242c51ce61a0bf680bd83fd3abe7cbcaa356"
 
 [tools."http:tfctl".platforms.linux-arm64]
 url = "https://releases.hashicorp.com/tfctl/{{version}}/tfctl_{{version}}_linux_arm64.zip"
-checksum = "sha256:1060b2903cd8f9cb0af5c878cf89790e0f588b735b6715d2eeadd52c5a71f8c5"
+checksum = "sha256:5f2caf7900b8f43dd72f390b992bafceab4ae85bbc58b60325bb1888ef9a0e53"
 
 # kotlin-lsp: JetBrains 公式 Kotlin Language Server。Claude Code の `kotlin-lsp@claude-plugins-official`
 # プラグイン（.claude/settings.json で有効化）が要求するバイナリで、PATH 上の `kotlin-lsp --stdio` を起動する。


### PR DESCRIPTION
## 概要

mise が `http` バックエンドで固定している `tfctl` を **0.3.0 → 0.4.0** へ上げる（Dependabot は mise を見ないため手動追従）。併せて、0.4.0 で新設された `tfctl harness` をガードレールの deny へ追加した。

Closes #711

## 変更内容

### `mise.toml`

- `[tools."http:tfctl"]` の `version` を `0.4.0` へ、4 platform の `checksum` を公式 SHA256SUMS の値へ差し替え。
  値は原典（ `https://releases.hashicorp.com/tfctl/0.4.0/tfctl_0.4.0_SHA256SUMS` ）を取得して照合済み（Issue 本文の表とも一致）。
- `mise.lock` は `mise install` しても自ホスト分しか書き換わらないため、6 エントリを手で揃える旨をコメントへ追記した（次回更新時の手戻り防止）。

### `mise.lock`

- `http:tfctl` の 6 エントリ（linux の `-musl` 派生を含む）の `version` / `url` / `checksum` を 0.4.0 へ更新。
- 別ホストで生成した名残で `macos-x64` だけ `blake3:` だった checksum を、他エントリと同じ `sha256:` へ揃えた（Issue の「方針を決める」項目）。

### `.claude/settings.json`

- `Bash(tfctl harness *)` を **deny** に追加。0.4.0 の `harness exec` はラップしたコマンド（＝すべてのサブプロセス）へ noninteractive な削除権限 `--allow-delete=...` を渡すが、**先頭トークンが既存の `tfctl <verb>` パターンのどれにも当たらない**ため素通りしていた。`.claude/rules/gcp-guardrails.md` の「変更系を env ランナーでラップすると deny/ask を迂回する」と同型のため、当面使う予定がないことも踏まえて ask ではなく deny を選んだ。

## 実測確認

| 確認 | 結果 |
| --- | --- |
| `mise install http:tfctl` | ✅ checksum 検証を通ってインストール成功 |
| `mise exec -- tfctl --version` | ✅ `v0.4.0` |
| `mise exec -- tfctl get workspaces -o ptiringo-tech` | ✅ 0.4.0 で新設されたアップデートチェック通知は**混ざらない**（ID 列は従来どおり読める） |
| `tfctl api ... --jq '.data[0].relationships.plan.data.id'` | ✅ `plan-…` を取得（`/hcp-run-inspect` の抽出形） |
| `tfctl api "/plans/<id>" --jq '{add:…"resource-additions", …}'` | ✅ `{add:0, change:0, destroy:0, status:"finished"}` |
| `dprint check` / lefthook pre-commit・pre-push | ✅ 緑（全テスト 199s も含む） |

→ **`/hcp-run-inspect` スキルの更新は不要**。0.4.0 の破壊的変更（`api --json`/`--jq` が 1 対 1 リレーション ID を `attributes` に混ぜなくなった）は、スキルが引くパス（生 JSON の `relationships` と API 本来の `attributes`）に当たらないという Issue の事前分析を、上の 2 コマンドの実測で裏づけた。`--all` もスキルでは使っていない。

## 影響範囲

- **CI への影響なし**: 全ワークフローが `mise.ci.toml` オーバーレイで `http` バックエンドのツール（`kotlin-lsp` / `tfctl`）を除外している（#464 / #510）。
- Kotlin / インフラのコード変更はなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
