### PR TITLE
refactor: #680 tennis のエラー型 TurnedProBeforeBirth を値オブジェクト保持に揃える

### DIFF
--- a/src/main/kotlin/com/example/api/domain/tennis/model/player/Player.kt
+++ b/src/main/kotlin/com/example/api/domain/tennis/model/player/Player.kt
@@ -5,7 +5,6 @@ import com.example.api.domain.shared.generateId
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
-import java.time.LocalDate
 import java.util.UUID
 import org.jmolecules.ddd.annotation.AggregateRoot
 import org.jmolecules.ddd.annotation.Identity
@@ -24,7 +23,7 @@ import org.jmolecules.ddd.annotation.ValueObject
  * @property dateOfBirth 生年月日
  * @property turnedProOn プロ転向日
  */
-data class TurnedProBeforeBirth(val dateOfBirth: LocalDate, val turnedProOn: LocalDate)
+data class TurnedProBeforeBirth(val dateOfBirth: DateOfBirth, val turnedProOn: TurnedProDate)
 
 /**
  * プロテニス選手を表す集約ルート。
@@ -86,7 +85,7 @@ private constructor(
                     )
                 )
             } else {
-                Err(TurnedProBeforeBirth(dateOfBirth.value, turnedProOn.value))
+                Err(TurnedProBeforeBirth(dateOfBirth, turnedProOn))
             }
     }
 }

--- a/src/test/kotlin/com/example/api/domain/tennis/model/player/PlayerTest.kt
+++ b/src/test/kotlin/com/example/api/domain/tennis/model/player/PlayerTest.kt
@@ -30,7 +30,7 @@ class PlayerTest {
 
         val error = Player.create(name, country, Handedness.LEFT, dateOfBirth, before).getError()
 
-        assert(error == TurnedProBeforeBirth(dateOfBirth.value, before.value))
+        assert(error == TurnedProBeforeBirth(dateOfBirth, before))
     }
 
     @Test
@@ -39,7 +39,7 @@ class PlayerTest {
 
         val error = Player.create(name, country, Handedness.RIGHT, dateOfBirth, sameDay).getError()
 
-        assert(error == TurnedProBeforeBirth(dateOfBirth.value, sameDay.value))
+        assert(error == TurnedProBeforeBirth(dateOfBirth, sameDay))
     }
 
     @Test


### PR DESCRIPTION
## 概要

Closes #680

`domain/tennis/model/player/Player.kt` のエラー型 `TurnedProBeforeBirth` が `LocalDate` の生値を保持していたのを、既存コンテキストの流儀（例: `BloodHorse` の `HorseAlreadyNamed(val currentName: HorseName)`）に合わせて**値オブジェクト保持**へ揃えた。

```kotlin
- data class TurnedProBeforeBirth(val dateOfBirth: LocalDate, val turnedProOn: LocalDate)
+ data class TurnedProBeforeBirth(val dateOfBirth: DateOfBirth, val turnedProOn: TurnedProDate)
```

Issue にあるとおり**実害はなく、等価性も情報量も変わらない**（コンテキスト内の一貫性のみ）。`#366` や tennis の永続化・UseCase に着手するタイミングでまとめて判断する選択肢もあったが、「単独で先に直しても構わない」との記載に従い、修正量が最小のうちに片づけた。エラー型はまだ Controller 境界へ露出していないため、写像先（`ProblemDetail`）への影響も無い。

## 変更内容

- **`src/main/kotlin/com/example/api/domain/tennis/model/player/Player.kt`**
  - `TurnedProBeforeBirth` のプロパティ型を `LocalDate` → `DateOfBirth` / `TurnedProDate` へ変更
  - `Err` 生成時の `.value` 剥がしを削除
  - 未使用になった `java.time.LocalDate` の import を削除（`allWarningsAsErrors = true` のため未使用 import はビルドを落とす）
- **`src/test/kotlin/com/example/api/domain/tennis/model/player/PlayerTest.kt`**
  - 期待値の組み立てを値オブジェクトそのままに変更（`.value` を外す）

挙動の変更は無い。既存テスト 2 件（`プロ転向日が生年月日より前なら〜` / `〜と同日なら〜`）がそのまま不変条件を担保する。

## 確認

- `./gradlew check` — BUILD SUCCESSFUL（ktfmt / detekt / ArchUnit 含むテスト / `koverVerifyMature`）
- 差分カバレッジ（CI の PR ジョブ限定ゲート）をローカルで先行確認: `diff-cover --fail-under 90` に対し **2 lines / Coverage 100%**
