### PR TITLE
chore: #716 Dependabot に cooldown を設定して直後版を掴むリスクを下げる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,14 @@ version: 2
 # - minor / patch の低リスク更新はエコシステムごとに 1 グループへ束ね、PR ノイズを削減する。
 # - major 更新はグループから外し個別 PR に残す（破壊的変更をまとめてレビューを難しくしない）。
 # - 例外的に高リスク・手作業を伴う依存（Spring Boot / Kotlin プラグイン）は個別・専用グループに分離する。
+#
+# cooldown 方針（#716）:
+# - リリース直後の欠陥版を掴むリスクと、短命なパッチの往復 PR を減らすため、全 4 エコシステムに揃えて置く。
+#   cooldown は version update 専用で security update には効かないため、延ばしても脆弱性修正は遅れない。
+# - 未設定でも version update には既定 3 日の cooldown がかかる。ここでの上乗せは major / minor のみで、
+#   patch は semver-patch-days を書かず既定 3 日のままにする（小さな修正まで待たせない）。
+# - semver-major-days / semver-minor-days は SemVer 対応マネージャ限定で、gradle と npm でしか使えない。
+#   github-actions / terraform は粒度を指定できないため default-days で一律に置く（minor 相当の 7 日）。
 updates:
   # Enable updates for Gradle dependencies
   - package-ecosystem: "gradle"
@@ -11,6 +19,10 @@ updates:
       interval: "weekly"
     # Keep PRs manageable by limiting the number of open PRs
     open-pull-requests-limit: 5
+    # major は破壊的変更と初期パッチが出やすいので長め、minor は中間、patch は既定 3 日（方針は先頭コメント）。
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
     groups:
       # Kotlin コンパイラ版と歩調を揃える必要がある依存を 1 グループに束ね、一般グループ
       # （gradle-minor-patch）を軽く緑に保つ。以下は常に同一 PR で足並みを揃える:
@@ -49,6 +61,9 @@ updates:
       interval: "weekly"
     # Keep PRs manageable by limiting the number of open PRs
     open-pull-requests-limit: 5
+    # github-actions は SemVer 粒度の cooldown 非対応（バンプ種別を区別できない）。一律 7 日で置く。
+    cooldown:
+      default-days: 7
     groups:
       # codeql-action の init / analyze / upload-sarif はバージョン完全一致が必須。
       # 分割更新すると "Loaded a configuration file for version X, but running version Y" で
@@ -71,6 +86,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # gradle と同じ粒度。react-router 7.18.0 の直後に 7.18.1 / 7.18.2 が出た実例（#693）が動機。
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
     groups:
       # React 本体と型定義はバージョン系列を揃える必要がある（react 19 に上げて @types/react が
       # 18 のままだと型エラーになる）。react / react-dom / それぞれの @types を major も含め
@@ -96,6 +115,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # terraform も SemVer 粒度の cooldown 非対応。github-actions と揃えて一律 7 日で置く。
+    cooldown:
+      default-days: 7
     groups:
       # /infra は実質 hashicorp/google 単一プロバイダ。minor / patch を集約、major は個別 PR に残る。
       terraform:


### PR DESCRIPTION
## 概要

Closes #716

`.github/dependabot.yml` に `cooldown` を設定し、リリース直後の版を掴むリスクと短命なパッチの往復 PR を減らす。#716 の「決めること」3 点はそれぞれ以下のとおり判断した。

### 1. そもそも入れるか → 入れる

`cooldown` は version update 専用で **security update には効かない**（原典で確認）。つまり延ばしても脆弱性修正は遅れず、入れる側のデメリットが小さい。Dependabot PR は auto-merge を使わず必ず人手のレビューを挟むので二重の保険にはなるが、#693 で `react-router` 7.18.0 の直後に 7.18.1 / 7.18.2 が出た実例があり、既定 3 日 + weekly では拾ってしまう幅が実際にあった。

### 2. 日数

| バンプ種別 | 日数 | 理由 |
| --- | --- | --- |
| major | 14 | 破壊的変更と初期パッチが出やすく 3 日は短い |
| minor | 7 | 中間 |
| patch | 既定 3 日（未設定） | 小さな修正まで待たせない |

`semver-patch-days` はあえて書かない。未設定なら `default-days`（未設定時は既定 3 日）が効く。

### 3. 適用範囲 → 4 エコシステム全部

グルーピング方針（#381）と同じく全エコシステムで揃える。ただし **`semver-*-days` は SemVer 対応マネージャ限定**で、この 4 つのうち対応するのは gradle と npm だけ。github-actions と terraform は非対応のため `default-days: 7`（minor 相当）で一律に置いた。

> **#716 の記述との差分**: Issue の仕様メモは「サポート対象に npm / gradle / github-actions / terraform はいずれも含まれる」としていたが、これは `cooldown` 自体（= `default-days`）の対応表であって、`semver-major-days` / `semver-minor-days` / `semver-patch-days` は github-actions / terraform では使えない。

## 変更内容

- `.github/dependabot.yml`
  - 先頭に cooldown 方針のコメントを追加（#381 のグルーピング方針コメントと同じ流儀。専用の ADR は起こさず、出所をファイル内に置いた）
  - gradle / npm: `semver-major-days: 14` / `semver-minor-days: 7`
  - github-actions / terraform: `default-days: 7`

## 検証

- `dprint check .github/dependabot.yml` 緑
- SchemaStore の `dependabot-2.0.json` に対する JSON Schema 検証をローカルで実行しパス（キー名・値域 1〜90 を含む）
- pre-push（`docker-available` + 全テスト）緑。Kotlin の変更は無し

## 典拠

GitHub Docs "Dependabot options reference"（`cooldown` の節と対応パッケージマネージャ表）を HTML から直接読んで確認した。
