### PR TITLE
fix: #769 issue-ops の候補一覧が limit 切り捨てで Issue を取りこぼすのを直す

### DIFF
--- a/.claude/skills/issue-ops/SKILL.md
+++ b/.claude/skills/issue-ops/SKILL.md
@@ -16,7 +16,8 @@ toy-box の Issue は **GitHub Projects #4（owner: ptiringo）** の `Priority`
   - project-id = `PVT_kwHOAGtZ7c4BbL04`
   - Priority field-id = `PVTSSF_lAHOAGtZ7c4BbL04zhV-LEM`
   - option-id = P1:`e9ce2b26` / P2:`61f24689` / P3:`1d0a06c9` / P4:`12ac3381`
-  - item-id は `gh project item-list 4 --owner ptiringo --format json` で issue number から引く。
+  - item-id は `gh project item-list 4 --owner ptiringo --format json --limit 1000` で issue number から引く
+    （`--limit` の既定は 30。省略すると先頭 30 件しか見ないので、目的の Issue が入らず空が返りやすい）。
 
 ---
 
@@ -31,12 +32,22 @@ priority だけ見て拾い、**クローズ済み・実装済みの Issue（例
 `.status != "Done"`（着手前だけ見たいなら `== "Todo"`）で絞る。1 回の呼び出しで priority + status が揃い join 不要。
 
 ```bash
-gh project item-list 4 --owner ptiringo --format json --limit 200 \
+gh project item-list 4 --owner ptiringo --query "-status:Done" --format json --limit 1000 \
   | jq -r '.items[] | select(.content.type=="Issue" and .status != "Done")
-      | "\(.priority // "未設定")\t\(.status)\t#\(.content.number)\t\(.content.title)"' | sort
+      | "\(.priority // "未設定")\t\(.status // "-")\t#\(.content.number)\t\(.content.title)"' | sort
 ```
 
 優先度順に整列したいときは `.priority` を `P1..P4 → 0..3` に写してソートする。
+
+**`--limit`（既定 30）は Project のアイテム総数（クローズ済み込み）に対して効く**。ボードは Done を
+溜め続けるので総数は open 数の数倍に膨らむ（2026-08-14 時点で 224 件に対し未 Done は 71 件）。
+超過分は**無音で切り捨てられる**ため、小さい値だと「一覧に出ない ＝ 無い」と誤読する。実際 `--limit 200`
+だった頃、唯一の P1 だった #760 が候補から丸ごと消えていた。件数を気にせず大きめ（1000）を渡すこと。
+
+`--query "-status:Done"`（Projects filter syntax）は**切り捨てより先に効く**サーバー側フィルタで、
+母集団を未 Done だけに縮めてくれる（`--limit 5` が全件 Todo を返すことを実測）。ただし絞るのは
+`Status` フィールドであって Issue の open/closed ではないため、**Status が Todo のままクローズされた
+Issue は残る**。jq 側の `.status != "Done"` は二重防御として残し、open/closed の担保は 3 の突き合わせで行う。
 
 ### 2. 動的な絞り込み（ラベル / キーワード / 担当）
 
@@ -48,13 +59,24 @@ gh issue list --state open --label security --search "breeding" --json number,ti
 
 `gh issue list` に優先度列は無いので、得た番号を 1 の出力と突き合わせて priority を引く。
 
-### 3. 整合性チェック（保険・任意）
+### 3. 整合性チェック（候補を提案する前に毎回）
 
-`.status` は派生値なので、たまに一次情報と件数照合する:
+`.status` は派生値、`--limit` は無音で切り捨てる。どちらも「候補が消える」向きに壊れるので、
+一次情報（`gh issue list`）と**差集合**で突き合わせる。件数だけの照合では、取りこぼしと
+「Project 未追加」が相殺して一致してしまう場合に気づけない。
 
 ```bash
-gh issue list --state open --limit 300 --json number -q '.[].number' | wc -l   # ↑ 1 の not-Done 件数と一致するはず
+S=<scratchpad>   # 一時ファイル置き場
+gh project item-list 4 --owner ptiringo --query "-status:Done" --format json --limit 1000 \
+  | jq -r '.items[] | select(.content.type=="Issue" and .status != "Done") | .content.number' | sort -n > $S/notdone.txt
+gh issue list --state open --limit 300 --json number -q '.[].number' | sort -n > $S/open.txt
+comm -23 $S/notdone.txt $S/open.txt   # 未 Done なのに CLOSED ＝ Status 未同期。候補から外す
+comm -13 $S/notdone.txt $S/open.txt   # OPEN なのに一覧に無い ＝ limit 切り捨て or Project 未追加
+# 両方とも空なら健全
 ```
+
+`cd` してから `gh` を叩くとリポジトリを見失う（`fatal: not a git repository`）。出力先はフルパスで
+指定し、**カレントディレクトリはリポジトリ内に置いたまま**にする。
 
 ### 4. 特定 Issue を「やりましょう」と推す前に実装済みでないか確認【必須】
 
@@ -85,7 +107,7 @@ gh issue create --title "<title>" --body "<body>"   # 返ってくる issue URL 
 gh project item-add 4 --owner ptiringo --url <issue-url>
 
 # 3) 優先度を設定（item-id は number から引く。ID 実値は冒頭参照）
-item=$(gh project item-list 4 --owner ptiringo --format json --limit 300 \
+item=$(gh project item-list 4 --owner ptiringo --format json --limit 1000 \
   | jq -r --argjson n <number> '.items[] | select(.content.number==$n) | .id')
 gh project item-edit --id "$item" --project-id PVT_kwHOAGtZ7c4BbL04 \
   --field-id PVTSSF_lAHOAGtZ7c4BbL04zhV-LEM --single-select-option-id <option-id>
@@ -96,7 +118,7 @@ gh project item-edit --id "$item" --project-id PVT_kwHOAGtZ7c4BbL04 \
 ## C. 既存 Issue の優先度を変更する
 
 ```bash
-item=$(gh project item-list 4 --owner ptiringo --format json --limit 300 \
+item=$(gh project item-list 4 --owner ptiringo --format json --limit 1000 \
   | jq -r --argjson n <number> '.items[] | select(.content.number==$n) | .id')
 gh project item-edit --id "$item" --project-id PVT_kwHOAGtZ7c4BbL04 \
   --field-id PVTSSF_lAHOAGtZ7c4BbL04zhV-LEM --single-select-option-id <option-id>
@@ -107,5 +129,7 @@ gh project item-edit --id "$item" --project-id PVT_kwHOAGtZ7c4BbL04 \
 ## やってはいけないこと
 
 - `gh project item-list` を priority だけ見て、open/closed・`.status` を無視して候補に出す（A）。
+- `--limit` を小さく渡して切り捨てに気づかないまま「候補はこれで全部」と言う（A-1）。切り捨ては無音で、
+  消えるのは並び順しだいで最優先の Issue でもありうる。
 - メモリや記憶だけに頼って「たぶん未対応」と推測で提案する（必ず A-4 を実行）。
 - Issue を作って Project 追加・優先度設定をせずに終える（B のルール違反）。


### PR DESCRIPTION
Closes #769

## 背景

`/issue-ops` の A-1（候補集合を作る）が `--limit 200` を使っていた。`gh project item-list` の `--limit`
（既定 30）は **Project のアイテム総数（クローズ済み込み）** に効くが、ボードは Done を溜め続けるため
総数は open 数の数倍に膨らむ（実測: **総数 224 件 / 未 Done 71 件**）。

結果、200 では切り捨てが起き、**当時ただ 1 件の P1 だった #760 が候補一覧から丸ごと消えていた**。
切り捨ては警告もエラーも出さないので「一覧に出ない ＝ 無い」と誤読する。#760 に着手した際に発覚した。

## 変更内容

- **`--limit` を 1000 へ引き上げ**（A-1 / B / C）。item-id 引きの例にも `--limit` を明記した。
- **`--query "-status:Done"` を追加**（A-1 / A-3）。Projects filter syntax のサーバー側フィルタで、
  母集団を未 Done だけに縮める。ただし絞るのは `Status` フィールドであって Issue の open/closed では
  ないため、jq 側の `.status != "Done"` は二重防御として残した。
- **A-3 の整合性チェックを「保険・任意」から「候補を提案する前に毎回」へ格上げ**し、件数照合を
  `comm` の差集合に変えた。件数だけでは取りこぼしと「Project 未追加」が相殺して一致し、検出できない。
- `cd` してから `gh` を叩くとリポジトリを見失う（`fatal: not a git repository`）落とし穴を追記。
- 「やってはいけないこと」に limit の項を追加。

## 実測

`--query` が切り捨てより先に効くこと（サーバー側フィルタであること）を確認した:

```console
$ gh project item-list 4 --owner ptiringo --query "-status:Done" --format json --limit 5 \
    | jq -r '.items[] | "\(.status)\t#\(.content.number)"'
Todo    #333
Todo    #332
Todo    #320
Todo    #319
Todo    #315
```

`--limit 5` でも返るのが全件 Todo なので、フィルタ適用後に件数が切られている。

修正後のコマンドで未 Done 71 件 / open 71 件が取得でき、`comm` の差集合が両方向とも空
（＝ Status 未同期も取りこぼしも無し）になることを確認した。

## 変更の性質

Claude 向け指示ファイル（`.claude/skills/`）のみの変更で、プロダクションコードには触れていない。
