### PR TITLE
chore: #396 onboarding を `mise bootstrap` 一本に統合する

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -22,14 +22,19 @@ jobs:
 
       - name: Set up mise
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          # `mise install` の代わりに `mise bootstrap` を走らせ、[tools] の導入に続けて
+          # `[tasks.bootstrap]`（= lefthook install）まで 1 ステップで流す（#396）。onboarding の
+          # 手順を mise.toml 側に寄せ、ワークフローに手書きの lefthook ステップを持たせない。
+          # 留意点: bootstrap は実験的機能で、有効化すると action が MISE_EXPERIMENTAL=1 を付与する。
+          # install_args とは併用不可だが、本ジョブは元々使っていない（除外は MISE_ENV=ci が担う）。
+          # lock ファイルがあるため action は `mise --locked bootstrap` を呼ぶ（install 経路と同じ扱い）。
+          bootstrap: true
         env:
           # CI 用オーバーレイ mise.ci.toml を読み込み、http backend ツール（kotlin-lsp/tfctl）を
           # インストール対象から外す（mise が per-platform SHA を mise.lock に永続化せず
           # `mise install --locked` を満たせない。#510 回帰。どちらも Copilot 環境では不要）。
           MISE_ENV: ci
-
-      - name: Set up lefthook
-        run: lefthook install
 
       - name: Set up JDK
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,10 +63,10 @@ Issue の優先度は **GitHub Projects（`toy-box` = Project #4）の `Priority
 
 ## ツール管理
 
-- **mise**: セットアップは `mise install`、確認は `mise list`。管理対象のツール一覧は `mise.toml` が出所（ビルド用 JDK、各種 lint / 解析、tbls、lefthook、fnox、terraform / tfctl、kotlin-lsp 等）。JDK のバージョン要件は `build.gradle.kts` の Gradle toolchain で宣言し、実体は mise が供給する（toolchain auto-detection が `JAVA_HOME` / `PATH` 経由で検出する）。
+- **mise**: セットアップは `mise bootstrap`（`[tools]` の導入に続けて `[tasks.bootstrap]` = `lefthook install` まで一括で流す。ツールだけ入れ直したいときは `mise install`）、確認は `mise list`。管理対象のツール一覧は `mise.toml` が出所（ビルド用 JDK、各種 lint / 解析、tbls、lefthook、fnox、terraform / tfctl、kotlin-lsp 等）。JDK のバージョン要件は `build.gradle.kts` の Gradle toolchain で宣言し、実体は mise が供給する（toolchain auto-detection が `JAVA_HOME` / `PATH` 経由で検出する）。
   - **`mise.lock` は生成したホストの platform 分しか記録しない**。macOS で生成した lock のまま Linux CI で `--locked` すると解決できず落ちるので、必要な platform のエントリを揃える（`http` backend は `mise lock` が sha を永続化しないため、公式の SHA256SUMS から手で追記する）。
   - **CI で `mise-action` の `install_args` にツールを列挙するときは `mise.toml` の `[tools]` キー（backend 修飾名）と完全一致させる**。短縮名では `--locked` が解決できず落ちる。ローカルの `--dry-run` は既インストール済みだと見逃す。
-- **Lefthook**: Git フックは `lefthook.yml` が出所（セットアップは `lefthook install`）。pre-commit で各種 lint、pre-push で全テスト、commit-msg で Conventional Commits 形式を検査する。フック全体の手動実行は `lefthook run pre-commit`、個別スキップは `LEFTHOOK_EXCLUDE=<name> git commit`。pre-push は Testcontainers を使うため Docker を要求し、到達できなければテストを起動する前に理由つきで落とす（[ADR-0071](docs/adr/0071-pre-push-docker-fail-fast-guard.md)、詳細は `.claude/rules/testing.md`）。
+- **Lefthook**: Git フックは `lefthook.yml` が出所（セットアップは `mise bootstrap` に含まれる。単体で張り直すなら `lefthook install`）。pre-commit で各種 lint、pre-push で全テスト、commit-msg で Conventional Commits 形式を検査する。フック全体の手動実行は `lefthook run pre-commit`、個別スキップは `LEFTHOOK_EXCLUDE=<name> git commit`。pre-push は Testcontainers を使うため Docker を要求し、到達できなければテストを起動する前に理由つきで落とす（[ADR-0071](docs/adr/0071-pre-push-docker-fail-fast-guard.md)、詳細は `.claude/rules/testing.md`）。
 
 ## MCP サーバー設定
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ Kotlin + Spring Boot で複数のドメインモデル（競馬・エンター�
 ツールバージョンは [mise](https://mise.jdx.dev/) で管理しています。mise を導入のうえ、以下で一式（JDK 25 ほか）をセットアップします。
 
 ```bash
-mise install        # mise.toml 記載のツールを導入
-lefthook install    # Git フックを有効化
+mise bootstrap      # mise.toml 記載のツールを導入し、続けて Git フック（lefthook）を有効化
 ```
 
 mise を活性化済みのシェル（または Claude Code セッション）では Gradle を直接実行できます。詳細は CLAUDE.md「ツール管理」を参照。

--- a/mise.toml
+++ b/mise.toml
@@ -23,6 +23,14 @@ uv = "0.11.24"
 vacuum = "0.29.9"
 zizmor = "1.26.1"
 
+# `mise bootstrap` の最終段で実行される特別扱いのタスク（mise が名前 `bootstrap` で拾う）。
+# ツール導入（[tools]）と git フック設定を 1 アクションに束ね、onboarding を `mise bootstrap` 一本に
+# 揃える（従来の `mise install` + `lefthook install` の二段手順を廃止。#396）。
+# lefthook install は冪等なので、既にフック設定済みの環境で再実行しても安全。
+[tasks.bootstrap]
+description = "git フック（lefthook）を設定する"
+run = "lefthook install"
+
 # tfctl: HCP Terraform / TFE 管理 CLI（run / variable / workspace 操作）。採否は ADR-0034 参照。
 # mise registry の短名 `tfctl` は別物（flux-iac/tofu-controller の tfctl）と衝突し、aqua-registry にも
 # 未登録・GitHub Releases にバイナリ資産なし（HashiCorp は releases.hashicorp.com で配布）のため、


### PR DESCRIPTION
Closes #396

## 概要

セットアップが `mise install` + `lefthook install` の二段手順に分かれていて、onboarding 手順（README / CLAUDE.md）と CI（`copilot-setup-steps.yml` の手書き lefthook ステップ）で二重管理になっていた。mise-action v4.2.0 の bootstrap mode を採用し、**「ツール導入 + git フック設定」を 1 アクションへ統合**する。

`mise bootstrap` は `[tools]` のインストール（ステップ 14）に続けて **名前 `bootstrap` のタスク（ステップ 15 = `mise run bootstrap`）** を実行するので、そこへ `lefthook install` を吸収させた。

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `mise.toml` | `[tasks.bootstrap]` を追加し `lefthook install` を担わせる |
| `.github/workflows/copilot-setup-steps.yml` | mise-action を `bootstrap: true` に変更し、手書きの `Set up lefthook` ステップを削除 |
| `README.md` | Getting Started のセットアップを `mise bootstrap` 一行に更新 |
| `CLAUDE.md` | 「ツール管理」の mise / Lefthook のセットアップ手順を更新 |

## 確認したこと（実測・原典）

- **`mise bootstrap` がタスクを実行する**: `mise bootstrap --help` のステップ一覧で `14. mise install` → `15. mise run bootstrap`（`bootstrap` という名前のタスクがあれば実行）を確認。
- **クリーンな git リポジトリで通ること**: scratch に `mise.toml` / `mise.lock` / `lefthook.yml` を置いた新規リポジトリで `mise bootstrap` を実行し、`tools`（全導入済み）→ `bootstrap` タスク → `sync hooks: ✔️(pre-push, commit-msg, pre-commit)` まで成功、`.git/hooks` に 3 フックが生成されることを確認。
- **`--locked` の扱いが install 経路と同じ**: mise-action の `src/index.ts` で `miseInstall` / `miseBootstrap` とも `shouldUseLockedInstall()` で同一に `--locked` を付与している（lock ファイルがあるので CI では `mise --locked bootstrap` になる）。lock の要求が現状から変わらないことを意味する。
- **`MISE_EXPERIMENTAL=1` の付与元**: 同ソースの `core.getBooleanInput('bootstrap')` 分岐で action 側が自動設定する。ローカルの `mise bootstrap`（mise 2026.8.2）は環境変数なしで動作した。
- **`install_args` 併用不可の制約に抵触しない**: 本ジョブは `install_args` を使っておらず、CI のツール絞り込みは `MISE_ENV: ci`（`mise.ci.toml` の `disable_tools`）が担う。
- `lefthook run pre-commit --all-files` 緑（actionlint / zizmor / dprint / editorconfig-checker 含む 16 チェック）、pre-push の全テスト緑。

## 実験的機能への依存の判断（受け入れ条件 4）

**許容する。** 影響範囲は onboarding と Copilot 用セットアップワークフローに限られ、品質ゲート（`check` / CI のテスト・lint）やデプロイのクリティカルパスには乗らない。壊れた場合も `mise install` + `lefthook install` の二段手順へ戻すだけで可逆なので、ADR を起こすほどの不可逆な方針転換ではないと判断した。判断の理由は `mise.toml` とワークフローのコメントに残している。

## レビュー時の注意

`copilot-setup-steps.yml` は `paths` フィルタで自身の変更時に走るので、本 PR で実際に `bootstrap: true` の CI 実行結果が出る。**CI 緑を確認してからマージ**したい（`Set up lefthook` ステップ削除後もフックが張られるか＝ bootstrap タスクが CI で実行されるかは、この run が唯一の実証になる）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
