### PR TITLE
chore: #759 Biome 2.x へ更新し biome.json を新スキーマへ移行する

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
-  "organizeImports": { "enabled": true },
+  "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
-    "rules": { "recommended": true }
+    "rules": { "preset": "recommended" }
   },
   "formatter": {
     "enabled": true,
@@ -11,5 +11,5 @@
     "indentWidth": 2,
     "lineWidth": 100
   },
-  "files": { "ignore": ["dist", "coverage", "node_modules"] }
+  "files": { "includes": ["**", "!**/dist", "!**/coverage", "!**/node_modules"] }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
-        "@biomejs/biome": "^1.9.0",
+        "@biomejs/biome": "^2.5.7",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.6.3",
@@ -105,11 +105,10 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
-      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.7.tgz",
+      "integrity": "sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
         "biome": "bin/biome"
@@ -122,20 +121,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "1.9.4",
-        "@biomejs/cli-darwin-x64": "1.9.4",
-        "@biomejs/cli-linux-arm64": "1.9.4",
-        "@biomejs/cli-linux-arm64-musl": "1.9.4",
-        "@biomejs/cli-linux-x64": "1.9.4",
-        "@biomejs/cli-linux-x64-musl": "1.9.4",
-        "@biomejs/cli-win32-arm64": "1.9.4",
-        "@biomejs/cli-win32-x64": "1.9.4"
+        "@biomejs/cli-darwin-arm64": "2.5.7",
+        "@biomejs/cli-darwin-x64": "2.5.7",
+        "@biomejs/cli-linux-arm64": "2.5.7",
+        "@biomejs/cli-linux-arm64-musl": "2.5.7",
+        "@biomejs/cli-linux-x64": "2.5.7",
+        "@biomejs/cli-linux-x64-musl": "2.5.7",
+        "@biomejs/cli-win32-arm64": "2.5.7",
+        "@biomejs/cli-win32-x64": "2.5.7"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.7.tgz",
+      "integrity": "sha512-vxo/Ls3/PYdQWyLhYYcgMOCzQypAjcY+iihS8M0wW03l16TCLW4zqZzGo75gm1VdCMj38hTVZ31KBWrZ4G9dJw==",
       "cpu": [
         "arm64"
       ],
@@ -150,9 +149,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.7.tgz",
+      "integrity": "sha512-Cd3Ga61amT/Yl/0x8elP5hhGYaFy4bw6WuysTgf7oo8TA5tJ5A1k+DkVoJ2BHbTVil51gTX9VPzArnrlLJ3Kyg==",
       "cpu": [
         "x64"
       ],
@@ -167,9 +166,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.7.tgz",
+      "integrity": "sha512-rR2QE0yF2GYSuYuKIa7pKvODGJqnOH+2eDREAM8wV+mWKSkMQKdAp4zXEZfTaxY8PMoNONnpgSWcBCyLDPDOKg==",
       "cpu": [
         "arm64"
       ],
@@ -184,9 +183,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.7.tgz",
+      "integrity": "sha512-xPI5yB6XlpDbNkS+bm1t42olw5c4l3UrlOmLg7KtLJvjvkNF/1V4tnUgfkylGIeb3u/T+BzMGYqgQhzjAoJzuQ==",
       "cpu": [
         "arm64"
       ],
@@ -201,9 +200,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.7.tgz",
+      "integrity": "sha512-FQgqJhscrqJUFptGaRSUJWlXAExwWcDwLuK49dvKfkQ1bB5SEEyFssnsxQY83Xm6jR0EbbX3+8+D5bfvYqUG2Q==",
       "cpu": [
         "x64"
       ],
@@ -218,9 +217,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.7.tgz",
+      "integrity": "sha512-rE5VZi+qtmPgQH+l7jVxYoZ18b/TiHEhulhMpjmCZH1PltSbjRcxNWywC3HZ9tYottG7ORkeTtoscBilKSBm0g==",
       "cpu": [
         "x64"
       ],
@@ -235,9 +234,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.7.tgz",
+      "integrity": "sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg==",
       "cpu": [
         "arm64"
       ],
@@ -252,9 +251,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.7.tgz",
+      "integrity": "sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ==",
       "cpu": [
         "x64"
       ],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "react-router-dom": "^7.18.2"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.0",
+    "@biomejs/biome": "^2.5.7",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.6.3",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-import { type ProblemDetail, isProblemContentType, problemMessage } from "./problem";
+import { isProblemContentType, type ProblemDetail, problemMessage } from "./problem";
 
 /** ID トークンを取り出す関数。未ログインなら null を返す（AuthContext.getToken）。 */
 export type GetToken = () => Promise<string | null>;

--- a/frontend/src/api/me.ts
+++ b/frontend/src/api/me.ts
@@ -1,4 +1,4 @@
-import { type GetToken, apiPost } from "./client";
+import { apiPost, type GetToken } from "./client";
 
 /** バックの MeResponse（accountId は wire 上 snake_case）。 */
 export type Me = {

--- a/frontend/src/api/worlds.ts
+++ b/frontend/src/api/worlds.ts
@@ -1,4 +1,4 @@
-import { type GetToken, apiDelete, apiGet, apiPatch, apiPost } from "./client";
+import { apiDelete, apiGet, apiPatch, apiPost, type GetToken } from "./client";
 
 /** バックの WorldResponse（controller/world/WorldResponse.kt）に対応する世界（セーブデータ）。 */
 export type World = {

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,5 +1,5 @@
-import { type User, onAuthStateChanged, signInWithEmailAndPassword, signOut } from "firebase/auth";
-import { type ReactNode, createContext, useContext, useEffect, useMemo, useState } from "react";
+import { onAuthStateChanged, signInWithEmailAndPassword, signOut, type User } from "firebase/auth";
+import { createContext, type ReactNode, useContext, useEffect, useMemo, useState } from "react";
 import { auth } from "./firebase";
 
 type AuthValue = {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -283,7 +283,9 @@ body {
   border: 1px solid var(--line);
   border-radius: var(--radius);
   font-size: 0.82rem;
-  transition: color 0.15s ease, border-color 0.15s ease;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
 }
 .btn-ghost:hover {
   color: var(--ink);
@@ -422,6 +424,7 @@ body {
 
 @media (prefers-reduced-motion: reduce) {
   * {
+    /* biome-ignore lint/complexity/noImportantStyles: OS の「視差を減らす」設定は、個別セレクタで指定した transition より確実に勝つ必要がある */
     transition: none !important;
   }
 }

--- a/frontend/src/worlds/useWorlds.ts
+++ b/frontend/src/worlds/useWorlds.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { errorMessage } from "../api/client";
-import { type World, createWorld, deleteWorld, listWorlds, renameWorld } from "../api/worlds";
+import { createWorld, deleteWorld, listWorlds, renameWorld, type World } from "../api/worlds";
 import { useAuth } from "../auth/AuthContext";
 
 type UseWorlds = {


### PR DESCRIPTION
Closes #759

## 概要

Dependabot の #745（`@biomejs/biome` 1.9.4 → 2.5.7）は `frontend/biome.json` が 1.x 形式のままで
**設定パースの時点**で落ちる。bump だけでは緑にできず、設定移行だけでも 1.x では新形式を読めないため、
**bump と設定移行を 1 つの PR にまとめた**。この PR をマージすると #745 は自動でクローズされる。

## やったこと

### 1. Biome を 2.5.7 へ更新

`package.json` / `package-lock.json` の `@biomejs/biome` を `^1.9.0` → `^2.5.7`（#745 と同じ版）。

### 2. `biome.json` を 2.x スキーマへ移行

`biome migrate --write` を実行し、加えて 1 箇所を手で直した。

| 項目 | 1.x | 2.x |
| --- | --- | --- |
| `$schema` | `1.9.0/schema.json` | `2.5.7/schema.json` |
| import 整列 | `organizeImports.enabled` | `assist.actions.source.organizeImports` |
| 除外 | `files.ignore` | `files.includes` の否定パターン |
| ルールセット | `linter.rules.recommended: true` | `linter.rules.preset: "recommended"` |

**`migrate` の変換をそのまま採らなかった点**: `migrate` は `recommended: true` を
`preset: "none"` に落とす。`preset` の値域は `recommended | all | none`（同梱の
`configuration_schema.json` で確認）で、`none` は**全 lint ルールを無効化する**。
実測でも `none` では `lint/**` の指摘が 1 件も出ず、1.x 用の `biome-ignore` が
「抑制対象のルールが無効」として `suppressions/unused` 警告に変わっていた。
移行前の意図（推奨ルール有効）に合わせて `preset: "recommended"` へ直している。

### 3. 2.x で変わった挙動へコードを追随

- **organizeImports の並び順**: `type` 指定子つきの名前を先頭に固めず、辞書順に混ぜるようになった。
  `biome check --write` の safe fix をそのまま適用（`api/{client,me,worlds}.ts` /
  `auth/AuthContext.tsx` / `worlds/useWorlds.ts`）。
- **フォーマッタ既定**: 複数値の `transition` が 1 値 1 行へ展開されるようになった（`styles.css`）。
- **`lint/complexity/noImportantStyles`（2.x の recommended 新ルール）**: `styles.css` の
  `prefers-reduced-motion` で使っている `transition: none !important` が該当。OS の「視差を減らす」
  設定を個別セレクタの `transition` より確実に勝たせるための意図的な指定なので、削除せず
  **理由つきで suppress** した（Issue の「無効化する場合は理由をコメントで残す」に従う）。
  これ以外に新規のルール違反は出ていない。

## 検証（ローカル実測）

CI の frontend ジョブと同じ 3 ステップ ＋ pre-commit の整形チェック:

| コマンド | 結果 |
| --- | --- |
| `npm run lint`（`biome check .`） | `Checked 35 files. No fixes applied.` — 指摘ゼロ |
| `npm run build`（`tsc && vite build`） | `✓ built in 450ms` |
| `npm run test`（`vitest run`） | `Test Files 11 passed (11) / Tests 45 passed (45)` |
| `npm run format` の再実行 | `No fixes applied.` — 追加差分なし |
| `dprint check`（biome.json / package.json / package-lock.json） | 差分なし |

## 備考

`preset` は `recommended` を明示している。2.x では recommended が既定なので省略もできるが、
「どのルールセットで lint しているか」を設定ファイルから読めるようにするため明示を残した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
