### PR TITLE
fix: #748 MeController の OpenAPI から削除済みの 409 レスポンスを消す

### DIFF
--- a/src/main/kotlin/com/example/api/controller/me/MeController.kt
+++ b/src/main/kotlin/com/example/api/controller/me/MeController.kt
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Clock
 import org.springframework.http.MediaType
-import org.springframework.http.ProblemDetail
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
@@ -43,18 +42,7 @@ class MeController(private val provisionMe: ProvisionMeUseCase, private val cloc
                                 mediaType = MediaType.APPLICATION_JSON_VALUE,
                             )
                         ],
-                ),
-                ApiResponse(
-                    responseCode = "409",
-                    description = "並行する同一 subject のセットアップと競合した",
-                    content =
-                        [
-                            Content(
-                                schema = Schema(implementation = ProblemDetail::class),
-                                mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                            )
-                        ],
-                ),
+                )
             ],
     )
     @PostMapping("/api/me:provision")


### PR DESCRIPTION
Closes #748

## 概要

`MeController` の `@Operation` に、**実際には返らない 409 レスポンス**の宣言が残っていたので削除する。

#713（PR #738）で `ProvisionMeError.Conflict` バリアントと 409 マッピングを削除した際、`@Operation` 側の `@ApiResponse` だけが取り残されていた。`MeProblem.kt` の KDoc は既に「競合（409）のバリアントは持たない。並行するセットアップは DB の UNIQUE を裁定者にして吸収され、呼び出し側に競合として見えないため（#713）」と正しく書かれており、**注釈だけが古い**状態だった。

`/v3/api-docs` と Swagger UI が誤った契約を公開しているため、クライアント実装者は「409 をハンドリングしなければ」と考えてしまう（実際 #714 のフロント実装は「409 は来ない」前提で書かれている）。

## 変更内容

- `src/main/kotlin/com/example/api/controller/me/MeController.kt`
  - `@Operation` の `responses` から `responseCode = "409"` の `@ApiResponse` ブロックを削除
  - 参照が無くなった `org.springframework.http.ProblemDetail` の import も削除（`allWarningsAsErrors = true` のため未使用 import はビルドを落とす）

## 検証

- `./gradlew check` → **BUILD SUCCESSFUL**（`:test` / `:koverVerifyMature` 実行済み）
- `./gradlew lintOpenApiDocs` → **BUILD SUCCESSFUL**、vacuum は `Passed`（Quality Score 97/100、informs のみで warn 以上なし）
- 生成物 `build/openapi.json` の `/api/me:provision` の `responses` が `["200"]` のみになることを確認

  ```console
  $ jq '.paths."/api/me:provision".post.responses | keys' build/openapi.json
  [
    "200"
  ]
  ```

- diff-cover: `No lines with coverage information in this diff.`（削除のみで新規行なし）
- テスト側に 409 を期待している箇所が無いことを確認（`MeControllerTest` / ArchUnit / `OpenApiTest` を grep）。frontend の 409 参照は `worlds` 系（`world-name-taken`）のみで無関係

🤖 Generated with [Claude Code](https://claude.com/claude-code)
