### PR TITLE
feat: #652 登録番号（血統・繁殖）の一意性を世界スコープの二層防御で担保する

### DIFF
--- a/dbdoc/studbook.blood_horse.md
+++ b/dbdoc/studbook.blood_horse.md
@@ -37,6 +37,7 @@
 | uq_blood_horse_world_id_id | UNIQUE | UNIQUE (world_id, id) |
 | fk_blood_horse_inspection | FOREIGN KEY | FOREIGN KEY (world_id, inspection_id) REFERENCES studbook.horse_inspection(world_id, id) |
 | uq_blood_horse_name | UNIQUE | UNIQUE (world_id, name) |
+| uq_blood_horse_registration_number | UNIQUE | UNIQUE (world_id, registration_number) |
 
 ## Indexes
 
@@ -48,6 +49,7 @@
 | ix_blood_horse_sire_id | CREATE INDEX ix_blood_horse_sire_id ON studbook.blood_horse USING btree (world_id, sire_id) |
 | ix_blood_horse_dam_id | CREATE INDEX ix_blood_horse_dam_id ON studbook.blood_horse USING btree (world_id, dam_id) |
 | uq_blood_horse_name | CREATE UNIQUE INDEX uq_blood_horse_name ON studbook.blood_horse USING btree (world_id, name) |
+| uq_blood_horse_registration_number | CREATE UNIQUE INDEX uq_blood_horse_registration_number ON studbook.blood_horse USING btree (world_id, registration_number) |
 
 ## Relations
 

--- a/dbdoc/studbook.breeding_registration.md
+++ b/dbdoc/studbook.breeding_registration.md
@@ -26,6 +26,7 @@
 | fk_breeding_registration_world | FOREIGN KEY | FOREIGN KEY (world_id) REFERENCES iam.world(id) ON DELETE CASCADE |
 | fk_breeding_registration_registered_horse | FOREIGN KEY | FOREIGN KEY (world_id, registered_horse_id) REFERENCES studbook.blood_horse(world_id, id) |
 | uq_breeding_registration_world_id_id | UNIQUE | UNIQUE (world_id, id) |
+| uq_breeding_registration_registration_number | UNIQUE | UNIQUE (world_id, registration_number) |
 
 ## Indexes
 
@@ -34,6 +35,7 @@
 | breeding_registration_pkey | CREATE UNIQUE INDEX breeding_registration_pkey ON studbook.breeding_registration USING btree (id) |
 | uq_breeding_registration_world_id_id | CREATE UNIQUE INDEX uq_breeding_registration_world_id_id ON studbook.breeding_registration USING btree (world_id, id) |
 | ix_breeding_registration_registered_horse_id | CREATE INDEX ix_breeding_registration_registered_horse_id ON studbook.breeding_registration USING btree (world_id, registered_horse_id) |
+| uq_breeding_registration_registration_number | CREATE UNIQUE INDEX uq_breeding_registration_registration_number ON studbook.breeding_registration USING btree (world_id, registration_number) |
 
 ## Relations
 

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -39,7 +39,7 @@
 | BloodHorse | 軽種馬 | 集約ルート | 血統及び個体識別を明らかにする血統登録の成立によって誕生する個体。ライフサイクル全体を通じて同一の `BloodHorse` が各ロールを担う。 | 禁止: 単に「Horse」と呼ぶと文脈で曖昧。父母・ロールも別個体として扱わない |
 | HorseName | 馬名 | 値オブジェクト | 血統登録済みの個体に一度だけ付与できる名。出生時は未命名（`null`）。 | — |
 | HorseNamed | 馬名登録された | ドメインイベント | 馬名登録（`BloodHorse.assignName`）の成功時に「起きたこと」を表すイベント。遷移後の集約とともに `StateTransition` で同梱して返し、発行は application 層が担う（[ADR-0029](adr/0029-domain-events-via-state-transition-return.md)）。 | 禁止: `Command`（何をしたいか）と混同しない。本型は結果（何が起きたか） |
-| PedigreeRegistrationNumber | 血統登録番号 | 値オブジェクト | 血統登録の成立時に交付される番号。 | — |
+| PedigreeRegistrationNumber | 血統登録番号 | 値オブジェクト | 血統登録の成立時に交付される番号。血統登録原簿の中で一意（登録規程 第3〜4条）。一意性の範囲は世界（セーブデータ）に閉じる。繁殖登録番号とは別の採番空間。 | — |
 | MicrochipNumber | マイクロチップ番号 | 値オブジェクト | 個体識別に用いるマイクロチップの番号。 | — |
 | StudBookEntry | 血統登録申請（個体識別の束） | 値オブジェクト | 申請者が持ち込む仔馬自身の個体識別情報の束。父母は集約をまたぐためここには含めない。 | — |
 | CarriedOverHorseEntry | 移行取り込み（carried-over）の個体識別の束 | 値オブジェクト | 先行する登録原簿に血統登録済みの馬をシステム境界で取り込む際の入力。JAIRS の手続ではなくシステム境界の移行経路。血統は先行原簿に記録済みのため父母 ID を持たず、輸入馬（`ImportedHorseEntry`）と異なり原産国・揚陸日も持たない（#633）。 | — |
@@ -70,7 +70,7 @@
 | CoveringValidityError | 種付有効性違反 | 値オブジェクト（sealed） | 種付が種畜証明書の有効区域外（`OutsideValidRegion`）／有効期間外（`OutsideValidPeriod`）であることを表す。 | sealed 親型は jMolecules 非付与のためカタログには出ない |
 | FoalingOutcome | 分娩結果 | 値オブジェクト（sealed） | 種付した繁殖牝馬がその年に迎えた帰結。生産（`LiveFoal`）と産駒なし各区分の sealed 語彙。 | sealed 親型自体は jMolecules 非付与（カタログには variant のみ出る） |
 | FoalingOutcome.LiveFoal | 生産（産駒あり） | 値オブジェクト | 分娩により生存産駒を得た帰結。血統登録（`BloodHorse.create`）の入力に接続する。 | — |
-| BreedingRegistrationNumber | 繁殖登録番号 | 値オブジェクト | 繁殖登録に交付される番号。 | — |
+| BreedingRegistrationNumber | 繁殖登録番号 | 値オブジェクト | 繁殖登録に交付される番号。繁殖登録原簿の中で一意（登録規程 第5条）。一意性の範囲は世界（セーブデータ）に閉じる。血統登録番号とは別の採番空間。 | — |
 | BreedingResultSummaryView | 繁殖成績年次集計 | 読み取りモデル（@QueryModel） | (種牡馬, 種付年) 単位の繁殖成績。様式第2号（繁殖登録原簿〈雄〉）に対応。種付雌馬数・受胎数・生産数・受胎率・生産率を持つ。 | 軽量 CQRS（L2）の読みモデルのため application 層に置く |
 | 種付雌馬数 | 種付雌馬数 | 集計値 | その種牡馬がその年に種付けした雌馬数（`covering` を持つ年次成績の件数）。 | — |
 | 受胎数／受胎率 | 受胎数／受胎率 | 集計値 | 種付雌馬数のうち受胎が確認された件数（不受胎を除く。流産・死産・生後直死は受胎に含む）／その種付雌馬数比。 | — |
@@ -304,6 +304,8 @@ graph LR
 | CoveringReportRepository | リポジトリポート | domain.studbook.model.breeding |
 | HorseInspectionRepository | リポジトリポート | domain.studbook.model.inspection |
 | HorseNamed | ドメインイベント | domain.studbook.model.horse.bloodhorse |
+| ensureBreedingRegistrationNumberAvailable | ドメインサービス | domain.studbook.service.breeding |
+| ensurePedigreeRegistrationNumberAvailable | ドメインサービス | domain.studbook.service.horse |
 | nameHorse | ドメインサービス | domain.studbook.service.horse |
 | recordCovering | ドメインサービス | domain.studbook.service.breeding |
 | recordUncovered | ドメインサービス | domain.studbook.service.breeding |

--- a/src/main/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCase.kt
@@ -8,6 +8,7 @@ import com.example.api.domain.studbook.model.breeding.BreedingRegistrationNumber
 import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseId
 import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.studbook.service.breeding.ensureBreedingRegistrationNumberAvailable
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.getOrElse
@@ -36,6 +37,10 @@ sealed interface RegisterBreedingRegistrationUseCaseError {
     /** 繁殖登録番号がブランク。 */
     data object InvalidRegistrationNumber : RegisterBreedingRegistrationUseCaseError
 
+    /** 繁殖登録番号が既にこの世界の他の繁殖登録に採番済み。 */
+    data class RegistrationNumberAlreadyTaken(val registrationNumber: String) :
+        RegisterBreedingRegistrationUseCaseError
+
     /** 繁殖登録の対象として指定された軽種馬が存在しない。 */
     data class HorseNotFound(val bloodHorseId: UUID) : RegisterBreedingRegistrationUseCaseError
 }
@@ -49,6 +54,9 @@ sealed interface RegisterBreedingRegistrationUseCaseError {
  *
  * 繁殖登録は種付記録・種付せず・分娩報告・供用停止といった繁殖の書き込み経路の起点であり、本ユースケースが その起点（`save` 経路）を開通させる。付与されるロールは対象個体の性から
  * [BreedingRegistration.create] が定める。 制度上の前提条件（馬名登録済み・競走馬登録抹消済み 等）は対応する集約が未モデル化のため現時点では検証しない。
+ *
+ * 繁殖登録番号の一意性は既存レコード集合への問い合わせを要する集合制約で、集約の構築時不変条件では完結しない ため、ドメインサービス
+ * [ensureBreedingRegistrationNumberAvailable] が引き当てる。血統登録番号とは別の採番空間であり、 照合先も繁殖登録原簿に限る（ADR-0022）。
  *
  * @return 成立した [BreedingRegistration]、または業務ルール違反を表す [RegisterBreedingRegistrationUseCaseError]
  */
@@ -70,6 +78,17 @@ class RegisterBreedingRegistrationUseCase(
                     RegisterBreedingRegistrationUseCaseError.InvalidRegistrationNumber
                 }
                 .bind()
+        ensureBreedingRegistrationNumberAvailable(
+                actor.worldId,
+                registrationNumber,
+                breedingRegistrationRepository,
+            )
+            .mapError {
+                RegisterBreedingRegistrationUseCaseError.RegistrationNumberAlreadyTaken(
+                    it.number.value
+                )
+            }
+            .bind()
 
         val horse =
             bloodHorseRepository

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterCarriedOverHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterCarriedOverHorseUseCase.kt
@@ -18,6 +18,7 @@ import com.example.api.domain.studbook.model.inspection.HorseInspectionRepositor
 import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.example.api.domain.studbook.service.horse.ensurePedigreeRegistrationNumberAvailable
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.getOrElse
@@ -56,6 +57,10 @@ sealed interface RegisterCarriedOverHorseUseCaseError {
     /** 血統登録番号がブランク。 */
     data object InvalidRegistrationNumber : RegisterCarriedOverHorseUseCaseError
 
+    /** 血統登録番号が既にこの世界の他の軽種馬に採番済み。 */
+    data class RegistrationNumberAlreadyTaken(val registrationNumber: String) :
+        RegisterCarriedOverHorseUseCaseError
+
     /** マイクロチップ番号が 15 桁の数字でない。 */
     data object InvalidMicrochipNumber : RegisterCarriedOverHorseUseCaseError
 
@@ -70,6 +75,9 @@ sealed interface RegisterCarriedOverHorseUseCaseError {
  * を生成して永続化する。父母・血統は先行原簿に記録済みで当システムに存在しない
  * ため、父母の引き当て・前提条件検証は行わず、親子判定も実施しない（[ParentageDetermination.NotApplicable]）。 Controller
  * 層は本クラスのみに依存し、ドメインの生成経路の詳細は知らない。
+ *
+ * 番号を先行原簿から引き継ぐ経路であっても、取り込み先の原簿の中では一意でなければならないため、他の登録経路と 同じドメインサービス
+ * [ensurePedigreeRegistrationNumberAvailable] で引き当てる（ADR-0022）。
  *
  * @return 登録された [RegisteredBloodHorse]、または業務ルール違反を表す [RegisterCarriedOverHorseUseCaseError]
  */
@@ -91,6 +99,16 @@ class RegisterCarriedOverHorseUseCase(
                     RegisterCarriedOverHorseUseCaseError.InvalidRegistrationNumber
                 }
                 .bind()
+        // 先行原簿で交付済みの番号を引き継ぐ経路でも、この世界の原簿の中では一意でなければならない。
+        ensurePedigreeRegistrationNumberAvailable(
+                actor.worldId,
+                registrationNumber,
+                bloodHorseRepository,
+            )
+            .mapError {
+                RegisterCarriedOverHorseUseCaseError.RegistrationNumberAlreadyTaken(it.number.value)
+            }
+            .bind()
         val microchipNumber =
             MicrochipNumber.create(input.microchipNumber)
                 .mapError { _: InvalidMicrochipNumber ->

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCase.kt
@@ -23,6 +23,7 @@ import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
 import com.example.api.domain.studbook.service.horse.RegisterFoalError
+import com.example.api.domain.studbook.service.horse.ensurePedigreeRegistrationNumberAvailable
 import com.example.api.domain.studbook.service.horse.registerFoal
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
@@ -69,6 +70,10 @@ sealed interface RegisterFoalUseCaseError {
     /** 血統登録番号がブランク。 */
     data object InvalidRegistrationNumber : RegisterFoalUseCaseError
 
+    /** 血統登録番号が既にこの世界の他の軽種馬に採番済み。 */
+    data class RegistrationNumberAlreadyTaken(val registrationNumber: String) :
+        RegisterFoalUseCaseError
+
     /** マイクロチップ番号が 15 桁の数字でない。 */
     data object InvalidMicrochipNumber : RegisterFoalUseCaseError
 
@@ -103,6 +108,9 @@ sealed interface RegisterFoalUseCaseError {
  * で前提条件（分娩結果が生産であること、および委譲先 registerInStudBook の父=雄・母=雌・DNA 親子整合・品種整合・毛色整合）を検証してから、誕生した
  * [BloodHorse] を永続化する。 Controller 層は本クラスのみに依存し、ポートやドメインサービスは知らない。
  *
+ * 血統登録番号の一意性は、原簿を共有する以上どの登録経路でも等しく成り立つ必要があるため、他の登録経路と同じ ドメインサービス
+ * [ensurePedigreeRegistrationNumberAvailable] で引き当てる（ADR-0022）。
+ *
  * @return 登録された [RegisteredBloodHorse]、または業務ルール違反を表す [RegisterFoalUseCaseError]
  */
 @Service
@@ -125,6 +133,13 @@ class RegisterFoalUseCase(
                     RegisterFoalUseCaseError.InvalidRegistrationNumber
                 }
                 .bind()
+        ensurePedigreeRegistrationNumberAvailable(
+                actor.worldId,
+                registrationNumber,
+                bloodHorseRepository,
+            )
+            .mapError { RegisterFoalUseCaseError.RegistrationNumberAlreadyTaken(it.number.value) }
+            .bind()
         // 審査をメモリ内で組み立てる。前提条件検証（registerFoal）を通った後にのみ永続化し、
         // 業務ルール違反での却下時に孤児レコードが残るのを防ぐ。
         val inspection = buildInspection(input).bind()

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCase.kt
@@ -21,6 +21,7 @@ import com.example.api.domain.studbook.model.inspection.HorseInspectionRepositor
 import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.example.api.domain.studbook.service.horse.ensurePedigreeRegistrationNumberAvailable
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.getOrElse
@@ -63,6 +64,10 @@ sealed interface RegisterImportedHorseUseCaseError {
     /** 血統登録番号がブランク。 */
     data object InvalidRegistrationNumber : RegisterImportedHorseUseCaseError
 
+    /** 血統登録番号が既にこの世界の他の軽種馬に採番済み。 */
+    data class RegistrationNumberAlreadyTaken(val registrationNumber: String) :
+        RegisterImportedHorseUseCaseError
+
     /** マイクロチップ番号が 15 桁の数字でない。 */
     data object InvalidMicrochipNumber : RegisterImportedHorseUseCaseError
 
@@ -79,6 +84,9 @@ sealed interface RegisterImportedHorseUseCaseError {
  * 境界の生入力を VO に変換し（不正なら検証エラー）、生成ファクトリ [BloodHorse.createImported] で輸入馬の [BloodHorse] を生成して
  * 永続化する。父母が当システムに存在しないため、内国産馬の登録（[RegisterInStudBookUseCase]）のような父母の引き当て・前提条件検証は 行わない。Controller
  * 層は本クラスのみに依存し、ドメインの生成経路の詳細は知らない。
+ *
+ * 血統登録番号の一意性は、原簿を共有する以上どの登録経路でも等しく成り立つ必要があるため、内国産馬の登録と同じ ドメインサービス
+ * [ensurePedigreeRegistrationNumberAvailable] で引き当てる（ADR-0022）。
  *
  * @return 登録された [RegisteredBloodHorse]、または業務ルール違反を表す [RegisterImportedHorseUseCaseError]
  */
@@ -100,6 +108,15 @@ class RegisterImportedHorseUseCase(
                     RegisterImportedHorseUseCaseError.InvalidRegistrationNumber
                 }
                 .bind()
+        ensurePedigreeRegistrationNumberAvailable(
+                actor.worldId,
+                registrationNumber,
+                bloodHorseRepository,
+            )
+            .mapError {
+                RegisterImportedHorseUseCaseError.RegistrationNumberAlreadyTaken(it.number.value)
+            }
+            .bind()
         val microchipNumber =
             MicrochipNumber.create(input.microchipNumber)
                 .mapError { _: InvalidMicrochipNumber ->

--- a/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
+++ b/src/main/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCase.kt
@@ -21,6 +21,7 @@ import com.example.api.domain.studbook.model.inspection.HorseInspectionRepositor
 import com.example.api.domain.studbook.model.inspection.InvalidMicrochipNumber
 import com.example.api.domain.studbook.model.inspection.MicrochipNumber
 import com.example.api.domain.studbook.model.inspection.ParentageDetermination
+import com.example.api.domain.studbook.service.horse.ensurePedigreeRegistrationNumberAvailable
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.getOrElse
@@ -67,6 +68,10 @@ sealed interface RegisterInStudBookUseCaseError {
     /** 血統登録番号がブランク。 */
     data object InvalidRegistrationNumber : RegisterInStudBookUseCaseError
 
+    /** 血統登録番号が既にこの世界の他の軽種馬に採番済み。 */
+    data class RegistrationNumberAlreadyTaken(val registrationNumber: String) :
+        RegisterInStudBookUseCaseError
+
     /** マイクロチップ番号が 15 桁の数字でない。 */
     data object InvalidMicrochipNumber : RegisterInStudBookUseCaseError
 
@@ -95,6 +100,9 @@ sealed interface RegisterInStudBookUseCaseError {
  * で前提条件（父=雄・母=雌・DNA 親子整合・品種整合・毛色整合）を検証してから、誕生した [BloodHorse] を 永続化する。Controller
  * 層は本クラスのみに依存し、ドメインの生成経路の詳細は知らない。
  *
+ * 血統登録番号の一意性は既存レコード集合への問い合わせを要する集合制約で、集約の構築時不変条件では完結しない ため、ドメインサービス
+ * [ensurePedigreeRegistrationNumberAvailable] が引き当てる（ADR-0022）。
+ *
  * @return 登録された [RegisteredBloodHorse]、または業務ルール違反を表す [RegisterInStudBookUseCaseError]
  */
 @Service
@@ -109,12 +117,7 @@ class RegisterInStudBookUseCase(
     ): Result<RegisteredBloodHorse, RegisterInStudBookUseCaseError> = binding {
         val input = command.payload
 
-        val registrationNumber =
-            PedigreeRegistrationNumber.create(input.registrationNumber)
-                .mapError { _: BlankPedigreeRegistrationNumber ->
-                    RegisterInStudBookUseCaseError.InvalidRegistrationNumber
-                }
-                .bind()
+        val registrationNumber = availableRegistrationNumber(actor, input.registrationNumber).bind()
         val microchipNumber =
             MicrochipNumber.create(input.microchipNumber)
                 .mapError { _: InvalidMicrochipNumber ->
@@ -168,5 +171,28 @@ class RegisterInStudBookUseCase(
                 error("新規の軽種馬の保存で楽観ロック競合はありえない: id=${bloodHorse.id.value}")
             }
         RegisteredBloodHorse(saved, inspection)
+    }
+
+    /** 血統登録番号を VO 検証し、原簿の中で未使用であること（集合制約）まで確かめて返す。 */
+    private fun availableRegistrationNumber(
+        actor: Actor,
+        rawRegistrationNumber: String,
+    ): Result<PedigreeRegistrationNumber, RegisterInStudBookUseCaseError> = binding {
+        val registrationNumber =
+            PedigreeRegistrationNumber.create(rawRegistrationNumber)
+                .mapError { _: BlankPedigreeRegistrationNumber ->
+                    RegisterInStudBookUseCaseError.InvalidRegistrationNumber
+                }
+                .bind()
+        ensurePedigreeRegistrationNumberAvailable(
+                actor.worldId,
+                registrationNumber,
+                bloodHorseRepository,
+            )
+            .mapError {
+                RegisterInStudBookUseCaseError.RegistrationNumberAlreadyTaken(it.number.value)
+            }
+            .bind()
+        registrationNumber
     }
 }

--- a/src/main/kotlin/com/example/api/controller/breeding/problem/BreedingRegistrationProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/breeding/problem/BreedingRegistrationProblem.kt
@@ -16,6 +16,8 @@ import org.springframework.http.ProblemDetail
  * [RegisterBreedingRegistrationUseCaseError] を RFC 9457 の [ProblemDetail] に変換する。
  *
  * - 繁殖登録番号の VO 検証エラーは入力不正として 400 Bad Request
+ * - 申請された繁殖登録番号が既に他の繁殖登録に採番済みは、原簿の既存登録番号と衝突するため 409 Conflict。 血統登録番号とは別の採番空間のため、血統側
+ *   （`registration-number-already-taken`）とは別の `errorCode` を割り当てる
  * - リクエストボディで参照する軽種馬の不在は、整った入力だが意味的に処理できないため 422 Unprocessable Entity
  *   （api-design.md「リソース不在のステータス（404 vs 422）」: ボディ内参照先の不在は 422）
  */
@@ -28,6 +30,14 @@ fun RegisterBreedingRegistrationUseCaseError.toProblemDetail(): ProblemDetail =
                 title = "Invalid breeding registration number",
                 detail = "registration_number は空であってはいけません。",
             )
+        is RegisterBreedingRegistrationUseCaseError.RegistrationNumberAlreadyTaken ->
+            problem(
+                    status = HttpStatus.CONFLICT,
+                    code = "breeding-registration-number-already-taken",
+                    title = "Breeding registration number already taken",
+                    detail = "申請された繁殖登録番号は既に他の繁殖登録に採番されています。",
+                )
+                .apply { setProperty("registration_number", registrationNumber) }
         is RegisterBreedingRegistrationUseCaseError.HorseNotFound ->
             problem(
                     status = HttpStatus.UNPROCESSABLE_CONTENT,

--- a/src/main/kotlin/com/example/api/controller/horse/problem/BloodHorseProblem.kt
+++ b/src/main/kotlin/com/example/api/controller/horse/problem/BloodHorseProblem.kt
@@ -18,6 +18,22 @@ import org.springframework.http.ProblemDetail
  */
 
 /**
+ * 血統登録番号の重複（409 Conflict）を描画する。
+ *
+ * 血統登録原簿は 1 つで、内国産・輸入・生産産駒・移行取り込みのどの経路から採番しても衝突の意味は同じ。 クライアントから見た分類軸を 1 つに保つため、経路ごとに `type` を割らず単一の
+ * `errorCode` を共用する （馬名の重複 `horse-name-already-taken` と同じ考え方）。繁殖登録番号は別の採番空間のため別 `errorCode`
+ * （`breeding-registration-number-already-taken`）を割り当てる。
+ */
+private fun registrationNumberAlreadyTaken(registrationNumber: String): ProblemDetail =
+    problem(
+            status = HttpStatus.CONFLICT,
+            code = "registration-number-already-taken",
+            title = "Registration number already taken",
+            detail = "申請された血統登録番号は既に他の軽種馬に採番されています。",
+        )
+        .apply { setProperty("registration_number", registrationNumber) }
+
+/**
  * [NameHorseUseCaseError] を RFC 9457 (`application/problem+json`) の [ProblemDetail] に変換する。
  *
  * - 馬名の不変条件違反は入力不正として 400 Bad Request
@@ -82,6 +98,7 @@ fun NameHorseUseCaseError.toProblemDetail(): ProblemDetail =
  * [RegisterInStudBookUseCaseError] を RFC 9457 (`application/problem+json`) の [ProblemDetail] に変換する。
  *
  * - VO 検証エラーは入力不正として 400 Bad Request
+ * - 申請された血統登録番号が既に他の軽種馬で採番済みは、原簿の既存登録番号と衝突するため 409 Conflict
  * - 父母の不在（ボディ内 sire_id / dam_id の参照先不在）・ドメイン前提条件違反は、整った入力だが意味的に 処理できないため 422 Unprocessable
  *   Entity（判断基準は ADR-0018 / ADR-0021、api-design.md「404 vs 422」）
  */
@@ -94,6 +111,8 @@ fun RegisterInStudBookUseCaseError.toProblemDetail(): ProblemDetail =
                 title = "Invalid registration number",
                 detail = "registration_number は空であってはいけません。",
             )
+        is RegisterInStudBookUseCaseError.RegistrationNumberAlreadyTaken ->
+            registrationNumberAlreadyTaken(registrationNumber)
         RegisterInStudBookUseCaseError.InvalidMicrochipNumber ->
             problem(
                 status = HttpStatus.BAD_REQUEST,
@@ -177,7 +196,8 @@ private fun RegisterInStudBookError.toProblemDetail(): ProblemDetail =
  * [RegisterImportedHorseUseCaseError] を RFC 9457 (`application/problem+json`) の [ProblemDetail] に
  * 変換する。
  *
- * 輸入馬登録は父母の引き当てを行わないため、失敗は VO 検証エラー（入力不正）のみで、すべて 400 Bad Request とする。
+ * 輸入馬登録は父母の引き当てを行わないため、失敗は VO 検証エラー（入力不正）＝ 400 Bad Request が主。ただし
+ * 申請された血統登録番号が既に採番済みの場合のみ、原簿の既存登録番号と衝突するため 409 Conflict とする。
  */
 fun RegisterImportedHorseUseCaseError.toProblemDetail(): ProblemDetail =
     when (this) {
@@ -188,6 +208,8 @@ fun RegisterImportedHorseUseCaseError.toProblemDetail(): ProblemDetail =
                 title = "Invalid registration number",
                 detail = "registration_number は空であってはいけません。",
             )
+        is RegisterImportedHorseUseCaseError.RegistrationNumberAlreadyTaken ->
+            registrationNumberAlreadyTaken(registrationNumber)
         RegisterImportedHorseUseCaseError.InvalidMicrochipNumber ->
             problem(
                 status = HttpStatus.BAD_REQUEST,
@@ -215,7 +237,8 @@ fun RegisterImportedHorseUseCaseError.toProblemDetail(): ProblemDetail =
  * [RegisterCarriedOverHorseUseCaseError] を RFC 9457 (`application/problem+json`) の [ProblemDetail]
  * に変換する。
  *
- * 移行取り込みは父母の引き当てを行わないため、失敗は VO 検証エラー（入力不正）のみで、すべて 400 Bad Request とする。
+ * 移行取り込みは父母の引き当てを行わないため、失敗は VO 検証エラー（入力不正）＝ 400 Bad Request が主。ただし
+ * 引き継いだ血統登録番号が取り込み先の原簿で既に採番済みの場合のみ、409 Conflict とする。
  */
 fun RegisterCarriedOverHorseUseCaseError.toProblemDetail(): ProblemDetail =
     when (this) {
@@ -226,6 +249,8 @@ fun RegisterCarriedOverHorseUseCaseError.toProblemDetail(): ProblemDetail =
                 title = "Invalid registration number",
                 detail = "registration_number は空であってはいけません。",
             )
+        is RegisterCarriedOverHorseUseCaseError.RegistrationNumberAlreadyTaken ->
+            registrationNumberAlreadyTaken(registrationNumber)
         RegisterCarriedOverHorseUseCaseError.InvalidMicrochipNumber ->
             problem(
                 status = HttpStatus.BAD_REQUEST,

--- a/src/main/kotlin/com/example/api/domain/studbook/model/breeding/BreedingRegistrationNumberAlreadyTaken.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/breeding/BreedingRegistrationNumberAlreadyTaken.kt
@@ -1,0 +1,10 @@
+package com.example.api.domain.studbook.model.breeding
+
+/**
+ * 繁殖登録番号が既に他の繁殖登録に採番済み（繁殖登録原簿の一意性違反）。
+ *
+ * 繁殖登録番号は登録原簿の中で一意（登録規程 第5条）。血統登録番号とは別の採番空間。ドメインサービス
+ * [com.example.api.domain.studbook.service.breeding.ensureBreedingRegistrationNumberAvailable]
+ * が既存レコード集合を引き当てて検証し、衝突時にこれを返す。
+ */
+data class BreedingRegistrationNumberAlreadyTaken(val number: BreedingRegistrationNumber)

--- a/src/main/kotlin/com/example/api/domain/studbook/model/breeding/BreedingRegistrationRepository.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/breeding/BreedingRegistrationRepository.kt
@@ -28,4 +28,12 @@ interface BreedingRegistrationRepository {
         worldId: WorldId,
         breedingRegistration: BreedingRegistration,
     ): Result<BreedingRegistration, UpdateConflict>
+
+    /**
+     * 指定の世界の中で、その繁殖登録番号が既に他の繁殖登録に採番されているかを判定する（繁殖登録番号の一意性照合用）。
+     *
+     * 繁殖登録原簿と血統登録原簿は別の採番空間のため（登録規程 第3〜5条）、本ポートが見るのは繁殖登録番号だけで、 血統登録番号は
+     * [com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository] が受け持つ。
+     */
+    fun existsByRegistrationNumber(worldId: WorldId, number: BreedingRegistrationNumber): Boolean
 }

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseRepository.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseRepository.kt
@@ -35,4 +35,12 @@ interface BloodHorseRepository {
 
     /** 指定の世界の中で、その馬名が既に他の軽種馬に付与されているかを判定する（馬名の一意性照合用）。 */
     fun existsByName(worldId: WorldId, name: HorseName): Boolean
+
+    /**
+     * 指定の世界の中で、その血統登録番号が既に他の軽種馬に採番されているかを判定する（血統登録番号の一意性照合用）。
+     *
+     * 血統登録原簿と繁殖登録原簿は別の採番空間のため（登録規程 第3〜5条）、本ポートが見るのは血統登録番号だけで、 繁殖登録番号は
+     * [com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository] が受け持つ。
+     */
+    fun existsByRegistrationNumber(worldId: WorldId, number: PedigreeRegistrationNumber): Boolean
 }

--- a/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/PedigreeRegistrationNumberAlreadyTaken.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/PedigreeRegistrationNumberAlreadyTaken.kt
@@ -1,0 +1,10 @@
+package com.example.api.domain.studbook.model.horse.bloodhorse
+
+/**
+ * 血統登録番号が既に他の軽種馬に採番済み（血統登録原簿の一意性違反）。
+ *
+ * 血統登録番号は登録原簿の中で一意（登録規程 第3条・第4条）。ドメインサービス
+ * [com.example.api.domain.studbook.service.horse.ensurePedigreeRegistrationNumberAvailable]
+ * が既存レコード集合を引き当てて検証し、衝突時にこれを返す。
+ */
+data class PedigreeRegistrationNumberAlreadyTaken(val number: PedigreeRegistrationNumber)

--- a/src/main/kotlin/com/example/api/domain/studbook/service/breeding/EnsureBreedingRegistrationNumberAvailable.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/service/breeding/EnsureBreedingRegistrationNumberAvailable.kt
@@ -1,0 +1,36 @@
+package com.example.api.domain.studbook.service.breeding
+
+import com.example.api.domain.shared.WorldId
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationNumber
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationNumberAlreadyTaken
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+
+/**
+ * 繁殖登録番号の一意性を検証するドメインサービス。
+ *
+ * 繁殖登録番号が繁殖登録原簿の中で一意であること（登録規程 第5条）は、既存レコード集合への問い合わせが
+ * なければ判定できない集合制約であり、単一集約の構築時不変条件では完結しない。よって本サービスが リポジトリポート [repository]
+ * を直接受け取り既存の採番を引き当てる（読み取りのみ。ADR-0022）。
+ *
+ * 血統登録番号とは別の採番空間のため、本サービスは繁殖登録原簿（[BreedingRegistrationRepository]）のみを見る。
+ *
+ * 一意性の範囲は世界（セーブデータ＝テナント）の中に閉じる（[worldId]）。プレイヤーごとに独立した原簿を持つ ため、番号が全プレイヤーで早い者勝ちになってはならない（ADR-0067）。
+ *
+ * @param worldId 一意性を照合する範囲となる世界のID
+ * @param number 検証する繁殖登録番号
+ * @param repository 既存の採番を引き当てる繁殖登録ポート（読み取りのみ）
+ * @return 未使用なら [Ok]（[Unit]）、既に採番済みなら [BreedingRegistrationNumberAlreadyTaken]
+ */
+fun ensureBreedingRegistrationNumberAvailable(
+    worldId: WorldId,
+    number: BreedingRegistrationNumber,
+    repository: BreedingRegistrationRepository,
+): Result<Unit, BreedingRegistrationNumberAlreadyTaken> =
+    if (repository.existsByRegistrationNumber(worldId, number)) {
+        Err(BreedingRegistrationNumberAlreadyTaken(number))
+    } else {
+        Ok(Unit)
+    }

--- a/src/main/kotlin/com/example/api/domain/studbook/service/horse/EnsurePedigreeRegistrationNumberAvailable.kt
+++ b/src/main/kotlin/com/example/api/domain/studbook/service/horse/EnsurePedigreeRegistrationNumberAvailable.kt
@@ -1,0 +1,37 @@
+package com.example.api.domain.studbook.service.horse
+
+import com.example.api.domain.shared.WorldId
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
+import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumberAlreadyTaken
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+
+/**
+ * 血統登録番号の一意性を検証するドメインサービス。
+ *
+ * 血統登録番号が登録原簿の中で一意であること（登録規程 第3条＝血統登録は個体識別を明らかにする登録／
+ * 第4条＝血統登録原簿に登録番号を記載）は、既存レコード集合への問い合わせがなければ判定できない集合制約であり、 単一集約の構築時不変条件では完結しない。よって本サービスがリポジトリポート
+ * [repository] を直接受け取り既存の採番を引き当てる（読み取りのみ。ADR-0022）。
+ *
+ * 血統登録番号と繁殖登録番号は別の採番空間のため、本サービスは血統登録原簿（[BloodHorseRepository]）のみを見る。
+ *
+ * 一意性の範囲は世界（セーブデータ＝テナント）の中に閉じる（[worldId]）。プレイヤーごとに独立した原簿を持つ ため、番号が全プレイヤーで早い者勝ちになってはならない（馬名の一意性
+ * [nameHorse] と同じ論法。ADR-0067）。
+ *
+ * @param worldId 一意性を照合する範囲となる世界のID
+ * @param number 検証する血統登録番号
+ * @param repository 既存の採番を引き当てる軽種馬ポート（読み取りのみ）
+ * @return 未使用なら [Ok]（[Unit]）、既に採番済みなら [PedigreeRegistrationNumberAlreadyTaken]
+ */
+fun ensurePedigreeRegistrationNumberAvailable(
+    worldId: WorldId,
+    number: PedigreeRegistrationNumber,
+    repository: BloodHorseRepository,
+): Result<Unit, PedigreeRegistrationNumberAlreadyTaken> =
+    if (repository.existsByRegistrationNumber(worldId, number)) {
+        Err(PedigreeRegistrationNumberAlreadyTaken(number))
+    } else {
+        Ok(Unit)
+    }

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/BreedingRegistrationSpringDataRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/BreedingRegistrationSpringDataRepository.kt
@@ -18,4 +18,7 @@ interface BreedingRegistrationSpringDataRepository : CrudRepository<BreedingRegi
      * を伴うこの口を通す。
      */
     fun findByWorldIdAndId(worldId: UUID, id: UUID): BreedingRegistrationRow?
+
+    /** 指定の世界の中で、繁殖登録番号（`breeding_registration.registration_number`）が一致する行が存在するか。 登録番号の一意性照合に用いる。 */
+    fun existsByWorldIdAndRegistrationNumber(worldId: UUID, registrationNumber: String): Boolean
 }

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepository.kt
@@ -47,6 +47,11 @@ class JdbcBreedingRegistrationRepository(
             Err(UpdateConflict)
         }
 
+    override fun existsByRegistrationNumber(
+        worldId: WorldId,
+        number: BreedingRegistrationNumber,
+    ): Boolean = rows.existsByWorldIdAndRegistrationNumber(worldId.value, number.value)
+
     /**
      * 永続化モデルからドメイン集約を再構成する（検証・採番なし）。
      *

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/horse/BloodHorseSpringDataRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/horse/BloodHorseSpringDataRepository.kt
@@ -14,6 +14,9 @@ interface BloodHorseSpringDataRepository : CrudRepository<BloodHorseRow, UUID> {
     /** 指定の世界の中で、馬名（`blood_horse.name`）が一致する行が存在するか。馬名の一意性照合に用いる。 */
     fun existsByWorldIdAndName(worldId: UUID, name: String): Boolean
 
+    /** 指定の世界の中で、血統登録番号（`blood_horse.registration_number`）が一致する行が存在するか。登録番号の一意性照合に用いる。 */
+    fun existsByWorldIdAndRegistrationNumber(worldId: UUID, registrationNumber: String): Boolean
+
     /**
      * 指定の世界の中から主キーで引く。
      *

--- a/src/main/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepository.kt
+++ b/src/main/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepository.kt
@@ -70,6 +70,11 @@ class JdbcBloodHorseRepository(private val rows: BloodHorseSpringDataRepository)
     override fun existsByName(worldId: WorldId, name: HorseName): Boolean =
         rows.existsByWorldIdAndName(worldId.value, name.value)
 
+    override fun existsByRegistrationNumber(
+        worldId: WorldId,
+        number: PedigreeRegistrationNumber,
+    ): Boolean = rows.existsByWorldIdAndRegistrationNumber(worldId.value, number.value)
+
     /**
      * 永続化モデルからドメイン集約を再構成する（検証・採番なし）。
      *

--- a/src/main/resources/db/migration/V22__add_registration_number_unique_backstop.sql
+++ b/src/main/resources/db/migration/V22__add_registration_number_unique_backstop.sql
@@ -1,0 +1,33 @@
+-- 血統登録番号・繁殖登録番号の一意性に対する DB UNIQUE 制約の backstop（#652）。
+-- ドメインサービス（ensurePedigreeRegistrationNumberAvailable / ensureBreedingRegistrationNumberAvailable）
+-- は既存レコードを読み取って一意性を検証するが、READ COMMITTED 下の read-then-insert には並行競合の窓が
+-- ある（#532）。検証をすり抜けた敗者の insert を DB 側で拒否する多層防御（V14 と同型）。
+--
+-- 血統登録番号（blood_horse）と繁殖登録番号（breeding_registration）は別の採番空間なので、原簿ごとに
+-- 独立した UNIQUE を張る（登録規程 第3〜5条: 血統登録原簿と繁殖登録原簿は別の原簿で、繁殖登録個体は
+-- 両番号を併せ持つ）。
+--
+-- 一意性の範囲は世界（セーブデータ＝テナント）の中に閉じるため先頭列に world_id を置く（ADR-0067）。
+-- プレイヤーごとに独立した原簿を持つので、登録番号が全プレイヤーで早い者勝ちになってはならない
+-- （V19 が uq_blood_horse_name を (world_id, name) へ張り替えたのと同じ論法）。
+--
+-- ロック: 既存テーブルへの UNIQUE 追加は索引構築のあいだ ACCESS EXCLUSIVE を取り、読み書きを止める。
+-- 現行のデータ量では一瞬で終わるため受け入れる。テーブルが育ったら CONCURRENTLY へ移す（ADR-0062）。
+--
+-- PostgreSQL は NOT VALID を CHECK と FOREIGN KEY にしか許さず UNIQUE には使えないため、ADR-0052 の
+-- 「VALIDATE を別マイグレーションへ分離する」規約は本ファイルの対象外。squawk の
+-- constraint-missing-not-valid / disallowed-unique-constraint はこの文脈では従えない助言なので、
+-- 当該文に限って抑止する。
+--
+-- registration_number は両テーブルとも NOT NULL（V2 / V3）のため、馬名（NULL 可）のような NULL 論点は無い。
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+ALTER TABLE studbook.blood_horse
+-- squawk-ignore disallowed-unique-constraint,constraint-missing-not-valid
+ADD CONSTRAINT uq_blood_horse_registration_number UNIQUE (world_id, registration_number);
+
+ALTER TABLE studbook.breeding_registration
+-- squawk-ignore disallowed-unique-constraint,constraint-missing-not-valid
+ADD CONSTRAINT uq_breeding_registration_registration_number
+UNIQUE (world_id, registration_number);

--- a/src/replay/kotlin/com/example/api/replay/BreedingReplayTest.kt
+++ b/src/replay/kotlin/com/example/api/replay/BreedingReplayTest.kt
@@ -116,7 +116,15 @@ class BreedingReplayTest(private val engine: ReplayEngine) : PostgresContainerSu
     @Test
     fun `全フィクスチャを流して突合レポートを書き出す`() {
         // 停止は「発見」なので失敗にしない。観測をレポートへ落とすことがこのテストの目的。
-        val outcomes = FixtureLoader.loadAll().map { engine.run(actor, it) }
+        // フィクスチャごとに別の世界へ流す。同じ個体を複数のフィクスチャが含む（01/04 のウインドインハーヘア、
+        // 03/06 のテスコパール）ため、1 つの世界に流すと登録番号の一意性（#652）で 2 頭目が弾かれ、
+        // 「モデルが実在の事実に耐えられなかった」ように見える停止が観測に混ざる。世界を分ければ、
+        // フィクスチャ 1 件＝1 頭のシーズンを独立に再生するという意味づけどおりになる。
+        val outcomes =
+            FixtureLoader.loadAll().map { fixture ->
+                worldIdValue = createWorld()
+                engine.run(actor, fixture)
+            }
 
         assert(outcomes.isNotEmpty())
         val report = ReconciliationReport.render(outcomes)

--- a/src/test/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/breeding/RegisterBreedingRegistrationUseCaseTest.kt
@@ -40,6 +40,7 @@ class RegisterBreedingRegistrationUseCaseTest {
                 mockk<BloodHorseRepository> { every { findById(worldId, mare.id) } returns mare }
             val breedingRegistrationRepository =
                 mockk<BreedingRegistrationRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
                     every { save(worldId, any()) } answers { Ok(secondArg()) }
                 }
             val useCase =
@@ -71,6 +72,7 @@ class RegisterBreedingRegistrationUseCaseTest {
                 }
             val breedingRegistrationRepository =
                 mockk<BreedingRegistrationRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
                     every { save(worldId, any()) } answers { Ok(secondArg()) }
                 }
             val useCase =
@@ -116,13 +118,44 @@ class RegisterBreedingRegistrationUseCaseTest {
         }
 
         @Test
+        fun `繁殖登録番号が既に採番済みのとき RegistrationNumberAlreadyTaken を返し永続化されない`() {
+            val mare = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+            val bloodHorseRepository = mockk<BloodHorseRepository>()
+            val breedingRegistrationRepository =
+                mockk<BreedingRegistrationRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns true
+                }
+            val useCase =
+                RegisterBreedingRegistrationUseCase(
+                    bloodHorseRepository,
+                    breedingRegistrationRepository,
+                )
+
+            val result =
+                useCase(
+                    actor,
+                    command(RegisterBreedingRegistrationCommand(mare.id.value, "B-2024-0001")),
+                )
+
+            val expected =
+                RegisterBreedingRegistrationUseCaseError.RegistrationNumberAlreadyTaken(
+                    "B-2024-0001"
+                )
+            assert(result.getError() == expected)
+            verify(exactly = 0) { breedingRegistrationRepository.save(worldId, any()) }
+        }
+
+        @Test
         fun `対象の軽種馬が存在しないとき HorseNotFound を返し永続化されない`() {
             val bloodHorseId = UUID.randomUUID()
             val bloodHorseRepository =
                 mockk<BloodHorseRepository> {
                     every { findById(worldId, BloodHorseId(bloodHorseId)) } returns null
                 }
-            val breedingRegistrationRepository = mockk<BreedingRegistrationRepository>()
+            val breedingRegistrationRepository =
+                mockk<BreedingRegistrationRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
+                }
             val useCase =
                 RegisterBreedingRegistrationUseCase(
                     bloodHorseRepository,

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterCarriedOverHorseUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterCarriedOverHorseUseCaseTest.kt
@@ -54,6 +54,7 @@ class RegisterCarriedOverHorseUseCaseTest {
         fun `正しい入力のとき移行取り込みの馬が登録され永続化される`() {
             val repository =
                 mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
                     every { save(worldId, any()) } answers { Ok(secondArg()) }
                 }
             val useCase = RegisterCarriedOverHorseUseCase(repository, inspectionRepository())
@@ -74,7 +75,10 @@ class RegisterCarriedOverHorseUseCaseTest {
     inner class FailureCase {
         @Test
         fun `血統登録番号がブランクのとき InvalidRegistrationNumber を返し永続化されない`() {
-            val repository = mockk<BloodHorseRepository>()
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
+                }
             val useCase = RegisterCarriedOverHorseUseCase(repository, inspectionRepository())
 
             val result = useCase(actor, command(validPayload().copy(registrationNumber = "")))
@@ -87,7 +91,10 @@ class RegisterCarriedOverHorseUseCaseTest {
 
         @Test
         fun `マイクロチップ番号が不正なとき InvalidMicrochipNumber を返し永続化されない`() {
-            val repository = mockk<BloodHorseRepository>()
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
+                }
             val useCase = RegisterCarriedOverHorseUseCase(repository, inspectionRepository())
 
             val result = useCase(actor, command(validPayload().copy(microchipNumber = "123")))
@@ -97,8 +104,28 @@ class RegisterCarriedOverHorseUseCaseTest {
         }
 
         @Test
+        fun `引き継いだ血統登録番号が取り込み先で採番済みのとき RegistrationNumberAlreadyTaken を返す`() {
+            // 先行原簿で交付済みの番号を引き継ぐ経路でも、取り込み先の原簿の中では一意でなければならない。
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns true
+                }
+            val useCase = RegisterCarriedOverHorseUseCase(repository, inspectionRepository())
+
+            val result = useCase(actor, command(validPayload()))
+
+            val expected =
+                RegisterCarriedOverHorseUseCaseError.RegistrationNumberAlreadyTaken("2002100501")
+            assert(result.getError() == expected)
+            verify(exactly = 0) { repository.save(worldId, any()) }
+        }
+
+        @Test
         fun `生産者名がブランクのとき BlankBreeder を返し永続化されない`() {
-            val repository = mockk<BloodHorseRepository>()
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
+                }
             val useCase = RegisterCarriedOverHorseUseCase(repository, inspectionRepository())
 
             val result = useCase(actor, command(validPayload().copy(breeder = " ")))

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterFoalUseCaseTest.kt
@@ -88,6 +88,7 @@ class RegisterFoalUseCaseTest {
             }
         val bloodHorseRepository =
             mockk<BloodHorseRepository> {
+                every { existsByRegistrationNumber(worldId, any()) } returns false
                 every { findById(worldId, sire.id) } returns sire
                 every { findById(worldId, dam.id) } returns dam
                 every { save(worldId, any()) } answers { Ok(secondArg()) }
@@ -132,6 +133,24 @@ class RegisterFoalUseCaseTest {
                 w.useCase()(actor, command(w.breedingResult.id.value, registrationNumber = ""))
 
             assert(result.getError() == RegisterFoalUseCaseError.InvalidRegistrationNumber)
+            verify(exactly = 0) { w.bloodHorseRepository.save(worldId, any()) }
+        }
+
+        @Test
+        fun `血統登録番号が既に採番済みだと RegistrationNumberAlreadyTaken を返す`() {
+            val w = Wiring()
+            every { w.bloodHorseRepository.existsByRegistrationNumber(worldId, any()) } returns true
+
+            val result =
+                w.useCase()(
+                    actor,
+                    command(w.breedingResult.id.value, registrationNumber = "2024104567"),
+                )
+
+            assert(
+                result.getError() ==
+                    RegisterFoalUseCaseError.RegistrationNumberAlreadyTaken("2024104567")
+            )
             verify(exactly = 0) { w.bloodHorseRepository.save(worldId, any()) }
         }
 

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterHorseTransactionRollbackTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterHorseTransactionRollbackTest.kt
@@ -13,6 +13,7 @@ import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseReposito
 import com.example.api.domain.studbook.model.horse.bloodhorse.BreedType
 import com.example.api.domain.studbook.model.horse.bloodhorse.CoatColor
 import com.example.api.domain.studbook.model.horse.bloodhorse.HorseName
+import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
 import com.example.api.domain.studbook.model.horse.bloodhorse.Sex
 import com.example.api.domain.studbook.model.inspection.DnaParentageResult
 import com.example.api.infrastructure.studbook.StudbookSeeder
@@ -100,8 +101,11 @@ class RegisterHorseTransactionRollbackTest(
 
     @Test
     fun `内国産血統登録で軽種馬の保存がインフラ障害で失敗すると先行する審査の保存もロールバックされる`() {
-        val sireFixture = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
-        val damFixture = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        // 血統登録番号は世界の中で一意（V22）なので、父・母・仔で別々の番号を振る
+        val sireFixture =
+            BloodHorseFixture.bloodHorse(sex = Sex.MALE, registrationNumber = "2018101111")
+        val damFixture =
+            BloodHorseFixture.bloodHorse(sex = Sex.FEMALE, registrationNumber = "2018102222")
         seeder.seedInspectionFor(sireFixture)
         seeder.seedInspectionFor(damFixture)
         val sire = failingRepository.save(worldId, sireFixture).unwrap()
@@ -174,4 +178,9 @@ class FailingBloodHorseRepository(private val delegate: BloodHorseRepository) :
 
     override fun existsByName(worldId: WorldId, name: HorseName): Boolean =
         delegate.existsByName(worldId, name)
+
+    override fun existsByRegistrationNumber(
+        worldId: WorldId,
+        number: PedigreeRegistrationNumber,
+    ): Boolean = delegate.existsByRegistrationNumber(worldId, number)
 }

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterImportedHorseUseCaseTest.kt
@@ -55,6 +55,7 @@ class RegisterImportedHorseUseCaseTest {
         fun `正しい入力のとき父母不明の輸入馬が登録され永続化される`() {
             val repository =
                 mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
                     every { save(worldId, any()) } answers { Ok(secondArg()) }
                 }
             val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
@@ -76,7 +77,10 @@ class RegisterImportedHorseUseCaseTest {
     inner class FailureCase {
         @Test
         fun `血統登録番号がブランクのとき InvalidRegistrationNumber を返し永続化されない`() {
-            val repository = mockk<BloodHorseRepository>()
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
+                }
             val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
 
             val result = useCase(actor, command(validPayload().copy(registrationNumber = "")))
@@ -87,7 +91,10 @@ class RegisterImportedHorseUseCaseTest {
 
         @Test
         fun `マイクロチップ番号が不正なとき InvalidMicrochipNumber を返し永続化されない`() {
-            val repository = mockk<BloodHorseRepository>()
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
+                }
             val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
 
             val result = useCase(actor, command(validPayload().copy(microchipNumber = "123")))
@@ -97,8 +104,29 @@ class RegisterImportedHorseUseCaseTest {
         }
 
         @Test
+        fun `血統登録番号が既に採番済みのとき RegistrationNumberAlreadyTaken を返し永続化されない`() {
+            // 原簿は 1 つなので、輸入馬の経路から採番しても内国産馬と同じ一意性が要る。
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns true
+                }
+            val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
+
+            val result = useCase(actor, command(validPayload()))
+
+            assert(
+                result.getError() ==
+                    RegisterImportedHorseUseCaseError.RegistrationNumberAlreadyTaken("2020900001")
+            )
+            verify(exactly = 0) { repository.save(worldId, any()) }
+        }
+
+        @Test
         fun `原産国がブランクのとき BlankOriginCountry を返し永続化されない`() {
-            val repository = mockk<BloodHorseRepository>()
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
+                }
             val useCase = RegisterImportedHorseUseCase(repository, inspectionRepository())
 
             val result = useCase(actor, command(validPayload().copy(originCountry = "")))

--- a/src/test/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCaseTest.kt
+++ b/src/test/kotlin/com/example/api/application/studbook/horse/RegisterInStudBookUseCaseTest.kt
@@ -62,6 +62,7 @@ class RegisterInStudBookUseCaseTest {
             val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
             val repository =
                 mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
                     every { findAllById(worldId, setOf(sire.id, dam.id)) } returns
                         mapOf(sire.id to sire, dam.id to dam)
                     every { save(worldId, any()) } answers { Ok(secondArg()) }
@@ -105,7 +106,10 @@ class RegisterInStudBookUseCaseTest {
 
         @Test
         fun `マイクロチップ番号が不正なとき InvalidMicrochipNumber を返し永続化されない`() {
-            val repository = mockk<BloodHorseRepository>()
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
+                }
             val useCase = RegisterInStudBookUseCase(repository, inspectionRepository())
 
             val result =
@@ -122,12 +126,30 @@ class RegisterInStudBookUseCaseTest {
         }
 
         @Test
+        fun `血統登録番号が既に採番済みのとき RegistrationNumberAlreadyTaken を返し永続化されない`() {
+            val repository =
+                mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns true
+                }
+            val useCase = RegisterInStudBookUseCase(repository, inspectionRepository())
+
+            val result = useCase(actor, command(validPayload(UUID.randomUUID(), UUID.randomUUID())))
+
+            assert(
+                result.getError() ==
+                    RegisterInStudBookUseCaseError.RegistrationNumberAlreadyTaken("2023104567")
+            )
+            verify(exactly = 0) { repository.save(worldId, any()) }
+        }
+
+        @Test
         fun `父が見つからないとき SireNotFound を返し永続化されない`() {
             val sireId = UUID.randomUUID()
             val damId = UUID.randomUUID()
             val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
             val repository =
                 mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
                     every {
                         findAllById(worldId, setOf(BloodHorseId(sireId), BloodHorseId(damId)))
                     } returns mapOf(BloodHorseId(damId) to dam)
@@ -147,6 +169,7 @@ class RegisterInStudBookUseCaseTest {
             val sire = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
             val repository =
                 mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
                     every {
                         findAllById(worldId, setOf(BloodHorseId(sireId), BloodHorseId(damId)))
                     } returns mapOf(BloodHorseId(sireId) to sire)
@@ -165,6 +188,7 @@ class RegisterInStudBookUseCaseTest {
             val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
             val repository =
                 mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
                     every { findAllById(worldId, setOf(sire.id, dam.id)) } returns
                         mapOf(sire.id to sire, dam.id to dam)
                 }
@@ -188,6 +212,7 @@ class RegisterInStudBookUseCaseTest {
             val dam = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
             val bloodHorseRepository =
                 mockk<BloodHorseRepository> {
+                    every { existsByRegistrationNumber(worldId, any()) } returns false
                     every { findAllById(worldId, setOf(sire.id, dam.id)) } returns
                         mapOf(sire.id to sire, dam.id to dam)
                 }

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
@@ -128,6 +128,34 @@ class BreedingRegistrationControllerTest(val mockMvc: MockMvc) {
     }
 
     @Test
+    fun `RegistrationNumberAlreadyTaken で 409 と繁殖登録固有の errorCode が返ること`() {
+        // 繁殖登録原簿は血統登録原簿と別の採番空間なので、血統側とは別の errorCode を割り当てる。
+        every {
+            registerBreedingRegistration(
+                any<Actor>(),
+                any<Command<RegisterBreedingRegistrationCommand>>(),
+            )
+        } returns
+            Err(
+                RegisterBreedingRegistrationUseCaseError.RegistrationNumberAlreadyTaken(
+                    "B-2024-0001"
+                )
+            )
+
+        tester
+            .post()
+            .uri(uri, worldId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validBody)
+            .assertThat()
+            .hasStatus(HttpStatus.CONFLICT)
+            .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+            .bodyJson()
+            .extractingPath("$.registration_number")
+            .isEqualTo("B-2024-0001")
+    }
+
+    @Test
     fun `存在する ID の照会で 200 と繁殖登録リソースが返ること`() {
         val id = UUID.fromString("22222222-2222-2222-2222-222222222222")
         val horseId = UUID.fromString("33333333-3333-3333-3333-333333333333")

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -219,6 +219,26 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
         }
 
         @Test
+        fun `RegistrationNumberAlreadyTaken で 409 と registration_number 付きの problem+json が返ること`() {
+            every {
+                registerInStudBook(any<Actor>(), any<Command<RegisterInStudBookCommand>>())
+            } returns
+                Err(RegisterInStudBookUseCaseError.RegistrationNumberAlreadyTaken("2023104567"))
+
+            tester
+                .post()
+                .uri("/api/worlds/{worldId}/bloodHorses", worldId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.CONFLICT)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.registration_number")
+                .isEqualTo("2023104567")
+        }
+
+        @Test
         fun `SireNotFound で 422 と sireId 付きの problem+json が返ること`() {
             val sireId = UUID.fromString("11111111-1111-1111-1111-111111111111")
             every {
@@ -594,6 +614,27 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
         }
 
         @Test
+        fun `RegistrationNumberAlreadyTaken で 409 と血統登録側と同じ errorCode が返ること`() {
+            // 原簿は 1 つなので、登録経路が違っても衝突の意味は同じ＝ errorCode を共用する。
+            every {
+                registerImportedHorse(any<Actor>(), any<Command<RegisterImportedHorseCommand>>())
+            } returns
+                Err(RegisterImportedHorseUseCaseError.RegistrationNumberAlreadyTaken("2020900001"))
+
+            tester
+                .post()
+                .uri(uri, worldId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.CONFLICT)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.error_code")
+                .isEqualTo("registration-number-already-taken")
+        }
+
+        @Test
         fun `BlankOriginCountry で 400 と problem+json が返ること`() {
             every {
                 registerImportedHorse(any<Actor>(), any<Command<RegisterImportedHorseCommand>>())
@@ -655,6 +696,34 @@ class BloodHorseControllerTest(val mockMvc: MockMvc, val jsonMapper: JsonMapper)
                 .bodyJson()
                 .extractingPath("$.origin.type")
                 .isEqualTo("CARRIED_OVER")
+        }
+
+        @Test
+        fun `RegistrationNumberAlreadyTaken で 409 と血統登録側と同じ errorCode が返ること`() {
+            // 先行原簿から番号を引き継ぐ経路でも、取り込み先で衝突すれば意味は同じ＝ errorCode を共用する。
+            every {
+                registerCarriedOverHorse(
+                    any<Actor>(),
+                    any<Command<RegisterCarriedOverHorseCommand>>(),
+                )
+            } returns
+                Err(
+                    RegisterCarriedOverHorseUseCaseError.RegistrationNumberAlreadyTaken(
+                        "2002100501"
+                    )
+                )
+
+            tester
+                .post()
+                .uri(uri, worldId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validBody)
+                .assertThat()
+                .hasStatus(HttpStatus.CONFLICT)
+                .hasContentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .bodyJson()
+                .extractingPath("$.error_code")
+                .isEqualTo("registration-number-already-taken")
         }
 
         @Test

--- a/src/test/kotlin/com/example/api/domain/studbook/model/breeding/BreedingFixture.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/model/breeding/BreedingFixture.kt
@@ -17,21 +17,27 @@ private val DEFAULT_REGION = BreedingRegion.create("北海道").unwrap()
  * は種牡馬のロールを持つ登録を組む。[BreedingResult.create] は両登録のロールを自己検証するため、 適切な登録を渡して `unwrap` で成功を取り出す。
  */
 object BreedingFixture {
-    /** ロールが繁殖牝馬の [BreedingRegistration] を生成する。繁殖牝馬は必要に応じて上書きする。 */
+    /**
+     * ロールが繁殖牝馬の [BreedingRegistration] を生成する。繁殖牝馬は必要に応じて上書きする。
+     *
+     * 繁殖登録番号は世界の中で一意（V22 / #652）なので、同じ世界へ複数の登録を永続化するテストは [registrationNumber] を明示して衝突を避ける。
+     */
     fun breedingRegistration(
-        broodmare: BloodHorse = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE)
+        broodmare: BloodHorse = BloodHorseFixture.bloodHorse(sex = Sex.FEMALE),
+        registrationNumber: String = "B-2024-0001",
     ): BreedingRegistration =
         BreedingRegistration.create(
-            registrationNumber = BreedingRegistrationNumber.create("B-2024-0001").unwrap(),
+            registrationNumber = BreedingRegistrationNumber.create(registrationNumber).unwrap(),
             horse = broodmare,
         )
 
-    /** ロールが種牡馬の [BreedingRegistration] を生成する。種牡馬は必要に応じて上書きする。 */
+    /** ロールが種牡馬の [BreedingRegistration] を生成する。種牡馬・番号は必要に応じて上書きする。 */
     fun stallionRegistration(
-        stallion: BloodHorse = BloodHorseFixture.bloodHorse(sex = Sex.MALE)
+        stallion: BloodHorse = BloodHorseFixture.bloodHorse(sex = Sex.MALE),
+        registrationNumber: String = "B-2024-0002",
     ): BreedingRegistration =
         BreedingRegistration.create(
-            registrationNumber = BreedingRegistrationNumber.create("B-2024-0002").unwrap(),
+            registrationNumber = BreedingRegistrationNumber.create(registrationNumber).unwrap(),
             horse = stallion,
         )
 

--- a/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseFixture.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/model/horse/bloodhorse/BloodHorseFixture.kt
@@ -62,11 +62,12 @@ object BloodHorseFixture {
         sex: Sex = Sex.MALE,
         coatColor: CoatColor = CoatColor.BAY,
         breedType: BreedType = BreedType.THOROUGHBRED,
+        registrationNumber: String = "2023104567",
     ): BloodHorse =
         BloodHorse.createImported(
             entry = importedHorseEntry(sex = sex, coatColor = coatColor, breedType = breedType),
             inspection = inspection(parentage = ParentageDetermination.NotApplicable),
-            registrationNumber = PedigreeRegistrationNumber.create("2023104567").unwrap(),
+            registrationNumber = PedigreeRegistrationNumber.create(registrationNumber).unwrap(),
         )
 
     /** 既定値を持つ [ImportedHorseEntry]（輸入馬）を生成する。必要な属性のみ上書きする。 */

--- a/src/test/kotlin/com/example/api/domain/studbook/service/breeding/EnsureBreedingRegistrationNumberAvailableTest.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/service/breeding/EnsureBreedingRegistrationNumberAvailableTest.kt
@@ -1,0 +1,59 @@
+package com.example.api.domain.studbook.service.breeding
+
+import com.example.api.domain.shared.WorldId
+import com.example.api.domain.shared.generateId
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationNumber
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationNumberAlreadyTaken
+import com.example.api.domain.studbook.model.breeding.BreedingRegistrationRepository
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+class EnsureBreedingRegistrationNumberAvailableTest {
+    private val worldId = WorldId(generateId())
+    private val number = BreedingRegistrationNumber.create("BR-0000430846").unwrap()
+
+    @Test
+    fun `未使用の繁殖登録番号なら Ok を返す`() {
+        val repository =
+            mockk<BreedingRegistrationRepository> {
+                every { existsByRegistrationNumber(worldId, number) } returns false
+            }
+
+        val result = ensureBreedingRegistrationNumberAvailable(worldId, number, repository)
+
+        assert(result.isOk)
+    }
+
+    @Test
+    fun `既に採番済みの繁殖登録番号なら BreedingRegistrationNumberAlreadyTaken を返す`() {
+        val repository =
+            mockk<BreedingRegistrationRepository> {
+                every { existsByRegistrationNumber(worldId, number) } returns true
+            }
+
+        val error =
+            ensureBreedingRegistrationNumberAvailable(worldId, number, repository).getError()
+
+        assert(error == BreedingRegistrationNumberAlreadyTaken(number))
+    }
+
+    @Test
+    fun `照合は引数で受けた世界の中に閉じる`() {
+        // 同じ番号でも、別の世界（別プレイヤーのセーブデータ）で採番済みかは問わない。
+        val otherWorldId = WorldId(generateId())
+        val repository =
+            mockk<BreedingRegistrationRepository> {
+                every { existsByRegistrationNumber(worldId, number) } returns false
+                every { existsByRegistrationNumber(otherWorldId, number) } returns true
+            }
+
+        val inOtherWorld =
+            ensureBreedingRegistrationNumberAvailable(otherWorldId, number, repository).getError()
+
+        assert(ensureBreedingRegistrationNumberAvailable(worldId, number, repository).isOk)
+        assert(inOtherWorld == BreedingRegistrationNumberAlreadyTaken(number))
+    }
+}

--- a/src/test/kotlin/com/example/api/domain/studbook/service/horse/EnsurePedigreeRegistrationNumberAvailableTest.kt
+++ b/src/test/kotlin/com/example/api/domain/studbook/service/horse/EnsurePedigreeRegistrationNumberAvailableTest.kt
@@ -1,0 +1,59 @@
+package com.example.api.domain.studbook.service.horse
+
+import com.example.api.domain.shared.WorldId
+import com.example.api.domain.shared.generateId
+import com.example.api.domain.studbook.model.horse.bloodhorse.BloodHorseRepository
+import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumber
+import com.example.api.domain.studbook.model.horse.bloodhorse.PedigreeRegistrationNumberAlreadyTaken
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.unwrap
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+class EnsurePedigreeRegistrationNumberAvailableTest {
+    private val worldId = WorldId(generateId())
+    private val number = PedigreeRegistrationNumber.create("2023104567").unwrap()
+
+    @Test
+    fun `未使用の血統登録番号なら Ok を返す`() {
+        val repository =
+            mockk<BloodHorseRepository> {
+                every { existsByRegistrationNumber(worldId, number) } returns false
+            }
+
+        val result = ensurePedigreeRegistrationNumberAvailable(worldId, number, repository)
+
+        assert(result.isOk)
+    }
+
+    @Test
+    fun `既に採番済みの血統登録番号なら PedigreeRegistrationNumberAlreadyTaken を返す`() {
+        val repository =
+            mockk<BloodHorseRepository> {
+                every { existsByRegistrationNumber(worldId, number) } returns true
+            }
+
+        val error =
+            ensurePedigreeRegistrationNumberAvailable(worldId, number, repository).getError()
+
+        assert(error == PedigreeRegistrationNumberAlreadyTaken(number))
+    }
+
+    @Test
+    fun `照合は引数で受けた世界の中に閉じる`() {
+        // 同じ番号でも、別の世界（別プレイヤーのセーブデータ）で採番済みかは問わない。
+        val otherWorldId = WorldId(generateId())
+        val repository =
+            mockk<BloodHorseRepository> {
+                every { existsByRegistrationNumber(worldId, number) } returns false
+                every { existsByRegistrationNumber(otherWorldId, number) } returns true
+            }
+
+        val inOtherWorld =
+            ensurePedigreeRegistrationNumberAvailable(otherWorldId, number, repository).getError()
+
+        assert(ensurePedigreeRegistrationNumberAvailable(worldId, number, repository).isOk)
+        assert(inOtherWorld == PedigreeRegistrationNumberAlreadyTaken(number))
+    }
+}

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/StudbookSeeder.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/StudbookSeeder.kt
@@ -57,11 +57,15 @@ class StudbookSeeder(
         return id
     }
 
-    /** 任意 ID の馬行（輸入馬の最小構成）を審査行ごと作り ID を返す（生 Row の sire/dam・種牡馬用）。 */
+    /**
+     * 任意 ID の馬行（輸入馬の最小構成）を審査行ごと作り ID を返す（生 Row の sire/dam・種牡馬用）。
+     *
+     * 登録番号の既定値は ID から導いて衝突しないようにする。同じ世界に複数の馬を seed するテストが多く、 固定値だと血統登録番号の UNIQUE（V22）に当たるため。
+     */
     fun seedHorseRow(
         id: UUID = generateId(),
         sex: String = "MALE",
-        registrationNumber: String = "2020900001",
+        registrationNumber: String = "SEED-$id",
     ): UUID {
         horseRows.save(
             BloodHorseRow(
@@ -82,13 +86,21 @@ class StudbookSeeder(
         return id
     }
 
-    /** 任意 ID の繁殖登録行を対象馬・審査行ごと作り ID を返す（生 Row の breeding_registration_id 用）。 */
-    fun seedRegistrationRow(id: UUID = generateId(), role: String = "BROODMARE"): UUID {
+    /**
+     * 任意 ID の繁殖登録行を対象馬・審査行ごと作り ID を返す（生 Row の breeding_registration_id 用）。
+     *
+     * 登録番号の既定値は ID から導いて衝突しないようにする（[seedHorseRow] と同じ理由。UNIQUE は V22）。
+     */
+    fun seedRegistrationRow(
+        id: UUID = generateId(),
+        role: String = "BROODMARE",
+        registrationNumber: String = "SEED-REG-$id",
+    ): UUID {
         registrationRows.save(
             BreedingRegistrationRow(
                 worldId = worldId.value,
                 id = id,
-                registrationNumber = "B-0001",
+                registrationNumber = registrationNumber,
                 registeredHorseId =
                     seedHorseRow(sex = if (role == "STALLION") "MALE" else "FEMALE"),
                 breedingRole = role,

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationQueriesContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationQueriesContractTest.kt
@@ -51,7 +51,7 @@ class JdbcBreedingRegistrationQueriesContractTest(
 
     @Test
     fun `供用中の繁殖登録を ID で引き列を詰めて返す`() {
-        val id = seeder.seedRegistrationRow(role = "BROODMARE")
+        val id = seeder.seedRegistrationRow(role = "BROODMARE", registrationNumber = "B-0001")
 
         val view = queries.findById(worldId, BreedingRegistrationId(id))
 

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingRegistrationRepositoryContractTest.kt
@@ -44,6 +44,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode
  * 7. 古い version での save が UpdateConflict を返し先行の書き込みを保つこと（楽観ロック）
  * 8. 供用停止の共在不変条件が CHECK 制約でスキーマ側にも強制されること
  * 9. 並行削除された集約への save が UpdateConflict を返すこと
+ * 10. 繁殖登録番号の一意性が世界の中で引き当て・UNIQUE 強制されること（世界をまたぐと衝突しないこと）
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)
@@ -242,5 +243,71 @@ class JdbcBreedingRegistrationRepositoryContractTest(
             row(retirementReason = RetirementReason.DEATH.name, retirementOccurredOn = null)
 
         assertThrows<DataIntegrityViolationException> { rows.save(inconsistent) }
+    }
+
+    @Test
+    fun `既に採番済みの繁殖登録番号は existsByRegistrationNumber が true を返す`() {
+        val number = BreedingRegistrationNumber.create("B-2024-0001").unwrap()
+        val mare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+        repository.save(worldId, BreedingRegistration.create(number, mare)).unwrap()
+
+        assert(repository.existsByRegistrationNumber(worldId, number))
+    }
+
+    @Test
+    fun `未使用の繁殖登録番号は existsByRegistrationNumber が false を返す`() {
+        val number = BreedingRegistrationNumber.create("B-2024-0001").unwrap()
+        val mare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+        repository.save(worldId, BreedingRegistration.create(number, mare)).unwrap()
+
+        assert(
+            !repository.existsByRegistrationNumber(
+                worldId,
+                BreedingRegistrationNumber.create("B-9999-9999").unwrap(),
+            )
+        )
+    }
+
+    @Test
+    fun `他の世界で採番済みの繁殖登録番号は existsByRegistrationNumber が false を返す`() {
+        val number = BreedingRegistrationNumber.create("B-2024-0001").unwrap()
+        val mare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+        repository.save(worldId, BreedingRegistration.create(number, mare)).unwrap()
+
+        assert(!repository.existsByRegistrationNumber(WorldId(createWorld()), number))
+    }
+
+    @Test
+    fun `同一世界での同一繁殖登録番号の二重insertはUNIQUE制約で拒否される`() {
+        // ドメインサービス ensureBreedingRegistrationNumberAvailable の検証をすり抜ける
+        // read-then-insert 並行競合（#532）の backstop。
+        val number = BreedingRegistrationNumber.create("B-2024-0001").unwrap()
+        val mare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+        repository.save(worldId, BreedingRegistration.create(number, mare)).unwrap()
+
+        // 別個体・同じ繁殖登録番号
+        val other =
+            seeder.seedHorse(
+                BloodHorseFixture.bloodHorse(sex = Sex.MALE, registrationNumber = "2018101111")
+            )
+
+        assertThrows<DataIntegrityViolationException> {
+            repository.save(worldId, BreedingRegistration.create(number, other))
+        }
+    }
+
+    @Test
+    fun `別の世界でなら同一の繁殖登録番号を採番できる`() {
+        // 一意性は世界（セーブデータ）の中に閉じる。プレイヤーをまたいで番号が早い者勝ちにならないこと。
+        val number = BreedingRegistrationNumber.create("B-2024-0001").unwrap()
+        val mare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+        repository.save(worldId, BreedingRegistration.create(number, mare)).unwrap()
+
+        val otherWorldId = WorldId(createWorld())
+        val otherSeeder = StudbookSeeder(otherWorldId, inspectionRows, horseRows, rows)
+        val otherMare = otherSeeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+        val registration = BreedingRegistration.create(number, otherMare)
+
+        assert(repository.save(otherWorldId, registration).unwrap().id == registration.id)
     }
 }

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/breeding/JdbcBreedingResultRepositoryContractTest.kt
@@ -71,15 +71,33 @@ class JdbcBreedingResultRepositoryContractTest(
         seeder = StudbookSeeder(worldId, inspectionRows, horseRows, registrationRows)
     }
 
-    /** 親（繁殖牝馬の登録と種牡馬）を seed 済みの、分娩結果未報告の成績を組む。 */
+    /**
+     * 親（繁殖牝馬の登録と種牡馬）を seed 済みの、分娩結果未報告の成績を組む。
+     *
+     * 血統登録番号・繁殖登録番号は世界の中で一意（V22 / #652）で、本ヘルパーは同じ世界で繰り返し呼ばれる ため、番号は呼び出しごとに一意な値を振る。
+     */
     private fun seededBreedingResult(): BreedingResult {
         val broodmareRegistration =
             BreedingFixture.breedingRegistration(
-                broodmare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+                broodmare =
+                    seeder.seedHorse(
+                        BloodHorseFixture.bloodHorse(
+                            sex = Sex.FEMALE,
+                            registrationNumber = "MARE-${generateId()}",
+                        )
+                    ),
+                registrationNumber = "B-MARE-${generateId()}",
             )
         val stallionRegistration =
             BreedingFixture.stallionRegistration(
-                stallion = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.MALE))
+                stallion =
+                    seeder.seedHorse(
+                        BloodHorseFixture.bloodHorse(
+                            sex = Sex.MALE,
+                            registrationNumber = "SIRE-${generateId()}",
+                        )
+                    ),
+                registrationNumber = "B-SIRE-${generateId()}",
             )
         seeder.seedRegistration(broodmareRegistration)
         seeder.seedRegistration(stallionRegistration)
@@ -89,11 +107,18 @@ class JdbcBreedingResultRepositoryContractTest(
         )
     }
 
-    /** 親（繁殖牝馬の登録）を seed 済みの、種付せず成績を組む。 */
+    /** 親（繁殖牝馬の登録）を seed 済みの、種付せず成績を組む。番号を一意にする理由は [seededBreedingResult] と同じ。 */
     private fun seededUncoveredResult(): BreedingResult {
         val broodmareRegistration =
             BreedingFixture.breedingRegistration(
-                broodmare = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+                broodmare =
+                    seeder.seedHorse(
+                        BloodHorseFixture.bloodHorse(
+                            sex = Sex.FEMALE,
+                            registrationNumber = "MARE-${generateId()}",
+                        )
+                    ),
+                registrationNumber = "B-MARE-${generateId()}",
             )
         seeder.seedRegistration(broodmareRegistration)
         return BreedingFixture.uncoveredBreedingResult(

--- a/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
+++ b/src/test/kotlin/com/example/api/infrastructure/studbook/horse/JdbcBloodHorseRepositoryContractTest.kt
@@ -46,6 +46,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode
  * 10. 並行削除された集約への save が UpdateConflict を返すこと
  * 11. 馬名の一意性が UNIQUE 制約でスキーマ側にも強制されること（read-then-insert 競合の backstop）
  * 12. 出自 CarriedOver の往復と CHECK 強制（バリアント固有列の混入を拒否）
+ * 13. 血統登録番号の一意性が世界の中で引き当て・UNIQUE 強制されること（世界をまたぐと衝突しないこと）
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestConstructor(autowireMode = AutowireMode.ALL)
@@ -88,15 +89,30 @@ class JdbcBloodHorseRepositoryContractTest(
 
     /** 内国産の父母を持つ命名済みの軽種馬を組み立てる（前提条件を満たす父=雄・母=雌・品種/ DNA 整合）。父母・仔馬自身の審査行は seed 済み。 */
     private fun namedDomesticFoal(): BloodHorse {
-        val sire = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.MALE))
-        val dam = seeder.seedHorse(BloodHorseFixture.bloodHorse(sex = Sex.FEMALE))
+        // 血統登録番号は世界の中で一意（V22 / #652）で、本ヘルパーは同じ世界で繰り返し呼ばれるため、
+        // 父・母・仔の番号は呼び出しごとに一意な値を振る。
+        val sire =
+            seeder.seedHorse(
+                BloodHorseFixture.bloodHorse(
+                    sex = Sex.MALE,
+                    registrationNumber = "SIRE-${generateId()}",
+                )
+            )
+        val dam =
+            seeder.seedHorse(
+                BloodHorseFixture.bloodHorse(
+                    sex = Sex.FEMALE,
+                    registrationNumber = "DAM-${generateId()}",
+                )
+            )
         val foal =
             BloodHorse.create(
                     sire = sire,
                     dam = dam,
                     entry = BloodHorseFixture.studBookEntry(sex = Sex.MALE),
                     inspection = BloodHorseFixture.inspection(),
-                    registrationNumber = PedigreeRegistrationNumber.create("2023109999").unwrap(),
+                    registrationNumber =
+                        PedigreeRegistrationNumber.create("FOAL-${generateId()}").unwrap(),
                 )
                 .unwrap()
         seeder.seedInspectionFor(foal)
@@ -310,5 +326,76 @@ class JdbcBloodHorseRepositoryContractTest(
             )
 
         assert(conflicted.getError() == UpdateConflict)
+    }
+
+    @Test
+    fun `既に採番済みの血統登録番号は existsByRegistrationNumber が true を返す`() {
+        val horse = BloodHorseFixture.bloodHorse(registrationNumber = "2023104567")
+        seeder.seedInspectionFor(horse)
+        repository.save(worldId, horse).unwrap()
+
+        assert(
+            repository.existsByRegistrationNumber(
+                worldId,
+                PedigreeRegistrationNumber.create("2023104567").unwrap(),
+            )
+        )
+    }
+
+    @Test
+    fun `未使用の血統登録番号は existsByRegistrationNumber が false を返す`() {
+        val horse = BloodHorseFixture.bloodHorse(registrationNumber = "2023104567")
+        seeder.seedInspectionFor(horse)
+        repository.save(worldId, horse).unwrap()
+
+        assert(
+            !repository.existsByRegistrationNumber(
+                worldId,
+                PedigreeRegistrationNumber.create("9999999999").unwrap(),
+            )
+        )
+    }
+
+    @Test
+    fun `他の世界で採番済みの血統登録番号は existsByRegistrationNumber が false を返す`() {
+        val horse = BloodHorseFixture.bloodHorse(registrationNumber = "2023104567")
+        seeder.seedInspectionFor(horse)
+        repository.save(worldId, horse).unwrap()
+
+        assert(
+            !repository.existsByRegistrationNumber(
+                WorldId(createWorld()),
+                PedigreeRegistrationNumber.create("2023104567").unwrap(),
+            )
+        )
+    }
+
+    @Test
+    fun `同一世界での同一血統登録番号の二重insertはUNIQUE制約で拒否される`() {
+        // ドメインサービス ensurePedigreeRegistrationNumberAvailable の検証をすり抜ける
+        // read-then-insert 並行競合（#532）の backstop。
+        val first = BloodHorseFixture.bloodHorse(registrationNumber = "2023104567")
+        seeder.seedInspectionFor(first)
+        repository.save(worldId, first).unwrap()
+
+        val duplicate = BloodHorseFixture.bloodHorse(registrationNumber = "2023104567")
+        seeder.seedInspectionFor(duplicate)
+
+        assertThrows<DataIntegrityViolationException> { repository.save(worldId, duplicate) }
+    }
+
+    @Test
+    fun `別の世界でなら同一の血統登録番号を採番できる`() {
+        // 一意性は世界（セーブデータ）の中に閉じる。プレイヤーをまたいで番号が早い者勝ちにならないこと。
+        val first = BloodHorseFixture.bloodHorse(registrationNumber = "2023104567")
+        seeder.seedInspectionFor(first)
+        repository.save(worldId, first).unwrap()
+
+        val otherWorldId = WorldId(createWorld())
+        val otherSeeder = StudbookSeeder(otherWorldId, inspectionRows, rows, registrationRows)
+        val sameNumber = BloodHorseFixture.bloodHorse(registrationNumber = "2023104567")
+        otherSeeder.seedInspectionFor(sameNumber)
+
+        assert(repository.save(otherWorldId, sameNumber).unwrap().id == sameNumber.id)
     }
 }


### PR DESCRIPTION
## 概要

血統登録番号（`blood_horse.registration_number`）と繁殖登録番号（`breeding_registration.registration_number`）に一意性を敷く（#652）。方式は馬名一意性（ADR-0022 / V14）と同じ **二層防御**で、**一意性の範囲は世界（セーブデータ＝テナント）の中に閉じる**（ADR-0067）。

- **第1層（ドメイン検証）**: 集合制約なので、ドメインサービス `ensurePedigreeRegistrationNumberAvailable` / `ensureBreedingRegistrationNumberAvailable` がリポジトリポートを読み取り引数で受けて既存の採番を照合する（ADR-0022）。書き込みユースケースが集約の生成前に検証し、衝突は `Result` の `Err` として返す（`throw` しない）。
- **第2層（DB UNIQUE backstop）**: `V22` が `UNIQUE (world_id, registration_number)` を両テーブルに独立に張り、READ COMMITTED 下の read-then-insert 並行競合（#532）の敗者 insert を DB で拒否する。

## 典拠（登録規程）

- 第3条: 登録は血統登録（＝血統及び**個体識別**を明らかにする登録）と繁殖登録（＝繁殖成績を明らかにする登録）に区分。
- 第4条・第5条: 各登録原簿に**登録番号**を記載。血統登録原簿と繁殖登録原簿は別の原簿＝**別の採番空間**。繁殖登録個体は両番号を併せ持つ。

→ 一意性は「個体識別を明らかにする登録」に内在する不変条件。血統・繁殖は別スコープとして独立に一意制約を張る。

## 先行 PR との関係

#656 が同じ設計で一度書かれたが、(1) Flyway 連番の衝突、(2) 世界スコープ化の後に作り直しになる、という理由でクローズされていた。両方とも解消済みなので、当時の設計を **world スコープ込みで作り直した**。

| #656 | 本 PR |
|---|---|
| `existsByRegistrationNumber(登録番号)` | `existsByRegistrationNumber(worldId, 登録番号)` |
| `UNIQUE (登録番号)` | `UNIQUE (world_id, 登録番号)` |

`V19` が `uq_blood_horse_name` を `(world_id, name)` へ張り替えたのと同じ論法で、登録番号が全プレイヤーで早い者勝ちにならないようにしている。#656 の時点で存在しなかった **移行取り込み経路（`RegisterCarriedOverHorse`）** も本 PR で塞いだ。

## 変更点

**血統スコープ**（内国産 `RegisterInStudBook` / 輸入 `RegisterImportedHorse` / 生産 `RegisterFoal` / 移行取り込み `RegisterCarriedOverHorse` の 4 経路）

- `BloodHorseRepository.existsByRegistrationNumber` ＋ Jdbc / Spring Data 実装
- ドメインサービス `ensurePedigreeRegistrationNumberAvailable` ＋ 失敗型 `PedigreeRegistrationNumberAlreadyTaken`
- 4 ユースケースに配線＋app エラー `RegistrationNumberAlreadyTaken`、409 描画（`registration-number-already-taken`）

**繁殖スコープ**（`RegisterBreedingRegistration`）

- 上記の繁殖版ミラー（`existsByRegistrationNumber` / `ensureBreedingRegistrationNumberAvailable` / 409 `breeding-registration-number-already-taken`）

**DB・ドキュメント**

- `V22__add_registration_number_unique_backstop.sql`（両テーブルの UNIQUE、V14 / V19 と同型）
- `dbdoc/` を `generateDbDoc` で再生成
- 用語集に一意性・2 つの採番空間・世界に閉じることを追記

**テスト**

- Fixture / Seeder を一意採番化（同じ世界へ複数頭を seed するテストが UNIQUE に当たるため）
- 契約テストに「別の世界でなら同じ番号を採番できる」を追加（テナント分離の担保）

## errorCode の割り当て

血統登録原簿は 1 つなので、**4 経路で `registration-number-already-taken` を共用**する（馬名の `horse-name-already-taken` と同じ考え方で、クライアントから見た分類軸を 1 つに保つ）。繁殖登録番号は別の採番空間なので独立した `breeding-registration-number-already-taken` を割り当てた。

## replay ハーネスへの影響

「全フィクスチャを流して突合レポートを書き出す」テストは 6 頭を 1 つの世界へ流していた。01/04 は同じウインドインハーヘア、03/06 は同じテスコパールを含むため、一意性を入れると 2 頭目が弾かれ、**「モデルが実在の事実に耐えられなかった」ように見える停止が観測に混ざる**。フィクスチャ 1 件＝1 頭のシーズンを独立に再生する意味づけどおりになるよう、**フィクスチャごとに世界を切る**よう変更した（変更後も 6/6 一周完了・停止 0）。

Issue #652 の「実際に踏んでいる」節が指摘していた重複はこれで、レポートのフィクスチャ間の汚染も同時に解消している。

## レビューしてほしい点

登録番号の一意性検証を **その番号の VO 検証の直後**に置いた（他フィールドの形式検証より前）。結果、番号重複と不正なマイクロチップ番号が同時にあるリクエストは 400 ではなく 409 を返す。フィールド単位で「形式 → 集合制約」をまとめる読みやすさを取ったもの（#656 とも同じ順序）。形式エラーを常に優先させたい場合は入れ替える。

## 検証

- `./gradlew check` → BUILD SUCCESSFUL
- `./gradlew replay` → BUILD SUCCESSFUL（6/6 一周完了・停止 0）
- `./gradlew e2eTest` → BUILD SUCCESSFUL
- sqlfluff / squawk → V22 で 0 issue
- diff-cover（`--fail-under 90`）→ 変更 70 行すべてカバーで 100%

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)
