### PR TITLE
fix: #780 Stop hook の並行実行ガードが発火しない判定を直す

### DIFF
--- a/.claude/hooks/stop-kotlin-quality.sh
+++ b/.claude/hooks/stop-kotlin-quality.sh
@@ -8,9 +8,12 @@
 # - check はフォーマットの自動修正を行わない。ktfmtCheck の失敗は exit 2 の
 #   フィードバックを受けた Claude が ktfmtFormat を実行して解消する想定。
 # - 失敗時は exit 2 で Claude にフィードバックして修正を促す。
-# - 空回り・並行競合対策（#519）:
-#   - Gradle クライアント JVM（GradleWrapperMain）が走っている間はスキップする。
-#     常駐 daemon は一致しない。共有 build cache の競合を避けるためマシン全体で見る。
+# - 空回り・並行競合対策（#519 / #780）:
+#   - Gradle クライアント JVM が走っている間はスキップする。判定は wrapper 起動が
+#     付ける `-Dorg.gradle.appname=gradlew` で行う（クライアントは `-jar` 起動で
+#     メインクラス名がコマンドラインに出ないため、GradleWrapperMain では当たらない）。
+#     常駐 daemon はこの引数を持たないので一致しない。共有 build cache の競合を
+#     避けるためマシン全体で見る。
 #   - 前回失敗時から作業ツリーが変わっていなければ再実行しない（失敗指紋 dedup）。
 
 set -uo pipefail
@@ -31,8 +34,8 @@ if [ ! -x ./gradlew ]; then
 fi
 
 if command -v pgrep >/dev/null 2>&1 \
-    && pgrep -f 'org\.gradle\.wrapper\.GradleWrapperMain' >/dev/null 2>&1; then
-    echo 'gradle 実行中のため check をスキップしました（並行実行ガード・#519）' >&2
+    && pgrep -f -- '-Dorg\.gradle\.appname=gradlew' >/dev/null 2>&1; then
+    echo 'gradle 実行中のため check をスキップしました（並行実行ガード・#519 / #780）' >&2
     exit 0
 fi
 


### PR DESCRIPTION
Closes #780

## 何をしたか

`.claude/hooks/stop-kotlin-quality.sh` の並行実行ガード（#519 / PR #524）が、判定文字列
`org.gradle.wrapper.GradleWrapperMain` にどのプロセスも当たらないため**一度も発火していなかった**。
判定を、wrapper 起動が必ず付ける `-Dorg.gradle.appname=gradlew` に差し替えた。

Gradle クライアント JVM は `-jar gradle-wrapper.jar` 起動で、メインクラスは JAR のマニフェストから
解決されるためコマンドラインに現れない。これが空振りの原因。

## 実測（2026-08-16）

`./gradlew :ktfmtCheckMain --rerun-tasks` を裏で走らせ、実行中に毎秒 pgrep で評価した。

| 判定パターン | gradle 実行中 | gradle 終了後 |
| --- | --- | --- |
| `org.gradle.wrapper.GradleWrapperMain`（従来） | 非検出 | 非検出 |
| `-Dorg.gradle.appname=gradlew`（採用） | クライアント JVM を検出（PID 8076） | 非検出 |
| `org.gradle.launcher.daemon.bootstrap.GradleDaemon` | 別 PID 183 で存在 | 存在 |

- 採用パターンは daemon に当たらない。「daemon を判定に混ぜない」方針（混ぜると常駐なので常にスキップ）は維持できている。
- gradle 終了後は非検出。偽陽性で永久スキップにはならない。

## ミューテーションで非空振りを確認した

gradle を裏で走らせた状態で hook を直接起動し、ガードが実際に発火することを確認した
（`git diff HEAD` に `.kt` が要るため、対象ファイルを一時的にダーティにしてから実行し、検証後に戻した）。

```console
client pids while running: [9858 ]
=== hook during gradle: rc=0 elapsed=0s ===
stdout/stderr: [gradle 実行中のため check をスキップしました（並行実行ガード・#519 / #780）]
```

修正前は同条件で `./gradlew check` が起動していた（それが #748 / PR #778 で偽の BUILD FAILED を招いた実害）。

## 併せて棚卸ししたこと

`.claude/hooks/stop-terraform-validate.sh` には同型の並行実行ガードがそもそも無く、空振りしている判定は存在しなかった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
