### PR TITLE
chore: #754 ArchUnit の domainIsFrameworkFree に Jackson 3 を加える

### DIFF
--- a/src/test/kotlin/com/example/api/architecture/OnionLayerRulesTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/OnionLayerRulesTest.kt
@@ -46,7 +46,14 @@ class OnionLayerRulesTest {
             .adapter("persistence", INFRASTRUCTURE)
             .adapter("mcp", MCP)
 
-    /** domain 層はフレームワークに依存しないこと。 */
+    /**
+     * domain 層はフレームワークに依存しないこと。
+     *
+     * Jackson は **2 系と 3 系でルートパッケージが割れている**ため両方を列挙する。本プロジェクトが使う Jackson 3 の core / databind は
+     * `tools.jackson..`（`ObjectMapper` 等）だが、アノテーション（`@JsonTypeInfo` 等）は 3 系でも
+     * `com.fasterxml.jackson.annotation` に据え置かれており、実際に controller の DTO が import している。
+     * 片方だけの列挙では取りこぼす（#754）。
+     */
     @ArchTest
     val domainIsFrameworkFree =
         noClasses()
@@ -54,7 +61,12 @@ class OnionLayerRulesTest {
             .resideInAPackage(DOMAIN)
             .should()
             .dependOnClassesThat()
-            .resideInAnyPackage("org.springframework..", "jakarta..", "com.fasterxml.jackson..")
+            .resideInAnyPackage(
+                "org.springframework..",
+                "jakarta..",
+                "com.fasterxml.jackson..",
+                "tools.jackson..",
+            )
 
     /**
      * ドメインサービス（`domain.*.service`）は Kotlin のトップレベル関数で書くこと。


### PR DESCRIPTION
Closes #754

## 概要

ArchUnit の `domainIsFrameworkFree`（domain 層のフレームワーク非依存ゲート）が、禁止パッケージを Jackson 2（`com.fasterxml.jackson..`）だけで列挙しており、本プロジェクトが実際に使う **Jackson 3（`tools.jackson..`）を取りこぼしていた**。domain に Jackson 3 を import しても、ゲートは何も言わずに通る状態だった。

禁止列挙に `tools.jackson..` を追加し、あわせて既存列挙（`org.springframework..` / `jakarta..` / `com.fasterxml.jackson..`）が空振りしていないかを棚卸しした。

## 変更

- `src/test/kotlin/com/example/api/architecture/OnionLayerRulesTest.kt`
  - `domainIsFrameworkFree` の禁止列挙に `tools.jackson..` を追加
  - KDoc に「Jackson は 2 系と 3 系でルートパッケージが割れている」ことを記録。core / databind は `tools.jackson..` だが、**アノテーションは 3 系でも `com.fasterxml.jackson.annotation` に据え置き**で実際に controller の DTO が import しているため、両方の列挙が要る

規約そのもの（domain は Spring / jakarta / Jackson に依存しない）は変えていないため `.claude/rules/architecture.md` の更新は無し。塞いだのはゲートの穴のみ。

## ミューテーション検証（非空振りの実測）

`domain.shared` に一時コードを置いて実測し、確認後に撤去した（コミットには含まれていない）。

**修正前** — domain に Jackson 3 を import しても素通り:

```
> Task :test
BUILD SUCCESSFUL in 40s
```

**修正後** — 同じ状態で発火:

```
OnionLayerRulesTest > domainIsFrameworkFree FAILED
    java.lang.AssertionError at ArchRule.java:94
```

違反理由も期待どおり（別の理由で落ちたのではない）:

```
Method <com.example.api.domain.shared.CommandKt.mutationProbe(tools.jackson.databind.ObjectMapper)>
  has parameter of type <tools.jackson.databind.ObjectMapper> in (Command.kt:71)
```

**既存列挙の棚卸し** — 4 パッケージすべてを同時にミューテーションしたところ、すべて違反として検出された。列挙とパッケージ名のズレ（今回の Jackson と同型の取りこぼし）は他に無い:

```
com.fasterxml.jackson.annotation.JsonIgnoreType
jakarta.servlet.http.HttpServletRequest
org.springframework.context.ApplicationEventPublisher
tools.jackson.databind.ObjectMapper
```

`com.fasterxml.jackson..` の列挙も引き続き有効。`runtimeClasspath` には Jackson 2（`jackson-bom:2.21.4` 系）と Jackson 3（`jackson-bom:3.1.4` 系）が**両方実在する**ため、片方だけの列挙にはしない。

## 確認

- `./gradlew check` → BUILD SUCCESSFUL（ktfmt + detekt + test + koverVerifyMature）
- 変更は `src/test` のみのため差分カバレッジゲート（`src/main/kotlin` 対象）への影響なし

## 備考（本 PR のスコープ外）

- この denylist 方式は「列挙にないフレームワーク」を構造的に見逃す（例: `io.modelcontextprotocol..` / `org.postgresql..`）。allowlist 反転は影響範囲が大きいため本 PR では触れていない
- `build.gradle.kts` が Jackson 2 系の `com.fasterxml.jackson.module:jackson-module-kotlin` を直接 `implementation` している。Jackson 3 移行の残骸の可能性があるが、本 Issue のスコープ外

🤖 Generated with [Claude Code](https://claude.com/claude-code)
