### PR TITLE
chore: #777 nanoid の high (GHSA-2v37-7h3g-55p8) を解消する

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2855,9 +2855,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## 概要

Closes #777

`frontend/` の推移的依存 `nanoid` を 3.3.17 → 3.3.18 へ上げ、`npm audit` の high 1 件
（[GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generator に
`size=0` を渡すと無限ループする）を解消する。`package.json` に直接依存は無く、
`vite@8.2.1 → postcss@8.5.26 → nanoid` の経路で入っている。

変更は `frontend/package-lock.json` の 3 行のみ（`version` / `resolved` / `integrity`）。

## npm 11 で更新した理由

Issue の手順どおり `npm audit fix` を実行したところ、**nanoid とは無関係な `libc` フィールドの削除が
4 箇所巻き添えで入った**。

```diff
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
```

`libc` は npm 11 系が optional 依存の解決用に書くメタデータで、mise が供給する node 22 同梱の
npm 10.9.8 は書き出さないため消える。この lock を生成しているのは Dependabot（npm 11 系）なので、
npm 10 の出力で上書きすると**次の Dependabot 更新でまた戻る往復差分**になる。

そこで lock を一度戻し、Dependabot と同じ npm 11（`npx --yes npm@11 audit fix`）で実行し直した。
結果、差分は nanoid の 3 行だけに収まっている。CI は `npm ci`（lock を書き換えない）なので、
CI 側の npm バージョンとは競合しない。

## 検証（実測）

修正前 — `npm audit --json` の `metadata.vulnerabilities`:

```
"high": 1, "total": 1     （nanoid <3.3.18 / GHSA-2v37-7h3g-55p8）
```

修正後 — lock どおりに入れ直して（`npm ci`）から全ゲートを実行:

| コマンド | 結果 |
| --- | --- |
| `npm ci` | `added 206 packages, and audited 207 packages` / `found 0 vulnerabilities` |
| `npm run lint` | exit 0（Biome）|
| `npm run build` | `tsc && vite build` 成功（`✓ built in 998ms`）|
| `npm run test` | `Test Files 11 passed (11)` / `Tests 45 passed (45)` |
| `npm audit` | `found 0 vulnerabilities` |

`npm run lint` は `biome.json` の `$schema` が 2.5.7、Biome 本体が 2.5.8 という info を 1 件出すが、
**exit code は 0**（`npm run lint > /dev/null 2>&1; echo $?` → `exit=0`）。この差は main 時点から
存在するもので、本 PR の変更とは無関係。

## 実露出

Issue に記載のとおり、`vite` / `postcss` / `nanoid` はいずれも `"dev": true` でビルド時のみ、
配布物（`dist/assets/*.js`）には含まれない。脆弱性の前提である「`size=0` を渡す custom generator」も
postcss の利用経路には当たらないため、緊急度は低い。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
