### PR TITLE
chore: #700 課金暴走を止める（Cloud Run spend cap ＋ プロジェクト全体 budget alert）

### DIFF
--- a/docs/adr/0074-billing-guardrails-spend-cap-and-budget-alert.md
+++ b/docs/adr/0074-billing-guardrails-spend-cap-and-budget-alert.md
@@ -6,7 +6,7 @@
 
 ## Context（背景・課題）
 
-toy-box は sandbox プロジェクト（`ptiringo-toy-box`、番号 `570581970285`）だが、課金は実費で発生する。`.github/workflows/deploy.yml` の Cloud Run 設定（`--min-instances=0 --max-instances=3 --memory=1Gi --cpu=1`）が 1 か月張り付いた場合の理論上限は約 ¥30,000/月にのぼる。一方で `infra/` には課金の見張りが一切無く、暴走（誤ったループ・想定外の高頻度リクエスト・設定ミスによるインスタンス張り付き）を検知・抑止する仕組みが無かった。
+toy-box は sandbox プロジェクト（`ptiringo-toy-box`）だが、課金は実費で発生する。`.github/workflows/deploy.yml` の Cloud Run 設定（`--min-instances=0 --max-instances=3 --memory=1Gi --cpu=1`）が 1 か月張り付いた場合の理論上限は約 ¥30,000/月にのぼる。一方で `infra/` には課金の見張りが一切無く、暴走（誤ったループ・想定外の高頻度リクエスト・設定ミスによるインスタンス張り付き）を検知・抑止する仕組みが無かった。
 
 2026年7月、Cloud Billing に Spend Cap Budgets（Public Preview）が入り、Cloud Run が対象サービスに含まれた。到達すると課金対象の利用そのものを自動停止できる（budget alert の「知らせるだけ」を超えて「止める」ことができる）。
 
@@ -17,7 +17,7 @@ toy-box は sandbox プロジェクト（`ptiringo-toy-box`、番号 `5705819702
 課金ガードレールを二段構えにする。
 
 1. **Cloud Run spend cap ¥1,000/月**（Console 手設定）。到達すると課金対象の利用が自動停止し、Cloud Run は 5xx を返す。復旧は手動解除のみ。
-2. **プロジェクト全体の budget alert ¥3,000/月**（`infra/modules/billing/`、`google_billing_budget`）。閾値は 50% / 90% / 100%（実績）と 100%（予測）の 4 本。通知先は明示せず、`all_updates_rule` を書かないことで請求先アカウント管理者宛の既定メールに委ねる。
+2. **プロジェクト全体の budget alert ¥3,000/月**（`infra/modules/billing/`、`google_billing_budget`）。閾値は 50% / 90% / 100%（実績）と 100%（予測）の 4 本。通知先は明示せず、`all_updates_rule` を書かないことで請求先アカウント管理者宛の既定メールに委ねる。通知先を明示しない（＝`all_updates_rule` を書かない）と、請求先アカウントの Billing Account Administrator / User ロール保持者にメールが届く。本プロジェクトの所有者は請求先アカウントの IAM で `roles/billing.admin` を持つため条件を満たす。今回付与した `roles/billing.costsManager` は既定受信者の対象ロールではないので、これだけでは通知を担保しない。
 
 ### spend cap を Terraform 外に置く理由
 
@@ -25,11 +25,13 @@ toy-box は sandbox プロジェクト（`ptiringo-toy-box`、番号 `5705819702
 
 ### 請求 IAM 付与が手作業になる理由
 
-鶏卵問題。請求先アカウント（`013C2D-F8F574-F19A62`、通貨 JPY）の IAM を Terraform で書くには、実行アイデンティティ `tfc-service-account@ptiringo-toy-box.iam.gserviceaccount.com`（WIF 経由）自身に請求 IAM の管理権限が要るが、その付与こそが最初にやりたいことだった。最初の 1 回は組織管理者が手で `roles/billing.costsManager` を付与し、あわせて HCP Terraform workspace 変数 `billing_account_id` を登録した（`billingbudgets.googleapis.com` も本作業まで未有効だった）。
+鶏卵問題。請求先アカウント（通貨 JPY。ID の出所は HCP workspace 変数 `billing_account_id`）の IAM を Terraform で書くには、実行アイデンティティ `tfc-service-account@ptiringo-toy-box.iam.gserviceaccount.com`（WIF 経由）自身に請求 IAM の管理権限が要るが、その付与こそが最初にやりたいことだった。最初の 1 回は組織管理者が手で `roles/billing.costsManager` を付与し、あわせて HCP Terraform workspace 変数 `billing_account_id` を登録した（`billingbudgets.googleapis.com` も本作業まで未有効だった）。
 
 ### 金額の根拠
 
 理論上限 ¥30,000/月に対し、Cloud Run の spend cap はその 1/30 の ¥1,000。scale-to-zero とリクエスト課金の平常時利用（数百円未満想定）には十分な余裕がある一方、張り付き事故が起きても数日で自動停止する。全体 budget alert の ¥3,000/月は Cloud Run 以外の課金要素を含めた見張り水準として設定した。
+
+閾値の役割は実績（50% / 90%）と予測（100%）で分かれる。予算 ¥3,000 の 50% は ¥1,500 だが、Cloud Run が支配的なコスト要因である以上、Cloud Run 暴走シナリオでは総額が ¥1,500 に届く前に spend cap（¥1,000）が先に切れてしまい、実績ベースの 50% / 90% はこのシナリオでは発火しない。したがって実績閾値が実質的に見張るのは、spend cap の対象外である Artifact Registry 等の緩やかな増加である。Cloud Run 暴走の予兆は、cap 到達前でも早期に踏み抜きうる `FORECASTED_SPEND` 100% が担う。
 
 ### spend cap が守らない範囲
 

--- a/docs/adr/0074-billing-guardrails-spend-cap-and-budget-alert.md
+++ b/docs/adr/0074-billing-guardrails-spend-cap-and-budget-alert.md
@@ -1,0 +1,43 @@
+# 0074. 課金ガードレールを Cloud Run spend cap（手設定）と budget alert（Terraform）の二段構えにする
+
+- Status: Accepted
+- Date: 2026-08-16
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+toy-box は sandbox プロジェクト（`ptiringo-toy-box`、番号 `570581970285`）だが、課金は実費で発生する。`.github/workflows/deploy.yml` の Cloud Run 設定（`--min-instances=0 --max-instances=3 --memory=1Gi --cpu=1`）が 1 か月張り付いた場合の理論上限は約 ¥30,000/月にのぼる。一方で `infra/` には課金の見張りが一切無く、暴走（誤ったループ・想定外の高頻度リクエスト・設定ミスによるインスタンス張り付き）を検知・抑止する仕組みが無かった。
+
+2026年7月、Cloud Billing に Spend Cap Budgets（Public Preview）が入り、Cloud Run が対象サービスに含まれた。到達すると課金対象の利用そのものを自動停止できる（budget alert の「知らせるだけ」を超えて「止める」ことができる）。
+
+[ADR-0036](0036-gcp-operation-guardrails.md) は Claude Code から GCP を触る際に「不可逆・課金を伴う変更は無確認で流さない」ガードレールを掲げている。今回はその延長として、実行時の課金暴走そのものを止める仕組みが必要だった。
+
+## Decision（決定）
+
+課金ガードレールを二段構えにする。
+
+1. **Cloud Run spend cap ¥1,000/月**（Console 手設定）。到達すると課金対象の利用が自動停止し、Cloud Run は 5xx を返す。復旧は手動解除のみ。
+2. **プロジェクト全体の budget alert ¥3,000/月**（`infra/modules/billing/`、`google_billing_budget`）。閾値は 50% / 90% / 100%（実績）と 100%（予測）の 4 本。通知先は明示せず、`all_updates_rule` を書かないことで請求先アカウント管理者宛の既定メールに委ねる。
+
+### spend cap を Terraform 外に置く理由
+
+`hashicorp/terraform-provider-google`・`-google-beta` いずれの `google_billing_budget` にも enforcement（利用停止）相当のフィールドが無い。持っているのは `threshold_rules` / `all_updates_rule` / `spend_basis` までで、Spend Cap Budgets 自体が Public Preview のため provider が追随していない。**再検討条件**: provider が spend cap の enforcement に対応したら `infra/` へ寄せる。
+
+### 請求 IAM 付与が手作業になる理由
+
+鶏卵問題。請求先アカウント（`013C2D-F8F574-F19A62`、通貨 JPY）の IAM を Terraform で書くには、実行アイデンティティ `tfc-service-account@ptiringo-toy-box.iam.gserviceaccount.com`（WIF 経由）自身に請求 IAM の管理権限が要るが、その付与こそが最初にやりたいことだった。最初の 1 回は組織管理者が手で `roles/billing.costsManager` を付与し、あわせて HCP Terraform workspace 変数 `billing_account_id` を登録した（`billingbudgets.googleapis.com` も本作業まで未有効だった）。
+
+### 金額の根拠
+
+理論上限 ¥30,000/月に対し、Cloud Run の spend cap はその 1/30 の ¥1,000。scale-to-zero とリクエスト課金の平常時利用（数百円未満想定）には十分な余裕がある一方、張り付き事故が起きても数日で自動停止する。全体 budget alert の ¥3,000/月は Cloud Run 以外の課金要素を含めた見張り水準として設定した。
+
+### spend cap が守らない範囲
+
+spend cap は Cloud Run のみが対象。Artifact Registry（イメージ蓄積による単調増加）・Secret Manager・Identity Platform は対象外で、ここは全体 budget alert が検知する（停止はしない）。Prisma Postgres は Prisma 側の請求であり GCP 課金の管轄外（[ADR-0044](0044-adopt-prisma-postgres-for-production-db.md)）。
+
+## Consequences（結果・影響）
+
+- Cloud Run の課金暴走は spend cap（¥1,000/月）で実際に止まる。全体の課金異常（spend cap 対象外のサービスを含む）は budget alert（¥3,000/月）が検知する。二段構えで「止める」と「知らせる」の役割が分かれる。
+- 手設定が 2 つ（Cloud Run spend cap・請求先アカウントへの IAM 付与）リポジトリの外に残る。[ADR-0068](0068-manual-infra-apply-with-notification.md) と同型の逸脱であり、本 ADR が唯一の記録になる。
+- spend cap は Public Preview のため、仕様変更や GA 化のタイミングで再確認が要る。provider が enforcement に対応した時点で `infra/` への統合を検討する。
+- spend cap 到達時は Cloud Run が 5xx を返す（可用性より課金停止を優先する設計）。本番相当の可用性を求める段階になったら、金額と「止める/知らせるのみ」の方針を見直す。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -83,3 +83,4 @@
 | [0071](0071-pre-push-docker-fail-fast-guard.md) | pre-push の Docker 依存は fail fast ガードで扱い、テストの切り分けは行わない | Accepted |
 | [0072](0072-idempotency-key-header-trial.md) | Idempotency-Key ヘッダを 1 エンドポイントで試作する | Accepted |
 | [0073](0073-mcp-adapter-local-only-world-scoped.md) | MCP アダプタを local プロファイル限定の世界スコープ探索ツールとして再導入する | Accepted |
+| [0074](0074-billing-guardrails-spend-cap-and-budget-alert.md) | 課金ガードレールを Cloud Run spend cap（手設定）と budget alert（Terraform）の二段構えにする | Accepted |

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -69,7 +69,6 @@ module "billing" {
   source = "./modules/billing"
 
   billing_account_id = var.billing_account_id
-  project_id         = "ptiringo-toy-box"
   monthly_amount_jpy = "3000"
 
   depends_on = [google_project_service.project]

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -70,6 +70,7 @@ module "billing" {
 
   billing_account_id = var.billing_account_id
   project_id         = "ptiringo-toy-box"
+  monthly_amount_jpy = "3000"
 
   depends_on = [google_project_service.project]
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,6 +1,7 @@
 resource "google_project_service" "project" {
   for_each = toset([
     "artifactregistry",
+    "billingbudgets",
     "iam",
     "iamcredentials",
     "identitytoolkit",
@@ -57,6 +58,18 @@ module "identity_platform" {
   source = "./modules/identity-platform"
 
   project_id = "ptiringo-toy-box"
+
+  depends_on = [google_project_service.project]
+}
+
+# 課金の見張り（プロジェクト全体の月次予算アラート）。#700 / ADR-0074。
+# 止めるのは Cloud Run の spend cap（Console 手設定）で、ここは検知のみ。
+# billingbudgets API 有効化に依存させ、初回 apply の順序レースを避ける。
+module "billing" {
+  source = "./modules/billing"
+
+  billing_account_id = var.billing_account_id
+  project_id         = "ptiringo-toy-box"
 
   depends_on = [google_project_service.project]
 }

--- a/infra/modules/billing/main.tf
+++ b/infra/modules/billing/main.tf
@@ -1,0 +1,47 @@
+# 予算の対象プロジェクト。budget_filter は projects/<project_number> 形式を要求するため、
+# ID から番号を引く（番号をハードコードしない）。
+data "google_project" "target" {
+  project_id = var.project_id
+}
+
+# プロジェクト全体の月次予算アラート。
+# 到達しても課金は止まらない（検知のみ）。止めるのは Cloud Run の spend cap（Console 手設定・ADR-0074）。
+#
+# 通知先は明示しない。all_updates_rule を書かないことで、請求先アカウントの管理者宛に
+# 既定のメール通知が飛ぶ（宛先をコードに載せずに済む）。
+resource "google_billing_budget" "project_total" {
+  billing_account = var.billing_account_id
+  display_name    = "toy-box project total"
+
+  budget_filter {
+    projects        = ["projects/${data.google_project.target.number}"]
+    calendar_period = "MONTH"
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "JPY"
+      units         = var.monthly_amount_jpy
+    }
+  }
+
+  # 50% / 90% で予兆を掴む
+  threshold_rules {
+    threshold_percent = 0.5
+  }
+
+  threshold_rules {
+    threshold_percent = 0.9
+  }
+
+  # 100% 到達
+  threshold_rules {
+    threshold_percent = 1.0
+  }
+
+  # 「今月このままだと超える」を月末を待たずに知る
+  threshold_rules {
+    threshold_percent = 1.0
+    spend_basis       = "FORECASTED_SPEND"
+  }
+}

--- a/infra/modules/billing/main.tf
+++ b/infra/modules/billing/main.tf
@@ -25,7 +25,9 @@ resource "google_billing_budget" "project_total" {
     }
   }
 
-  # 50% / 90% で予兆を掴む
+  # 50% / 90%（実績）。Cloud Run は spend cap（¥1,000・ADR-0074）が先に切れるため、
+  # Cloud Run 暴走時はここに届く前に利用停止する。実質的にここが見張るのは
+  # spend cap 対象外のサービス（Artifact Registry 等）の緩やかな増加。
   threshold_rules {
     threshold_percent = 0.5
   }
@@ -39,7 +41,8 @@ resource "google_billing_budget" "project_total" {
     threshold_percent = 1.0
   }
 
-  # 「今月このままだと超える」を月末を待たずに知る
+  # 「今月このままだと超える」を月末を待たずに知る。
+  # Cloud Run 暴走の予兆はこちら（予測）が担う（実績閾値は spend cap に先を越される）。
   threshold_rules {
     threshold_percent = 1.0
     spend_basis       = "FORECASTED_SPEND"

--- a/infra/modules/billing/main.tf
+++ b/infra/modules/billing/main.tf
@@ -1,8 +1,6 @@
 # 予算の対象プロジェクト。budget_filter は projects/<project_number> 形式を要求するため、
-# ID から番号を引く（番号をハードコードしない）。
-data "google_project" "target" {
-  project_id = var.project_id
-}
+# provider に設定された project を対象に番号を引く（番号をハードコードしない）。
+data "google_project" "target" {}
 
 # プロジェクト全体の月次予算アラート。
 # 到達しても課金は止まらない（検知のみ）。止めるのは Cloud Run の spend cap（Console 手設定・ADR-0074）。

--- a/infra/modules/billing/variables.tf
+++ b/infra/modules/billing/variables.tf
@@ -1,0 +1,15 @@
+variable "billing_account_id" {
+  description = "budget を作成する Cloud Billing アカウント ID（例: 012345-6789AB-CDEF01）"
+  type        = string
+}
+
+variable "project_id" {
+  description = "予算の対象とする GCP プロジェクト ID"
+  type        = string
+}
+
+variable "monthly_amount_jpy" {
+  description = "プロジェクト全体の月次予算額（円）。この額に対する割合で閾値アラートが飛ぶ"
+  type        = string
+  default     = "3000"
+}

--- a/infra/modules/billing/variables.tf
+++ b/infra/modules/billing/variables.tf
@@ -3,11 +3,6 @@ variable "billing_account_id" {
   type        = string
 }
 
-variable "project_id" {
-  description = "予算の対象とする GCP プロジェクト ID"
-  type        = string
-}
-
 variable "monthly_amount_jpy" {
   description = "プロジェクト全体の月次予算額（円）。この額に対する割合で閾値アラートが飛ぶ"
   type        = string

--- a/infra/modules/billing/versions.tf
+++ b/infra/modules/billing/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.15"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 7.36.0"
+    }
+  }
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -20,3 +20,8 @@ variable "prisma_project_name" {
   type        = string
   sensitive   = true
 }
+
+variable "billing_account_id" {
+  description = "Cloud Billing アカウント ID（HCP workspace 変数で供給。公開リポジトリに直書きしない）"
+  type        = string
+}


### PR DESCRIPTION
## 概要

#700。課金が想定外に膨らんだときに **止める** 手段と **気づく** 手段を用意する。

| 層 | 対象 | 管理方法 | 効果 |
|---|---|---|---|
| spend cap | Cloud Run ¥1,000/月 | Console 手設定（Terraform 非対応） | 到達で自動停止（5xx） |
| budget alert | プロジェクト全体 ¥3,000/月 | 本 PR（`infra/modules/billing/`） | 検知のみ |

## 変更

- `infra/modules/billing/`: `google_billing_budget` を新設。閾値は 50% / 90% / 100%（実績）と 100%（予測）。
  通知は `all_updates_rule` を書かず、請求先アカウント管理者宛の既定メールに委ねる。
  `budget_filter` が要求するプロジェクト番号は `data "google_project"` から引き、ハードコードしない。
- `infra/main.tf`: `billingbudgets` API を有効化し、モジュールを `depends_on` 付きで呼ぶ。
- `infra/variables.tf`: `billing_account_id` を追加（値は HCP workspace 変数で供給。リポジトリに直書きしない）。
- `docs/adr/0074-*.md`: 二段構えの決定と、spend cap を Terraform 外に置く理由・再検討条件を記録。

## 閾値の役割分担（レビューで判明した点）

Cloud Run は spend cap（¥1,000）が全体予算の 50%（¥1,500）より先に切れるため、**実績ベースの閾値は Cloud Run には届かない**。
実績閾値が見張るのは cap 対象外のサービス（Artifact Registry 等）の緩やかな増加で、**Cloud Run 暴走の予兆は予測（`FORECASTED_SPEND`）閾値が担う**。
金額は変えず、この役割分担をコードコメントと ADR に明文化した。

また既定メール通知の受信者は、請求先アカウントの **Billing Account Administrator / User** ロール保持者であって、
今回付与した `roles/billing.costsManager` ではない。所有者が `roles/billing.admin` を持つことを確認済みで、ADR に根拠を残した。

## リポジトリ外で済ませた前提

- 請求先アカウントに `tfc-service-account` の `roles/billing.costsManager` を付与（鶏卵問題のため手作業）。
- HCP workspace `toy-box` に `billing_account_id` 変数を登録。

## 残作業（マージ後）

- Cloud Run の spend cap を Console で設定する（CLI / Terraform 非対応）。
- Prisma Postgres 側の上限・アラートの有無を Prisma Console で確認する。
