### PR TITLE
chore: #766 エラー型が値オブジェクトを保持する流儀を error-handling.md に明文化する

### DIFF
--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -28,6 +28,7 @@ paths:
 - 共通親 `interface`（`DomainError` 等）は **当面導入しない**。Controller 境界で横串のハンドリングが重複し始めた段階で初めて切り出す
 - エラーバリアントの `Throwable` 保持は、外部 API / ファイル I/O など **例外起因のバリアントだけ** に持たせる。共通 interface に `cause: Throwable?` を強制しない
 - ドメインオブジェクトの不変条件違反（例: 名前のブランク）は、そのドメインオブジェクトの `companion object.create()` ファクトリで `Result<T, ValidationError>` を返して表現する。application 層は受けたエラーを必要に応じて自分のエラー型に wrap する
+- **エラーバリアントが抱える値は、対応する値オブジェクトが既にあるなら生値ではなく VO をそのまま保持する**（例: `HorseAlreadyNamed(val currentName: HorseName)` / `TurnedProBeforeBirth(val dateOfBirth: DateOfBirth, val turnedProOn: TurnedProDate)`）。生値でよいのは **その値がまだ VO になっていないとき**に限り、典型は 2 つ。(1) VO 生成ファクトリが検証している入力そのもの（例: `InvalidCountryCode(val raw: String)` / `InvalidValidityPeriod(val start: LocalDate, val end: LocalDate)`）、(2) 対応する VO が存在しない値（例: `AlreadyGraduated(val graduatedOn: LocalDate)`）。**判定基準は「その値が VO になっているか」であって「`create` の入力検証か」ではない**。ファクトリが検証済みの VO を受け取る場合（例: `Tracklist.create(tracks: List<Track>)`）は入力が既に VO なので、`.value` で剥がさず VO のまま載せる
 - **単一エラー型を固定のエラーへ写す `mapError` は、変換元の型をラムダパラメータで明示する**（例: `mapError { _: BlankHorseName -> InvalidName }`）。パラメータを参照しないラムダは、変換元エラー型が sealed interface へ昇格（バリアント追加）されてもコンパイルが通り、新バリアントが既存の誤った errorCode・メッセージへ無音で変換される。型明示をトリップワイヤにして、昇格（型の付け替え）時に全変換箇所をコンパイルエラーで浮かび上がらせる。変換元が**既に sealed** の場合は型明示ではなく、cause を保持する wrap（`PreconditionViolated(it)`）または網羅 `when` で写す（バリアント追加を型検査で検知できる形を保つ）
 
 > **機械強制**: 変換元エラーを参照も型明示もしない `mapError` ラムダは detekt カスタムルール `NoSilentMapError`（`:detekt-rules` モジュール）が検出してビルドを失敗させる。ラムダパラメータの参照（wrap・網羅 `when`）または型明示（`_: 変換元エラー型 ->`）があれば検出されない。テストコードは detekt 設定の `excludes` で対象外。

--- a/src/main/kotlin/com/example/api/domain/sakamichi/model/release/Tracklist.kt
+++ b/src/main/kotlin/com/example/api/domain/sakamichi/model/release/Tracklist.kt
@@ -17,16 +17,16 @@ sealed interface TracklistError {
     /**
      * トラック番号が重複している。
      *
-     * @property values 重複しているトラック番号の値の集合
+     * @property values 重複しているトラック番号の集合
      */
-    data class DuplicateNumber(val values: Set<Int>) : TracklistError
+    data class DuplicateNumber(val values: Set<TrackNumber>) : TracklistError
 
     /**
      * トラック番号の集合が 1..n（n = 曲数）と一致しない（1 始まりでない・欠番がある等）。
      *
-     * @property values 実際に与えられたトラック番号の値の集合
+     * @property values 実際に与えられたトラック番号の集合
      */
-    data class NonContiguousNumbers(val values: Set<Int>) : TracklistError
+    data class NonContiguousNumbers(val values: Set<TrackNumber>) : TracklistError
 }
 
 /**
@@ -48,13 +48,13 @@ data class Tracklist private constructor(val tracks: List<Track>) {
          * @return 検証済みの [Tracklist]、または不変条件違反を表す [TracklistError]
          */
         fun create(tracks: List<Track>): Result<Tracklist, TracklistError> {
-            val duplicates = tracks.groupBy { it.number.value }.filterValues { it.size > 1 }.keys
-            val actualNumbers = tracks.map { it.number.value }.toSet()
-            val expectedNumbers = (1..tracks.size).toSet()
+            val duplicates = tracks.groupBy { it.number }.filterValues { it.size > 1 }.keys
+            val actualNumbers = tracks.map { it.number }.toSet()
+            val expectedValues = (1..tracks.size).toSet()
             return when {
                 tracks.isEmpty() -> Err(TracklistError.Empty)
                 duplicates.isNotEmpty() -> Err(TracklistError.DuplicateNumber(duplicates))
-                actualNumbers != expectedNumbers ->
+                actualNumbers.map { it.value }.toSet() != expectedValues ->
                     Err(TracklistError.NonContiguousNumbers(actualNumbers))
                 else -> Ok(Tracklist(tracks.sortedBy { it.number.value }))
             }

--- a/src/test/kotlin/com/example/api/domain/sakamichi/model/release/TracklistTest.kt
+++ b/src/test/kotlin/com/example/api/domain/sakamichi/model/release/TracklistTest.kt
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.Test
 
 /** Tracklist 値オブジェクトの構築時不変条件（空でない・番号が 1..n の連番・重複なし）のユニットテスト。 */
 class TracklistTest {
+    private fun number(value: Int): TrackNumber = TrackNumber.create(value).unwrap()
+
     private fun track(number: Int, title: String): Track =
-        Track(TrackNumber.create(number).unwrap(), TrackTitle.create(title).unwrap())
+        Track(number(number), TrackTitle.create(title).unwrap())
 
     @Test
     fun `1からnの連番なら生成できる`() {
@@ -32,21 +34,21 @@ class TracklistTest {
     fun `番号が重複すると DuplicateNumber を返す`() {
         val error = Tracklist.create(listOf(track(1, "A"), track(1, "B"))).getError()
 
-        assert(error == TracklistError.DuplicateNumber(setOf(1)))
+        assert(error == TracklistError.DuplicateNumber(setOf(number(1))))
     }
 
     @Test
     fun `1始まりでないと NonContiguousNumbers を返す`() {
         val error = Tracklist.create(listOf(track(2, "A"), track(3, "B"))).getError()
 
-        assert(error == TracklistError.NonContiguousNumbers(setOf(2, 3)))
+        assert(error == TracklistError.NonContiguousNumbers(setOf(number(2), number(3))))
     }
 
     @Test
     fun `欠番があると NonContiguousNumbers を返す`() {
         val error = Tracklist.create(listOf(track(1, "A"), track(3, "B"))).getError()
 
-        assert(error == TracklistError.NonContiguousNumbers(setOf(1, 3)))
+        assert(error == TracklistError.NonContiguousNumbers(setOf(number(1), number(3))))
     }
 
     @Test


### PR DESCRIPTION
Closes #766

## 概要

エラーバリアントが抱える値を生値と値オブジェクトのどちらで持つかは、これまで「既存コンテキストの流儀」という暗黙知だった（#680 / PR #764 がこの暗黙知に依存して修正された）。これを `.claude/rules/error-handling.md`「エラー型の設計」節へ明文化する。

あわせて、明文化した規約の**反例が現行コードに残っていた**ため同時に直した。

## 1. 規約の明文化（`.claude/rules/error-handling.md`）

「エラー型の設計」節の箇条書きに 1 項追加した。

- エラーバリアントが抱える値は、対応する VO が既にあるなら生値ではなく VO をそのまま保持する
- 生値でよいのは「その値がまだ VO になっていないとき」に限り、典型は 2 つ
  1. VO 生成ファクトリが検証している入力そのもの（`InvalidCountryCode(val raw: String)` / `InvalidValidityPeriod(val start: LocalDate, val end: LocalDate)`）
  2. 対応する VO が存在しない値（`AlreadyGraduated(val graduatedOn: LocalDate)`）

### Issue の但し書き案から変えた点

Issue 本文の案は但し書きを「**`create` の入力検証**なら生値を保持してよい」と書いていたが、この文言だと下記の反例（`Tracklist.create` の入力検証）を規約準拠と誤読させる。判定基準は「`create` の入力検証か」ではなく「**その値が VO になっているか**」なので、そちらを基準として書き、ファクトリが検証済み VO を受け取る場合は `.value` で剥がさない旨を明示した。

### 機械強制について

Issue の検討ポイントどおり、**機械強制はしない**。「対応する VO が存在するか」の判定には型解決が要り、`NoThrowInDomainAndApplication` / `NoSilentMapError` のような構文レベルの detekt ルールでは書けない。ルール文＋レビューで担保する（`architecture.md`「機械強制しない規約」と同じ位置づけ）。

## 2. 反例の修正（`Tracklist`）

Issue 本文は「生値を保持しているエラー型はすべて『VO 生成前の入力検証』型であり、直すべき対象は #680 で解消済みで残っていない」としていたが、`domain/` 全体を突き合わせたところ **`TracklistError` が反例として残っていた**。

```kotlin
// Tracklist.create(tracks: List<Track>) の入力は既に TrackNumber VO を持っている
// （Track(number: TrackNumber, title: TrackTitle)）のに、it.number.value で剥がしていた
data class DuplicateNumber(val values: Set<Int>)
data class NonContiguousNumbers(val values: Set<Int>)
```

同じ sakamichi でも `Single.kt` / `Album.kt` / `Formation.kt` は `Set<TrackNumber>` / `Set<MemberId>` と VO で持っており、流儀が割れていた（＝明文化しないと再発する、という Issue の主張の実例）。`Set<TrackNumber>` へ揃えた。`1..n` との一致判定だけは `value` へ写して比較する。

なお `ReportAlreadySubmitted(submittedOn: LocalDate)` / `AlreadyGraduated(graduatedOn: LocalDate)` は対応する VO が存在しないため、規約文の「対応する VO が既にあるなら」で正しく除外される（違反ではない）。

## 検証

- `./gradlew check` 緑（ktfmt + detekt + test + koverVerifyMature、3m17s）
- 差分カバレッジ 100%（`diff-cover build/reports/kover/reportMature.xml --compare-branch origin/main --src-roots src/main/kotlin --fail-under 90` / 6 lines, Missing 0）
- テストは先に期待値を `Set<TrackNumber>` へ変えて RED（型不一致 3 箇所）を確認してから本体を直した

`TracklistError` の利用箇所は本 PR のテスト 3 箇所のみで、sakamichi は Controller 未配線のため HTTP 契約への影響は無い。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
