### PR TITLE
docs: #700 既存の手設定 budget（¥500）の存在と役割分担を ADR-0074 に追記する

### DIFF
--- a/docs/adr/0074-billing-guardrails-spend-cap-and-budget-alert.md
+++ b/docs/adr/0074-billing-guardrails-spend-cap-and-budget-alert.md
@@ -18,7 +18,7 @@ toy-box は sandbox プロジェクト（`ptiringo-toy-box`）だが、課金は
 
 課金ガードレールを二段構えにする。
 
-1. **Cloud Run spend cap ¥1,000/月**（Console 手設定）。到達すると課金対象の利用が自動停止し、Cloud Run は 5xx を返す。復旧は手動解除のみ。
+1. **Cloud Run spend cap ¥1,000/月**（Console 手設定。予算名 `ptiringo-toy-box利用額上限`、対象はプロジェクト `ptiringo-toy-box` の Cloud Run のみ、期間は月別）。到達すると課金対象の利用が自動停止し、Cloud Run は 5xx を返す。復旧は手動解除のみ。**適用は即時ではないため ¥1,000 は厳密な hard limit ではなく、すり抜けた超過分は課金される**（Console の注記）。
 2. **プロジェクト全体の budget alert ¥3,000/月**（`infra/modules/billing/`、`google_billing_budget`）。閾値は 50% / 90% / 100%（実績）と 100%（予測）の 4 本。通知先は明示せず、`all_updates_rule` を書かないことで請求先アカウント管理者宛の既定メールに委ねる。通知先を明示しない（＝`all_updates_rule` を書かない）と、請求先アカウントの Billing Account Administrator / User ロール保持者にメールが届く。本プロジェクトの所有者は請求先アカウントの IAM で `roles/billing.admin` を持つため条件を満たす。今回付与した `roles/billing.costsManager` は既定受信者の対象ロールではないので、これだけでは通知を担保しない。
 
 ### spend cap を Terraform 外に置く理由
@@ -34,6 +34,8 @@ toy-box は sandbox プロジェクト（`ptiringo-toy-box`）だが、課金は
 理論上限 ¥30,000/月に対し、Cloud Run の spend cap はその 1/30 の ¥1,000。scale-to-zero とリクエスト課金の平常時利用（数百円未満想定）には十分な余裕がある一方、張り付き事故が起きても数日で自動停止する。全体 budget alert の ¥3,000/月は Cloud Run 以外の課金要素を含めた見張り水準として設定した。
 
 閾値の役割は実績（50% / 90%）と予測（100%）で分かれる。予算 ¥3,000 の 50% は ¥1,500 だが、Cloud Run が支配的なコスト要因である以上、Cloud Run 暴走シナリオでは総額が ¥1,500 に届く前に spend cap（¥1,000）が先に切れてしまい、実績ベースの 50% / 90% はこのシナリオでは発火しない。したがって実績閾値が実質的に見張るのは、spend cap の対象外である Artifact Registry 等の緩やかな増加である。Cloud Run 暴走の予兆は、cap 到達前でも早期に踏み抜きうる `FORECASTED_SPEND` 100% が担う。
+
+加えて、**spend cap 自身が実績ベースの通知を持つ**（Console で 50% / 80% / 100% ＝ ¥500 / ¥800 / ¥1,000 が既定で設定され、通知先は「課金管理者とユーザー」と「プロジェクトオーナー」の両方）。したがって Cloud Run 固有の実績警報は cap 側が担い、全体 budget alert の実績閾値が cap 対象外サービス向けであるという上記の分担は変わらないまま、Cloud Run の予兆は「cap の 50% / 80% 通知（実績）」と「全体予算の予測 100%」の二経路で確保される。
 
 ### 既存の手設定 budget（¥500）との役割分担
 

--- a/docs/adr/0074-billing-guardrails-spend-cap-and-budget-alert.md
+++ b/docs/adr/0074-billing-guardrails-spend-cap-and-budget-alert.md
@@ -6,7 +6,9 @@
 
 ## Context（背景・課題）
 
-toy-box は sandbox プロジェクト（`ptiringo-toy-box`）だが、課金は実費で発生する。`.github/workflows/deploy.yml` の Cloud Run 設定（`--min-instances=0 --max-instances=3 --memory=1Gi --cpu=1`）が 1 か月張り付いた場合の理論上限は約 ¥30,000/月にのぼる。一方で `infra/` には課金の見張りが一切無く、暴走（誤ったループ・想定外の高頻度リクエスト・設定ミスによるインスタンス張り付き）を検知・抑止する仕組みが無かった。
+toy-box は sandbox プロジェクト（`ptiringo-toy-box`）だが、課金は実費で発生する。`.github/workflows/deploy.yml` の Cloud Run 設定（`--min-instances=0 --max-instances=3 --memory=1Gi --cpu=1`）が 1 か月張り付いた場合の理論上限は約 ¥30,000/月にのぼる。一方で `infra/` には課金の見張りが一切無く、暴走（誤ったループ・想定外の高頻度リクエスト・設定ミスによるインスタンス張り付き）を**止める**仕組みは無かった。
+
+なお、**検知**については手設定の budget alert `意図せぬ高額請求検知`（月 ¥500、請求先アカウント全体、閾値 50% / 90% / 100% の実績のみ）が既に存在した。これは本作業の apply 後に `gcloud billing budgets list` で実在を確認して初めて判明したもので、着手時点の想定（「課金の見張りが無い」）は `infra/` に限れば正しかったが、実態としては ¥500 の早期警報が動いていた。
 
 2026年7月、Cloud Billing に Spend Cap Budgets（Public Preview）が入り、Cloud Run が対象サービスに含まれた。到達すると課金対象の利用そのものを自動停止できる（budget alert の「知らせるだけ」を超えて「止める」ことができる）。
 
@@ -33,6 +35,15 @@ toy-box は sandbox プロジェクト（`ptiringo-toy-box`）だが、課金は
 
 閾値の役割は実績（50% / 90%）と予測（100%）で分かれる。予算 ¥3,000 の 50% は ¥1,500 だが、Cloud Run が支配的なコスト要因である以上、Cloud Run 暴走シナリオでは総額が ¥1,500 に届く前に spend cap（¥1,000）が先に切れてしまい、実績ベースの 50% / 90% はこのシナリオでは発火しない。したがって実績閾値が実質的に見張るのは、spend cap の対象外である Artifact Registry 等の緩やかな増加である。Cloud Run 暴走の予兆は、cap 到達前でも早期に踏み抜きうる `FORECASTED_SPEND` 100% が担う。
 
+### 既存の手設定 budget（¥500）との役割分担
+
+Context に書いた `意図せぬ高額請求検知`（月 ¥500、請求先アカウント全体）は**削除せず残す**。金額が本 ADR の ¥3,000 より 6 倍厳しいため、**早期警報としては常にこちらが先に鳴る**。本 ADR で追加した ¥3,000 の budget が上乗せするのは次の 2 点に限られる。
+
+- **予測ベース（`FORECASTED_SPEND`）の閾値**。既存の ¥500 は実績閾値しか持たないため、「今月このままだと超える」を月末前に掴めない。
+- **プロジェクトスコープ**。既存は請求先アカウント全体が対象で、プロジェクト単位の切り分けができない。
+
+つまり ¥500 = 早期警報（手設定・請求先アカウント全体・実績のみ）、¥3,000 = 予測とプロジェクト単位の見張り（Terraform 管理）という分担になる。両者は競合しない。ただし**課金の見張りの出所が 2 つに分かれた**状態であり、既存 budget を Terraform に import して一本化するかは別途判断する。
+
 ### spend cap が守らない範囲
 
 spend cap は Cloud Run のみが対象。Artifact Registry（イメージ蓄積による単調増加）・Secret Manager・Identity Platform は対象外で、ここは全体 budget alert が検知する（停止はしない）。Prisma Postgres は Prisma 側の請求であり GCP 課金の管轄外（[ADR-0044](0044-adopt-prisma-postgres-for-production-db.md)）。
@@ -43,3 +54,5 @@ spend cap は Cloud Run のみが対象。Artifact Registry（イメージ蓄積
 - 手設定が 2 つ（Cloud Run spend cap・請求先アカウントへの IAM 付与）リポジトリの外に残る。[ADR-0068](0068-manual-infra-apply-with-notification.md) と同型の逸脱であり、本 ADR が唯一の記録になる。
 - spend cap は Public Preview のため、仕様変更や GA 化のタイミングで再確認が要る。provider が enforcement に対応した時点で `infra/` への統合を検討する。
 - spend cap 到達時は Cloud Run が 5xx を返す（可用性より課金停止を優先する設計）。本番相当の可用性を求める段階になったら、金額と「止める/知らせるのみ」の方針を見直す。
+- 課金の見張りの出所が Terraform（¥3,000）と手設定（¥500）の 2 つに分かれた。役割は分担できているが、片方が Terraform の外にある以上、変更が state に反映されず気づかれない経路が残る。一本化するなら既存 budget を `infra/` へ import する。
+- budget の実在確認には `gcloud billing budgets list --billing-account=<id> --billing-project=ptiringo-toy-box` が要る。`--billing-project`（クォータプロジェクト）を省くと、ADC が gcloud 共有プロジェクトを見に行き `SERVICE_DISABLED` で失敗する。


### PR DESCRIPTION
## 概要

#789 の apply 後に `gcloud billing budgets list` で実在確認をしたところ、**手設定の budget が既に存在していた**ことが判明した。

- `意図せぬ高額請求検知` — 月 **¥500**、請求先アカウント**全体**、閾値 50% / 90% / 100%（実績のみ）

#700 と ADR-0074 は「課金の見張りが一切無かった」という前提で書かれていたが、これは `infra/`（Terraform）に限れば正しく、実態としては ¥500 の早期警報が動いていた。ADR が事実と食い違ったままになるため追記する。

## 判断

既存の ¥500 は**削除せず残す**。金額が 6 倍厳しいため早期警報としては常にこちらが先に鳴る。ADR-0074 で追加した ¥3,000 の上乗せは次の 2 点に縮む。

- 予測ベース（`FORECASTED_SPEND`）の閾値 — 既存には無い
- プロジェクトスコープ — 既存は請求先アカウント全体

## 変更

- **Context**: 既存 budget の存在と、それが apply 後の確認で初めて判明した経緯を追記。
- **Decision**: 「既存の手設定 budget との役割分担」節を追加。
- **Consequences**: 見張りの出所が 2 つに分かれた帰結（一本化するなら import）と、実在確認に `--billing-project` が要る点を追記。

文書のみの変更で、Terraform 構成には触れていない。
