### PR TITLE
chore: #788 biome.json の $schema を node_modules 内のスキーマ参照へ切り替える

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -65,6 +65,12 @@ Vite dev server が `/api/*` を `http://localhost:8080`（バックエンド）
 
 CI（`.github/workflows/frontend.yml`）と lefthook の pre-commit が `frontend/**` の変更時に lint/build/test を回す。
 
+> **`biome.json` の `$schema` はバージョン付き URL に戻さない**（#788）。`https://biomejs.dev/schemas/<version>/schema.json`
+> を直書きすると、Dependabot が `@biomejs/biome` を上げるたびに版がずれて `npm run lint` が info を 1 件出す
+> （パッチ版を落とした `2.5/schema.json` 等では回避できず、Biome は完全一致を要求する）。`node_modules` 内の
+> スキーマを相対パスで指す形（Biome 公式ドキュメントの第一候補）ならインストール済みの実体を指すので常に一致する。
+> なお設定が本体と非互換になったときは、この info ではなく `biome check` 自体がエラー（exit 1）で落ちる。
+
 ## 構成
 
 ```

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,


### PR DESCRIPTION
Closes #788

## 概要

`frontend/biome.json` の `$schema` を、バージョン付き URL の直書きから **`node_modules` 内のスキーマへの相対パス参照**へ切り替える。これにより `npm run lint` の info が 0 件になり、Dependabot が `@biomejs/biome` を上げても版ずれが再発しなくなる。

```diff
-  "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
```

## 判断の根拠（すべて実測）

Issue に挙がっていた選択肢を順に潰した。

**1. パッチ版を落とした URL では回避できない**

`https://biomejs.dev/schemas/2.5/schema.json` に変えて `npm run lint` を実行したところ、`Expected: 2.5.8 / Found: 2.5` として同じ info が出た。Biome は完全一致を要求する。

**2. `node_modules` 参照は Biome 公式ドキュメントの第一候補**

原典（`biomejs/website` の `reference/configuration.mdx`）は、`@biomejs/biome` が `node_modules` にあるなら相対パス参照を先に案内し、バージョン付き URL は「物理ファイルの解決に問題がある場合」のフォールバックとして併記している。この repo は `frontend/node_modules` にインストールしているため第一候補が該当する。

**3. 何が起きているかの正確な理解**

Biome は `$schema` の値を**ファイルとして解決していない**。公式 URL のパターンに一致したときだけ版を照合する（存在しないローカルパス `./node_modules/@biomejs/biome/NO_SUCH_FILE.json` を指定しても無警告だった）。したがって今回の変更は、厳密には「照合を無効化しつつ、エディタが読む実体を常にインストール版と一致させる」ものである。

失うのは `biome migrate` を促す info だけで、**設定が本体と非互換になった場合は info ではなく `biome check` 自体がエラー（exit 1）で落ちる**（未知キー `thisKeyDoesNotExist` を差し込んで確認）。壊れる変更は引き続き検知できる。

## 確認

```
$ npm run lint
> biome check .
Checked 35 files in 40ms. No fixes applied.
$ echo $?
0
```

- 変更前: info 1 件 / exit 0
- 変更後: info 0 件 / exit 0

`frontend/README.md` に、URL 直書きへ戻さない理由（更新のたびに再発する・パッチ版を落とす回避が効かない）を注記した。`biome.json` は JSON でコメントを書けないため README を置き場所にしている。

## 関連

- #788（この Issue）
- #759 Biome 2.x の設定スキーマ変更に biome.json を追随させる（前回の追随作業。今回で追随作業自体が不要になる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
