### PR TITLE
chore: #800 #793 pre-commit の glob と terraform fmt が CI とズレて見逃す穴を塞ぐ

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,14 +15,17 @@ pre-commit:
       tags: format
 
     # ktfmt によるフォーマットチェック
+    # glob の `{,**/}` はルート直下と入れ子の両方に一致させるため（dprint と同じ理由。`**/*.{kt,kts}`
+    # だとルート直下の build.gradle.kts / settings.gradle.kts が漏れ、ビルド構成だけを触った
+    # コミットで ktfmt / detekt が 1 度も走らない。#800）。
     ktfmt-check:
-      glob: "**/*.{kt,kts}"
+      glob: "{,**/}*.{kt,kts}"
       run: mise exec -- ./gradlew ktfmtCheck --daemon
       tags: format
 
     # detekt による静的解析
     detekt:
-      glob: "**/*.{kt,kts}"
+      glob: "{,**/}*.{kt,kts}"
       run: mise exec -- ./gradlew detekt --daemon
       tags: lint
 
@@ -30,9 +33,11 @@ pre-commit:
     # root を frontend に切ると、実行ディレクトリだけでなく {staged_files} も frontend/ からの
     # 相対パスへ書き換わる（cd するだけだと絶対パス化されない root 相対の staged_files が二重に
     # frontend/ を含んで解決できなくなる。実測で確認済み）。
+    # glob の `{,**/}` は dprint と同じ理由。`frontend/**/*` だと frontend/ 直下の
+    # vite.config.ts / biome.json / package.json が検査対象から漏れる（#800）。
     biome-frontend:
       root: "frontend/"
-      glob: "frontend/**/*.{ts,tsx,json}"
+      glob: "frontend/{,**/}*.{ts,tsx,json}"
       run: npx biome check {staged_files}
       tags: lint
 
@@ -50,14 +55,18 @@ pre-commit:
 
     # ShellCheck によるシェルスクリプトの lint
     shellcheck:
-      glob: "**/*.sh"
+      glob: "{,**/}*.sh"
       run: mise exec -- shellcheck {staged_files}
       tags: lint
 
     # Terraform フォーマットチェック
+    # `-recursive` は CI（.github/workflows/terraform-check.yml）と揃えるため。付けないと
+    # infra/ 直下しか見ず、infra/modules/** の整形崩れがローカルを素通りして CI で初めて落ちる（#793）。
+    # なお glob の `infra/*.tf` は module 配下にも一致する（lefthook の `*` は `/` をまたぐ。
+    # 一方 `**/` は 1 階層以上を要求する ＝ dprint / biome-frontend の `{,**/}` が要る理由。実測で確認済み）。
     terraform-fmt-check:
       glob: "infra/*.tf"
-      run: terraform fmt -check infra/
+      run: terraform fmt -check -recursive infra/
       tags: format
 
     # Terraform バリデーション
@@ -95,13 +104,13 @@ pre-commit:
 
     # sqlfluff による SQL の書式・スタイルチェック
     sqlfluff:
-      glob: "**/*.sql"
+      glob: "{,**/}*.sql"
       run: mise exec -- sqlfluff lint {staged_files}
       tags: format
 
     # squawk によるマイグレーション安全性チェック
     squawk:
-      glob: "**/*.sql"
+      glob: "{,**/}*.sql"
       run: mise exec -- squawk {staged_files}
       tags: lint
 
@@ -129,7 +138,7 @@ pre-push:
     # priority で full-test より先に走らせる（lefthook の既定はコマンド名の辞書順）。
     docker-available:
       priority: 1
-      glob: "**/*.{kt,kts,java}"
+      glob: "{,**/}*.{kt,kts,java}"
       run: scripts/check-docker-available.sh
       tags: test
 
@@ -150,7 +159,7 @@ pre-push:
     # スコープ分離）が実装されたら、性能を犠牲にしない形へ置き換えられる。
     full-test:
       priority: 2
-      glob: "**/*.{kt,kts,java}"
+      glob: "{,**/}*.{kt,kts,java}"
       run: mise exec -- ./gradlew test $([ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ] && echo --no-daemon)
       tags: test
 


### PR DESCRIPTION
## 概要

pre-commit の検査範囲が CI とズレて見逃す穴を塞ぐ。Close #800 / Close #793。

どちらも「pre-commit が対象ファイルを拾えず、壊れたものが CI まで通ってしまう」同じ構図。
#800 の指示どおり lefthook の他フックも横断で見たところ、**同型の漏れがもう 1 つ（より影響の大きいもの）
見つかった**ので合わせて塞いだ。

## 変更

### 1. biome-frontend の glob（#800）

`frontend/**/*.{ts,tsx,json}` → `frontend/{,**/}*.{ts,tsx,json}`

lefthook の `**/` は 1 階層以上を要求するため、`frontend/vite.config.ts` / `biome.json` /
`package.json` / `tsconfig.json` にマッチしていなかった。

### 2. terraform-fmt-check の `-recursive`（#793）

`terraform fmt -check infra/` → `terraform fmt -check -recursive infra/`

CI（`.github/workflows/terraform-check.yml`）は `-recursive` で走るのに pre-commit は非再帰で、
`infra/modules/**` の整形崩れがローカルを素通りしていた。

### 3. 横断で見つかった同型の漏れ（`**/` → `{,**/}`）

`ktfmt-check` / `detekt` / `shellcheck` / `sqlfluff` / `squawk` と pre-push の
`docker-available` / `full-test`。

とくに **`**/*.{kt,kts}` はルート直下の `build.gradle.kts` / `settings.gradle.kts` にマッチしない**。
つまりビルド構成だけを触ったコミットでは ktfmt も detekt も 1 度も走らず、push しても
テストが走らない状態だった。実測では、整形を崩した `build.gradle.kts` を stage しても
`ktfmt-check (skip) no matching staged files` になっていた。

（ルート直下の `.json` は dprint が既に `{,**/}` で拾えている。`.sh` / `.sql` は現状ルート直下に
ファイルが無いが、同じ罠を再発させないため形を揃えた。）

## 実測（ミューテーションで発火を確認 = #782 の趣旨）

| 対象 | 修正前 | 修正後 |
| --- | --- | --- |
| `frontend/vite.config.ts` を stage | `(skip) no files for inspection` | `Checked 1 file` |
| 不正キーを入れた `frontend/biome.json` を stage | 素通り（コミットできる） | `× Biome exited because the configuration resulted in errors` で fail |
| 整形を崩した `infra/modules/billing/variables.tf` を stage | `✔️ terraform-fmt-check`（見逃し） | `🥊 terraform-fmt-check` / 対象ファイル名を出力して fail |
| 整形を崩した `build.gradle.kts` を stage | `(skip) no matching staged files` | `🥊 ktfmt-check` / `:ktfmtCheckScripts` が検出して fail |
| `frontend/src/main.tsx`（入れ子）を stage | 発火 | 発火（回帰なし） |
| `src/main/kotlin/.../ApiApplication.kt`（入れ子）を stage | 発火 | 発火（回帰なし） |

## #793 の前提の訂正

#793 は「`terraform-validate` / `tflint` / `trivy-config` の glob が `infra/*.tf` で非再帰なので、
モジュールのみを変更したコミットでは pre-commit のこれらが 1 つも走らない」としていたが、**これは誤り**。

実測では `infra/modules/billing/variables.tf` のみを stage した状態で 4 フックすべてが発火し、
tflint はそのファイルの警告を報告した（`on modules/billing/variables.tf line 13`）。
lefthook の `*` は `/` をまたぐため `infra/*.tf` は module 配下にも一致する
（一方 `**/` は 1 階層以上を要求する ＝ `{,**/}` が要る理由）。
したがって #793 の実バグは `-recursive` の欠落だけで、glob 側の変更は不要。

この意味論は `terraform-fmt-check` のコメントに残した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
