### PR TITLE
docs: #797 GCP プロジェクト ID を秘匿対象にしない判断を ADR-0075 に残す

### DIFF
--- a/.claude/rules/gcp-guardrails.md
+++ b/.claude/rules/gcp-guardrails.md
@@ -8,6 +8,8 @@ paths:
 
 Claude Code から Google Cloud（project `ptiringo-toy-box`）を扱うときの安全な既定。auto mode（bypassPermissions / acceptEdits）でも副作用ある操作が無確認で走らないようにする。決定経緯は [ADR-0036](../../docs/adr/0036-gcp-operation-guardrails.md)。
 
+プロジェクト ID は**秘匿対象にしない**（利用者の ID トークンとログイン画面が既に配っており隠す効果が無い）。逆に請求先アカウント ID のような未開示の識別子は書かず、変数名で参照する（[ADR-0075](../../docs/adr/0075-gcp-project-id-not-a-secret.md)）。
+
 ## 2 層のガードレール
 
 役割は**非対称**: **permissions＝強制**（アイデンティティ非依存で無確認変更を止める）、**viewer SA＝安全な既定＋多層防御**（owner は IAM でハード強制できない）。

--- a/docs/adr/0075-gcp-project-id-not-a-secret.md
+++ b/docs/adr/0075-gcp-project-id-not-a-secret.md
@@ -1,0 +1,57 @@
+# 0075. GCP プロジェクト ID は秘匿対象にせず、識別子の扱いは開示済みかどうかで分ける
+
+- Status: Accepted
+- Date: 2026-08-16
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+[ADR-0074](0074-billing-guardrails-spend-cap-and-budget-alert.md) の作業中に、「攻撃面を減らすため GCP プロジェクト ID（`ptiringo-toy-box`）をリポジトリから消したい」という検討が持ち上がった。公開リポジトリに本番プロジェクトの識別子が平文で並んでいる状態は、直感的には落ち着かない。
+
+一方で同じ作業で、**請求先アカウント ID は ADR の記述から削除し、HCP Terraform の workspace 変数 `billing_account_id` を出所とする**扱いに変えた。同じ「GCP の識別子」でありながら逆の判断をしており、その線引きがどこにも書かれていない。放置すると同じ検討が再燃する。
+
+### プロジェクト ID は原理的に秘匿できない
+
+消したところで、動いているシステムが利用者へ配っている。
+
+- **ID トークンに入っている**。`src/main/resources/application.yml` の OAuth2 リソースサーバ設定は `issuer-uri: https://securetoken.google.com/${GCP_PROJECT_ID}` / `audiences: ${GCP_PROJECT_ID}`（[ADR-0064](0064-authn-via-identity-platform-authz-in-app.md)）。ログインした利用者は全員、自分の JWT の `iss` / `aud` としてプロジェクト ID を受け取っている。
+- **ログイン画面がブラウザへ配信している**。`frontend/src/auth/firebase.ts` の `authDomain` は `<project-id>.firebaseapp.com`。値はリポジトリではなく env（`VITE_FIREBASE_AUTH_DOMAIN`）由来だが、Vite のビルド成果物に埋め込まれてブラウザに届くため、リポジトリから消しても利用者からは見える。
+- **公開リポジトリの org 名とリポジトリ名から推測できる**。実際 `ptiringo` / `toy-box` の連結そのものである。
+
+（Cloud Run の URL に現れるのはプロジェクト**番号**でプロジェクト ID とは別値だが、「プロジェクトを指す識別子はエンドポイントに露出する」という点では同じ性質を持つ。）
+
+### 知られても攻撃者にできることが増えない
+
+プロジェクト ID は IAM の宛先を指す識別子であって認証 material ではない。API を叩くには結局 IAM で認可されたアイデンティティが要る。Google 自身も秘密として扱っておらず、API レスポンスにも URL にも現れる。
+
+### 消すコストは実在する
+
+`ptiringo-toy-box` はリポジトリ内に 17 行 / 9 ファイル存在する（このファイルを除く。うち 6 行は ADR 本文の記述で、残りが実配線）。
+
+| 種別 | ファイル |
+| --- | --- |
+| infra | `infra/main.tf` / `infra/providers.tf` / `infra/modules/identity-platform/variables.tf` |
+| CI/CD | `.github/workflows/deploy.yml` |
+| frontend | `frontend/src/pages/LoginPage.tsx`（ログイン画面の表示文字列） |
+| 指示ファイル | `.claude/rules/gcp-guardrails.md` |
+| ADR | `0036` / `0064` / `0074` |
+
+消すには workflows の repository variable 化・HCP 変数の追加・frontend の env 配線が要り、deploy の回帰リスクを負う。加えて SA メール（`deployer@ptiringo-toy-box.iam.gserviceaccount.com` 等）と Firebase ドメインは ID を部分文字列として含むため、機械的な置換では消えない。security by obscurity の対価としては見合わない。
+
+## Decision（決定）
+
+**GCP プロジェクト ID（`ptiringo-toy-box`）を秘匿対象として扱わない。** リポジトリ・ADR・rules に平文で書いてよく、消す作業は行わない。
+
+**識別子を書くかどうかは「動いているシステムが既に開示しているか」で決める。**
+
+- **開示済みの識別子は書く**（プロジェクト ID、Cloud Run の URL、SA のメールアドレス）。隠す効果が無く、隠すコストだけが残るため。
+- **未開示の識別子は書かない**（請求先アカウント ID）。誰にも配っていない値は、出さない選択にコストがかからない。出所は HCP Terraform の workspace 変数などリポジトリ外に置き、ドキュメントからは変数名で参照する。
+
+秘密（API キー・トークン・認証情報）はこの線引き以前の問題として、いずれもリポジトリに置かない（[ADR-0004](0004-secrets-fnox-1password.md)）。
+
+## Consequences（結果・影響）
+
+- プロジェクト ID を隠す作業（workflows の variable 化・frontend の env 配線）を行わないので、deploy 経路に手を入れずに済む。ドキュメントは実値を書けるため、コマンド例をそのまま貼れる状態が保たれる。
+- 攻撃面の削減は識別子の秘匿ではなく、**権限と監査**で行う。ローカルは最小権限 viewer SA の impersonation に限定し（[ADR-0036](0036-gcp-operation-guardrails.md)）、変更は正規ルート（GitHub Actions / HCP Terraform run）へ寄せる。実際の施策は #472（blast radius 縮小）/ #473（Cloud Audit Logs）/ #475（viewer SA impersonation の env 配線）で追う。
+- 「開示済みかどうか」という線引きは判断を要する。新しい識別子を書くときは、それが利用者・ブラウザ・エンドポイントのいずれかに露出しているかを確認する。露出していないなら書かない。
+- プロジェクト ID が公開前提である以上、**IAM の設定ミスがそのまま攻撃面になる**。プロジェクトを特定する手間が攻撃者側のコストとして期待できないため、権限側の緩みは identifier の秘匿では埋め合わせできない。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -84,3 +84,4 @@
 | [0072](0072-idempotency-key-header-trial.md) | Idempotency-Key ヘッダを 1 エンドポイントで試作する | Accepted |
 | [0073](0073-mcp-adapter-local-only-world-scoped.md) | MCP アダプタを local プロファイル限定の世界スコープ探索ツールとして再導入する | Accepted |
 | [0074](0074-billing-guardrails-spend-cap-and-budget-alert.md) | 課金ガードレールを Cloud Run spend cap（手設定）と budget alert（Terraform）の二段構えにする | Accepted |
+| [0075](0075-gcp-project-id-not-a-secret.md) | GCP プロジェクト ID は秘匿対象にせず、識別子の扱いは開示済みかどうかで分ける | Accepted |


### PR DESCRIPTION
## 概要

Closes #797

#700 / [ADR-0074](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0074-billing-guardrails-spend-cap-and-budget-alert.md) の作業中に持ち上がった「攻撃面を減らすため GCP プロジェクト ID をリポジトリから消すか」の検討を **追わない** と決めた判断が、どこにも記録されていなかった。同じ検討が再燃しないよう ADR に起こす。ドキュメントのみの変更で、コードや設定の挙動は変わらない。

## 変更内容

### `docs/adr/0075-gcp-project-id-not-a-secret.md`（新規）

決定は 2 つ。

1. **プロジェクト ID（`ptiringo-toy-box`）を秘匿対象として扱わない**
2. **識別子を書くかどうかは「動いているシステムが既に開示しているか」で決める** — 開示済み（プロジェクト ID・Cloud Run URL・SA メール）は書く、未開示（請求先アカウント ID）は書かず変数名で参照する

根拠は執筆時に実測して裏を取った。

- **ID トークンに入っている**: `src/main/resources/application.yml:49-50` の `issuer-uri: https://securetoken.google.com/${GCP_PROJECT_ID}` / `audiences: ${GCP_PROJECT_ID}`。ログインした利用者は全員 JWT の `iss` / `aud` として受け取っている
- **ブラウザへ配信している**: `frontend/src/auth/firebase.ts:7` の `authDomain`（`<project-id>.firebaseapp.com`）。値は env 由来だが Vite のビルド成果物に埋め込まれて届くため、リポジトリから消しても利用者からは見える
- **消すコストが実在する**: リポジトリ内 17 行 / 9 ファイル（うち 6 行は ADR 本文）。SA メールと Firebase ドメインは ID を部分文字列として含むため機械置換では消えない

Issue 本文の「16 箇所 / 9 ファイル」との差は、起票後に追加された ADR-0074 の記述分。

Issue の依頼どおり、攻撃面を実際に削る施策（#472 / #473 / #475）への導線も Consequences に張った。ADR-0036 の追補ではなく新規 ADR にしたのは、ADR は確定した過去の記録であり後から書き換えない方針（`/adr` スキル）に従ったため。

### `docs/adr/README.md`

索引に 0075 を 1 行追加。

### `.claude/rules/gcp-guardrails.md`

この rules 自身がプロジェクト ID を平文で書いているため、その理由が辿れるよう冒頭に線引きの 1 行と ADR-0075 へのリンクを足した。

## 確認したこと

- ADR 連番は `git ls-tree --name-only origin/main docs/adr/` で確認（最大 0074 → 0075）
- editorconfig-checker（`ec`）を 3 ファイルに実行して通過
- pre-commit / pre-push 通過（Kotlin 変更が無いため `full-test` は UP-TO-DATE）
