### PR TITLE
docs: #765 #687 で判明した規約知見を .claude/rules へ書き戻す

### DIFF
--- a/.claude/rules/api-design.md
+++ b/.claude/rules/api-design.md
@@ -105,6 +105,14 @@ VO で表す項目（番号・名前など）は素の文字列で DTO に受け
 | URL パス上の操作対象が不在 | **404 Not Found** | パスで識別される対象そのものが無い | `/api/worlds/{worldId}/bloodHorses/{id}:registerName` の対象馬不在（`HorseNotFound`）、`BreedingResultNotFound` |
 | リクエストボディ内で参照する別リソースが不在 | **422 Unprocessable Entity** | リクエストは構文的に正しく処理されたが、ボディ内参照先が無く意味的に処理できない | `SireNotFound` / `DamNotFound`（`sire_id` / `dam_id`）、`BreedingRegistrationNotFound` |
 
+- **`error_code`（= `type` の URN 末尾）は 404 と 422 で共用しない**。同じリソースの不在でも、パス上の対象不在（404）とボディ内参照先不在（422）には別の値を割り当てる。同一 type が両方のステータスを持つと、クライアント側の場合分けが濁るため。命名の型は **ボディ参照は限定語・パス対象は一般語**。
+
+  | リソース | 404（パス上の対象不在） | 422（ボディ内参照先不在） |
+  |---|---|---|
+  | 軽種馬 | `horse-not-found` | `blood-horse-not-found` |
+  | 繁殖登録 | `registration-not-found` | `breeding-registration-not-found` |
+
+- **逆に、ステータスも意味も同じ不在は発生箇所ごとに割らず共用する**（照会の対象不在と馬名登録のパス対象不在はどちらも `horse-not-found` で、`detail` だけ変える）。クライアントから見た分類軸を 1 つに保つのが狙いで、割る基準は「発生箇所が違うか」ではなく「ステータスと意味が違うか」。
 - VO 検証エラー（形式不正）は入力不正として **400 Bad Request**、状態の競合（二重登録等）は **409 Conflict** とする。
 - なお [AIP-193](https://google.aip.dev/193) は参照先/親の不在に `NOT_FOUND`（404）を must とし、その error code 体系に 422 は存在しない。本プロジェクトはエラーのステータス選択を AIP の管轄外とし、RFC 9457 側で 422 を採る（リソース設計は AIP / エラー描画は RFC 9457 の二系統使い分け）。詳細は ADR-0021。
 - 経緯は [ADR-0018](../../docs/adr/0018-uncovered-via-discriminated-single-create.md)（基準の確立）と [ADR-0021](../../docs/adr/0021-parent-not-found-unprocessable-entity.md)（父母不在への適用・AIP との対比）を参照。

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -130,6 +130,21 @@ mise exec -- diff-cover build/reports/kover/reportMature.xml \
 
 `--src-roots src/main/kotlin` は必須（省略するとソースパスを解決できずレポートが空になる）。
 
+**診断メッセージのラムダを単独行に折らない**（ktfmt × diff-cover）。`checkNotNull(x) { "診断メッセージ" }` のように正常系では通らない分岐へメッセージのラムダを添えるとき、ktfmt が行長の都合でラムダ本体を単独行へ折ると、**壊れたデータでしか実行されない行が独立した行として計上され、常に未カバーになる**。列は先にローカル変数へ取り出し、`checkNotNull` の呼び出しごと 1 行に収めること（先例: `JdbcBloodHorseQueries.toOrigin()`）。
+
+```kotlin
+// 悪い例: ラムダ本体が単独行に折られ、その行が常に未カバーになる
+sireId = BloodHorseId(checkNotNull(getObject("sire_id", UUID::class.java)) {
+    "内国産の父IDが欠落: id=$id"
+})
+
+// 良い例: 列を先に取り出し、checkNotNull の呼び出しごと 1 行に収める
+val sire = getObject("sire_id", UUID::class.java)
+sireId = BloodHorseId(checkNotNull(sire) { "内国産の父IDが欠落: id=$id" })
+```
+
+[#687](https://github.com/ptiringo/toy-box/issues/687) では読み取り経路（`JdbcBloodHorseQueries` / `JdbcBreedingRegistrationQueries` / `JdbcBreedingResultQueries`）の NULL 診断がこの形で折られ、差分カバレッジが **89%** まで落ちて `--fail-under 90` を割った。1 行に収め直して **98%** へ回復している。同じ診断を持つ書き込み側（`JdbcBloodHorseRepository`）が 100% だったのは、たまたま 1 行に収まっていたからで設計の差ではない。**同じコードでも整形結果でゲートの通過可否が変わる**のが要点。
+
 ### 実行
 
 ```bash


### PR DESCRIPTION
## 概要

Closes #765

#687（PR #763）の作業で出た規約知見 2 つは、該当箇所の KDoc / コードコメントにしか残っていなかった。**別のファイルで同じ形を書く人は気づけない**ため、`.claude/rules` へ書き戻す。ドキュメントのみの変更で、コードの挙動は変わらない。

## 変更内容

### `.claude/rules/testing.md`（差分ゲート節）

「診断メッセージのラムダを単独行に折らない」（ktfmt × diff-cover）を追記した。

`checkNotNull(x) { "診断メッセージ" }` のように正常系では通らない分岐へメッセージのラムダを添えると、ktfmt が行長の都合でラムダ本体を単独行へ折り、**壊れたデータでしか実行されない行が独立した行として計上されて常に未カバーになる**。悪い例／良い例のコード片を添え、列を先にローカル変数へ取り出して呼び出しごと 1 行に収める形を示した。

実測（#687）: 読み取り経路の NULL 診断がこの形で折られて差分カバレッジが 89% まで落ち、`--fail-under 90` を割った。1 行に収め直して 98% へ回復。同じ診断を持つ書き込み側（`JdbcBloodHorseRepository`）が 100% だったのはたまたま 1 行に収まっていたからで、設計の差ではない。**同じコードでも整形結果でゲートの通過可否が変わる**のが要点。

### `.claude/rules/api-design.md`（リソース不在のステータス（404 vs 422）節）

`error_code`（= `type` の URN 末尾）の割り当て原則を追記した。既存の節はステータスの選び方だけを書いており、`error_code` をどう割るかは書かれていなかった。

- **404 と 422 で type を共用しない**（同一 type が両方のステータスを持つとクライアント側の場合分けが濁る）。命名の型は「ボディ参照は限定語・パス対象は一般語」。実装済みの 2 リソースを表で示した。
- **逆に、ステータスも意味も同じ不在は発生箇所ごとに割らず共用する**（照会と馬名登録のパス対象不在はどちらも `horse-not-found`）。割る基準は「発生箇所が違うか」ではなく「ステータスと意味が違うか」であることを明示した。

## 裏取り

追記した内容が現行実装と一致することを確認済み。

| 記述 | 実装 |
| --- | --- |
| 404 = `horse-not-found` | `BloodHorseProblem.kt:283`（照会）/ `:58`（馬名登録） |
| 422 = `blood-horse-not-found` | `BreedingRegistrationProblem.kt:44` |
| 404 = `registration-not-found` | `BreedingRegistrationProblem.kt:63` |
| 422 = `breeding-registration-not-found` | `BreedingResultProblem.kt:74` / `:165` |
| 1 行に収めた `checkNotNull` | `JdbcBloodHorseQueries.kt:108-114`（コメントごと現物と一致） |

## 検証

- pre-commit: editorconfig-check / gitleaks 通過（Markdown のみのため他の lint は対象外）
- pre-push: `.kt/.kts/.java` の glob には当たらないが実行され、`./gradlew test` BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
