### PR TITLE
docs: #776 copilot-instructions のツール導入手順と実態の乖離を解消する

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,216 +1,121 @@
-# GitHub Copilot グローバル指示 (Global Instructions)
+# GitHub Copilot 向けリポジトリ指示
 
-## 基本方針（Basic Guidelines）
+## このファイルの位置づけ
 
-### 言語とスタイル（Language and Style）
-- **コメントとドキュメントは日本語で記述してください**
-- 変数名、関数名、クラス名は英語で記述し、意味が明確になるようにしてください
-- コードの説明やドキュメンテーションコメントは日本語で詳細に記述してください
-- コミットメッセージも日本語で記述してください
+**規約の出所はこのファイルではない。** 詳細を再掲せず、出所へのリンクで辿らせる。
 
-## ツール管理（Tool Management）
+| 対象 | 出所 |
+| --- | --- |
+| 全体方針・開発コマンド・ツール管理 | [CLAUDE.md](../CLAUDE.md) |
+| 領域別の規約（アーキテクチャ / テスト / API 設計 / エラー / マイグレーション / Terraform 等） | [.claude/rules/](../.claude/rules/) |
+| 決定の経緯 | [docs/adr/](../docs/adr/) |
+| ツールとそのバージョン | [mise.toml](../mise.toml) |
+| Git フックの内容 | [lefthook.yml](../lefthook.yml) |
+| セットアップ手順 | [README.md](../README.md) |
 
-### mise によるツール管理
-このリポジトリでは **mise** を使用してプロジェクトで必要なツールを管理しています：
+ここに手順やバージョンを書き写すと二重管理になり、出所が更新されても追従せず乖離する（実際に
+lefthook の手動導入手順が `mise.toml` と食い違ったまま残っていた。#776）。**このファイルを増やす前に、
+出所側へ書いてここからリンクできないかを先に検討すること。**
 
-- **設定ファイル**: `mise.toml` にプロジェクトで使用するツールとバージョンを定義
+## 言語とスタイル
 
-### 開発者向け mise 使用方法
-- **ツールのインストール**: `mise install` コマンドで定義されたツールを一括インストール
-- **ツールの確認**: `mise list` コマンドで現在インストールされているツールを確認
-- **自動有効化**: プロジェクトディレクトリに入ると自動的に適切なバージョンのツールが有効化されます
+- **コメント・ドキュメントは日本語**、**識別子（変数・関数・クラス名）は英語**で書く。
+- **コミットメッセージは日本語・Conventional Commits 形式**（`feat: 新機能を追加`）。commit-msg フックが検査する。
+- 命名は Kotlin 標準に従う（ktfmt / detekt が強制する）。
 
-### CI/CD での mise 使用
-GitHub Actionsワークフローでも mise を使用してツール管理の一貫性を保っています。
-新しいツールを追加する際は `mise.toml` ファイルを更新してください。
-
-## 命名規則とコード構成（Naming Conventions and Code Organization）
-
-### 命名規則
-- **クラス名**: PascalCase（例: UserService, OrderHandler）
-- **関数名**: camelCase（例: createUser, validateInput）
-- **定数**: UPPER_SNAKE_CASE（例: MAX_RETRY_COUNT）
-- **プロパティ**: camelCase（例: userId, emailAddress）
-
-## EditorConfig 準拠（EditorConfig Compliance）
-
-### ファイル形式の遵守
-- **全てのファイルはEditorConfigの設定に従う必要があります**
-- `.editorconfig` ファイルで定義された以下の設定を厳密に守ってください：
-  - `end_of_line = lf`: 改行コードはLF（Unix形式）を使用
-  - `insert_final_newline = true`: ファイル末尾に必ず改行を挿入
-  - `trim_trailing_whitespace = true`: 行末の空白文字を削除
-  - `charset = utf-8`: UTF-8エンコーディングを使用
-- **マークダウンファイルの特例**: `*.md` ファイルでは行末空白の削除は無効（`trim_trailing_whitespace = false`）
-
-### CI/CDでの自動チェック
-- EditorConfig Checkがプルリクエスト時に自動実行されます
-- 違反があると自動的にエラーとなるため、コミット前に必ず確認してください
-- ローカルでの事前チェックを推奨します
-
-## Pre-commit Hooks with Lefthook
-
-このプロジェクトでは Lefthook を使用した pre-commit hooks を導入しています。
-
-### セットアップ
-
-プロジェクトをクローンした後、以下のコマンドで git hooks をインストールしてください：
+## セットアップ
 
 ```bash
-lefthook install
+mise bootstrap      # mise.toml 記載のツールを導入し、続けて Git フック（lefthook）を有効化
+mise list           # 導入済みツールの確認
 ```
 
-### 実行される検証項目
+**ツールを手動で導入しない**（`apt` / `wget` / 個別のインストーラ）。バージョンの出所は `mise.toml` 一つで、
+手動導入は手元と CI で挙動が食い違う原因になる。新しいツールが要るときは `mise.toml` に足す。
 
-#### pre-commit
+## アーキテクチャ（最重要）
 
-コミット前に以下の検証が自動実行されます：
+**Spring MVC + Virtual Thread を採用し、リアクティブ流派は採らない**（[ADR-0002](../docs/adr/0002-virtual-thread-over-reactive.md)）。
 
-1. **EditorConfig チェック** - `.editorconfig` の設定に準拠しているかチェック
-2. **API テスト** - 変更されたKotlinファイルに関連するテストの実行
+- **WebFlux / Reactor / coroutine を導入しない。** `suspend` / `Mono` / `Flux` を使ったコードを提案しない。
+  ブロッキング IO は Virtual Thread 上で走るので、**同期コードで素直に書く**。
+- 永続化は **Spring Data JDBC + PostgreSQL**（R2DBC ではない。[ADR-0027](../docs/adr/0027-persistence-spring-data-jdbc.md) /
+  [ADR-0030](../docs/adr/0030-jdbc-only-persistence-retire-inmemory.md)）。
+- オニオンアーキテクチャの 4 リング（domainModel / domainService / applicationService / adapter）と
+  境界づけられたコンテキストで構成する。各リングの責務・依存方向・パターン（Value Object / Entity /
+  Command / Domain Event / 軽量 CQRS）は [.claude/rules/architecture.md](../.claude/rules/architecture.md) が出所。
+- **これらの規約は ArchUnit + jMolecules と detekt カスタムルールで機械強制されており、違反すると
+  `./gradlew check` が落ちる。**
 
-#### pre-push
+### ディレクトリ
 
-プッシュ前に全体のテストスイートが実行されます。
+| パス | 内容 |
+| --- | --- |
+| `src/main/kotlin/com/example/api/` | API 本体（`domain` / `application` / `controller` / `infrastructure` / `mcp` / `config`） |
+| `src/main/resources/db/migration/` | Flyway マイグレーション（規約は [.claude/rules/migrations.md](../.claude/rules/migrations.md)） |
+| `detekt-rules/` | プロジェクト固有の detekt カスタムルール |
+| `frontend/` | Vite + React の SPA |
+| `infra/` | Terraform 構成（規約は [.claude/rules/terraform.md](../.claude/rules/terraform.md)） |
 
-#### commit-msg
-
-コミットメッセージが conventional commit 形式に準拠しているかチェックします。
-
-### 手動実行
-
-フックを手動で実行したい場合：
+## ビルドと検証
 
 ```bash
-# 全ての pre-commit hooks を実行
-lefthook run pre-commit
-
-# 特定のコマンドのみ実行
-lefthook run pre-commit api-test
+./gradlew build
+./gradlew test
+./gradlew check     # ktfmt + detekt + test + koverVerifyMature を一括
+./gradlew bootRun
 ```
 
-### フックのスキップ
+**Kotlin の変更は `test` ではなく `check` で締める。** ArchUnit の規約テスト・detekt カスタムルール・
+カバレッジゲートは focused なテスト実行では走らない。
 
-緊急時にフックをスキップしたい場合：
+## テスト
+
+記法も戦略も [.claude/rules/testing.md](../.claude/rules/testing.md) が出所。要点だけ:
+
+- **JUnit 5**（`org.junit.jupiter.api.Test`）を使う。`kotlin.test.Test` は使わない。
+- **アサーションは Kotlin 標準の `assert` 関数**（Power Assert が式を分解して表示する）。
+- **Controller の slice テストは `@WebMvcTest` + `MockMvcTester`**（`@WebFluxTest` / `WebTestClient` ではない）。
+- **モックは applicationService の Repository ポート境界に限る。** ドメイン層は Fixture で実物を組む。
+- テストケース名は日本語で意図を表す。
+- DB を要する層は Testcontainers（PostgreSQL）を使う。
+
+## Git フック（lefthook）
+
+内容の出所は [lefthook.yml](../lefthook.yml)。**個々のコマンド名はそちらを見る**（ここで一覧すると増減に追従できない）。
+
+- **pre-commit**: シークレット検査・EditorConfig・各種 lint / フォーマットチェック（Kotlin / frontend /
+  Terraform / SQL / シェル / ワークフロー / 設定ファイル）。対象ファイルを含まないコミットでは該当フックがスキップされる。
+- **pre-push**: 全テスト。Testcontainers を使うため Docker を要求し、到達できなければテスト起動前に
+  理由つきで落とす（[ADR-0071](../docs/adr/0071-pre-push-docker-fail-fast-guard.md)）。
+- **commit-msg**: Conventional Commits 形式の検査（マージコミットは除外）。
 
 ```bash
-# pre-commit hooks をスキップしてコミット
-git commit --no-verify -m "緊急修正"
-
-# 特定のコマンドをスキップ
-LEFTHOOK_EXCLUDE=api-test git commit -m "テストをスキップしてコミット"
+lefthook run pre-commit                 # 手動で一括実行
+LEFTHOOK_EXCLUDE=<name> git commit      # 個別フックのスキップ（<name> は lefthook.yml のコマンド名）
 ```
 
-### トラブルシューティング
+フックが動かないときは `mise bootstrap`（または `lefthook install`）で張り直す。
 
-#### Lefthook がインストールされていない場合
+## フォーマット
 
-```bash
-# Ubuntu/Debian
-curl -1sLf 'https://dl.cloudsmith.io/public/evilmartians/lefthook/setup.deb.sh' | sudo -E bash
-sudo apt install lefthook
+`.editorconfig` が出所（`end_of_line = lf` / `insert_final_newline = true` /
+`trim_trailing_whitespace = true` / `charset = utf-8`。`*.md` は行末空白の削除が無効）。
+editorconfig-checker が pre-commit と CI の両方で強制する。
 
-# または直接ダウンロード
-wget "https://github.com/evilmartians/lefthook/releases/download/v1.10.0/lefthook_1.10.0_Linux_x86_64" -O lefthook
-chmod +x lefthook && sudo mv lefthook /usr/local/bin/
-```
+Kotlin は ktfmt、設定ファイル（TOML / JSON / YAML）は dprint、frontend は Biome が整形する。
 
-#### hooks が実行されない場合
+## CI/CD（GitHub Actions）
 
-```bash
-# hooks を再インストール
-lefthook install
+- **アクションは完全なコミット SHA に固定する**（タグ参照にしない）。
+- **ジョブには `timeout-minutes` を必ず指定する**。
+- ワークフローは actionlint（lint）と zizmor（セキュリティ監査）が pre-commit と CI で検査する。
 
-# hooks の状態を確認
-lefthook version
-git config --list | grep hook
-```
+## セキュリティ
 
-# API開発専用指示 (API Development Instructions)
-
-## プロジェクト構造（Project Structure）
-このディレクトリはKotlin Spring Boot WebFluxを使用したAPIプロジェクトです：
-- `api/` ディレクトリにメインのAPIコードが含まれています
-- Gradle Kotlin DSLを使用してビルド設定を管理しています
-- WebFluxとコルーチンを使用した非同期プログラミングを採用しています
-
-## セキュリティベストプラクティス（Security Best Practices）
-
-### コード提案時の考慮事項
-- **入力値検証**: 全ての外部入力に対して適切な検証を実装してください
-- **SQLインジェクション対策**: データベースクエリではパラメータ化クエリを使用してください
-- **機密情報の保護**: API キー、パスワード、その他の機密情報をハードコーディングしないでください
-- **ログ出力**: 機密情報をログに出力しないよう注意してください
-
-## パフォーマンスと保守性（Performance and Maintainability）
-
-### パフォーマンス指針
-- **非同期処理**: WebFluxとコルーチンを活用した非ブロッキング処理を推奨します
-- **効率的なデータ処理**: Streamやシーケンスを適切に使用してメモリ効率を考慮してください
-- **キャッシュ戦略**: 適切な場所でキャッシュの実装を提案してください
-- **データベース最適化**: N+1問題の回避やクエリ最適化を考慮してください
-
-### コード品質と保守性
-- **単一責任原則**: 各クラス・関数は単一の責任を持つよう設計してください
-- **依存性注入**: Spring DIコンテナを適切に活用してください
-- **イミュータブル設計**: 可能な限りデータクラスをimmutableに設計してください
-- **関数型プログラミング**: Kotlinの関数型機能を活用してください
-
-## テスト開発（Testing Development）
-
-### Spring Boot テスト
-- **@SpringBootTest**: 統合テストでアプリケーションコンテキスト全体をテストする場合に使用
-- **@WebFluxTest**: WebFluxコントローラーの単体テストに使用
-- **@DataR2dbcTest**: R2DBCリポジトリのテストに使用
-- **TestContainers**: データベースなど外部リソースが必要な場合は積極的に活用
-
-### テストアノテーション（Test Annotations）
-- **JUnit5アノテーションの使用**: テストメソッドには `org.junit.jupiter.api.Test` アノテーションを使用してください
-- **kotlin.test.Testは使用禁止**: マルチプラットフォーム対応が不要なため、JUnit5の機能を積極的に活用します
-- **JUnit5拡張機能の活用**: `@Nested`、`@ParameterizedTest`、`@BeforeEach`、`@AfterEach` などの機能を積極的に使用してください
-
-### アサーション方法（Assertion Methods）
-- **Kotlin assert関数の優先利用**: 単体テストでは kotlin.test パッケージのアサーション関数ではなく、Kotlin 標準の `assert` 関数（Power Assert）を優先的に使用してください
-- **Power Assertの利点**: 詳細なデバッグ情報が自動的に生成され、テスト失敗時の原因特定が容易になります
-- **適切な使い分け**: 
-  - 単体テスト: `assert` 関数を使用
-  - 統合テスト（WebFlux）: `WebTestClient` のアサーションメソッドを使用
-  - 特定のフレームワークテスト: そのフレームワークに適したアサーション方法を使用
-
-## ドキュメンテーション（Documentation）
-
-### ドキュメンテーション標準（Documentation Standards）
-
-#### コメント記述
-- **KDoc**: パブリックなAPI要素にはKDocコメントを必ず記述してください
-- **複雑なロジック**: 複雑なビジネスロジックには日本語で詳細な説明を追加してください
-- **TODO/FIXME**: 将来の改善点や既知の問題を明記してください
-
-#### API ドキュメント
-- **OpenAPI/Swagger**: REST API の仕様書は自動生成を活用してください
-- **エンドポイント説明**: 各エンドポイントの目的、パラメータ、レスポンス例を明記してください
-- **エラーハンドリング**: 想定されるエラーケースとその対処法を文書化してください
-
-# テスト開発専用指示 (Testing Development Instructions)
-
-## テスト指針（Testing Guidelines）
-
-### ユニットテスト
-- **テストケース命名**: 日本語でテストの意図を明確に表現してください
-- **テストデータ**: 意味のあるテストデータを使用してください
-- **モック使用**: 外部依存をモックして単体テストの独立性を保ってください
-- **例外テスト**: 正常系だけでなく異常系のテストも実装してください
-
-### テストコード品質
-- **可読性**: テストコードは仕様書の役割も果たすため、意図が明確に伝わるように記述してください
-- **保守性**: テスト対象コードの変更に対して適切に追従できるよう、疎結合なテスト設計を心がけてください
-- **独立性**: テスト間の依存関係を排除し、単独で実行可能なテストを作成してください
-
-# CI/CD
-
-## GitHub Actions
-- CI/CD には GitHub Actions を利用してください。
-
-### ワークフローファイル
-- アクションを完全なコミット SHA に固定してください。
-- ジョブには timeout-minutes を必ず指定してください。
+- **シークレットをコミットしない**（gitleaks が pre-commit で検査する）。ローカル開発のシークレットは
+  平文で export せず 1Password + fnox 経由で渡す（[ADR-0004](../docs/adr/0004-secrets-fnox-1password.md)）。
+- **API キー・パスワードをハードコードしない。機密情報をログへ出さない。**
+- SQL はパラメータ化クエリを使う。外部入力は検証する（エラー描画の規約は
+  [.claude/rules/error-handling.md](../.claude/rules/error-handling.md)）。
+- **GitHub 操作は MCP ではなく `gh` CLI で行う**（[ADR-0001](../docs/adr/0001-drop-github-mcp-use-gh-cli.md)）。


### PR DESCRIPTION
## 概要

Closes #776

`.github/copilot-instructions.md` を **リンク委譲型へ再構成**した（216 行 → 121 行、`-178 / +83`）。

Issue が挙げていた「lefthook のツール導入手順が実態から乖離している」を直すために全体を読んだところ、
**ツール導入手順以外にも実態と真逆の記述が複数あった**ため、Issue の「ついでにファイル全体を棚卸しし、
他にも実態と乖離した記述がないか確認する」に沿ってまとめて訂正している。

## 直した乖離（すべて実測で確認）

| 箇所 | 旧記述 | 実態 |
| --- | --- | --- |
| アーキテクチャ | 「Kotlin Spring Boot **WebFlux**」「**WebFlux とコルーチン**を使用した非同期プログラミングを採用」 | Spring MVC + Virtual Thread。リアクティブ流派は**採らない**（[ADR-0002](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0002-virtual-thread-over-reactive.md)） |
| ディレクトリ | 「**`api/` ディレクトリ**にメインの API コードが含まれています」 | `api/` は存在しない（`src/main/kotlin/com/example/api/`） |
| テスト | `@WebFluxTest` / `WebTestClient` / `@DataR2dbcTest` | `@WebMvcTest` + `MockMvcTester`、永続化は Spring Data JDBC |
| フック | `lefthook run pre-commit **api-test**` / `LEFTHOOK_EXCLUDE=**api-test**` | `lefthook.yml` に `api-test` というコマンドは無い |
| ツール導入 | `curl`/`apt`/`wget` で lefthook を手動導入（**v1.10.0 固定**） | `mise bootstrap` 一本。`mise.toml` の lefthook は **2.1.9** |
| セットアップ | `mise install` → `lefthook install` の二段（2 箇所） | `mise bootstrap` 一本（#396 / PR #772 で統合済み） |

とくに上 3 つは、Copilot coding agent がこのファイルをカスタム指示として読む以上、
**リアクティブなコード（`suspend` / `Mono` / `Flux`）や R2DBC のテストを書いてくる**向きの誤誘導だった。
`./gradlew check` の ArchUnit / detekt カスタムルールが最終的には止めるが、指示ファイルの側が
規約と逆を向いているのは無駄な往復を生む。

## 方針: 詳細を再掲せずリンクで辿らせる

Issue の「記述の出所を増やさない方針に沿って、詳細を再掲せずリンクで辿らせる形に寄せられないか検討する」
を採った。冒頭に出所の表を置き、以降は要点だけ書いてリンクで委譲する。

| 対象 | 出所 |
| --- | --- |
| 全体方針・開発コマンド・ツール管理 | `CLAUDE.md` |
| 領域別の規約 | `.claude/rules/` |
| 決定の経緯 | `docs/adr/` |
| ツールとそのバージョン | `mise.toml` |
| Git フックの内容 | `lefthook.yml` |
| セットアップ手順 | `README.md` |

**再掲が今回の乖離そのものの原因**だった（lefthook のバージョンを書き写したせいで `mise.toml` の更新に
追従できず、`api-test` のようにフック名まで固定化していた）。pre-commit の検証項目一覧は増減が続くため
`lefthook.yml` を指すに留め、こちらで数えない形にしている。

## 追記したこと

- **`./gradlew check` で締める**（`test` だけでは ArchUnit / detekt カスタムルール / カバレッジゲートが走らない）
- **pre-push の Docker fail-fast ガード**（[ADR-0071](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0071-pre-push-docker-fail-fast-guard.md)）
- **モックの範囲**（applicationService の Repository ポート境界に限る。ドメイン層は Fixture で実物を組む）
- **シークレットは fnox + 1Password**（[ADR-0004](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0004-secrets-fnox-1password.md)）、**GitHub 操作は `gh` CLI**（[ADR-0001](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0001-drop-github-mcp-use-gh-cli.md)）

## 検証

- 相対リンク 17 本すべてについて実ファイル / ディレクトリの存在を確認（リンク切れなし）。リンク先はいずれも git 管理下
- `ec`（editorconfig-checker）が通ること、pre-commit（editorconfig-check / gitleaks）が緑であることを確認
- Kotlin の変更なしのため `./gradlew check` は不要（`.md` 1 ファイルのみ）

## 関連

- #776（この Issue）
- #396 / PR #772 onboarding を `mise bootstrap` 一本に統合
- [ADR-0002](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0002-virtual-thread-over-reactive.md) Virtual Thread を採りリアクティブを採らない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
