### PR TITLE
chore: #749 WorldsPage の粗さ（二重送信・空名・リンク表示・useParams の型）を直す

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -20,6 +20,7 @@ vi.mock("./worlds/useWorlds", () => ({
   useWorlds: () => ({
     worlds: [{ id: "w1", name: "はじまりの世界" }],
     loading: false,
+    busy: false,
     error: null,
     create: vi.fn(),
     rename: vi.fn(),

--- a/frontend/src/pages/BloodHorseListPage.test.tsx
+++ b/frontend/src/pages/BloodHorseListPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "../api/client";
 
 vi.mock("../auth/AuthContext", () => ({
@@ -23,23 +23,35 @@ import { BloodHorseListPage } from "./BloodHorseListPage";
 
 const apiGetMock = vi.mocked(apiGet);
 
-function renderPage() {
+// 呼び出し履歴はテストをまたいで積み上がるので、各テストの前に落とす（実装＝mockResolvedValue は残す）。
+beforeEach(() => {
+  apiGetMock.mockClear();
+});
+
+function renderAt(path: string) {
   useWorldsMock.mockReturnValue({
     worlds: [{ id: "w1", name: "はじまりの世界" }],
     loading: false,
+    busy: false,
     error: null,
     create: vi.fn(),
     rename: vi.fn(),
     remove: vi.fn(),
   });
   return render(
-    <MemoryRouter initialEntries={["/worlds/w1/bloodHorses"]}>
+    <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="/worlds/:worldId/bloodHorses" element={<BloodHorseListPage />} />
+        {/* ルート定義から :worldId が外れた場合を再現するための経路（App.tsx には無い）。 */}
+        <Route path="/bloodHorses" element={<BloodHorseListPage />} />
         <Route path="/worlds" element={<div>世界一覧ページ</div>} />
       </Routes>
     </MemoryRouter>,
   );
+}
+
+function renderPage() {
+  return renderAt("/worlds/w1/bloodHorses");
 }
 
 describe("BloodHorseListPage", () => {
@@ -84,6 +96,15 @@ describe("BloodHorseListPage", () => {
     });
     expect(screen.getByRole("link", { name: "世界一覧へ" })).toBeInTheDocument();
     expect(screen.getByTitle("直近レスポンス")).toHaveTextContent("404");
+  });
+
+  // useParams の worldId は型上 undefined になりうる。ルート定義が変わっても
+  // /api/worlds/undefined/... を叩かず世界一覧へ戻す。
+  it("worldId が無いパスでは API を叩かず世界一覧へ戻す", () => {
+    renderAt("/bloodHorses");
+
+    expect(screen.getByText("世界一覧ページ")).toBeInTheDocument();
+    expect(apiGetMock).not.toHaveBeenCalled();
   });
 
   it("失敗時はエラー banner とステータスを出す", async () => {

--- a/frontend/src/pages/BloodHorseListPage.tsx
+++ b/frontend/src/pages/BloodHorseListPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, Navigate, useParams } from "react-router-dom";
 import { ApiError, apiGet, errorMessage } from "../api/client";
 import { useAuth } from "../auth/AuthContext";
 import { breedLabels, coatColors, coatLabels, label, sexLabels } from "../labels";
@@ -18,7 +18,9 @@ type BloodHorseSummary = {
 };
 
 export function BloodHorseListPage() {
-  const { worldId } = useParams<{ worldId: string }>();
+  // 型引数で string に狭めない。react-router が返すのは string | undefined で、
+  // 現在のルート定義（/worlds/:worldId/bloodHorses の 1 経路のみ）に依存した嘘になるため。
+  const { worldId } = useParams();
   const { getToken, signOutUser } = useAuth();
   // 世界名は表示専用。取得に失敗しても名前を出さないだけで、アクセス可否の判断はしない
   // （それは API の 404 world-not-found が担う）。
@@ -29,6 +31,9 @@ export function BloodHorseListPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (worldId === undefined) {
+      return;
+    }
     let active = true;
     (async () => {
       try {
@@ -54,6 +59,11 @@ export function BloodHorseListPage() {
       active = false;
     };
   }, [getToken, worldId]);
+
+  // どの世界を見るか決まらないので原簿は描けない。世界一覧へ戻して選び直させる。
+  if (worldId === undefined) {
+    return <Navigate to="/worlds" replace />;
+  }
 
   return (
     <div className="ledger">

--- a/frontend/src/pages/WorldsPage.test.tsx
+++ b/frontend/src/pages/WorldsPage.test.tsx
@@ -32,6 +32,7 @@ function renderPage() {
 type WorldsStub = {
   worlds: { id: string; name: string }[];
   loading: boolean;
+  busy: boolean;
   error: string | null;
   create: ReturnType<typeof vi.fn>;
   rename: ReturnType<typeof vi.fn>;
@@ -42,6 +43,7 @@ function stubWorlds(overrides: Partial<WorldsStub> = {}): WorldsStub {
   const value: WorldsStub = {
     worlds: [{ id: "w1", name: "はじまりの世界" }],
     loading: false,
+    busy: false,
     error: null,
     create: vi.fn().mockResolvedValue(true),
     rename: vi.fn().mockResolvedValue(true),
@@ -95,6 +97,21 @@ describe("WorldsPage", () => {
     expect(value.rename).toHaveBeenCalledWith("w1", "改名後");
   });
 
+  // 空名はサーバが world-name-blank で弾くが、送る前に止めて作成側（required）と揃える。
+  it("空の名前では作成も改名もしない", async () => {
+    const value = stubWorlds();
+
+    renderPage();
+
+    await userEvent.click(screen.getByRole("button", { name: "作る" }));
+    expect(value.create).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: "改名" }));
+    await userEvent.clear(screen.getByLabelText("変更後の名前"));
+    await userEvent.click(screen.getByRole("button", { name: "保存" }));
+    expect(value.rename).not.toHaveBeenCalled();
+  });
+
   it("削除は確認してから実行し、取り消したら実行しない", async () => {
     const value = stubWorlds();
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
@@ -107,6 +124,18 @@ describe("WorldsPage", () => {
     confirmSpy.mockReturnValue(true);
     await userEvent.click(screen.getByRole("button", { name: "削除" }));
     expect(value.remove).toHaveBeenCalledWith("w1");
+  });
+
+  // 連打すると 2 本目が 409 の赤帯を出し、世界は 1 つできているのに失敗したように見える。
+  it("変更の実行中は作成・保存・削除を押せない", async () => {
+    stubWorlds({ busy: true });
+
+    renderPage();
+
+    expect(screen.getByRole("button", { name: "作る" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "削除" })).toBeDisabled();
+    await userEvent.click(screen.getByRole("button", { name: "改名" }));
+    expect(screen.getByRole("button", { name: "保存" })).toBeDisabled();
   });
 
   it("エラーがあれば alert で表示する", async () => {

--- a/frontend/src/pages/WorldsPage.tsx
+++ b/frontend/src/pages/WorldsPage.tsx
@@ -10,7 +10,7 @@ import { useWorlds } from "../worlds/useWorlds";
  */
 export function WorldsPage() {
   const { signOutUser } = useAuth();
-  const { worlds, loading, error, create, rename, remove } = useWorlds();
+  const { worlds, loading, busy, error, create, rename, remove } = useWorlds();
   const navigate = useNavigate();
   const [newName, setNewName] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -24,7 +24,8 @@ export function WorldsPage() {
     }
   };
 
-  const onSaveRename = async (worldId: string) => {
+  const onSaveRename = async (e: FormEvent, worldId: string) => {
+    e.preventDefault();
     if (await rename(worldId, editingName)) {
       setEditingId(null);
     }
@@ -66,24 +67,27 @@ export function WorldsPage() {
           {worlds.map((world) => (
             <li className="worlds__item" key={world.id}>
               {editingId === world.id ? (
-                <>
+                // 作成側と同じく form + required にする（required の検証は submit のときだけ走るので、
+                // ボタンの onClick で保存すると空名が素通りする）。
+                <form className="worlds__edit" onSubmit={(e) => void onSaveRename(e, world.id)}>
                   {/* 作成フォームの「新しい世界の名前」と紛れないラベルにする。 */}
                   <label className="field worlds__field">
                     <span>変更後の名前</span>
                     <input
                       value={editingName}
                       onChange={(e) => setEditingName(e.target.value)}
+                      required
                       // biome-ignore lint/a11y/noAutofocus: 改名ボタンから開いた入力に即入力できるようにする
                       autoFocus
                     />
                   </label>
-                  <button className="btn" type="button" onClick={() => void onSaveRename(world.id)}>
+                  <button className="btn" type="submit" disabled={busy}>
                     保存
                   </button>
                   <button className="btn-ghost" type="button" onClick={() => setEditingId(null)}>
                     やめる
                   </button>
-                </>
+                </form>
               ) : (
                 <>
                   <button
@@ -107,6 +111,7 @@ export function WorldsPage() {
                     className="btn-ghost"
                     type="button"
                     onClick={() => void onDelete(world.id, world.name)}
+                    disabled={busy}
                   >
                     削除
                   </button>
@@ -122,7 +127,8 @@ export function WorldsPage() {
           <span>新しい世界の名前</span>
           <input value={newName} onChange={(e) => setNewName(e.target.value)} required />
         </label>
-        <button className="btn" type="submit">
+        {/* 変更中は文言を変えず disabled だけにする（busy はどの操作でも立つので「作成中…」は嘘になりうる）。 */}
+        <button className="btn" type="submit" disabled={busy}>
           作る
         </button>
       </form>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -276,6 +276,7 @@ body {
   border-color: color-mix(in srgb, var(--danger) 55%, var(--line));
 }
 
+/* button だけでなく Link（アンカー）にも当てるので、リセット（button, input）が触らない下線をここで消す。 */
 .btn-ghost {
   padding: 0.35rem 0.75rem;
   background: transparent;
@@ -283,6 +284,7 @@ body {
   border: 1px solid var(--line);
   border-radius: var(--radius);
   font-size: 0.82rem;
+  text-decoration: none;
   transition:
     color 0.15s ease,
     border-color 0.15s ease;
@@ -464,6 +466,14 @@ body {
 .worlds__field {
   flex: 1;
   margin: 0;
+}
+
+/* 改名フォーム。行（.worlds__item）の flex を引き継ぎ、入力とボタンが 1 行に並ぶようにする。 */
+.worlds__edit {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .worlds__new {

--- a/frontend/src/worlds/useWorlds.test.ts
+++ b/frontend/src/worlds/useWorlds.test.ts
@@ -116,6 +116,82 @@ describe("useWorlds", () => {
     expect(result.current.worlds).toEqual([]);
   });
 
+  it("変更操作の実行中は busy が立ち、終わったら下りる", async () => {
+    listMock.mockResolvedValue([]);
+    let finishCreate: ((world: { id: string; name: string }) => void) | undefined;
+    createMock.mockReturnValue(
+      new Promise((resolve) => {
+        finishCreate = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() => useWorlds());
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.busy).toBe(false);
+
+    let creating: Promise<boolean> | undefined;
+    act(() => {
+      creating = result.current.create("2周目");
+    });
+    await waitFor(() => {
+      expect(result.current.busy).toBe(true);
+    });
+
+    await act(async () => {
+      finishCreate?.({ id: "w2", name: "2周目" });
+      await creating;
+    });
+    expect(result.current.busy).toBe(false);
+  });
+
+  // 変更が通っても一覧を引き直すまで画面は古いままなので、その間も操作を止めておきたい。
+  it("変更後の一覧の引き直しが終わるまで busy は下りない", async () => {
+    let finishReload: ((worlds: { id: string; name: string }[]) => void) | undefined;
+    listMock.mockResolvedValueOnce([]).mockReturnValueOnce(
+      new Promise((resolve) => {
+        finishReload = resolve;
+      }),
+    );
+    createMock.mockResolvedValue({ id: "w2", name: "2周目" });
+
+    const { result } = renderHook(() => useWorlds());
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    let creating: Promise<boolean> | undefined;
+    act(() => {
+      creating = result.current.create("2周目");
+    });
+    await waitFor(() => {
+      expect(result.current.busy).toBe(true);
+    });
+
+    await act(async () => {
+      finishReload?.([{ id: "w2", name: "2周目" }]);
+      await creating;
+    });
+    expect(result.current.busy).toBe(false);
+  });
+
+  it("変更操作が失敗しても busy は下りる", async () => {
+    listMock.mockResolvedValue([]);
+    createMock.mockRejectedValue(new ApiError(500));
+
+    const { result } = renderHook(() => useWorlds());
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.create("2周目");
+    });
+
+    expect(result.current.busy).toBe(false);
+  });
+
   it("一覧の取得に失敗したら error に文言が入る", async () => {
     listMock.mockRejectedValue(new ApiError(500));
 

--- a/frontend/src/worlds/useWorlds.ts
+++ b/frontend/src/worlds/useWorlds.ts
@@ -6,6 +6,7 @@ import { useAuth } from "../auth/AuthContext";
 type UseWorlds = {
   worlds: World[];
   loading: boolean;
+  busy: boolean;
   error: string | null;
   create: (name: string) => Promise<boolean>;
   rename: (worldId: string, name: string) => Promise<boolean>;
@@ -20,11 +21,15 @@ type UseWorlds = {
  *
  * 変更操作は例外を投げず、失敗を error の文言と戻り値 false で表す。呼び出し側は成否だけを見て
  * 入力欄や編集モードを閉じるか決める（失敗したのに入力を捨てるとユーザーが打ち直しになる）。
+ *
+ * 変更操作が進行中かは busy で表す。呼び出し側はこれで操作を無効化して連打を防ぐ（連打すると
+ * 2 本目が 409 の赤帯を出し、世界は 1 つできているのに失敗したように見える）。
  */
 export function useWorlds(): UseWorlds {
   const { getToken } = useAuth();
   const [worlds, setWorlds] = useState<World[]>([]);
   const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const reload = useCallback(async () => {
@@ -44,15 +49,20 @@ export function useWorlds(): UseWorlds {
 
   const mutate = useCallback(
     async (operation: () => Promise<unknown>, fallback: string): Promise<boolean> => {
+      // 一覧を引き直して画面が API に追いつくまでを 1 つの操作とみなし、その間 busy を立てる。
+      setBusy(true);
       try {
         await operation();
+        setError(null);
+        // reload は取得の失敗を自分で error に載せて投げないので、下の catch には operation の失敗だけが来る。
+        await reload();
+        return true;
       } catch (e) {
         setError(errorMessage(e, fallback));
         return false;
+      } finally {
+        setBusy(false);
       }
-      setError(null);
-      await reload();
-      return true;
     },
     [reload],
   );
@@ -74,5 +84,5 @@ export function useWorlds(): UseWorlds {
     [mutate, getToken],
   );
 
-  return { worlds, loading, error, create, rename, remove };
+  return { worlds, loading, busy, error, create, rename, remove };
 }


### PR DESCRIPTION
Closes #749

#714（PR #740）のレビューで Minor として先送りした 4 点を消化する。いずれも数行だが、既存画面との一貫性を欠いていた箇所。

## 1. 変更操作に in-flight の無効化が無い

`useWorlds` に `busy` を足し、`WorldsPage` の**作る・保存・削除**を進行中は `disabled` にした。`LoginPage` の `submitting` と同じ形。

- **範囲は「一覧を引き直して画面が API に追いつくまで」**とした。変更が通っても引き直すまで表示は古いままなので、その間も操作を止める。`mutate` 全体を `try`/`finally` で包んでいる。
- **文言は変えない**（`LoginPage` は「確認中…」に変えるが、`busy` はどの操作でも立つので「作成中…」は削除中に嘘になる）。

これで、連打して 2 本目が 409 `world-name-taken` の赤帯を出す（世界は 1 つできて一覧にも並ぶので**表示だけが矛盾する**）状態が起きなくなる。

## 2. 改名の入力に `required` が無い

Issue には「1 行で揃う」と書いたが、**`required` を足すだけでは効かない**ことが実測で分かった。`required` の検証は form の submit のときだけ走り、改名の保存はボタンの `onClick` だったため、空名がそのまま `rename` に渡っていた。

そこで**編集領域を `form` + `type="submit"` にして作成側と対称にした**うえで `required` を付けた。テスト（`空の名前では作成も改名もしない`）は、実装前は作成側だけ通り改名側が `rename("w1", "")` を呼んで落ちる — つまり穴の所在をそのまま写している。

`form` でラップした分の flex は `.worlds__edit` で行（`.worlds__item`）から引き継ぐ。

## 3. 「世界一覧へ」リンクの見た目が隣のボタンと揃わない

`.btn-ghost` に `text-decoration: none` を足した。`styles.css` のリセットが `button, input` のみでアンカーを含まないため、`Link` に当てたときだけ下線が出ていた。

## 4. `useParams` の型の緩み

`useParams<{ worldId: string }>()` の型引数をやめた（react-router が返すのは `string | undefined`）。`worldId` が `undefined` のときは **API を叩かず `/worlds` へ戻す**。ルート定義が変わっても `/api/worlds/undefined/bloodHorses` を叩かない。

## 検証

frontend で以下を実行し、いずれも成功した。

- `npm test` — **51 passed**（追加した 6 件を含む。変更前は 45）
- `npm run lint`（biome）
- `npm run build`（tsc + vite build）

各テストは実装前に落ちることを確認してから実装している（3 の CSS を除く）。

**未確認**: `.btn-ghost` の下線と `.worlds__edit` のレイアウトは**見た目の変更で、jsdom では検証できないため目視していない**。`.worlds__edit` は `form` でラップした要素に元の行と同じ flex 指定（`flex: 1` / `display: flex` / `align-items: center` / `gap: 0.75rem`）を与えたもので、構造上は変更前と同じ並びになる想定。

## 関連

- #714 / PR #740（これらを Minor として deferred にした作業）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
