### PR TITLE
chore: #809 vitest のモック状態がテスト間で漏れないよう設定で締める

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,11 +1,7 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ApiError, apiDelete, apiGet, apiPatch, apiPost, errorMessage } from "./client";
 
 const token = async () => "id-token-123";
-
-afterEach(() => {
-  vi.restoreAllMocks();
-});
 
 describe("apiGet", () => {
   it("Authorization: Bearer にIDトークンを載せてJSONを返す", async () => {

--- a/frontend/src/api/me.test.ts
+++ b/frontend/src/api/me.test.ts
@@ -1,11 +1,7 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { provisionMe } from "./me";
 
 const token = async () => "id-token-123";
-
-afterEach(() => {
-  vi.restoreAllMocks();
-});
 
 function okResponse(): Response {
   return new Response(JSON.stringify({ account_id: "a1" }), {

--- a/frontend/src/api/worlds.test.ts
+++ b/frontend/src/api/worlds.test.ts
@@ -1,11 +1,7 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createWorld, deleteWorld, listWorlds, renameWorld } from "./worlds";
 
 const token = async () => "id-token-123";
-
-afterEach(() => {
-  vi.restoreAllMocks();
-});
 
 function stubFetch(status: number, body: unknown): ReturnType<typeof vi.fn> {
   const fetchMock = vi.fn().mockResolvedValue(

--- a/frontend/src/auth/AuthContext.test.tsx
+++ b/frontend/src/auth/AuthContext.test.tsx
@@ -22,9 +22,9 @@ function Probe() {
   return <div>{loading ? "loading" : user ? "signed-in" : "signed-out"}</div>;
 }
 
+// signInMock の履歴は clearMocks（vite.config.ts）が落とすので、ここは listeners だけ戻す。
 beforeEach(() => {
   listeners.length = 0;
-  signInMock.mockReset();
 });
 
 describe("AuthContext", () => {

--- a/frontend/src/pages/BloodHorseListPage.test.tsx
+++ b/frontend/src/pages/BloodHorseListPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ApiError } from "../api/client";
 
 vi.mock("../auth/AuthContext", () => ({
@@ -22,11 +22,6 @@ import { apiGet } from "../api/client";
 import { BloodHorseListPage } from "./BloodHorseListPage";
 
 const apiGetMock = vi.mocked(apiGet);
-
-// 呼び出し履歴はテストをまたいで積み上がるので、各テストの前に落とす（実装＝mockResolvedValue は残す）。
-beforeEach(() => {
-  apiGetMock.mockClear();
-});
 
 function renderAt(path: string) {
   useWorldsMock.mockReturnValue({

--- a/frontend/src/pages/WorldsPage.test.tsx
+++ b/frontend/src/pages/WorldsPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../auth/AuthContext", () => ({
   useAuth: () => ({ signOutUser: vi.fn() }),
@@ -11,10 +11,6 @@ const useWorldsMock = vi.fn();
 vi.mock("../worlds/useWorlds", () => ({ useWorlds: () => useWorldsMock() }));
 
 import { WorldsPage } from "./WorldsPage";
-
-afterEach(() => {
-  vi.restoreAllMocks();
-});
 
 function renderPage() {
   return render(

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,5 +17,14 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
+    // モックの呼び出し履歴はテストをまたいで積み上がる（既定は false）。放置すると
+    // toHaveBeenCalledWith が前のテストの履歴で通り、偽陰性になる。
+    // 実装（mockResolvedValue 等）は各テストが入れ直す前提なので、履歴だけ落とす。
+    clearMocks: true,
+    // vi.spyOn で差し替えた実装を各テストの前に戻す（afterEach(vi.restoreAllMocks) の代替）。
+    restoreMocks: true,
+    // vi.stubGlobal で差し替えた global（fetch 等）を各テストの前に戻す。restoreMocks では
+    // 戻らない（vi.restoreAllMocks は spy のみが対象）ため、これが無いと stub が漏れ続ける。
+    unstubGlobals: true,
   },
 });


### PR DESCRIPTION
Closes #809

## やったこと

vitest のモック状態（呼び出し履歴・spy・global スタブ）がテストをまたいで持ち越される問題を、ファイルごとの手当てではなく `frontend/vite.config.ts` の設定へ一本化した。

```ts
clearMocks: true,
restoreMocks: true,
unstubGlobals: true,
```

合わせて、設定に吸収された各ファイルの後始末を消した。差分は 7 ファイル・+15/-27 行。

## 直った穴

### 1. 呼び出し履歴の持ち越し（Issue 本体）

`clearMocks` が既定 `false` のため、`toHaveBeenCalledWith` が **前のテストの履歴で通る**（偽陰性）。`not.toHaveBeenCalled()` は逆に落ちる向きなので気づけるが（#749 / PR #808 で踏んだのはこちら）、`toHaveBeenCalledWith` は「このテストで呼ばれた」ことを主張しているつもりで通ってしまう。

### 2. `vi.stubGlobal` が戻っていなかった（作業中に判明）

`src/api/{client,me,worlds}.test.ts` は `afterEach(vi.restoreAllMocks)` を置いていたが、**この 3 ファイルのモックは `vi.stubGlobal("fetch", ...)` で入れており、`vi.restoreAllMocks()` の対象は spy だけ**。つまりこの `afterEach` は fetch を一切戻していなかった（実測で確認。下記ミューテーション 2）。実効的な後始末は `unstubGlobals` が担う。

各テストが毎回 `stubGlobal` で入れ直すため現時点で実害は出ていないが、「後始末しているつもり」の状態だった。

## ミューテーションによる発火確認（#782 の方針）

設定を入れる前後で、それぞれ意図どおり通る／落ちることを実測した。

**1. 履歴の持ち越し** — 一度も `apiGet` を呼んでいないテストに `toHaveBeenCalledWith` を仕込む

| | 結果 |
| --- | --- |
| 設定前 | 4 passed（**通ってしまう** ＝ 穴の実例） |
| `clearMocks: true` 後 | `AssertionError ... Number of calls: 0` で落ちる |

**2. global スタブの持ち越し** — fetch を stub しないテストで `expect(vi.isMockFunction(globalThis.fetch)).toBe(true)`

| | 結果 |
| --- | --- |
| 設定前（`afterEach(vi.restoreAllMocks)` あり） | 11 passed（**モックのまま残っている**） |
| `unstubGlobals: true` 後 | `expected false to be true` で落ちる |

いずれのミューテーションも確認後に削除した。

## `mockReset` を入れなかった理由

実測では `mockReset: true` でも 51 テストすべて通る（現状どのファイルもテスト内で実装を入れ直しているため）。それでも入れていない。目的の偽陰性は `clearMocks`（履歴のみ）で塞げており、`mockReset` は実装まで落として「既定の実装をモジュールスコープに置く」書き方を封じる。必要になった時点で個別に入れれば足りると判断した。

## 検証

- `npm test` → 11 files / 51 tests passed
- `biome check .` → 35 files checked, no fixes applied
- `tsc --noEmit` → エラーなし

Kotlin 側は無変更のため `./gradlew check` は回していない。

## 関連

- #749 / PR #808 この事象を踏んだ作業（手動 `beforeEach` を入れた側。本 PR で外した）
- #782 ゲートを新設・変更したらミューテーションで発火を確認する
- #747 frontend のテストダブルを本番の契約に合わせて棚卸しする（別軸で未着手）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
