### PR TITLE
chore: #804 pre-push の glob が効かず .md だけの push でも Docker と全テストを要求する問題を直す

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -59,6 +59,7 @@ Testcontainers の PostgreSQL はプロセス内で共有されるため、テ�
 
 pre-push（lefthook の `full-test`）は `./gradlew test` を丸ごと回す。**Testcontainers 依存テストも対象のまま**で、Docker 不要なテストだけを切り出す運用は採らない（[ADR-0071](../../docs/adr/0071-pre-push-docker-fail-fast-guard.md)。穴が空くのが永続化契約テストという最も守りたい場所になること、`@Tag` の付け忘れが危険側に転ぶことが理由）。したがって **push には Docker が要る**。
 
+- 要るのは **`.kt` / `.kts` / `.java` を含む push のとき**だけ（両コマンドの `glob`）。ドキュメントや設定だけの push はゲートごとスキップされ、Docker を落としていても通る。glob を当てる対象は `scripts/list-push-target-files.sh` が供給する（lefthook 既定の `{push_files}` は worktree で比較対象を取り違え、`.md` だけの push でもゲートが起動していた。#804）。
 - pre-push の先頭で `scripts/check-docker-available.sh` が Docker 到達性を確認し、駄目なら理由と対処を出して即座に落とす（`piped: true` で `full-test` は走らない）。ハングして「push が無反応」に見える状態を潰すためのガードで、ゲートの範囲は変えない。
 - 判定は `docker info` の成否のみ。**Docker は生きているが Testcontainers だけ失敗する**ケース（イメージの pull 不可・リソース枯渇等）はガードを素通りし、従来どおりテストの失敗として出る。
 - Docker が復旧しないまま push したいときは **`LEFTHOOK_EXCLUDE=docker-available,full-test git push`**（`--no-verify` は gitleaks 等まで飛ばすので最後の手段）。同じテストは CI（`api-tests.yml`）で走る。

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -127,10 +127,10 @@ pre-push:
   piped: true
 
   # glob を当てる対象（push 予定の変更ファイル）を自前で供給する（#804）。
-  # lefthook 既定の {push_files} は worktree で比較対象を取り違え、無関係な別リポジトリ
-  # （infra リモート = toy-box-infra）との差分を返すため、.md だけの push でもほぼ全ファイルが
-  # 「push 対象」と見なされて下の glob が素通りしていた。取り違えの機序と切り分けの実測は
-  # スクリプト冒頭のコメントにある。
+  # lefthook 既定の {push_files} は worktree で比較対象を取り違える。origin より前の名前を持つ
+  # リモートが 1 つでもあると無関係な履歴との差分を返すため、.md だけの push でもほぼ全ファイルが
+  # 「push 対象」と見なされ、下の glob が素通りする。取り違えの機序・切り分けの実測・この供給を
+  # 残す理由は、スクリプト冒頭のコメントにある。
   files: scripts/list-push-target-files.sh
 
   commands:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -125,6 +125,14 @@ pre-commit:
 pre-push:
   # piped: 先頭のコマンドが落ちたら後続を打ち切る（docker-available → full-test の順で fail fast）。
   piped: true
+
+  # glob を当てる対象（push 予定の変更ファイル）を自前で供給する（#804）。
+  # lefthook 既定の {push_files} は worktree で比較対象を取り違え、無関係な別リポジトリ
+  # （infra リモート = toy-box-infra）との差分を返すため、.md だけの push でもほぼ全ファイルが
+  # 「push 対象」と見なされて下の glob が素通りしていた。取り違えの機序と切り分けの実測は
+  # スクリプト冒頭のコメントにある。
+  files: scripts/list-push-target-files.sh
+
   commands:
     # Docker 到達性の事前確認（#679 / ADR-0071）。
     #

--- a/scripts/list-push-target-files.sh
+++ b/scripts/list-push-target-files.sh
@@ -11,13 +11,18 @@
 #
 # worktree では 2 が必ず外れる。lefthook が見る `<git-dir>` は `.git/worktrees/<name>` で、
 # `refs/remotes/origin/HEAD` はそこではなく共有の git-common-dir にあるためである。すると 3 へ
-# 落ち、`git branch --remotes` はアルファベット順なので当リポジトリでは origin より前に並ぶ
-# `infra/HEAD -> infra/main`（別リポジトリ toy-box-infra）が拾われる。無関係な履歴との差分に
+# 落ちるが、`git branch --remotes` はアルファベット順に並ぶので、**origin より前に来る名前の
+# リモートが 1 つでもあると、そちらの `HEAD -> ...` が先に一致する**。無関係な履歴との差分に
 # なるため事実上ほぼ全ファイルが「push 対象」と見なされ、glob が素通りする。
 #
 # その結果 `.md` だけの push でも Kotlin 向けのゲート（docker-available / full-test）が起動し、
 # Docker を落としているとドキュメントだけの push が塞がれる。upstream を設定していない間ずっと
 # 起きる（初回 push に限らない。切り分けの実測は #804）。
+#
+# 実際に踏んだのは archive 済みの `infra` リモート（toy-box-infra）で、これは #804 の調査後に
+# 削除した。よって現状の 3 は `origin/HEAD -> origin/main` を拾う。それでもこのスクリプトを
+# 残すのは、fork や backup など origin より前に並ぶリモートを足すと再発するうえ、症状が
+# 「テストが余計に走る」だけで無音だからである（2 の欠落は worktree である限り直らない）。
 #
 # そこで比較対象を lefthook 任せにせず、ここで明示する。
 #

--- a/scripts/list-push-target-files.sh
+++ b/scripts/list-push-target-files.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# pre-push の glob 判定に使う「これから push される変更ファイル」を列挙する（#804）。
+#
+# 背景: lefthook の既定の判定材料 `{push_files}` は、リンクされた作業ツリー（git worktree）で
+# 誤った比較対象を選ぶ。lefthook は次の順に基準を決めるが、
+#
+#   1. `git diff --name-only HEAD @{push}`
+#   2. 1 が失敗したら `<git-dir>/refs/remotes/origin/HEAD` を読む
+#   3. 2 も空なら `git branch --remotes` の出力から最初に `HEAD -> ...` に一致した行を使う
+#   4. それも無ければリポジトリの全追跡ファイル
+#
+# worktree では 2 が必ず外れる。lefthook が見る `<git-dir>` は `.git/worktrees/<name>` で、
+# `refs/remotes/origin/HEAD` はそこではなく共有の git-common-dir にあるためである。すると 3 へ
+# 落ち、`git branch --remotes` はアルファベット順なので当リポジトリでは origin より前に並ぶ
+# `infra/HEAD -> infra/main`（別リポジトリ toy-box-infra）が拾われる。無関係な履歴との差分に
+# なるため事実上ほぼ全ファイルが「push 対象」と見なされ、glob が素通りする。
+#
+# その結果 `.md` だけの push でも Kotlin 向けのゲート（docker-available / full-test）が起動し、
+# Docker を落としているとドキュメントだけの push が塞がれる。upstream を設定していない間ずっと
+# 起きる（初回 push に限らない。切り分けの実測は #804）。
+#
+# そこで比較対象を lefthook 任せにせず、ここで明示する。
+#
+# 使い方: lefthook.yml の pre-push から `files:` として呼ぶ（標準出力にファイルパスを 1 行 1 件）。
+# 終了コード: 常に 0（列挙できない状況では安全側に倒すため、後述のとおり全追跡ファイルを出す）。
+#
+# 基準の決め方:
+#   1. `@{push}` が解決できればそれ（= 実際に push 済みの地点。lefthook の第一候補と同じ）
+#   2. 解決できなければ origin/main との merge-base（= 作業ブランチが分岐した地点）
+#   3. どちらも取れなければ全追跡ファイルを出す
+#
+# 3 は「判定できないならゲートを走らせる」という安全側の倒し方である。空を返すと lefthook は
+# コマンドを丸ごとスキップするため、テストゲートが無音で無効化されてしまう（#782 の趣旨どおり、
+# ゲートは壊れたときに素通りするのではなく発火する側へ倒す）。
+#
+# 2 の基準では、すでに push 済みのコミットの変更も差分に含まれることがある（push のたびに分岐点
+# から数え直すため）。過剰にゲートが走る向きの誤差なので許容する。
+set -euo pipefail
+
+# 作業ブランチの分岐元。CLAUDE.md のとおり main が唯一の統合先。
+readonly DEFAULT_BASE="origin/main"
+
+base=""
+if resolved=$(git rev-parse --verify --quiet '@{push}' 2>/dev/null) && [ -n "$resolved" ]; then
+  base="$resolved"
+elif resolved=$(git merge-base HEAD "$DEFAULT_BASE" 2>/dev/null) && [ -n "$resolved" ]; then
+  base="$resolved"
+fi
+
+if [ -z "$base" ]; then
+  git ls-files
+  exit 0
+fi
+
+git diff --name-only "$base" HEAD --


### PR DESCRIPTION
Closes #804

## 原因（切り分け済み）

lefthook の `{push_files}` が、**worktree で比較対象を取り違える**のが原因だった。glob の書き方の問題ではない。

lefthook v2.1.9 の `PushFiles()` は次の順に基準を決める（[internal/git/repo.go](https://github.com/evilmartians/lefthook/blob/v2.1.9/internal/git/repo.go#L188-L226) ）。

1. `git diff --name-only HEAD @{push}`
2. 1 が失敗したら `<git-dir>/refs/remotes/origin/HEAD` を読む
3. 2 も空なら `git branch --remotes` の出力で最初に `HEAD -> ...` に一致した行
4. それも無ければ全追跡ファイル

**worktree では 2 が必ず外れる**。lefthook が見る `<git-dir>` は `git rev-parse --git-dir` の結果 = `.git/worktrees/<name>` だが、`refs/remotes/origin/HEAD` はそこではなく共有の git-common-dir にあるため。

```
$ git rev-parse --git-dir
/Users/…/toy-box/.git/worktrees/toy-box-sub1
$ ls $(git rev-parse --git-dir)/refs/remotes/origin/HEAD
No such file or directory          ← 2 は空になる
$ ls $(git rev-parse --git-common-dir)/refs/remotes/origin/HEAD
（存在する）
```

すると 3 へ落ちる。`git branch --remotes` はアルファベット順なので、このリポジトリでは origin より前に **infra**（別リポジトリ `toy-box-infra`）が並ぶ。

```
$ git branch --remotes
  infra/HEAD -> infra/main     ← 最初の一致。これが基準に選ばれる
  infra/main
  origin/HEAD -> origin/main
```

無関係な履歴との差分になるので、事実上ほぼ全ファイルが「push 対象」と見なされ、glob が素通りする。

```
$ git diff --name-only HEAD infra/main -- | wc -l
     710      （うち .kt が 433 件 → glob "{,**/}*.{kt,kts,java}" にマッチ）
$ git diff --name-only HEAD origin/main -- | wc -l
      25      （本来の基準ならこれ）
```

### 再現条件（隔離環境での実測）

本物の origin を触らないローカル bare リポジトリで、条件を 1 つずつ変えて測った。

| ケース | worktree | upstream | infra リモート | Kotlin ゲート |
|---|---|---|---|---|
| A | あり | 無し | あり | **起動（再現）** |
| B | 無し（メインチェックアウト） | 無し | あり | スキップ |
| C | あり | 無し（2 回目の push） | あり | **起動** |
| E | あり | **あり** | あり | スキップ |
| D | あり | 無し | **無し** | スキップ |

**3 条件の AND** で起きる。Issue に書いた「新規ブランチの初回 push だけ」という仮説は誤りで、正しくは **upstream を設定していない間ずっと**（ケース C）。またメインチェックアウトでは起きない（ケース B）。infra リモートを消しても直る（ケース D）が、それは対処にならないので採らなかった。

## 対処

lefthook の基準決定に任せず、**glob を当てる対象を自前で供給する**（hook レベルの `files:`）。

- `scripts/list-push-target-files.sh`（新規）: 基準を `@{push}` → `origin/main` との merge-base の順に解決し、**どちらも取れなければ全追跡ファイルを出す**。空を返すと lefthook はコマンドごとスキップするため、判定できない状況ではゲートを走らせる側（安全側）へ倒している（#782 の趣旨）。
- `lefthook.yml`: pre-push に `files:` を追加。glob 自体は変更していない。
- `.claude/rules/testing.md`: Docker が要るのは `.kt` / `.kts` / `.java` を含む push に限られること、判定材料の出所を明記。

取り違えの機序はスクリプト冒頭のコメントに残した（Issue とこの PR が流れても手元で追えるように）。

## 検証

**この PR 自身の push が実証になっている**。`.md` / `.yml` / `.sh` だけの新規ブランチ初回 push（＝ Issue が報告した条件そのもの）で、両ゲートがスキップされた。

```
│  docker-available (skip) no files for inspection
│  full-test (skip) no files for inspection
summary: (done in 0.13 seconds)
```

ゲートを殺していないことも確認した。`.kt` を含む一時コミットを積むと起動する。

```
┃  docker-available ❯
✔️ docker-available (2.24 seconds)
```

隔離環境では、実物のスクリプトと同じ glob を持つ構成で 3 ケースとも期待どおりだった（A: `.md` のみ → スキップ / F: `.kt` を含む → 起動 / B: メインチェックアウト → スキップ）。さらに **`files:` の 1 行だけを取り除くミューテーション**を当てると、ケース A が「起動」へ戻ることを確認している（スキップが環境差ではなくこの修正の効果であることの確認）。

## 影響範囲

pre-push の発火条件のみ。CI・`check`・pre-commit は不変。`glob` の値も変えていない。
