### PR TITLE
chore: #757 ADR 連番の二重採番と索引のズレを機械検知する

### DIFF
--- a/.github/workflows/adr-check.yml
+++ b/.github/workflows/adr-check.yml
@@ -1,0 +1,44 @@
+# ADR チェックワークフロー
+#
+# 目的: ADR の連番が二重採番されていないか、索引（docs/adr/README.md）と実ファイルが食い違って
+# いないかを検査する（#757）。ADR のファイル名は番号が同じでもサフィックスが違えば別ファイルで、
+# 索引行が離れていれば git は自動マージするため、二重採番は衝突として現れず main に入りうる。
+#
+# pull_request が見るのは**その実行時点**の main と PR の合成である。PR 作成後に main へ別の ADR が
+# 入り、PR 側に新しい push が無ければ再実行されないため、マージ直前に生じた衝突は取り逃す余地が
+# 残る。push（main）側にも載せているのはそのためで、事後ではあるが #597 のように人間が気づくまで
+# 放置される状態は避けられる。
+
+name: ADR Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docs/adr/**"
+      - "scripts/check-adr-numbering.sh"
+  push:
+    branches: [main]
+    paths:
+      - "docs/adr/**"
+      - "scripts/check-adr-numbering.sh"
+  workflow_dispatch:
+
+jobs:
+  adr-check:
+    runs-on: ubuntu-latest
+    name: ADR Numbering and Index Check
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # 素の bash だけで動くのでツールのインストールは要らない（mise のセットアップも不要）。
+      - name: ADR numbering and index check
+        run: scripts/check-adr-numbering.sh

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -122,6 +122,16 @@ pre-commit:
       run: scripts/check-migration-validate-separation.sh {staged_files}
       tags: lint
 
+    # ADR の採番と索引の整合チェック（#757）。
+    # 番号の重複はリポジトリ全体を見ないと判定できないため {staged_files} は渡さず常に全件を
+    # 検査する（glob は発火の条件だけを絞る役）。素の bash なのでコミットは実質重くならない。
+    # ここで見られるのは自ブランチ内の重複まで。PR 作成後に main へ入った ADR との衝突は
+    # ローカルからは原理的に見えないので、CI（.github/workflows/adr-check.yml）が本命になる。
+    adr-numbering:
+      glob: "docs/adr/*.md"
+      run: scripts/check-adr-numbering.sh
+      tags: lint
+
 pre-push:
   # piped: 先頭のコマンドが落ちたら後続を打ち切る（docker-available → full-test の順で fail fast）。
   piped: true

--- a/scripts/check-adr-numbering.sh
+++ b/scripts/check-adr-numbering.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# ADR（docs/adr/）の採番と索引の整合を検査する（#757）。
+#
+# ADR のファイル名は番号が同じでもサフィックスが違えば別ファイルなので、二重採番が起きても
+# git は衝突を検出しない。索引（README.md）の行が離れていれば両方が自動マージされるため、
+# 二重採番のまま main に入りうる（#597 が実際にこの経路で入った）。検知を運任せにしない。
+#
+# 検査する 3 点:
+#   1. NNNN の重複が無い（#597 / #712 の直接の再発防止）
+#   2. README.md の索引が張る相対リンクの先が実在する（繰り下げ後の直し忘れ）
+#   3. すべての ADR が索引に載っている（索引への追加漏れ）
+#
+# 使い方:
+#   scripts/check-adr-numbering.sh
+#   - 引数は取らず常に全件を検査する。重複はリポジトリ全体を見ないと判定できないため、
+#     lefthook からも {staged_files} を渡さない（glob で発火だけを絞る）。
+#   - リポジトリ root からの実行を前提とする。
+# 終了コード: 違反があれば 1、なければ 0。
+#
+# 互換: macOS 標準の bash 3.2 で動くよう連想配列/mapfile を使わない。
+set -euo pipefail
+
+ADR_DIR="docs/adr"
+INDEX="$ADR_DIR/README.md"
+
+if [ ! -d "$ADR_DIR" ]; then
+  echo "NG: $ADR_DIR がありません（リポジトリ root から実行してください）。" >&2
+  exit 1
+fi
+if [ ! -f "$INDEX" ]; then
+  echo "NG: $INDEX がありません。" >&2
+  exit 1
+fi
+
+# ADR のファイル名一覧（1 行 1 件）。README.md は 4 桁始まりではないので自然に外れる。
+adrs=""
+for f in "$ADR_DIR"/[0-9][0-9][0-9][0-9]-*.md; do
+  [ -e "$f" ] || continue
+  adrs="$adrs$(basename "$f")
+"
+done
+
+if [ -z "$adrs" ]; then
+  echo "NG: $ADR_DIR に ADR（NNNN-*.md）が 1 つもありません。" >&2
+  exit 1
+fi
+
+status=0
+
+# 1. 番号の重複
+dups=$(printf '%s' "$adrs" | cut -c1-4 | sort | uniq -d) || true
+for n in $dups; do
+  echo "NG: ADR 番号 $n が二重採番されています:" >&2
+  for f in "$ADR_DIR/$n"-*.md; do
+    echo "    $f" >&2
+  done
+  echo "    どちらかを未使用の番号へ繰り下げ、$INDEX の索引と本文中の参照も揃えてください。" >&2
+  status=1
+done
+
+# 2. 索引が張るリンク先の実在
+#    索引の相対リンクは docs/adr/ からの相対パス。アンカー（#見出し）が付いても実体だけを見る。
+links=$(grep -oE '\]\([^)]+\)' "$INDEX" | sed -e 's/^](//' -e 's/)$//' -e 's/#.*$//' | sort -u) || true
+for l in $links; do
+  # 外部 URL は対象外（相対リンクの切れだけを見る）
+  case "$l" in
+    http://* | https://* | mailto:*) continue ;;
+  esac
+  if [ ! -e "$ADR_DIR/$l" ]; then
+    echo "NG: $INDEX の索引リンク先がありません: $l" >&2
+    status=1
+  fi
+done
+
+# 3. 索引への掲載漏れ
+while IFS= read -r base; do
+  [ -n "$base" ] || continue
+  if ! grep -qF "($base)" "$INDEX"; then
+    echo "NG: $ADR_DIR/$base が $INDEX の索引に載っていません。" >&2
+    status=1
+  fi
+done <<EOF
+$adrs
+EOF
+
+exit "$status"


### PR DESCRIPTION
## 概要

ADR の連番の二重採番と、索引（`docs/adr/README.md`）と実ファイルのズレを機械検知するゲートを新設する。Closes #757

二重採番は 2 回起きている（#597 は main に入ってから発覚、#712 は索引が git 衝突したので偶然気づけた）。ADR のファイル名は番号が同じでもサフィックスが違えば別ファイルなので git は衝突を検出せず、索引行が離れていれば両方が自動マージされる。「PR 作成直後に mergeable を確認する」という運用は衝突として現れたときしか効かず、検知率は実測 50% だった。

Issue の案 1（連番の一意性を機械検査する）を採った。案 2（タイムスタンプ採番）は既存 76 本の ADR 参照が本文・コード・指示ファイルに埋まっており移行コストが見合わない。案 3（運用でカバー）は現状そのもの。

## 変更内容

### `scripts/check-adr-numbering.sh`（新規）

既存の `scripts/check-migration-validate-separation.sh` と同じ流儀（bash 3.2 互換 / `NG:` 形式で stderr / 違反があれば exit 1）。3 点を検査する。

| # | 検査 | 拾う事故 |
|---|------|---------|
| 1 | `NNNN` の重複が無い | #597 / #712 の二重採番そのもの |
| 2 | 索引が張る相対リンクの先が実在する | 繰り下げ後の索引の直し忘れ |
| 3 | すべての ADR が索引に載っている | 索引への追加漏れ |

**引数は取らず常に全件を検査する。** 重複はリポジトリ全体を見ないと判定できないため、`{staged_files}` を渡す既存スクリプトとはここだけ流儀が異なる。

### `lefthook.yml`

pre-commit に `adr-numbering` を追加。`glob: "docs/adr/*.md"` で ADR を触ったコミットだけ発火する。素の bash で Docker も mise ツールも要らないためコミットは実質重くならない。

### `.github/workflows/adr-check.yml`（新規）

`sql-check.yml` と同型（`pull_request` + `push: [main]`、`paths` は `docs/adr/**` と当スクリプト）。ツールのインストールが要らないので checkout してスクリプトを叩くだけ。

## 設計上の判断

**Flyway の `V<n>__*.sql` は対象に含めない。** `spring.flyway.enabled: true` のもとで Testcontainers を使う既存の統合テストが起動時に migrate を走らせるため、バージョン重複は Flyway 自身が `Found more than one migration with version` で落とす。ADR にだけこのゲートが無いという非対称がこの Issue の本質で、Flyway 側を二重に検査する必要はない。

**pre-commit だけでは足りない。** ローカルで見えるのは自ブランチ内の重複までで、#712 型（PR 作成後に main へ別の ADR が入った）は原理的に見えない。CI が本命になる。

**CI にも限界がある。** `pull_request` が見るのは**その実行時点**の main と PR の合成なので、PR 作成後に main へ ADR が入り、PR 側に新しい push が無ければ再実行されず取り逃す。`push: [main]` 側にも載せているのはそのためで、事後ではあるが #597 のように人間が気づくまで放置される状態は避けられる。この限界はワークフローのコメントに書き残した。

## 検証（#782 の方針）

3 つの検査それぞれをミューテーションで壊し、発火することを確認した。

| ミューテーション | 結果 |
|---|---|
| `0076-duplicate-number-mutation-test.md` を追加 | 検査 1 が `NG: ADR 番号 0076 が二重採番されています` で exit 1 |
| 索引の `0071-...md` を存在しないパスへ書き換え | 検査 2 が `NG: 索引リンク先がありません` で exit 1 |
| 索引から `0075-...md` の行を削除 | 検査 3 が `NG: 索引に載っていません` で exit 1 |
| 健全な状態（現在の main） | exit 0 |

lefthook 側も実測した。ADR を触っていない stage では `adr-numbering (skip) no matching staged files`、二重採番のダミーを stage すると発火して `exit status 1`。

`shellcheck` / `actionlint` / `zizmor` / `dprint` / `editorconfig-checker` はいずれも通っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
