### PR TITLE
chore: #782 ゲート規約の paths に scripts/** を足す

### DIFF
--- a/.claude/rules/gates.md
+++ b/.claude/rules/gates.md
@@ -3,6 +3,7 @@ paths:
   - "src/test/**"
   - "detekt-rules/src/**"
   - ".github/workflows/**"
+  - "scripts/**"
   - "lefthook.yml"
   - ".claude/hooks/**"
   - ".claude/settings.json"


### PR DESCRIPTION
## 概要

PR #820（#782）の積み残し。`.claude/rules/gates.md` は CI ジョブの節で

> 検査の本体はワークフローのインラインではなく `scripts/*.sh` へ切り出す。違反状態を作ってローカルで直接実行するだけで発火を確認できる

と推奨しておきながら、自身の `paths` に `scripts/**` が入っておらず、**ゲート本体を編集するときに規約がロードされない**状態だった。

実際 `scripts/` の 6 本のうち 4 本はゲートの本体・周辺である。

| スクリプト | 位置づけ |
| --- | --- |
| `check-adr-numbering.sh` | CI ゲート本体（`.github/workflows/adr-check.yml`） |
| `check-docker-available.sh` | pre-push ゲート本体（ADR-0071） |
| `check-migration-validate-separation.sh` | pre-commit ゲート本体 |
| `list-push-target-files.sh` | pre-push の glob 対象の供給（#804） |

ここが規約の届く範囲から外れていた。`paths` に `scripts/**` を 1 行足す。

## 検証

- Kotlin を触っていないので `./gradlew check` は対象外
- pre-commit（editorconfig-check / gitleaks）は通過
