### PR TITLE
chore: #731 postgresql の暫定バージョン上書きを外して BOM 任せに戻す

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 kotlin = "2.4.10"
 
 # プラグインのバージョン
-spring-boot = "4.1.0"
+spring-boot = "4.1.1"
 spring-dependency-management = "1.1.7"
 springdoc-openapi-gradle = "1.9.0"
 ktfmt = "0.27.0"
@@ -20,12 +20,6 @@ springmockk = "5.0.1"
 archunit = "1.5.0"
 jmolecules-bom = "2025.0.2"
 junit = "6.1.3"
-# PostgreSQL JDBC ドライバ。通常は他の Spring 管理依存と同じく BOM に委ねるが、Spring Boot 4.1.0 の
-# managed version（42.7.11）が GHSA-j92g-9f8w-j867（high。未対応の証明書アルゴリズム経由で
-# channel binding 認証がサイレントにダウングレードされる）の脆弱範囲に入るため、修正版 42.7.12 を
-# 暫定で上書きする（#694）。Spring Boot の検証済み組み合わせから外れる暫定対処なので、
-# managed version が 42.7.12 以上になった Spring Boot へ更新したらこの上書きを外して BOM に戻す。
-postgresql = "42.7.13"
 
 [libraries]
 # Spring AI（MCP server。WebMVC SSE/Streamable トランスポート）
@@ -38,11 +32,10 @@ springdoc-openapi-starter-webmvc-ui = { module = "org.springdoc:springdoc-openap
 
 # 永続化（Spring Data JDBC + Flyway + PostgreSQL。ADR-0027 / ADR-0044）。
 # バージョンは Spring Boot の依存管理（BOM）に委ねるため version は指定しない
-# （postgresql だけは脆弱性回避で暫定上書き中。理由と外す条件は [versions] のコメント参照）
 spring-boot-starter-data-jdbc = { module = "org.springframework.boot:spring-boot-starter-data-jdbc" }
 spring-boot-starter-flyway = { module = "org.springframework.boot:spring-boot-starter-flyway" }
 spring-boot-docker-compose = { module = "org.springframework.boot:spring-boot-docker-compose" }
-postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
+postgresql = { module = "org.postgresql:postgresql" }
 flyway-database-postgresql = { module = "org.flywaydb:flyway-database-postgresql" }
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql" }
 


### PR DESCRIPTION
## 概要

#694（PR #728）で入れた `org.postgresql:postgresql` の暫定バージョン上書きを外し、Spring Boot の BOM 任せに戻す。

解除条件は「managed version が 42.7.12 以上になった Spring Boot へ更新したら」だった。**Spring Boot 4.1.1 の managed version が 42.7.13** で条件を満たすため、4.1.1 へ更新したうえで上書きを外す。

Closes #731

## 変更内容

`gradle/libs.versions.toml`

- `[versions]` の `postgresql = "42.7.13"` と、上書きの理由・解除条件を書いた 5 行のコメントを削除
- `[libraries]` の `postgresql` から `version.ref` を外して BOM 任せに戻し、「postgresql だけは暫定上書き中」の補記コメントも削除
- 上書き解除の前提として `spring-boot` を 4.1.0 → 4.1.1 へ更新

## 検証（実測）

**解決バージョンが BOM 任せでも 42.7.12 以上であること**（GHSA-j92g-9f8w-j867 が再燃しない）

```
$ ./gradlew -q dependencyInsight --dependency org.postgresql:postgresql --configuration runtimeClasspath
org.postgresql:postgresql:42.7.13 (selected by rule)
...
org.postgresql:postgresql -> 42.7.13
\--- runtimeClasspath
```

`version.ref` を消した状態で 42.7.13 に解決される（`selected by rule` = spring-dependency-management の BOM 管理）。上書き前後で解決バージョンは変わらない。

**`./gradlew check`**（Testcontainers の永続化契約テスト込み）

```
BUILD SUCCESSFUL in 11m 7s
27 actionable tasks: 22 executed, 5 up-to-date
```

## 留意点

- **Spring Boot 4.1.1 への更新をこの PR に含んでいる**。上書き解除は 4.1.1 の managed version に依存するため分離できない。Dependabot の Spring Boot 更新 PR が後から来ても no-op になる
- 4.1.1 は Maven Central に 2026-08-20 公開済み（GA。マイルストーン／RC ではない）。GitHub 側の release ノートは本 PR 作成時点でまだ未公開だが、アーティファクトは公開されている
