### PR TITLE
perf: #817 web 環境を要するテストコンテキストを 1 つに畳んで :test を 20.5% 縮める

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -71,7 +71,16 @@ Spring テストの主コストは `ApplicationContext` の構築。速度の本
 - **distinct なコンテキスト構成を増やさない**。キャッシュは「同一の unique 構成」のときだけ再利用される（キーは classes / context customizers / active profiles / property sources 等の組合せ）。`@MockkBean` は context customizer を足してキーを分けるので**乱発しない**、`@Import` 構成は揃える、`@SpringBootTest(webEnvironment=...)` を不必要に散らさない。
 - **`@DirtiesContext` は原則使わない**（キャッシュを退避させ再構築を強いる）。状態リークは設計で断つ。
 - **テスト並列化（`maxParallelForks` / JUnit 5 の `junit.jupiter.execution.parallel`）は採らない**。フォークはキャッシュが JVM 単位のため逆効果、JVM 内並列は `@MockBean`/`@MockkBean` や共有状態を使うテストを Spring 公式が非推奨とする。加えて DB を触るテストの後始末（共有コンテナの全テーブル TRUNCATE。[ADR-0070](../../docs/adr/0070-db-test-cleanup-via-truncate-not-transactional.md)）は JVM 内並列と両立しない（他スレッドのデータまで消す）。再評価は #690。
-- 速度を縮めたいときの効く順: ビルドキャッシュ/デーモン（[ADR-0015](../../docs/adr/0015-gradle-build-performance-tuning.md)）→ コンテキスト構成の共通化 → （将来）隔離を整えた上での並列化。
+- 速度を縮めたいときの効く順: ビルドキャッシュ/デーモン（[ADR-0015](../../docs/adr/0015-gradle-build-performance-tuning.md)）→ コンテキスト構成の共通化（#817 で実施済み。下記）→ （将来）隔離を整えた上での並列化。
+
+### web 環境を要する `@SpringBootTest` は 1 構成に揃える（崩すと -20.5% が消える）
+
+`ApiApplicationTests` / `McpDisabledByDefaultTest` / `HealthEndpointTest` / `OpenApiTest` / `SecurityConfigTest` の 5 クラスは、**`RANDOM_PORT` + `@AutoConfigureRestTestClient` + `@Import(TestJwtDecoderConfiguration)` という同一キー**でコンテキストを 1 つ共有する（[ADR-0077](../../docs/adr/0077-consolidate-web-test-contexts-trading-jwt-decoder-assurance.md)）。CI 実測（各 3 回の中央値）で `:test` が 84.93s → 67.55s（**-20.5%**）になった構成であり、**どれか 1 つに `@MockkBean` / `@TestPropertySource` / 別の `@Import` を足すと、そのクラスだけ別コンテキストへ分岐して効果が失われる**。web 環境を要する `@SpringBootTest` を新しく足すときも、この 5 クラスと同じ構成に揃える。ArchUnit / detekt では強制できないのでレビューで担保する。
+
+- `RestTestClient` も JWT も使わないクラス（`ApiApplicationTests` / `McpDisabledByDefaultTest`）が `@AutoConfigureRestTestClient` と `@Import` を持つのは、**キーを一致させるためだけ**。不自然に見えても外さない。
+- 引き換えに「本番の `issuer-uri` 設定から `JwtDecoder` Bean が生成される」ことを確かめるコンテキストが無くなっている（API E2E もブラウザ E2E も decoder を差し替えるため、リポジトリ全体で担保が無い）。この穴は #813 が引き取る。
+- **`@WebMvcTest` スライスの 11 個は削減対象にしない**。`controllers` 引数ごとに 1 コンテキストになるのはスライステストの機械的帰結で、束ねると「そのコントローラだけを載せる」意図が壊れる。
+- **効果は推論せず実測で確かめる**。実測では 18→17 個で -3.7〜-6.3%、17→16 個で -14.1% と、1 個あたりの効果が 2 倍以上違った（機序は未特定）。ローカルは初回コンテキスト構築の振れが大きく（同一構成で 17.5s / 36.5s、外れ値では `:test` が 74 分停止）効果より測定ノイズが大きいため、**CI（`workflow_dispatch` で 3 回）で測る**。
 
 ## E2E（ブラックボックス API テスト・ゲート外）
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,11 +106,13 @@ tasks.withType<Test> {
     // maxParallelForks（テスト JVM の並列フォーク）は意図的に既定（1）のまま据え置く。
     // 計測上、単一モジュール・小規模スイートの本プロジェクトでは forks を増やすと逆に遅くなる
     // （42s→97s @ forks=4）。コンテキストキャッシュ統計の実測では distinct な ApplicationContext は
-    // 6 個のみ・ヒット率 ~99%（hit 525 / miss 6）で、:test の時間は「一度きりの 6 コンテキスト構築 +
-    // JVM ウォームアップ(~7.8s)」が支配的。Spring のキャッシュは JVM 単位のためフォークすると 6 構築が
+    // 16 個・ヒット率 99.7%（hit 4860 / miss 16）で、:test の時間は「一度きりの 16 コンテキスト構築 +
+    // JVM ウォームアップ」が支配的。Spring のキャッシュは JVM 単位のためフォークすると 16 構築が
     // 各 JVM で重複し JVM 起動も N 倍になる。JVM 内スレッド並列も @MockkBean(springmockk＝@MockBean 機構)が
-    // Spring 公式「Parallel Test Execution」の非推奨条件に該当するため不可。詳細・根拠は ADR-0015 / #349。
-    // #338 で DB 導入後にテスト隔離を整えるか統合テストが多数になったら再評価する。
+    // Spring 公式「Parallel Test Execution」の非推奨条件に該当するため不可。加えて DB を触るテストの
+    // 後始末（共有コンテナの全テーブル TRUNCATE。ADR-0070）が JVM 内並列と両立しない。
+    // 詳細・根拠は ADR-0015 / #349、コンテキストを 18 → 16 に畳んだ経緯は ADR-0077 / #817。
+    // 並列化の再評価は #690（#338 はクローズ済みで受け皿がここへ移っている）。
     // ユビキタス言語カタログの再生成フラグ（-DubiquitousLanguage.update=true）をフォークした JVM へ引き渡す。
     // UbiquitousLanguageCatalogTest が docs/ubiquitous-language.md の自動生成ブロックを書き戻すために参照する。
     System.getProperty("ubiquitousLanguage.update")?.let {

--- a/docs/adr/0077-consolidate-web-test-contexts-trading-jwt-decoder-assurance.md
+++ b/docs/adr/0077-consolidate-web-test-contexts-trading-jwt-decoder-assurance.md
@@ -1,0 +1,61 @@
+# 0077. web 環境を要するテストコンテキストを 1 つに畳み、本番 JwtDecoder Bean 生成の担保を手放す
+
+- Status: Accepted
+- Date: 2026-08-21
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+[ADR-0015](0015-gradle-build-performance-tuning.md) は「テスト速度の本筋は並列化ではなくコンテキストキャッシュの再利用最大化」と決め、速度を縮めたいときの効く順の 2 番目に「コンテキスト構成の共通化」を置いた。しかしそこは着手されないまま、スイートだけが育っていた。
+
+[#690 のフェーズ1 実測](https://github.com/ptiringo/toy-box/issues/690#issuecomment-5351503881)で、`:test` 壁時計の 31.2% がコンテキスト構築であること、distinct な `ApplicationContext` が ADR-0015 当時の 6 個から **18 個**へ増えていることが分かった。ヒット率自体は 99.6%（hit 4861 / miss 18 / failure 0）と最適に近く、**問題は再利用率ではなく構成の種類**にある。同じ実測でテスト並列化の利得上限は **-19%** と見積もられており、構成の共通化がそれを上回るなら並列化より先に手を付ける価値がある。これを確かめるのが #817 である。
+
+### 18 個の内訳（実測 = 静的分析と一致）
+
+アノテーション構成から数えた distinct と、`logging.level.org.springframework.test.context.cache=DEBUG` の実測が完全に一致した。
+
+| 群 | 個数 | 内訳 |
+|---|---|---|
+| `@WebMvcTest` スライス | 11 | `controllers` 引数ごとに 1 個（`JockeyController` だけ `JockeyControllerTest` と `GlobalExceptionHandlerTest` で共有済み） |
+| `@SpringBootTest` | 7 | `NONE` 素 / `NONE`+リスナ記録 / `NONE`+失敗注入 / 既定（`MOCK`）/ `RANDOM_PORT` / `RANDOM_PORT`+`TestJwtDecoderConfiguration` / `local` プロファイル |
+
+ADR-0015 当時（distinct 6）と突き合わせると、増加 +12 個の内訳は **WebMvc スライス +7 / `@SpringBootTest` +5** である。前者は「コントローラが 4 種 → 11 種に増えた」ことの機械的帰結で、**揃っていないだけの重複ではない**（`@WebMvcTest` は 1 コントローラ = 1 コンテキストになる）。したがって削減余地は `@SpringBootTest` 側の 7 個に限られる。
+
+### 実測（CI・ubuntu-latest 4 コア・各 3 回の中央値）
+
+ローカル（8 論理コア / 16GB）は測定に使えなかった。同一構成の反復で初回コンテキスト構築が 17.5s / 36.5s と振れ、1 回は `:test` が **74 分**停止した（`RegisterHorseTransactionRollbackTest` に 4482 秒が計上され、その間ログが 1 行も出ない。#690 が観測した 402 秒ブロック・#818 と同型で、より極端）。削減見込みに対しノイズが 1 桁大きい。CI は振れが 3〜11% に収まるため、4 条件をそれぞれ 3 回測って比較した。
+
+| 構成 | distinct | Tomcat | Hikari プール | `:test` 中央値 | 効果 |
+|---|---|---|---|---|---|
+| 現状 | 18 | 2 | 7 | 84.93s | — |
+| ApiApplication 側のみ統合 | 17 | 2 | 6 | 79.54s | -6.3% |
+| SecurityConfig 側のみ統合 | 17 | 1 | 6 | 81.79s | -3.7% |
+| **両方統合** | **16** | 1 | 5 | **67.55s** | **-20.5%** |
+
+**-20.5% は 16 個にしたときだけ現れる。** 17 個は組み合わせを変えても -4〜6% どまりで、しかも Tomcat を 1 個に減らした側（-3.7%）の方が 2 個のまま（-6.3%）より遅い。したがって Tomcat インスタンス数でも HikariCP プール数でも説明がつかず、**機序は特定できていない**（`:test` の削減 17.38s のうち、コンテキスト構築時間の削減で説明できるのは 6.88s だけで、残り約 10.5s は「構築以外」が速くなった分である）。効果そのものは、最も不利なペア（ベースライン最小 83.54s vs 統合案最大 73.99s）で比べても -9.55s あり、振れの範囲を超えている。
+
+### 引き受けるトレードと、却下した代替案
+
+16 個にするには、既定（`MOCK`）の `@SpringBootTest` グループ（`ApiApplicationTests` / `McpDisabledByDefaultTest`）を `RANDOM_PORT` + `@Import(TestJwtDecoderConfiguration)` のグループへ畳む必要がある。`TestJwtDecoderConfiguration` は HS256 の `JwtDecoder` を差し込み、Spring Boot の `JwtDecoder` 自動構成は `@ConditionalOnMissingBean` なので、**本番の `issuer-uri` 設定から `JwtDecoder` Bean が生成されることの担保が消える**。
+
+この担保はリポジトリ全体でこのコンテキストだけが持っていた。API E2E（`src/e2eTest`）は全クラスが `TestJwtDecoderConfiguration` を `@Import` し、ブラウザ E2E は `EmulatorJwtDecoder` を使う（[ADR-0076](0076-browser-e2e-playwright-auth-emulator-boottestrun.md)）ため、どちらも本番 decoder を通らない。
+
+- **17 個構成（担保を維持）**: 効果が -3.7〜-6.3% と 1/3 以下。並列化の利得上限 -19% にも遠く、ADR-0015 の「効く順」を書き換えるだけの根拠にならない。
+- **現状維持**: -20.5% を見送る。CI の全 PR とローカルの pre-push に効く幅なので、見送る理由が担保の薄さに見合わない。
+- **担保を別の軽いテストで代替**: `webEnvironment = NONE` では OAuth2 リソースサーバの自動構成が効かず `JwtDecoder` が生えないため、既存の `NONE` 素グループには寄せられない。新しいコンテキストを足せば削減した分を打ち消す。
+
+失う担保は「Bean が生成できる」ところまでで、**`issuer` / `audience` の値が正しいかも、JWKS を実際に引けるかも元々検証していない**（`TestJwtSupport` の KDoc に明記のとおり射程外）。これは #813（JWKS 取得・RS256 検証を通すテストが無い状態を埋めるか判断する）が埋めようとしている領域と地続きであり、そちらへ引き継ぐ。
+
+## Decision（決定）
+
+- `src/test` の `@SpringBootTest` のうち **web 環境を要する 5 クラス**（`ApiApplicationTests` / `McpDisabledByDefaultTest` / `HealthEndpointTest` / `OpenApiTest` / `SecurityConfigTest`）を **`RANDOM_PORT` + `@AutoConfigureRestTestClient` + `@Import(TestJwtDecoderConfiguration)` の単一構成**に揃え、1 つのコンテキストを共有させる。
+- 手放す「本番 `issuer-uri` 設定で `JwtDecoder` Bean が生成されることの担保」は **#813 へ引き継ぐ**。#813 で JWKS 取得・RS256 検証を通すテストを入れれば、失った担保より強い形で復活する。
+- **`@WebMvcTest` スライスの 11 個は削減対象にしない**。コントローラ数の機械的帰結であり、`controllers` 引数を束ねるとスライステストの意図（そのコントローラだけを載せる）が壊れる。
+
+## Consequences（結果・影響）
+
+- CI の `:test` が中央値 84.93s → 67.55s（**-20.5%**）。distinct コンテキスト 18 → 16、Tomcat 2 → 1、HikariCP プール 7 → 5。
+- **本番 `issuer-uri` 設定で `JwtDecoder` Bean が生成されることを確かめるコンテキストが、リポジトリから無くなる**。設定の消失や自動構成の破損は、この変更以降 E2E でも検知できない（E2E も decoder を差し替えるため）。#813 が着手されるまでこの穴は開いたままである。
+- 速度改善の**機序は未特定**のまま採用している。したがって「コンテキストを 1 個減らせば約 N 秒縮む」と一般化してはならない。実測では 18→17 と 17→16 で効果が 2 倍以上違った。次に構成をいじるときも**推論ではなく実測で確かめる**（ローカルはノイズが効果より大きいため CI で測る）。
+- 5 クラスは「同一キーであること」に依存して速い。**どれか 1 つに `@MockkBean` や `@TestPropertySource` を足すと、そのクラスだけ別コンテキストへ分岐して効果が失われる**。この規律は `.claude/rules/testing.md` に書く（ArchUnit / detekt では強制できない）。
+- `ApiApplicationTests` / `McpDisabledByDefaultTest` は `RestTestClient` も JWT も使わないが、キー一致のために `@AutoConfigureRestTestClient` と `@Import` を持つ。読み手には不自然に見えるため、各ファイルに理由と本 ADR への参照を残す。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -86,3 +86,4 @@
 | [0074](0074-billing-guardrails-spend-cap-and-budget-alert.md) | 課金ガードレールを Cloud Run spend cap（手設定）と budget alert（Terraform）の二段構えにする | Accepted |
 | [0075](0075-gcp-project-id-not-a-secret.md) | GCP プロジェクト ID は秘匿対象にせず、識別子の扱いは開示済みかどうかで分ける | Accepted |
 | [0076](0076-browser-e2e-playwright-auth-emulator-boottestrun.md) | ブラウザ E2E を Playwright + Auth Emulator + bootTestRun で組み、ゲート外の独立ワークフローで回す | Accepted |
+| [0077](0077-consolidate-web-test-contexts-trading-jwt-decoder-assurance.md) | web 環境を要するテストコンテキストを 1 つに畳み、本番 JwtDecoder Bean 生成の担保を手放す | Accepted |

--- a/src/test/kotlin/com/example/api/ApiApplicationTests.kt
+++ b/src/test/kotlin/com/example/api/ApiApplicationTests.kt
@@ -1,12 +1,22 @@
 package com.example.api
 
 import com.example.api.support.PostgresContainerSupport
+import com.example.api.support.TestJwtDecoderConfiguration
 import org.junit.jupiter.api.Test
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 
 // datasource は外部供給（H2 全面脱却・#451）のため、コンテキスト起動には
 // PostgresContainerSupport の Testcontainers PostgreSQL を注入する。
-@SpringBootTest
+//
+// webEnvironment / @AutoConfigureRestTestClient / @Import は、web 環境を要する @SpringBootTest 5 クラス
+// （本クラス / McpDisabledByDefaultTest / HealthEndpointTest / OpenApiTest / SecurityConfigTest）で
+// キーを揃えてコンテキストを 1 つ共有するためのもの（#817 / ADR-0077）。本クラス自身は RestTestClient も
+// JWT も使わないが、1 つでも構成がずれるとそのクラスだけ別コンテキストへ分岐し、効果（:test -20.5%）が失われる。
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureRestTestClient
+@Import(TestJwtDecoderConfiguration::class)
 class ApiApplicationTests : PostgresContainerSupport() {
     @Test fun contextLoads() {}
 }

--- a/src/test/kotlin/com/example/api/OpenApiTest.kt
+++ b/src/test/kotlin/com/example/api/OpenApiTest.kt
@@ -1,9 +1,11 @@
 package com.example.api
 
 import com.example.api.support.PostgresContainerSupport
+import com.example.api.support.TestJwtDecoderConfiguration
 import org.junit.jupiter.api.Test
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.TestConstructor
 import org.springframework.test.context.TestConstructor.AutowireMode
 import org.springframework.test.web.servlet.client.RestTestClient
@@ -13,9 +15,16 @@ import org.springframework.test.web.servlet.client.RestTestClient
  *
  * springdoc-openapi による REST API ドキュメントの自動生成が正しく動作することを検証します。 datasource は外部供給（H2 全面脱却・#451）のため
  * PostgresContainerSupport を継承する。
+ *
+ * `@Import` する [TestJwtDecoderConfiguration] は、web 環境を要する `@SpringBootTest` 5 クラス
+ * （[com.example.api.ApiApplicationTests] / [com.example.api.mcp.McpDisabledByDefaultTest] /
+ * [com.example.api.actuator.HealthEndpointTest] / [com.example.api.controller.SecurityConfigTest] /
+ * 本クラス）でキーを揃えてコンテキストを 1 つ共有するためのもの（#817 / ADR-0077）。本テストは認証を 要しない `/v3/api-docs` しか叩かないので
+ * `JwtDecoder` の実装は結果に影響しない。1 つでも構成がずれると そのクラスだけ別コンテキストへ分岐する。
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureRestTestClient
+@Import(TestJwtDecoderConfiguration::class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class OpenApiTest(private val restTestClient: RestTestClient) : PostgresContainerSupport() {
     @Test

--- a/src/test/kotlin/com/example/api/actuator/HealthEndpointTest.kt
+++ b/src/test/kotlin/com/example/api/actuator/HealthEndpointTest.kt
@@ -1,17 +1,25 @@
 package com.example.api.actuator
 
 import com.example.api.support.PostgresContainerSupport
+import com.example.api.support.TestJwtDecoderConfiguration
 import org.junit.jupiter.api.Test
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.TestConstructor
 import org.springframework.test.context.TestConstructor.AutowireMode
 import org.springframework.test.web.servlet.client.RestTestClient
 
 // datasource は外部供給（H2 全面脱却・#451）のため、コンテキスト起動には
 // PostgresContainerSupport の Testcontainers PostgreSQL を注入する。
+//
+// @Import(TestJwtDecoderConfiguration) は、web 環境を要する @SpringBootTest 5 クラス（ApiApplicationTests /
+// McpDisabledByDefaultTest / HealthEndpointTest / OpenApiTest / SecurityConfigTest）でキーを揃えて
+// コンテキストを 1 つ共有するためのもの（#817 / ADR-0077）。本テストは認証を要しないエンドポイントしか
+// 叩かないので JwtDecoder の実装は結果に影響しない。1 つでも構成がずれると別コンテキストへ分岐する。
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureRestTestClient
+@Import(TestJwtDecoderConfiguration::class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class HealthEndpointTest(val restTestClient: RestTestClient) : PostgresContainerSupport() {
     @Test

--- a/src/test/kotlin/com/example/api/controller/SecurityConfigTest.kt
+++ b/src/test/kotlin/com/example/api/controller/SecurityConfigTest.kt
@@ -19,6 +19,11 @@ import org.springframework.test.web.servlet.client.RestTestClient
  *
  * `@WebMvcTest` の slice は認証フィルタを無効化してあるため（ADR-0064）、フィルタ層の振る舞いはここと E2E だけが担保する。 `JwtDecoder` は
  * [TestJwtDecoderConfiguration] の HS256 実装に差し替え、実 JWKS を引かずに本物のフィルタチェーンを走らせる。
+ *
+ * この構成（`RANDOM_PORT` + `@AutoConfigureRestTestClient` + `@Import(TestJwtDecoderConfiguration)`）は、
+ * web 環境を要する `@SpringBootTest` 5 クラス（[com.example.api.ApiApplicationTests] /
+ * [com.example.api.mcp.McpDisabledByDefaultTest] / [com.example.api.actuator.HealthEndpointTest] /
+ * [com.example.api.OpenApiTest] / 本クラス）の共通キーでもある（#817 / ADR-0077）。
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureRestTestClient

--- a/src/test/kotlin/com/example/api/mcp/McpDisabledByDefaultTest.kt
+++ b/src/test/kotlin/com/example/api/mcp/McpDisabledByDefaultTest.kt
@@ -3,11 +3,14 @@ package com.example.api.mcp
 import com.example.api.mcp.iam.world.WorldMcpTools
 import com.example.api.mcp.racing.jockey.JockeyMcpTools
 import com.example.api.support.PostgresContainerSupport
+import com.example.api.support.TestJwtDecoderConfiguration
 import io.modelcontextprotocol.server.McpSyncServer
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Import
 
 /**
  * 既定プロファイルでは MCP が 1 つも生えないことの検証（#712）。
@@ -21,10 +24,16 @@ import org.springframework.context.ApplicationContext
  *
  * `@Autowired` の失敗（コンテキスト起動エラー）に頼らず Bean 名の集合を直接見るのは、 「起動が壊れないこと」も同時に確かめたいため。
  *
- * `@SpringBootTest` は [com.example.api.ApiApplicationTests] と同一構成にしてコンテキストキャッシュを共有する
- * （プロファイルもプロパティも足さない）。
+ * `@SpringBootTest` の構成は、web 環境を要する 5 クラス（[com.example.api.ApiApplicationTests] /
+ * [com.example.api.actuator.HealthEndpointTest] / [com.example.api.OpenApiTest] /
+ * [com.example.api.controller.SecurityConfigTest] / 本クラス）でキーを揃え、コンテキストを 1 つ共有する ためのもの（#817 /
+ * ADR-0077）。**MCP の在不在に効く設定（プロファイル・`spring.ai.mcp.server.enabled`）は
+ * 本番と同じ既定のままで、一切足していない**。`@Import` する [TestJwtDecoderConfiguration] は `JwtDecoder` を HS256
+ * 実装へ差し替えるだけで、MCP の Bean 登録には関与しない。
  */
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureRestTestClient
+@Import(TestJwtDecoderConfiguration::class)
 class McpDisabledByDefaultTest : PostgresContainerSupport() {
     @Autowired private lateinit var context: ApplicationContext
 


### PR DESCRIPTION
Closes #817

`distinct ApplicationContext` 18 個の内訳を分析し、統合できるものを実測で見極めた。結論として **web 環境を要する `@SpringBootTest` 5 クラスを 1 コンテキストに畳み、CI の `:test` を 84.93s → 67.55s（-20.5%）に縮めた**。決定と経緯の全体は ADR-0077 に残した。

## 18 個の内訳（実測 = 静的分析と完全一致）

アノテーション構成から数えた distinct と、`logging.level.org.springframework.test.context.cache=DEBUG` の実測（`size = 18` / `hit 4861` / `miss 18` / `failure 0`）が一致した。

| 群 | 個数 | 性質 |
|---|---|---|
| `@WebMvcTest` スライス | 11 | `controllers` 引数ごとに 1 個。**コントローラ 11 種の機械的帰結で、揃っていないだけの重複ではない** |
| `@SpringBootTest` | 7 | `NONE` 素 / `NONE`+リスナ記録 / `NONE`+失敗注入 / `MOCK` / `RANDOM_PORT` / `RANDOM_PORT`+TestJwtDecoder / `local` |

ADR-0015 当時（distinct 6）と比べると増加 +12 個の内訳は **WebMvc +7 / `@SpringBootTest` +5**。前者は削減できないため、余地は `@SpringBootTest` 側の 7 個に限られる。

## CI 実測（各 3 回・`:test` 中央値）

ローカルは測定に使えなかった。同一構成の反復で初回コンテキスト構築が 17.5s / 36.5s と振れ、1 回は `:test` が **74 分**停止した（`RegisterHorseTransactionRollbackTest` に 4482 秒が計上され、その間ログが 1 行も出ない。#818 と同型でより極端）。そこで 4 条件を CI で 3 回ずつ測った。

| 構成 | distinct | Tomcat | Hikari プール | `:test` 中央値 | 効果 |
|---|---|---|---|---|---|
| 現状 | 18 | 2 | 7 | 84.93s | — |
| ApiApplication 側のみ統合 | 17 | 2 | 6 | 79.54s | -6.3% |
| SecurityConfig 側のみ統合 | 17 | 1 | 6 | 81.79s | -3.7% |
| **両方統合（本 PR）** | **16** | 1 | 5 | **67.55s** | **-20.5%** |

- **-20.5% は 16 個にしたときだけ現れる**。17 個は組み合わせを変えても -4〜6% どまりで、しかも Tomcat を 1 個に減らした側の方が遅い。**Tomcat 数でも HikariCP プール数でも説明できず、機序は特定できていない**（`:test` 削減 17.38s のうち構築時間で説明できるのは 6.88s、残り約 10.5s は「構築以外」）。
- 効果自体は最も不利なペア（ベースライン最小 83.54s vs 本 PR 最大 73.99s）でも -9.55s あり、振れの範囲を超えている。
- #690 のフェーズ1 実測は「3 件はログ行が出ておらず計上できていない」としていたが、原因は `@Nested` 起点だと `Started BloodHorseControllerTest.RegisterCarriedOverCase in ...` となり正規表現 `Started [A-Za-z]+ in` に一致しないだけだった。**18 件すべてログに出ている**（#690 に訂正済み）。

## 引き換えに手放したもの

`TestJwtDecoderConfiguration` を 5 クラス全部に広げるため、Spring Boot の `JwtDecoder` 自動構成（`@ConditionalOnMissingBean`）が効かなくなり、**本番の `issuer-uri` 設定から `JwtDecoder` Bean が生成されることを確かめるコンテキストがリポジトリから無くなる**。API E2E は全クラスが `TestJwtDecoderConfiguration` を `@Import` し、ブラウザ E2E は `EmulatorJwtDecoder` を使うため、この担保はここだけが持っていた。

失うのは「Bean が生成できる」ところまでで、`issuer` / `audience` の値も JWKS 取得も元々検証していない（`TestJwtSupport` の KDoc に射程外と明記）。**#813 へ引き継ぐ**（コメント済み）。

## 検証

- `./gradlew check` 緑（BUILD SUCCESSFUL in 3m10s）。
- **ミューテーションで空振りしていないことを確認した**。`McpDisabledByDefaultTest` は MOCK → RANDOM_PORT へ変えたため「MCP が生えない」ことの検証が別の理由で通る恐れがあった。`@ActiveProfiles("local")` + `toy-box.mcp.subject-id` を一時的に足すと 4 テストすべてが落ちる（`.claude/rules/gates.md`）。

  ```
  McpDisabledByDefaultTest > 既定プロファイルではMCPサーバー本体のBeanも登録されない() FAILED
  McpDisabledByDefaultTest > 既定プロファイルではMCPツールBeanが登録されない() FAILED
  McpDisabledByDefaultTest > 既定プロファイルでは公開MCPツールが1つも無い() FAILED
  McpDisabledByDefaultTest > 既定プロファイルでもActor解決のBeanは生えない() FAILED
  29 tests completed, 4 failed
  ```

## 射程外

- **`@WebMvcTest` スライス 11 個は削減しない**。`controllers` を束ねると「そのコントローラだけを載せる」意図が壊れる。
- **テスト並列化の採否（#690）は決めていない**。本 PR の実測は #690 のフェーズ1 から派生した別テーマで、並列化の利得上限（-19%）との比較材料にはなるが、#690 の結論は #690 で出す。
