### PR TITLE
chore: #702 CI の pull_request トリガを main 以外の base ブランチでも走らせる

### DIFF
--- a/.github/workflows/adr-check.yml
+++ b/.github/workflows/adr-check.yml
@@ -13,7 +13,6 @@ name: ADR Check
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
     paths:
       - "docs/adr/**"

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -5,7 +5,6 @@ run-name: API Tests for ${{ github.ref }}
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
   push:
     branches: [main]

--- a/.github/workflows/browser-e2e.yml
+++ b/.github/workflows/browser-e2e.yml
@@ -12,7 +12,6 @@ run-name: Browser E2E for ${{ github.ref }}
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
     paths-ignore:
       - "docs/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,7 +5,6 @@ run-name: CodeQL Analysis for ${{ github.ref }}
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
   push:
     branches: [main]

--- a/.github/workflows/container-smoke-test.yml
+++ b/.github/workflows/container-smoke-test.yml
@@ -7,7 +7,6 @@ run-name: Container Smoke Test for ${{ github.ref }}
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
     paths-ignore:
       - "infra/**"

--- a/.github/workflows/db-doc-check.yml
+++ b/.github/workflows/db-doc-check.yml
@@ -8,7 +8,6 @@ name: DB Doc Check
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
     paths:
       - "src/main/resources/db/migration/**"

--- a/.github/workflows/dprint-check.yml
+++ b/.github/workflows/dprint-check.yml
@@ -7,7 +7,6 @@ name: dprint Check
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
     paths:
       - "**/*.toml"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,7 +6,6 @@ run-name: E2E API Tests for ${{ github.ref }}
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
   push:
     branches: [main]

--- a/.github/workflows/editorconfig-check.yml
+++ b/.github/workflows/editorconfig-check.yml
@@ -6,7 +6,6 @@ run-name: EditorConfig Check for ${{ github.ref }}
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,7 +8,6 @@ name: frontend
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
     paths:
       - "frontend/**"

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -10,7 +10,6 @@ name: OpenAPI Lint
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
     paths:
       - "src/main/**"

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,7 +7,6 @@ name: ShellCheck
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
     paths:
       - "**/*.sh"

--- a/.github/workflows/sql-check.yml
+++ b/.github/workflows/sql-check.yml
@@ -7,7 +7,6 @@ name: SQL Check
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
     paths:
       - "src/main/resources/db/migration/**"

--- a/.github/workflows/terraform-check.yml
+++ b/.github/workflows/terraform-check.yml
@@ -7,7 +7,6 @@ name: Terraform Check
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
     paths:
       - "infra/**"


### PR DESCRIPTION
## 概要

base が main 以外の PR で CI が 1 つも起動しない状態を解消する。`pull_request` 側の
`branches: [main]` フィルタを 14 本の workflow から撤廃した。

Closes #702

## なぜ

CI ワークフローの `pull_request` トリガはすべて base を main に限定していた。このため
stacked pull requests（#701）のスタック 2 層目以降（base が下層の作業ブランチになる PR）では
API Tests・E2E・OpenAPI lint・dprint・editorconfig・CodeQL 等がすべてスキップされ、
スタック運用そのものが成り立たない。

## 方針の判断（Issue の検討事項）

Issue では「フィルタごと外す」か「作業ブランチの命名規約を許可リストにする」かを決める、と
していた。**フィルタごと撤廃**を採る。

- 許可リスト方式は、stacked PR の下層 base が `chore/**` ・ `feat/**` ・ `fix/**` 等になるため
  事実上「全部」を列挙することになり、prefix を増やすたびに追従が要る管理コストだけが残る。
- フィルタ撤廃で追加起動するのは **base が main 以外の PR だけ**。Dependabot PR も含め既存の
  PR はすべて base=main なので、現行の Actions 実行量は変わらない。

## 変更内容

- `.github/workflows/{adr-check,api-tests,browser-e2e,codeql,container-smoke-test,db-doc-check,dprint-check,e2e-tests,editorconfig-check,frontend,openapi-lint,shellcheck,sql-check,terraform-check}.yml`
  — `pull_request` 直下の `branches: [main]` を削除（14 本）。`types` ・ `paths` /
  `paths-ignore` は変更していないので、どのイベントで何が走るかの他の条件は不変。

据え置いたもの:

- **`push` 側の `branches: [main]`** — メインライン集計の発火条件は変えない。
- **`deploy.yml`** — push(main) のみのトリガで、そもそも `pull_request` を持たない。
- **`copilot-setup-steps.yml`** — 元から `branches` フィルタが無い。

## ブランチ名を前提にした step の確認

`.github/workflows/` 全体を `base_ref` / `refs/heads/main` / `origin/main` / `github.ref ==` /
`default_branch` で grep したところ、該当は `api-tests.yml` の差分カバレッジ step 1 箇所のみ。

```yaml
env:
  BASE_REF: ${{ github.base_ref }}
run: |
  mise exec -- diff-cover ... --compare-branch "origin/$BASE_REF"
```

比較先は `github.base_ref` 由来で main 決め打ちではなく、checkout も `fetch-depth: 0` なので
base が main 以外でも `origin/<base>` を解決できる。壊れる step は無い。

## 単独での価値

現状 base が main 以外の PR は作られていないため、この変更単独では既存の挙動は変わらない。
#701 の検証を始める前の前提整備という位置づけ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
