### PR TITLE
chore: #475 ローカルの GCP アクセスを viewer SA impersonation 既定にする

### DIFF
--- a/.claude/rules/gcp-guardrails.md
+++ b/.claude/rules/gcp-guardrails.md
@@ -23,13 +23,37 @@ Claude Code から Google Cloud（project `ptiringo-toy-box`）を扱うとき�
 - infra apply: HCP Terraform run（tfctl / HCP UI。[ADR-0034](../../docs/adr/0034-adopt-tfctl-cli.md)）。ローカルは `terraform plan` まで。
 - 変更系を流したいときは ask の確認に従うか、上記の正規ルートに寄せる。
 
-## viewer SA を使う（impersonation）
+## viewer SA は既定で効く（impersonation）
 
-`local_readonly_impersonators` に自分の `user:<mail>` を追加して apply（CI/HCP 経由）したうえで:
+`mise.toml` の `[env]` が `CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT`（gcloud）と `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT`（terraform の google / google-beta provider）を設定するため、**プロジェクトディレクトリでは何も付けなくても viewer SA で走る**。対話シェル（`mise activate`）と Claude Code セッション（session-start hook の `mise hook-env`）の双方に適用される。read-only を「最小抵抗の既定」にするのが狙いで、フラグを覚えている必要はない。
+
+前提は `local_readonly_impersonators`（HCP workspace の Terraform 変数）に自分の `user:<mail>` が入った状態で apply 済みであること。付与前に env だけ有効化すると impersonation が解決できず、**読み取りを含む全 gcloud が壊れる**。
+
+変数は `list(string)` なので HCP UI で登録するときは **HCL フラグをオンにする**（`["user:foo@example.com"]`）。忘れると文字列として渡り run が型エラーで落ちる。付与対象は**実際に `gcloud config list` の `[core] account` になるアカウント**にすること（複数アカウントを使い分けているなら、切り替え先も入れておかないと切り替えた瞬間に全 gcloud が壊れる）。
+
+効いているかは次で確認する:
 
 ```bash
-gcloud <read-only command> --impersonate-service-account=local-readonly@ptiringo-toy-box.iam.gserviceaccount.com
+gcloud config list                          # [auth] impersonate_service_account に SA が出る
+gcloud projects describe ptiringo-toy-box   # 通れば tokenCreator 付与まで含めて健全
 ```
+
+impersonation が効いている間は実行のたびに `WARNING: This command is using service account impersonation.` が stderr へ出る（2 行出ることがある）。**正常動作の合図でエラーではない**ので、出力をパースするスクリプトでは stdout だけを見ること。
+
+`gcloud auth login` 等の auth 系は impersonation の影響を受けない（資格情報の取得自体はローカル identity で行う）。
+
+terraform 側の `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` が効くのは **provider がローカルで認証するときだけ**。`infra/` は HCP Terraform（`cloud` ブロック）なので `plan` / `apply` は HCP 上で HCP の資格情報で走り、この env は渡らない。ローカルの多層防御（将来のローカル実行・別ディレクトリでの provider 利用）として置いてある。`gcloud config list` の `[core] account` も **owner のまま表示される**（impersonation は実行時に被さるだけでアクティブアカウントを置き換えない）ので、これを見て「効いていない」と誤読しないこと。
+
+## owner へ昇格する（例外）
+
+- **変更系は昇格しない**。正規ルート（GitHub Actions / HCP Terraform run）に寄せる。
+- viewer では見えない**読み取り**（課金など）に限り、対話シェルで env を外してから叩く:
+
+  ```bash
+  unset CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT   # そのシェルの間だけ owner に戻る
+  ```
+
+- **`VAR= gcloud ...` の env 代入プレフィックスで昇格しない**。先頭トークンが `gcloud` でなくなり、permissions の deny/ask マッチャに当たらないまま走りうる（下記「変更系を env ランナーでラップしない」と同じ穴）。
 
 ## メンテナンス
 

--- a/docs/adr/0036-gcp-operation-guardrails.md
+++ b/docs/adr/0036-gcp-operation-guardrails.md
@@ -31,7 +31,7 @@ GCP 操作のガードレールを 2 層で構成する。**役割は非対称**
 - **変更作業はローカルのアイデンティティを通さない**: アプリ deploy は GitHub Actions（WIF → `deployer@`）、infra apply は HCP Terraform run（tfctl/UI）で、いずれも CI/HCP の資格で走る。稀にローカルで変更が要るときだけ owner 等への**明示的な昇格**で行う（摩擦は意図的）。「viewer SA だけでは変更できない」のは仕様であり、変更は正規ルートか明示昇格に寄せる。
 - **owner は IAM で強制できない**: project owner（本リポジトリの利用者）は常に owner 権限を持ち、`--account` 切替や env 上書きで viewer 既定を回避できる。したがって viewer SA の使用を owner に**ハード強制することはできない**。実際の強制は permissions 層（deny/ask）が担う（アイデンティティ非依存で無確認変更を止める）。viewer SA の価値は「安全な既定」と「多層防御（コマンドがすり抜けても被害が閲覧に限定）」。
 - **非 owner の協力者には実効的**: 協力者には viewer SA への tokenCreator のみを渡せば impersonation が唯一の経路になり、read-only を本当に強制できる。
-- impersonation を最小抵抗の既定にする（`CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT` / `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` を env で既定化）配線は、SA の apply と tokenCreator 付与の**後**に行う必要があるためフォローアップとする。
+- impersonation を最小抵抗の既定にする（`CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT` / `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` を env で既定化）配線は、SA の apply と tokenCreator 付与の**後**に行う必要があるためフォローアップとした（#475 で `mise.toml` の `[env]` に配線済み。手順は `.claude/rules/gcp-guardrails.md`）。
 
 ### スコープ
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,32 @@
 [settings]
 lockfile = true
 
+# ローカルの GCP アクセスを read-only の「最小抵抗の既定」にする（#475 / ADR-0036）。
+# ローカル identity（owner）のまま叩くと変更操作まで通ってしまうため、プロジェクトディレクトリに
+# いる間は viewer SA（roles/viewer のみ）への impersonation を既定にし、覚えていなくても
+# read-only で動くようにする。対話シェル（mise activate）と Claude Code セッション
+# （.claude/hooks/session-start-mise.sh の `mise hook-env`）の双方に適用される。
+#
+# これは「強制」ではなく既定であって、owner は常に回避できる（ハード強制は不可）。無確認の変更操作を
+# 実際に止めるのは .claude/settings.json の permissions（deny/ask）で、本設定はその多層防御
+# ＋事故防止。運用・昇格手順は .claude/rules/gcp-guardrails.md を参照。
+#
+# 前提: local-readonly SA が apply 済みで、利用者に roles/iam.serviceAccountTokenCreator が
+# 付いていること（infra/modules/local-readonly/ と HCP の local_readonly_impersonators）。
+# 付与前にこの env を有効化すると impersonation が解決できず、読み取りを含む全 gcloud が壊れる。
+#
+# CI では効かせる必要がない: deploy.yml は mise を経由せず WIF + deployer@ で認証し、
+# terraform-check.yml は `terraform init -backend=false` + validate/fmt なので provider 認証を
+# 行わない。将来 mise 経由の CI ジョブで gcloud / terraform apply を使うなら、そのジョブで
+# 明示的に空へ上書きすること（さもないと viewer 権限で失敗する）。
+[env]
+# gcloud CLI（--impersonate-service-account の既定値に相当）
+CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT = "local-readonly@ptiringo-toy-box.iam.gserviceaccount.com"
+# terraform の google / google-beta provider（provider ブロックの impersonate_service_account に相当）。
+# infra/ は HCP Terraform（cloud ブロック）で remote 実行されるためこの env は HCP の run には渡らない。
+# provider がローカルで認証する場合のみ効く多層防御。
+GOOGLE_IMPERSONATE_SERVICE_ACCOUNT = "local-readonly@ptiringo-toy-box.iam.gserviceaccount.com"
+
 [tools]
 actionlint = "1.7.12"
 "aqua:cli/cli" = "2.96.0"


### PR DESCRIPTION
Closes #475

## 背景

ADR-0036 で viewer SA（`local-readonly`、`roles/viewer` のみ）を定義したが、ローカルの gcloud / terraform は owner のままで、impersonation を**明示**しないと使われなかった。read-only を「最小抵抗の既定」にして、フラグを覚えていなくても read-only で動くようにする。

「強制」ではなく既定であって、owner は常に回避できる。無確認の変更操作を実際に止めるのは `.claude/settings.json` の permissions（deny/ask）で、本 PR はその多層防御＋事故防止。

## 変更内容

### `mise.toml`

`[env]` を新設し、2 つの env を既定化した。対話シェル（`mise activate`）と Claude Code セッション（session-start hook の `mise hook-env`）の双方に効く。

- `CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT`（gcloud）
- `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT`（terraform の google / google-beta provider）

### `.claude/rules/gcp-guardrails.md`

- 「viewer SA を使う」節を、毎回フラグを付ける手順から**既定で効く**前提へ書き換え
- 効いているかの確認コマンド、`[core] account` は owner のまま表示されるので誤読しない旨、impersonation の WARNING は正常動作の合図である旨を追記
- HCP 変数 `local_readonly_impersonators` は `list(string)` なので **HCL フラグが要る**ことを明記
- **owner へ昇格する（例外）** 節を新設。変更系は正規ルート（Actions / HCP run）に寄せること、`VAR= gcloud ...` の env 代入プレフィックスは permissions の deny/ask マッチャを迂回するため昇格に使わないことを明記

### `docs/adr/0036-gcp-operation-guardrails.md`

env 配線を「フォローアップとする」から配線済み（#475）へ更新。

## 前提（本 PR の外で実施済み）

Issue #475 の「順序依存（重要）」のとおり、**tokenCreator 付与が先**でなければ読み取りを含む全 gcloud が壊れる。着手時点で HCP 変数 `local_readonly_impersonators` は未設定（variable set も無し）＝ default `[]` で、tokenCreator が 1 つも作られていなかった。

そこで先に HCP UI で変数を設定し apply 済み:

- `local_readonly_impersonators` = `["user:admin@ptiringo.tech"]`（HCL）
- run `run-AZf5b9SKHCrHiZ8B` → `applied`（add 1 / change 0 / destroy 0）

## 動作確認（実測）

| 確認項目 | 結果 |
| --- | --- |
| `mise hook-env` が両 env を出力 | OK |
| `gcloud config list` の `[auth] impersonate_service_account` | SA が反映 |
| SA の IAM policy | `roles/iam.serviceAccountTokenCreator` に `user:admin@ptiringo.tech` |
| impersonation 経由の `gcloud projects describe` | 成功 |
| impersonation 経由の `gcloud run services list` | 成功（`api` を取得） |
| dprint / editorconfig-checker / gitleaks | 通過（pre-commit） |

## CI への影響

無い。

- `deploy.yml` は mise を経由せず WIF + `deployer@` で認証する
- `terraform-check.yml` は mise を使うが `terraform init -backend=false` + validate / fmt / tflint / trivy で provider 認証を行わない

将来 mise 経由の CI ジョブで gcloud / terraform apply を使う場合は、そのジョブで env を空へ上書きする必要がある（mise.toml のコメントに明記）。

## 既知の制約

- **impersonators は `admin@ptiringo.tech` のみ**。`gcloud config set account ptiringo@gmail.com` に切り替えると impersonation が解決できず読み取りも壊れる（rules に注記済み）。切り替え運用が要るなら HCP 変数へ追加する。
- `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` は `infra/` の plan / apply には効かない。HCP Terraform（`cloud` ブロック、execution-mode: remote）の run は HCP 側の資格情報で走るため。provider がローカル認証する場合のみ効く多層防御として置いている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
