### PR TITLE
chore: #806 Markdown の相対リンク切れを機械検知する

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,42 @@
+# Markdown リンクチェックワークフロー
+#
+# 目的: Markdown が張る相対リンクの切れを検知する（#806）。#776 で指示ファイルをリンク委譲型へ
+# 再構成したため、リンクが切れると情報がどこにも無い状態になる。主要因は ADR の連番繰り下げ
+# （#597 / #712 の実績）と .claude/rules/ の分割・改名で、どちらも静かに壊れる。
+#
+# pre-commit（lefthook の markdown-links）でも同じスクリプトが走るが、--no-verify や GitHub の
+# web 編集はローカルフックを通らない。push（main）側にも載せているのは、PR 作成後に main 側の
+# 改名でリンクが切れた場合、PR 側に新しい push が無ければ pull_request が再実行されないため。
+
+name: Markdown Link Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "**/*.md"
+      - "scripts/check-markdown-links.sh"
+  push:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - "scripts/check-markdown-links.sh"
+  workflow_dispatch:
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    name: Markdown Relative Link Check
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # 素の bash だけで動くのでツールのインストールは要らない（mise のセットアップも不要）。
+      - name: Markdown relative link check
+        run: scripts/check-markdown-links.sh

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -132,6 +132,18 @@ pre-commit:
       run: scripts/check-adr-numbering.sh
       tags: lint
 
+    # Markdown の相対リンク切れチェック（#806）。
+    # リンク切れは「リンク先が消えた・改名された」ときに起きるが、そのときリンク元の .md は
+    # stage されない。{staged_files} を渡すと主要因（ADR の繰り下げ）を取り逃すため、常に全件を
+    # 検査する（glob は発火の条件だけを絞る役。adr-numbering と同じ形）。
+    # glob の `{,**/}` はルート直下（CLAUDE.md / README.md）を漏らさないため（#800 と同じ理由）。
+    # pre-push ではなく pre-commit に置くのは、pre-push の glob 判定が worktree で当てにならない
+    # 経緯があるため（#804）。
+    markdown-links:
+      glob: "{,**/}*.md"
+      run: scripts/check-markdown-links.sh
+      tags: lint
+
 pre-push:
   # piped: 先頭のコマンドが落ちたら後続を打ち切る（docker-available → full-test の順で fail fast）。
   piped: true

--- a/scripts/check-markdown-links.sh
+++ b/scripts/check-markdown-links.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Markdown が張る相対リンクの切れを検査する（#806）。
+#
+# #776 で指示ファイルをリンク委譲型（詳細を再掲せず出所へのリンクで辿らせる形）へ再構成したため、
+# リンクが切れると情報がどこにも無い状態になる。主要因は ADR の連番繰り下げ（#597 / #712 の実績）と
+# .claude/rules/ の分割・改名で、どちらも静かに壊れて CI は何も言わなかった。
+#
+# 検査するのは相対リンクの実在だけで、外部 URL とアンカー（#見出し）は見ない。外部 URL は
+# ネットワークに出るためレート制限・flaky・オフライン実行の問題が付き、相対リンクのアンカーは
+# 導入時点の実測で 0 本だったため守る対象が無い。
+#
+# 使い方:
+#   scripts/check-markdown-links.sh
+#   - 引数は取らず、常に追跡下の *.md 全件を検査する。リンク切れは「リンク先が消えた・改名された」
+#     ときに起きるが、そのときリンク元の .md は stage されない。{staged_files} だけを見る設計は
+#     主要因（ADR の繰り下げ）を狙って取り逃すため、lefthook からも全件で呼ぶ（glob は発火を絞る役）。
+#   - リポジトリ root からの実行を前提とする。
+# 終了コード: 違反があれば 1、なければ 0。
+#
+# 互換: macOS 標準の bash 3.2 で動くよう連想配列/mapfile を使わない（check-adr-numbering.sh と同じ）。
+set -euo pipefail
+
+status=0
+
+# 追跡下の .md だけを対象にする。gitignore された生成物（build/・node_modules/・
+# docs/superpowers/）は git が自然に除くので、除外リストを自前で持たなくて済む。
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  dir=$(dirname "$file")
+
+  # コードフェンス内の行を捨て、行内のインラインコードを落としてから `](...)` を行番号つきで拾う。
+  # インラインコードを落とすのは、ドキュメントが書く例示（`[NNNN](NNNN-....md)` 等）を
+  # 実在チェックに掛けないため。
+  while IFS="$(printf '\t')" read -r lineno link; do
+    [ -n "$link" ] || continue
+
+    # 外部 URL と純アンカーは対象外（相対リンクの切れだけを見る）。
+    case "$link" in
+      http://* | https://* | mailto:* | \#*) continue ;;
+    esac
+
+    # アンカーは剥がして実体だけを見る。
+    path=${link%%#*}
+    [ -n "$path" ] || continue
+
+    # ディレクトリへのリンク（例: ../docs/adr/）が実在するので -f ではなく -e で見る。
+    if [ ! -e "$dir/$path" ]; then
+      echo "NG: $file:$lineno リンク先がありません: $link" >&2
+      status=1
+    fi
+  done < <(awk '
+    /^[[:space:]]*```/ { fence = !fence; next }
+    fence { next }
+    {
+      line = $0
+      gsub(/`[^`]*`/, "", line)
+      while (match(line, /\]\([^)]+\)/)) {
+        printf "%d\t%s\n", FNR, substr(line, RSTART + 2, RLENGTH - 3)
+        line = substr(line, RSTART + RLENGTH)
+      }
+    }
+  ' "$file")
+done < <(git ls-files '*.md')
+
+exit "$status"

--- a/scripts/check-markdown-links.sh
+++ b/scripts/check-markdown-links.sh
@@ -20,10 +20,20 @@
 # 互換: macOS 標準の bash 3.2 で動くよう連想配列/mapfile を使わない（check-adr-numbering.sh と同じ）。
 set -euo pipefail
 
+# リポジトリ root へ移動してから検査する（check-adr-numbering.sh と同じ前提の機械的な担保）。
+# root 外から実行すると git ls-files が対象を欠いたまま「出力なし・exit 0」になり成功と区別が
+# つかず、git 管理外のディレクトリから実行すると git コマンドが失敗するだけで status=0 のまま
+# 抜けてしまう。set -e があるので非 git ディレクトリでは rev-parse の失敗でここで落ちる。
+root=$(git rev-parse --show-toplevel)
+cd "$root"
+
 status=0
 
 # 追跡下の .md だけを対象にする。gitignore された生成物（build/・node_modules/・
 # docs/superpowers/）は git が自然に除くので、除外リストを自前で持たなくて済む。
+# core.quotePath（既定 true）は非 ASCII パスを `"f-\346\227\245..."` のように 8 進エスケープで
+# クォートするため、無効化しないと日本語ファイル名の .md が awk で開けず無検査のまま素通りする
+# （fail-open。このリポジトリは日本語ファイル名のドキュメントが普通に増える）。
 while IFS= read -r file; do
   [ -n "$file" ] || continue
   dir=$(dirname "$file")
@@ -60,6 +70,6 @@ while IFS= read -r file; do
       }
     }
   ' "$file")
-done < <(git ls-files '*.md')
+done < <(git -c core.quotePath=false ls-files '*.md')
 
 exit "$status"


### PR DESCRIPTION
## 概要

Markdown が張る**相対リンクの切れ**を機械検知する仕組みを入れる。#776（PR #805）で `.github/copilot-instructions.md` をリンク委譲型（詳細を再掲せず出所へのリンクで辿らせる形）へ再構成したため、リンクが切れると**情報がどこにも無い状態**になる。主要因は ADR の連番繰り下げ（#597 / #712 の実績）と `.claude/rules/` の分割・改名で、どちらも静かに壊れて CI は何も言わなかった。

Closes #806

## 入れたもの（3 点）

| ファイル | 役割 |
|---|---|
| `scripts/check-markdown-links.sh` | 検査本体。素の bash / awk / grep / git のみ |
| `lefthook.yml` | pre-commit に `markdown-links` を追加 |
| `.github/workflows/markdown-link-check.yml` | CI ゲート（`adr-check.yml` と同型） |

スクリプトは**引数を取らず、常に `git ls-files '*.md'` の全件を検査する**。リンク切れは「リンク**先**が消えた・改名された」ときに起きるが、そのときリンク**元**の `.md` は stage されない。`{staged_files}` を渡す設計は主要因（ADR の繰り下げ）を狙って取り逃すため、lefthook からも全件で呼ぶ（glob は発火の条件を絞る役だけ。#757 の `adr-numbering` と同じ形）。

コードフェンス内の行とインラインコードを除いてから `](...)` を抽出するので、ドキュメントが書く例示パス（`.claude/skills/adr/SKILL.md` の `[NNNN](NNNN-....md)` 等）は実在チェックに掛からない。

## 設計時の実測（main 87adc39 時点）

| 項目 | 値 |
|---|---|
| 追跡下の `.md` | 113 ファイル |
| 相対リンク（外部 URL 除く） | 557 本 |
| 現状の切れ | 0 本 |
| アンカー付きの相対リンク | 0 本 |
| コードフェンス内のリンク記法 | 0 件 |
| 参照リンク定義 `[x]: path` | 0 件 |
| リンク先の空白 / `%` エスケープ | 0 件 |
| ルート絶対パスのリンク | 0 件 |

アンカー検査を入れないのは、相対リンクのアンカーが実測 0 本で守る対象が無いため（リンクから `#` 以降は剥がして無視する）。

## ゲートの発火をミューテーションで確認した（#782）

**スクリプト単体**（scratchpad の fixture）: 壊れたリンク 2 本 ＋ 誤検知しては困る 4 パターン（外部 URL / 純アンカー / インラインコード / コードフェンス内）を仕込み、**壊れた 2 本だけ**を検出して `exit=1`。欠けていたファイルを作ると `exit=0` になることも実測。

**pre-commit フック**: `README.md` に壊れたリンクを一時的に足して実行し、実際に落ちることを実測。

```
NG: README.md:110 リンク先がありません: docs/definitely-missing.md
```

**CI**: この PR 上で `README.md` に壊れたリンクを足して push し、`Markdown Relative Link Check` が **fail** することを実測（確認後 `git reset --hard` ＋ force push で巻き戻し済み。ブランチは通常のコミットのみ）。

| 状態 | 結果 |
|---|---|
| 壊す前（`958b654`） | **pass** 6s |
| 壊れたリンクを push（`f2d3fc4`） | **fail** 4s |
| 巻き戻し後（`958b654`） | **pass** 5s |

失敗ジョブのログ本文:

```
2026-08-21T23:26:02.0805571Z NG: README.md:110 リンク先がありません: docs/definitely-missing.md
```

なおこの PR は `.md` を 1 つも含まないため、`Markdown Relative Link Check` が最初から一覧に現れたこと自体が `paths` の 2 つ目（`scripts/check-markdown-links.sh`）で発火することの確認になっている。

## スコープ外（YAGNI）

- **外部 URL の検査** — ネットワークに出るとレート制限・flaky・オフライン実行の問題が付く
- **アンカー（`#見出し`）の検査** — 相対リンクのアンカーは実測 0 本
- **参照リンク定義 `[x]: path` 形式への対応** — 実測 0 件。必要になってから足す
- **`scripts/check-adr-numbering.sh` の変更** — 索引リンクの実在検査が新スクリプトと重複するが、#757 のスクリプトは「ADR の採番と索引の整合」で自己完結したままにする。二重検査のコストは素の bash なので実質ゼロで、壊れ方も安全側

## レビューで塞いだ穴

ブランチ全体のレビューで、**ゲートが出力なしで exit 0 を返す経路が 2 つ**見つかったため塞いだ（コミット `866d62d`）。どちらも失敗の向きが偽陰性で、放置すると「空振りしているゲート」になる。

- **非 ASCII を含むパスの `.md` が無検査のまま緑になっていた** — `git ls-files` は `core.quotePath`（既定 true）で日本語パスを `"\347\224\250..."` の形にクォートするため awk が開けず、そのファイルを 1 本も検査しないまま `status` が 0 のままだった。このリポジトリはドキュメントが全部日本語なので `docs/用語集.md` のようなファイルが足される余地がある。`git -c core.quotePath=false ls-files` にして塞いだ（日本語ファイル名のリンク切れを検出して `exit=1` になることを実測）
- **リポジトリ root 外から実行すると出力なしで exit 0 だった** — `docs/` から実行すると `docs/` 配下だけを黙って検査し、git 管理外では `fatal: not a git repository` を出すだけで 0 を返していた。先例 `check-adr-numbering.sh` は同じ問題で明示的に落とすので揃えた（`git rev-parse --show-toplevel` して `cd`。非 git では `set -e` で `exit=128`）

## 既知の穴（いずれも追跡下 0 件・偽陽性側のため未対応）

- リンクタイトル構文 `[text](path "title")` は `path "title"` 全体をパスとして扱うため false positive になる
- チルダフェンス（`~~~`）は無視しないため、その中のリンク例示を誤検知しうる
- フェンス検出が単純トグルのため、4 連バッククォート内に 3 連を書くネストに非対応
- ルート絶対パスリンク `](/path)` は常に `$dir/$path` で解決する（root 直下では偶然通り、サブディレクトリでは偽陽性）
- `http` / `https` / `mailto` 以外のスキーム（`tel:` / `vscode://` 等）は相対パス扱いになる（先例 `check-adr-numbering.sh` も同じ制限）

このほか、**リンク先が `.md` でないもの 6 本**（`lefthook.yml` / `mise.toml` / ディレクトリ）は、それらを改名する PR が `.md` を 1 つも触らないため lefthook の glob にも CI の `paths` にも当たらない。件数が小さいので今回は追わない。
