### PR TITLE
chore: #786 package-lock.json を書く npm のバージョンを mise で固定する

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -526,6 +526,10 @@ url = "https://nodejs.org/dist/v22.23.1/node-v22.23.1-darwin-x64.tar.gz"
 checksum = "sha256:7df0bc9375723f4a86b3aa1b7cc73342423d9677a8df4538aca31a049e309c29"
 url = "https://nodejs.org/dist/v22.23.1/node-v22.23.1-win-x64.zip"
 
+[[tools."npm:npm"]]
+version = "12.0.2"
+backend = "npm:npm"
+
 [[tools."pipx:diff-cover"]]
 version = "10.3.0"
 backend = "pipx:diff-cover"

--- a/mise.toml
+++ b/mise.toml
@@ -36,6 +36,21 @@ fnox = "1.27.1"
 gitleaks = "8.30.1"
 java = "temurin-25.0.3+9.0.LTS"
 lefthook = "2.1.9"
+# npm 自体も node とは別に固定する（#786）。node 22 同梱の npm 10 は optional 依存の `libc` メタデータを
+# 書き出さないため、npm 11 以降が書いた `frontend/package-lock.json` を手元で更新すると、本題と無関係な
+# `libc` の削除が巻き添えで入る。Dependabot は新しい npm で lock を書くので、固定しないと
+# 「手で触ると消える → Dependabot が足す」の往復差分がレビューのたびに混ざる（PR #785 で直した直後、
+# c6d9877 で再び 4 箇所が消えた）。
+#
+# 実測: 同じ package.json から生成した lock の `libc` は npm 10 で 0 件、npm 11 / 12 で 14 件。
+# npm 11 と 12 の出力はバイト単位で一致するため、Dependabot が 11 系のままでも 12 で揃う。
+#
+# CI の install_args には足していない。frontend / browser-e2e のジョブは `npm ci`（lock を書き換えない）
+# しか使わず node 同梱の npm で足りるので、「そのジョブが使うツールだけ入れる」方針（#464）を優先する。
+#
+# **`node` より前に書くこと**。mise は [tools] の宣言順に PATH を積むため、node の後ろに置くと node 同梱の
+# npm 10 が先に解決され、この固定は無言で効かなくなる（`mise exec -- npm --version` が 10.9.8 を返すのを実測）。
+"npm:npm" = "12.0.2"
 node = "22"
 "aqua:koalaman/shellcheck" = "0.11.0"
 "pipx:diff-cover" = "10.3.0"


### PR DESCRIPTION
Closes #786

## やったこと

`frontend/package-lock.json` を書く npm のバージョンを **mise.toml に固定**した（Issue の選択肢 a）。

```toml
"npm:npm" = "12.0.2"
node = "22"
```

## なぜ

node 22 同梱の npm 10 は optional 依存の `libc` メタデータを書き出さない。そのため npm 11 以降が書いた lock を手元で更新すると、本題と無関係な `libc` の削除が巻き添えで入る。Dependabot は新しい npm で lock を書くので、揃えないと「手で触ると消える → Dependabot が足す」の往復差分がレビューのたびに混ざる。

**実害は継続していた**。PR #785 で npm 11 を使って直した後、8 月の c6d9877（#725 の作業）で再び npm 10 が `libc` を 4 箇所削っている。

## 実測

### 1. どの npm が `libc` を書くか（同じ package.json からフル生成して比較）

| npm | `libc` の件数 | 行数 |
| --- | --- | --- |
| 10.9.8（node 22 同梱） | 0 | 12355 |
| 11 系 | 14 | 12397 |
| 12.0.2 | 14 | 12397 |

npm 11 と 12 の出力は `diff` でバイト単位に一致した。したがって Dependabot が 11 系のままでも 12 で揃う。

### 2. 往復差分が止まることの対照実験

`libc` を 4 件持っていた当時の lock（c6d9877 の親）を、それぞれの npm で `npm install --package-lock-only` した結果:

| 更新に使った npm | 更新後の `libc` |
| --- | --- |
| 10.9.8 | 0（消える＝これが往復差分の正体） |
| 12.0.2 | 4（保たれる） |

### 3. PATH の解決順

mise は `[tools]` の**宣言順に PATH を積む**。`node` の後ろに置くと node 同梱の npm 10 が先に解決され、この固定は無言で効かなくなる。

```
# node より後に置いた場合
$ mise exec -- npm --version
10.9.8

# node より前に置いた場合（本 PR）
$ mise exec -- npm --version
12.0.2
```

順序依存という脆い性質なので、mise.toml のコメントに理由つきで明記した。dprint の toml プラグインはキーを並び替えないことも `dprint check` で確認済み。

## 判断したこと

- **既存の `frontend/package-lock.json` は書き直さない**。lock を消してフル再生成すると `libc` は戻るが、依存バージョンの上げ（biome 2.5.9 → 2.5.10 等）を巻き込む。Dependabot の担当領域なので本 PR では触らない。
- **CI の `install_args` には足さない**。frontend / browser-e2e のジョブは `npm ci`（lock を書き換えない）しか使わず node 同梱の npm で足りるため、「そのジョブが使うツールだけ入れる」方針（#464）を優先した。

## 変更ファイル

- `mise.toml` — `[tools]` に `"npm:npm" = "12.0.2"` を追加（`node` より前）。上記の理由をコメントで残した
- `mise.lock` — `npm:npm` 12.0.2 のエントリを追加。npm backend は platform 非依存なので http backend と違い 1 エントリで足りる

## 確認

- `mise install --locked "npm:npm"` が lock から解決できる
- `mise exec -- npm --version` → `12.0.2`
- pre-commit（dprint / gitleaks / editorconfig-check）が緑
- Kotlin には触れていないため `./gradlew check` は対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)
