### PR TITLE
chore: #473 GCP の正規ルート外の変更を検知するアラートを追加する

### DIFF
--- a/.claude/rules/gcp-guardrails.md
+++ b/.claude/rules/gcp-guardrails.md
@@ -55,6 +55,20 @@ terraform 側の `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` が効くのは **provider
 
 - **`VAR= gcloud ...` の env 代入プレフィックスで昇格しない**。先頭トークンが `gcloud` でなくなり、permissions の deny/ask マッチャに当たらないまま走りうる（下記「変更系を env ランナーでラップしない」と同じ穴）。
 
+## 監査（何が記録され、何が鳴るか）
+
+記録は **Admin Activity ログ**が担う。常時有効・無効化不可で、既定シンクにより `_Required` バケット（保持 400 日・`locked` で変更不可・課金対象外）へ入る。**Data Access ログは有効化していない**ので、読み取りと impersonation のトークン発行（`GenerateAccessToken`）は記録されない。決定経緯と実測値は [ADR-0078](../../docs/adr/0078-audit-via-admin-activity-detect-only.md)。
+
+**呼び出し元は `principalEmail` ではなく delegation 側で見る**。正規ルートの変更は principal が SA になるため、人間や CI を突き止めるには `protoPayload.authenticationInfo.serviceAccountDelegationInfo[].principalSubject` を読む。ここに WIF の subject が入り、GitHub Actions ならリポジトリと environment、HCP Terraform なら workspace と `run_phase` まで分かる。
+
+```bash
+gcloud logging read 'log_id("cloudaudit.googleapis.com/activity")' --project=ptiringo-toy-box \
+  --limit=10 --freshness=7d \
+  --format='value(protoPayload.authenticationInfo.principalEmail,protoPayload.methodName)'
+```
+
+**アラートが鳴る条件は「Admin Activity の principal が SA ではない」**（`infra/modules/audit/`）。正規ルート（GitHub Actions の `deployer@` / HCP run の `tfc-service-account@`）はすべて SA なので鳴らない。鳴るのは **owner へ昇格しての直接変更**と **Console 操作**で、平時は無音なので鳴ったこと自体が信号になる。閲覧では鳴らない（Data Access 側のため）。通知先は HCP workspace の sensitive 変数 `audit_alert_email` で供給する。
+
 ## メンテナンス
 
 - 新しい変更系コマンド（別ツールや新サブコマンド）を使い始めたら、deny/ask 語彙へ追記する。read-only は allow に足してよい。`gsutil` / `bq` は現状未列挙なので、使い始めたら同様に追記する。

--- a/.claude/rules/terraform.md
+++ b/.claude/rules/terraform.md
@@ -11,31 +11,43 @@ paths:
 
 ```
 infra/
-├── main.tf              # 共有リソースとモジュール呼び出し
+├── main.tf              # 共有リソース（API 有効化・Artifact Registry）とモジュール呼び出し
 ├── providers.tf         # Google プロバイダー設定
 ├── terraform.tf         # Terraform / バックエンド設定
 ├── variables.tf         # ルート変数（wif_project_number など）
 └── modules/
-    ├── cicd/            # CI/CD パイプライン基盤
-    │   ├── main.tf      # deployer SA、WIF バインディング、AR 書き込み権限
-    │   ├── variables.tf
-    │   └── outputs.tf
-    └── cloudrun/        # Cloud Run デプロイ基盤
-        ├── main.tf      # api-runner SA、run.developer 権限、actAs 権限
-        ├── variables.tf
-        └── outputs.tf
+    ├── audit/             # 正規ルート外の変更を検知するアラートと通知チャネル
+    ├── billing/           # 月次予算アラート
+    ├── cicd/              # CI/CD パイプライン基盤
+    ├── cloudrun/          # Cloud Run デプロイ基盤
+    ├── identity-platform/ # 認証委譲先
+    ├── local-readonly/    # ローカル作業用の read-only SA
+    └── prisma-postgres/   # 本番 DB と接続情報
 ```
+
+各モジュールは `main.tf` / `variables.tf` / `versions.tf`（必要なら `outputs.tf`）で構成する。
 
 ## モジュール
 
+- **audit**: 正規ルートを外れた変更操作の検知（log-based alert + メール通知チャネル）。記録そのものは Admin Activity ログが担うので、ここで持つのは「気づく手段」だけ（[ADR-0078](../../docs/adr/0078-audit-via-admin-activity-detect-only.md)）
+- **billing**: プロジェクト全体の月次予算アラート。到達しても課金は止まらない検知のみ（[ADR-0074](../../docs/adr/0074-billing-guardrails-spend-cap-and-budget-alert.md)）
 - **cicd**: GitHub Actions がイメージをビルド・プッシュするために必要なリソース群（deployer SA、WIF、AR 権限）
 - **cloudrun**: Cloud Run へのデプロイと実行に必要なリソース群（api-runner SA、デプロイ権限）
+- **identity-platform**: 認証の委譲先（email/password + authorized_domains。[ADR-0064](../../docs/adr/0064-authn-via-identity-platform-authz-in-app.md)）
+- **local-readonly**: ローカル作業用の `roles/viewer` のみの SA と impersonation 許可（[ADR-0036](../../docs/adr/0036-gcp-operation-guardrails.md)）
+- **prisma-postgres**: 本番 DB（Prisma Postgres）と接続情報を格納する Secret Manager（[ADR-0044](../../docs/adr/0044-adopt-prisma-postgres-for-production-db.md)）
+
+## 変数の供給
+
+機微な値（請求先アカウント ID、Prisma のトークン・プロジェクト名、監査アラートの通知先メール）は公開リポジトリに直書きせず、**HCP workspace の変数**で供給する。`list(string)` 型の変数を HCP UI で登録するときは **HCL フラグをオンにする**（詳細は `.claude/rules/gcp-guardrails.md`）。
 
 ## コマンド
 
 ```bash
 terraform init              # 初期化
 terraform plan             # 差分確認
-terraform apply            # 適用
+terraform apply            # 適用（ローカルでは実行しない。HCP run に寄せる）
 terraform fmt -recursive   # フォーマット
 ```
+
+CI（`.github/workflows/terraform-check.yml`）が `fmt -check` / `validate` / `tflint` / `trivy config` を PR で回す。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ Issue の優先度は **GitHub Projects（`toy-box` = Project #4）の `Priority
 
 ## Google Cloud 操作のガードレール
 
-Claude Code から GCP を触るときは、変更・削除・課金を伴う操作を deny（CI/HCP 専用）/ ask（確認強制）で抑え、ローカルは最小権限 viewer SA の impersonation で読み取りに限定する。強制の実体は `.claude/settings.json` の permissions で、語彙・手順は `.claude/rules/gcp-guardrails.md`、決定経緯は [ADR-0036](docs/adr/0036-gcp-operation-guardrails.md)。**変更系は正規ルート（アプリ deploy は GitHub Actions、infra apply は HCP Terraform run）に寄せる**。
+Claude Code から GCP を触るときは、変更・削除・課金を伴う操作を deny（CI/HCP 専用）/ ask（確認強制）で抑え、ローカルは最小権限 viewer SA の impersonation で読み取りに限定する。強制の実体は `.claude/settings.json` の permissions で、語彙・手順は `.claude/rules/gcp-guardrails.md`、決定経緯は [ADR-0036](docs/adr/0036-gcp-operation-guardrails.md)。**変更系は正規ルート（アプリ deploy は GitHub Actions、infra apply は HCP Terraform run）に寄せる**。予防をすり抜けた変更は事後に検知する（Admin Activity ログと、正規ルート外の変更を知らせるアラート。[ADR-0078](docs/adr/0078-audit-via-admin-activity-detect-only.md)）。
 
 ## インフラストラクチャ（Terraform）
 

--- a/docs/adr/0078-audit-via-admin-activity-detect-only.md
+++ b/docs/adr/0078-audit-via-admin-activity-detect-only.md
@@ -1,0 +1,42 @@
+# 0078. GCP の監査は Admin Activity ログに委ね、正規ルート外の変更検知だけを足す
+
+- Status: Accepted
+- Date: 2026-08-22
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+[ADR-0036](0036-gcp-operation-guardrails.md) は「無確認の変更を止める」予防のガードレールで、「誰が何をしたか」を後から追う監査はスコープ外として分割していた（#473）。さらに #475 でローカルの gcloud が viewer SA の impersonation を既定にしたため、Audit Logs 上の `principalEmail` は人間ではなく SA になり、監査設計の前提が変わっていた。
+
+そこで設計に入る前に、推測ではなく実物のログで前提を確認した（project `ptiringo-toy-box`・2026-08-22 時点）。
+
+- **記録の器はすでにある**: Admin Activity は常時有効・無効化不可で、既定シンクにより `_Required` バケットへ入る。保持は 400 日で `locked: true`（変更不可）、かつ課金対象外。カスタムシンクは無い。
+- **呼び出し元は復元できる**: 変更操作の principal は SA だが、`protoPayload.authenticationInfo.serviceAccountDelegationInfo[].principalSubject` に呼び出し元が入る。実物は GitHub Actions が `principal://…/workloadIdentityPools/github/subject/repo:ptiringo/toy-box:environment:production`、HCP Terraform が `…/hcp-tf-pool/subject/organization:ptiringo-tech:project:toy-box-project:workspace:toy-box:run_phase:apply` で、**リポジトリ・environment や workspace・run_phase まで**判別できる。
+- **記録されていないものもある**: `auditConfigs` は未設定＝ Data Access ログは既定どおり無効で、`data_access` ログは 0 件。`iamcredentials.googleapis.com` の `GenerateAccessToken` も Admin Activity には 1 件も出ない。つまり「誰が viewer SA を借りたか」は記録されていない。
+- **実際の principal 分布**: 直近 30 日の Admin Activity は `deployer@` 192 件 / `tfc-service-account@` 8 件で、**人間は 0 件**。保持期間全体（400 日）まで広げると `admin@ptiringo.tech` 34 件・`ptiringo@gmail.com` 2 件があり、これは impersonation 既定化・IaC 化より前の Console 操作にあたる。
+
+この結果、Issue が挙げていた「Audit Logs の有効化」「保持方針」は**すでに満たされている**か、そもそも変更できない（`_Required` は locked）ことが分かった。足りないのは記録ではなく、**逸脱に気づく手段**だけだった。
+
+検討した代替案:
+
+- **Data Access ログを有効化する**: ローカルの読み取りと impersonation のトークン発行まで可視化でき、「誰が viewer SA を借りたか」が残る。しかし得られるのは read-only 作業の記録で、`_Default`（30 日）へ入り課金対象のログ量が増える。守りたいのは変更操作の追跡なので、費用に見合わないと判断した。
+- **ログベースメトリクス＋閾値アラート**: メトリクス経由は集計の遅延が乗る。また「1 件でも出たら異常」であって閾値に意味が無い。
+- **検知を入れず記録だけで済ませる**: 記録は追えるが、見に行かなければ気づけない。平時の該当が 0 件（実測）である以上、通知はほぼ鳴らず、鳴ったときの信号価値が高い。
+
+## Decision（決定）
+
+**監査の記録は Admin Activity ログに委ね、追加で足すのは正規ルート外の変更検知だけとする。**
+
+- `infra/modules/audit/` に log-based alert（`google_monitoring_alert_policy` の `condition_matched_log`）とメール通知チャネルを置く。ログベースメトリクスは作らない。
+- 検知条件は principal の**否定形**で書く。SA を列挙せず「`\.gserviceaccount\.com$` にマッチしない」とし、SA が増えても追随不要にする（列挙漏れが検知漏れに化けない）。`principalEmail:*` を併記して、principal を持たないエントリ（実測で 400 日に 1 件）が `NOT` を素通りするのを防ぐ。
+- 通知先メールは公開リポジトリに直書きせず、HCP workspace の sensitive 変数 `audit_alert_email` で供給する（`billing_account_id` / `prisma_*` と同じ扱い）。
+- **Data Access ログは有効化しない**。ログのエクスポート先（BigQuery / GCS sink）も追加せず、保持期間も触らない（`_Required` は locked で不可）。
+
+## Consequences（結果・影響）
+
+- ADR-0036 の「変更は CI/HCP に寄せる」に違反した操作が事後に検知される。GitHub Actions（`deployer@`）と HCP Terraform run（`tfc-service-account@`）は principal が SA なので鳴らず、鳴るのは **owner へ昇格した直接変更**と **Console 操作**に限られる。実測上その該当は直近 30 日で 0 件なので、平時は無音で、鳴ったこと自体が信号になる。
+- **読み取りでは鳴らない**。閲覧は Data Access ログ側で、これを無効のままにする決定と表裏である。「誰が viewer SA を借りて何を見たか」は引き続き記録されない。追跡が必要になったら Data Access の有効化を再検討する（費用とのトレードオフを引き受ける判断になる）。
+- 検知は事後であって予防ではない。無確認実行を止める役割は引き続き permissions 層（ADR-0036）が担う。
+- `audit_alert_email` は HCP workspace にしか無いため、[#794](https://github.com/ptiringo/toy-box/issues/794) が指摘する「コードから読めない変数」が 1 つ増える。
+- `monitoring.googleapis.com` は有効だったが Terraform 管理外だったため、この機会に `google_project_service` へ取り込んだ。
+- 運用上の結論（どのフィールドで呼び出し元を復元するか、何が鳴るか）は `.claude/rules/gcp-guardrails.md` に置く。関連: [ADR-0036](0036-gcp-operation-guardrails.md) / [ADR-0074](0074-billing-guardrails-spend-cap-and-budget-alert.md)。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -87,3 +87,4 @@
 | [0075](0075-gcp-project-id-not-a-secret.md) | GCP プロジェクト ID は秘匿対象にせず、識別子の扱いは開示済みかどうかで分ける | Accepted |
 | [0076](0076-browser-e2e-playwright-auth-emulator-boottestrun.md) | ブラウザ E2E を Playwright + Auth Emulator + bootTestRun で組み、ゲート外の独立ワークフローで回す | Accepted |
 | [0077](0077-consolidate-web-test-contexts-trading-jwt-decoder-assurance.md) | web 環境を要するテストコンテキストを 1 つに畳み、本番 JwtDecoder Bean 生成の担保を手放す | Accepted |
+| [0078](0078-audit-via-admin-activity-detect-only.md) | GCP の監査は Admin Activity ログに委ね、正規ルート外の変更検知だけを足す | Accepted |

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -65,23 +65,27 @@ module "identity_platform" {
 
 # 課金の見張り（プロジェクト全体の月次予算アラート）。#700 / ADR-0074。
 # 止めるのは Cloud Run の spend cap（Console 手設定）で、ここは検知のみ。
-# billingbudgets API 有効化に依存させ、初回 apply の順序レースを避ける。
+# billingbudgets API 有効化に依存させ、初回 apply の順序レースを避ける。依存先は for_each 全体では
+# なく、このモジュールが実際に使う API のキーだけにする。
+# なお depends_on を持つモジュール内の data source は plan 時に読まれず apply へ延期されるため、
+# budget_filter.projects が unknown になり plan に update が出る（値は不変で実害なし。#834）。
 module "billing" {
   source = "./modules/billing"
 
   billing_account_id = var.billing_account_id
   monthly_amount_jpy = "3000"
 
-  depends_on = [google_project_service.project]
+  depends_on = [google_project_service.project["billingbudgets"]]
 }
 
 # 監査の検知（正規ルートを外れた変更操作のアラート）。#473 / ADR-0078。
 # 記録は Admin Activity ログが常時担うので、ここで足すのは「気づく手段」だけ。
-# monitoring API 有効化に依存させ、初回 apply の順序レースを避ける。
+# monitoring API 有効化に依存させ、初回 apply の順序レースを避ける。依存先は for_each 全体ではなく
+# 該当キーだけにする（billing と同じ方針）。
 module "audit" {
   source = "./modules/audit"
 
   alert_email = var.audit_alert_email
 
-  depends_on = [google_project_service.project]
+  depends_on = [google_project_service.project["monitoring"]]
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -5,6 +5,7 @@ resource "google_project_service" "project" {
     "iam",
     "iamcredentials",
     "identitytoolkit",
+    "monitoring",
     "orgpolicy",
     "run",
     "secretmanager",
@@ -70,6 +71,17 @@ module "billing" {
 
   billing_account_id = var.billing_account_id
   monthly_amount_jpy = "3000"
+
+  depends_on = [google_project_service.project]
+}
+
+# 監査の検知（正規ルートを外れた変更操作のアラート）。#473 / ADR-0078。
+# 記録は Admin Activity ログが常時担うので、ここで足すのは「気づく手段」だけ。
+# monitoring API 有効化に依存させ、初回 apply の順序レースを避ける。
+module "audit" {
+  source = "./modules/audit"
+
+  alert_email = var.audit_alert_email
 
   depends_on = [google_project_service.project]
 }

--- a/infra/modules/audit/main.tf
+++ b/infra/modules/audit/main.tf
@@ -1,0 +1,74 @@
+# 監査アラートの通知先。宛先は公開リポジトリに直書きせず HCP workspace の変数で供給する
+# （billing_account_id / prisma_* と同じ扱い）。
+resource "google_monitoring_notification_channel" "audit" {
+  display_name = "Audit alert"
+  type         = "email"
+
+  labels = {
+    email_address = var.alert_email
+  }
+}
+
+# 正規ルート（GitHub Actions の deployer@ / HCP Terraform run の tfc-service-account@）を
+# 外れた変更を事後に検知する。ADR-0036 の「変更は CI/HCP に寄せる」を破ったときに鳴る。
+#
+# 記録そのものは Admin Activity ログが常時・無料で担っており（_Required バケットに 400 日、
+# 保持は locked で変更不可）、呼び出し元も serviceAccountDelegationInfo から復元できる。
+# 足りないのは気づく手段だけなので、ここでは検知だけを足す（ADR-0078）。
+resource "google_monitoring_alert_policy" "human_admin_activity" {
+  display_name = "Admin Activity by non-service-account principal"
+  combiner     = "OR"
+  severity     = "WARNING"
+
+  conditions {
+    display_name = "Admin Activity performed by a human principal"
+
+    # ログベースメトリクス + 閾値ではなく log-based alert（condition_matched_log）にしている。
+    # メトリクス経由は集計の遅延が乗るうえ、閾値の意味を持たない「1 件でも出たら異常」だから。
+    condition_matched_log {
+      # principal を列挙せず「サービスアカウントではない」の否定形で書く。SA が増えても追随不要で、
+      # 列挙漏れが検知漏れに化けない。principalEmail:* は principal を持たないエントリ
+      # （実測で 400 日に 1 件ある）が NOT を素通りして誤検知になるのを防ぐ。
+      #
+      # HCL の heredoc はバックスラッシュを解釈しないため、正規表現の \. をそのまま書ける
+      # （quoted string だと不正なエスケープになる）。
+      filter = <<-EOT
+        log_id("cloudaudit.googleapis.com/activity")
+        AND protoPayload.authenticationInfo.principalEmail:*
+        AND NOT protoPayload.authenticationInfo.principalEmail=~"\.gserviceaccount\.com$"
+      EOT
+    }
+  }
+
+  # LogMatch 条件では notification_rate_limit が必須（未指定だと API に拒否される）。
+  # Console 操作は 1 回の作業で複数の Admin Activity を生むため、まとめて 1 通にする。
+  alert_strategy {
+    notification_rate_limit {
+      period = "300s"
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.audit.id]
+
+  documentation {
+    subject   = "GCP: 正規ルート外の変更操作を検知しました"
+    mime_type = "text/markdown"
+    content   = <<-EOT
+      Admin Activity ログに、サービスアカウント以外（人間）の principal による操作が記録されました。
+
+      正規の変更ルートは GitHub Actions（deployer@）と HCP Terraform run（tfc-service-account@）で、
+      どちらも principal はサービスアカウントになります。この通知が出たということは、次のどちらかです。
+
+      - owner へ昇格してローカルから直接変更した（CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT を外した）
+      - Google Cloud Console から操作した
+
+      意図した作業なら対応は不要です。心当たりがなければ、次で「誰が・何を」を確認してください。
+
+          gcloud logging read 'log_id("cloudaudit.googleapis.com/activity")
+            AND protoPayload.authenticationInfo.principalEmail:*
+            AND NOT protoPayload.authenticationInfo.principalEmail=~"\.gserviceaccount\.com$"' \
+            --project=ptiringo-toy-box --limit=10 --freshness=1d \
+            --format='value(protoPayload.authenticationInfo.principalEmail,protoPayload.methodName,protoPayload.resourceName)'
+    EOT
+  }
+}

--- a/infra/modules/audit/variables.tf
+++ b/infra/modules/audit/variables.tf
@@ -1,0 +1,5 @@
+variable "alert_email" {
+  description = "監査アラートの通知先メールアドレス（機微。HCP workspace の sensitive 変数で供給する）"
+  type        = string
+  sensitive   = true
+}

--- a/infra/modules/audit/versions.tf
+++ b/infra/modules/audit/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.15"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 7.36.0"
+    }
+  }
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -25,3 +25,9 @@ variable "billing_account_id" {
   description = "Cloud Billing アカウント ID（HCP workspace 変数で供給。公開リポジトリに直書きしない）"
   type        = string
 }
+
+variable "audit_alert_email" {
+  description = "監査アラート（正規ルート外の変更検知）の通知先メールアドレス（機微。HCP workspace 変数で供給。公開リポジトリに直書きしない）"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
Closes #473

## 何をしたか

「GCP の操作を監査可能にする」にあたり、まず **推測せず実物のログを見た**（Issue のコメントが求めていた前提確認）。その結果、Issue が挙げていた「Audit Logs の有効化」「保持方針」は**すでに満たされている**か、そもそも変更できないことが分かった。足りないのは**逸脱に気づく手段**だけだったので、検知だけを足している。

## 実測（設計の根拠・project `ptiringo-toy-box` / 2026-08-22）

| 確認項目 | 実測 |
|---|---|
| `auditConfigs` | **なし**＝ Data Access ログは既定どおり無効（`data_access` ログは 0 件） |
| ログバケット | `_Required` 400 日・**locked**（Admin Activity はここ・課金対象外）、`_Default` 30 日 |
| シンク | 既定の 2 つのみ。カスタムシンクなし |
| 直近 30 日の Admin Activity | `deployer@` 192 件 / `tfc-service-account@` 8 件。**人間は 0 件** |
| 保持期間全体（400 日） | 上記＋ `admin@` 34 件・`ptiringo@gmail.com` 2 件（impersonation 既定化・IaC 化より前の Console 操作） |

**呼び出し元は復元できる。** ただし `principalEmail` ではなく `protoPayload.authenticationInfo.serviceAccountDelegationInfo[].principalSubject` を見る:

- GitHub Actions: `principal://…/workloadIdentityPools/github/subject/repo:ptiringo/toy-box:environment:production`
- HCP Terraform: `…/hcp-tf-pool/subject/organization:ptiringo-tech:project:toy-box-project:workspace:toy-box:run_phase:apply`（**run_phase まで**）

**記録されていないものもある。** `iamcredentials.googleapis.com` の `GenerateAccessToken` は Admin Activity に 1 件も出ない（Data Access 側の扱い）。つまり「誰が viewer SA を借りたか」は残っていない。これは Data Access を有効化しない決定と表裏。

## 変更点

- **`infra/modules/audit/`（新規）**: log-based alert（`condition_matched_log`）とメール通知チャネル。ログベースメトリクスは作らない（集計遅延が乗るうえ「1 件でも出たら異常」で閾値に意味がないため）
- **`infra/main.tf` / `variables.tf`**: モジュール呼び出し、`audit_alert_email`（sensitive）、Terraform 管理外だった `monitoring` API の取り込み
- **`docs/adr/0078-…`**: 判断と実測値を記録
- **`.claude/rules/gcp-guardrails.md`**: 「監査」節を追加
- **`.claude/rules/terraform.md`**: モジュール一覧を実態へ（`audit` 追加に加え、記載漏れだった billing / identity-platform / local-readonly / prisma-postgres も解消）
- **`CLAUDE.md`**: 事後検知の存在を 1 文

## 何が鳴るか

principal が SA でない Admin Activity、つまり **ADR-0036 の「変更は CI/HCP に寄せる」を破ったときだけ**。GitHub Actions と HCP run は SA なので鳴らず、impersonation 中も principal は SA（かつ viewer では変更できない）。鳴るのは **owner へ昇格しての直接変更**と **Console 操作**に限られる。実測上、直近 30 日の該当は 0 件なので平時は無音で、鳴ったこと自体が信号になる。**読み取りでは鳴らない**（Data Access 側のため）。

フィルタは principal を列挙せず否定形（`NOT …=~"\.gserviceaccount\.com$"`）で書いた。SA が増えても追随不要で、列挙漏れが検知漏れに化けない。`principalEmail:*` の併記は、principal を持たないエントリ（実測で 400 日に 1 件）が `NOT` を素通りするのを防ぐため。

## 検証

- **フィルタは陽性・陰性の両方で実測**した。同じフィルタを `gcloud logging read` に渡し、400 日で人間 36 件を検出（`admin@` 34 / `ptiringo@gmail.com` 2）、SA 943 件と principal 不明 1 件はすべて除外。直近 30 日では 0 件。**壊れたフィルタがちゃんと構文エラーになることも確認**した（「エラーが出ない＝検証できている」の取り違えを避けるため）
- `email` 通知チャネルの label キー（`email_address`）は `notificationChannelDescriptors` API で実測して確認
- pre-commit 全フック緑（tflint / terraform-fmt-check / editorconfig-check / adr-numbering / gitleaks / trivy-config / terraform-validate / markdown-links）

## plan の結果（HCP・変数登録後）

**add 3 / change 1 / destroy 0**。追加は期待どおりの 3 つ:

- `google_project_service.project["monitoring"]`
- `module.audit.google_monitoring_notification_channel.audit`
- `module.audit.google_monitoring_alert_policy.human_admin_activity`

**`change: 1` はこの PR の変更内容とは独立した既存の性質**で、`module.billing.google_billing_budget.project_total` です。食い違う属性は `budget_filter.projects` だけで、`after_unknown` が `{"projects": true}`＝ unknown。値の出所である `module.billing.data.google_project.target` が plan では `read`（apply へ延期）になっているためです。

延期の引き金は「依存先が未確定だから」ではなく、**モジュールが `depends_on` を持っていること自体**でした（依存先を plan で no-op のキーに絞っても解消しないことを実測で確認）。project number は不変なので apply すれば同じ値に解決され、**実質的な変更はゼロ**です。追跡は #834 に切り出しました。

なお、ついでに billing と audit の `depends_on` を **for_each 全体から実際に使う API のキーだけに絞って**います。意図を正確にするためで、上記の update を消す効果はありません（消えなかったことも #834 に記録済み）。

## マージ後に必要な操作

HCP Terraform で **apply** してください（ローカル apply はしない方針のため）。apply 後、メール通知チャネルは Google から確認メールが届く場合があります。
