### PR TITLE
chore: #735 Kover 成熟ゲートの下限を実測に合わせて引き上げる

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -153,7 +153,7 @@ Kover 0.9 の検証ルールはパッケージ単位のフィルタを持てな�
 ### ゲートの考え方（ラチェット）
 
 - **excludes 反転でゲート対象を決める**: 全体をゲート対象とし、探索段階のパッケージだけを `variant("mature")` の `excludes` に列挙する。パッケージが成熟したら `excludes` から外す＝ゲート対象へ昇格。**外し忘れても「より厳しくなる」安全側**（includes 方式では追加忘れが「緩くなる」危険側だった）。
-- **カバレッジ単位は LINE と BRANCH の 2 ボーンド**。下限は反転後母集団の実測直下のキリ番（LINE 90% / BRANCH 80%）に固定した**手動ラチェット**。実測が上がったら手で下限を上げてよい。割ると `./gradlew check`（CI の `koverVerifyMature`）が失敗する。
+- **カバレッジ単位は LINE と BRANCH の 2 ボーンド**。下限は実測直下のキリ番（**LINE 95% / BRANCH 85%**。出所は `build.gradle.kts` の `minValue`）に固定した**手動ラチェット**。実測が上がったら手で下限を上げてよい（[#735](https://github.com/ptiringo/toy-box/issues/735) で 90% / 80% から引き上げ。そのときの実測は LINE 97.35% / BRANCH 90.36%）。割ると `./gradlew check`（CI の `koverVerifyMature`）が失敗する。
 - **自動ラチェット機構は持たない**（YAGNI）。手動で引き上げる。
 
 探索除外パッケージ（`build.gradle.kts` の `variant("mature")` の `excludes` が唯一の出所。ここは要約）:
@@ -210,7 +210,7 @@ CI（`api-tests.yml`）は test 後に `koverVerifyMature` でゲートを掛け
 
 `total` レポートで 0% に見える領域は、成熟させるときにテストを添える。優先度は実装の成熟度に従う:
 
-- `infrastructure.*`（JDBC リポジトリ）: `Jockey` は Testcontainers 契約テスト済み。残り集約（`BloodHorse` / `BreedingRegistration` / `BreedingResult`）は JDBC 実装＋契約テストが未整備で、移行に伴い InMemory を廃止する（JDBC 一本化。[ADR-0030](../../docs/adr/0030-jdbc-only-persistence-retire-inmemory.md) / #435）。なお `infrastructure.*` は `excludes` に入れておらず**既にゲート母集団内**。未テスト分は集計に乗るが現状の LINE 90% / BRANCH 80% を満たしている（割り込んだらテストを添えること）。
+- `infrastructure.*`（JDBC リポジトリ）: `Jockey` は Testcontainers 契約テスト済み。残り集約（`BloodHorse` / `BreedingRegistration` / `BreedingResult`）は JDBC 実装＋契約テストが未整備で、移行に伴い InMemory を廃止する（JDBC 一本化。[ADR-0030](../../docs/adr/0030-jdbc-only-persistence-retire-inmemory.md) / #435）。なお `infrastructure.*` は `excludes` に入れておらず**既にゲート母集団内**。未テスト分は集計に乗るが現状の LINE 95% / BRANCH 85% を満たしている（割り込んだらテストを添えること）。
 - `domain.racing.service`（`confirmRaceResult`）: サービスだがテスト無し。`excludes` 在籍。
 - `domain.racing.model`（`race`）: 探索段階のモデル。`excludes` 在籍（`sakamichi` は #367、`tennis` は #677 でテストが揃いゲート対象へ昇格済み）。
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -237,15 +237,18 @@ kover {
                 onCheck = true
                 rule("成熟領域の行・分岐カバレッジ（リグレッション防止のラチェット）") {
                     bound {
-                        // 反転後母集団の実測 94.57% を 90 に固定したラチェット。
-                        minValue = 90
+                        // 実測 97.35%（3417/3510 行）を 95 に固定したラチェット（#735）。
+                        // 余裕 2.35pt ≒ 82 行。手動ラチェットのため、実測が上がったら手で上げる。
+                        minValue = 95
                         coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                         aggregationForGroup =
                             kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
                     }
                     bound {
-                        // 反転後母集団の実測 84.91% を 80 に固定したラチェット。
-                        minValue = 80
+                        // 実測 90.36%（675/747 分岐）を 85 に固定したラチェット（#735）。
+                        // BRANCH は母集団が LINE の約 1/4.7 と小さく 1 分岐の重みが効くため、
+                        // LINE（2.35pt）より厚い 5.36pt ≒ 40 分岐ぶんの余裕を残す。
+                        minValue = 85
                         coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.BRANCH
                         aggregationForGroup =
                             kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE

--- a/docs/adr/0040-coverage-gate-operation-model.md
+++ b/docs/adr/0040-coverage-gate-operation-model.md
@@ -4,6 +4,8 @@
 - Date: 2026-06-30
 - Deciders: Matsui
 
+> 注: 下限の具体値はその後 **LINE 95% / BRANCH 85%** へ引き上げた（[#735](https://github.com/ptiringo/toy-box/issues/735)、実測 LINE 97.35% / BRANCH 90.36%）。本 ADR の「3. 閾値は手動ラチェットで維持する」に従った運用の一回であり、運用モデル自体は不変。以下の 90% / 80% と `excludes` の一覧は本 ADR 決定時点の値で、**現行値の出所は `build.gradle.kts`**（要約は `.claude/rules/testing.md`）。
+
 ## Context（背景・課題）
 
 [ADR-0006](0006-kover-over-jacoco.md) で Kover を採用し、「成熟パッケージのみ `includes` フィルタで絞ったゲート（`variant("mature")`）」を設けた。


### PR DESCRIPTION
Closes #735

## 概要

Kover 成熟ゲート（`koverVerifyMature`）の下限を **LINE 90% → 95% / BRANCH 80% → 85%** へ引き上げる。ADR-0040 が定めた手動ラチェット（自動機構は持たず人が引き上げる）の「一回」にあたる。

## 実測（このブランチの base = f44b45b）

Issue の数値は #677 マージ時点のものだったので取り直した。出所は `koverVerifyMature` の出力と `build/reports/kover/reportMature.xml`。

| 単位 | 実測 | 母集団 | 1 単位あたり | 旧下限との余裕 | 新下限との余裕 |
|---|---|---|---|---|---|
| LINE | **97.3504%** | 3417/3510 行 | 0.028pt | 7.35pt | 2.35pt（≒82 行） |
| BRANCH | **90.3614%** | 675/747 分岐 | 0.134pt | 10.36pt | 5.36pt（≒40 分岐） |

つまり引き上げ前は **LINE 7.35pt・BRANCH 10.36pt ぶんの劣化が黙って通る**状態だった。

## 判断

- **上げる**。集約ゲートは絶対水準の底を守る役目で diff-cover（`--fail-under 90`）と補完関係にあるが、実測から 7〜10pt も離れているとリグレッション防止の役に立たない。
- **余裕の付け方を LINE と BRANCH で変える**。BRANCH は母集団が LINE の約 1/4.7 と小さく 1 分岐あたりの重みが 4.7 倍効くため、LINE（2.35pt）より厚い 5.36pt を残す。
- **逆流リスクは実測で潰した**。Issue が懸念した「探索領域が `excludes` から昇格すると実測が下がり、下限を下げる羽目になる」件は、昇格候補（`racing.model.race` / `racing.service`）が合計 **LINE 14 行・BRANCH 0** しかなく、テスト無しのまま昇格させても LINE は 97.35% → 96.96%（-0.39pt）にしか動かない。新下限 95% を割らない。

## 変更内容

- **`build.gradle.kts`**: `minValue` を 95 / 85 へ。コメントの根拠を現在の実測へ更新し、BRANCH に厚い余裕を残す意図を明記
- **`.claude/rules/testing.md`**: 「ゲートの考え方（ラチェット）」と「当面の宿題」の下限記述を追従。値の出所が `build.gradle.kts` の `minValue` であることと、引き上げ時点の実測を併記
- **`docs/adr/0040-coverage-gate-operation-model.md`**: 決定時点の 90% / 80% が現行値でないことを冒頭に注記（ADR-0006 の先例に倣う）。運用モデル自体は不変で、本引き上げは同 ADR「3. 閾値は手動ラチェットで維持する」に従った運用

## 検証

**ミューテーション**（#782 の方針）— 一時的に LINE 98 / BRANCH 91 へ上げると、両ボーンドとも発火した:

```
> Task :koverVerifyMature FAILED
    branches covered percentage is 90.361400, but expected minimum is 91
    lines covered percentage is 97.350400, but expected minimum is 98
BUILD FAILED
```

引き上げ後の値へ戻して `./gradlew check` が `BUILD SUCCESSFUL`（`:koverVerifyMature` は UP-TO-DATE ではなく executed であることをタスクログで確認）。pre-push の全テストも緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
