### PR TITLE
docs: #836 ADR の古いカバレッジ下限を出所参照に置き換える

### DIFF
--- a/docs/adr/0055-patch-coverage-diff-cover-gate.md
+++ b/docs/adr/0055-patch-coverage-diff-cover-gate.md
@@ -4,6 +4,8 @@
 - Date: 2026-07-07
 - Deciders: Matsui
 
+> 注: 本 ADR が決めた差分ゲートの閾値（`--fail-under 90`）は現行も 90% で不変。一方、本文が引用する集約ゲート（`koverVerifyMature`）の **LINE 90% / BRANCH 80% は [ADR-0040](0040-coverage-gate-operation-model.md) 決定時点の値**で、その後 [#735](https://github.com/ptiringo/toy-box/issues/735) で **LINE 95% / BRANCH 85%** へ引き上げられた（**現行値の出所は `build.gradle.kts`**、要約は `.claude/rules/testing.md`）。したがって決定 2 の「`koverVerifyMature` の LINE 下限に揃えた」という関係は現在は成立していない（追従させるかは [#843](https://github.com/ptiringo/toy-box/issues/843) で判断する）。
+
 ## Context（背景・課題）
 
 [ADR-0040](0040-coverage-gate-operation-model.md) は「成熟領域全体の絶対水準」を守る集約ゲート（`koverVerifyMature`、LINE 90% / BRANCH 80%）を確立した一方、差分カバレッジ（patch coverage: PR で変更した行のカバレッジ）は別概念として #437 に委譲していた。
@@ -57,7 +59,7 @@ diff-cover に食わせる XML は `koverVerifyMature` と同じ `mature` varian
 
 ## 関連
 
-- [ADR-0040](0040-coverage-gate-operation-model.md): 集約ゲート（絶対水準・LINE 90% / BRANCH 80%）の運用モデル。本 ADR が差分カバレッジを委譲された先
+- [ADR-0040](0040-coverage-gate-operation-model.md): 集約ゲート（絶対水準・LINE / BRANCH の 2 ボーンド。現行値の出所は `build.gradle.kts`）の運用モデル。本 ADR が差分カバレッジを委譲された先
 - [ADR-0006](0006-kover-over-jacoco.md): Kover 採用の前提（本 ADR が入力とする XML レポートの生成元）
 - #437: 差分カバレッジ（patch coverage）の検討 Issue（本 ADR の決定対象）
 - #412: ADR-0040 に対応する実装 Issue（`mature` variant の excludes 反転を実装）

--- a/docs/adr/0073-mcp-adapter-local-only-world-scoped.md
+++ b/docs/adr/0073-mcp-adapter-local-only-world-scoped.md
@@ -111,7 +111,8 @@ application 層には**新しいポートも新しい認可判断も足してい
   `variant("mature")` の includes に追加する」は **includes 方式時代の記述**であり、現行の excludes 反転方式
   （[ADR-0040](0040-coverage-gate-operation-model.md)）では探索段階のパッケージだけを列挙して残り全部を
   ゲートするため、`com.example.api.mcp` は列挙されておらず**既にゲート母集団に入る**。`mcp` を excludes へ
-  追加して逃げることはせず、LINE 90% / BRANCH 80% を満たす（slice 相当のテストで賄う）。
+  追加して逃げることはせず、`koverVerifyMature` の下限（現行値の出所は `build.gradle.kts`）を満たす
+  （slice 相当のテストで賄う）。
 - **本プロジェクト初の `@ConfigurationProperties` 利用になる。** `ApiApplication` に
   `@ConfigurationPropertiesScan` を足すとアプリ全体のスキャン方針を変えることになるため、`McpConfig` の
   `@EnableConfigurationProperties(McpProperties::class)` で局所的に有効化した。以後 `@ConfigurationProperties`


### PR DESCRIPTION
## 概要

Closes #836

Kover 成熟ゲートの下限は手動ラチェット（[ADR-0040](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0040-coverage-gate-operation-model.md) の決定 3）で、現行値の出所は `build.gradle.kts` の `minValue`（LINE 95% / BRANCH 85%）。ADR に散在する古い具体値のうち、**現行値として読まれうる記述だけ**を出所参照に置き換えた（Issue の検討 2）。決定時点の記録である歴史記述は据え置いている。

## 方針（Issue の 4 案からの判断）

| 案 | 判断 | 理由 |
| --- | --- | --- |
| 1. 何もしない | 却下 | ADR-0073 の記述は「達成すべき条件」の形で書かれており、事前の見積もりを誤らせる。手動ラチェットは今後も繰り返す |
| **2. B だけを直す** | **採用** | 歴史記述（A）を壊さずに、現行値として読まれる箇所だけを出所参照へ寄せられる |
| 3. 追従漏れを機械検出する | 却下 | 歴史記述（A）を誤検出するため除外表現が要り、その検査自体の検証という #829 と同じ問いに当たる。実害は「事前の見積もりを誤る」程度で、真の判定者は `koverVerifyMature`（CI で落ちて気づく）。割に合わない |
| 4. ADR の書き方の規約にする | 見送り（#836 に書き戻す） | 今後の ADR には効くが既存には効かない。本 PR のスコープ外 |

## 変更内容

### `docs/adr/0073-mcp-adapter-local-only-world-scoped.md`

`mcp` パッケージが満たすべき条件として書かれていた「LINE 90% / BRANCH 80%」を、`koverVerifyMature` の下限（出所は `build.gradle.kts`）への参照に置き換えた。Issue が「もっとも古い値で読まれやすい」と挙げた箇所。

### `docs/adr/0055-patch-coverage-diff-cover-gate.md`

- 冒頭に [ADR-0006](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0006-kover-over-jacoco.md) / ADR-0040 と同じ形式の注記を追加。本文が引用する LINE 90% / BRANCH 80% が ADR-0040 決定時点の値であり、現行値の出所が `build.gradle.kts` であることを明示した（本文中の 3 箇所をまとめてカバーする）
- 「関連」の ADR-0040 の説明から具体値を外した

## 作業中に見つかった食い違い（→ #843 を起票）

ADR-0055 の決定 2 は「diff-cover の閾値は `koverVerifyMature` の LINE 下限（90%）に揃えた」と書いている。しかし #735 / PR #833 で LINE 下限を 95% へ引き上げた際、`api-tests.yml` の `--fail-under 90` は追従していない。**「揃えた」という関係が現在は成立していない**。

追従させるか（差分ゲートは母集団が小さく 95% は体感でかなり厳しい）／独立の閾値と決めるかは判断が要るため、#843 として切り出した。本 PR の注記にはその事実と判断先を記載している。

## 確認

- `lefthook run pre-commit` 相当（commit 時に実行）: editorconfig-check / adr-numbering / gitleaks / markdown-links すべて緑
- ドキュメントのみの変更（Kotlin・インフラ・CI 設定の変更なし）
