### PR TITLE
perf: #690 テストを JVM 内のクラス間並列で走らせて :test を 11.5% 縮める

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -70,8 +70,8 @@ Spring テストの主コストは `ApplicationContext` の構築。速度の本
 
 - **distinct なコンテキスト構成を増やさない**。キャッシュは「同一の unique 構成」のときだけ再利用される（キーは classes / context customizers / active profiles / property sources 等の組合せ）。`@MockkBean` は context customizer を足してキーを分けるので**乱発しない**、`@Import` 構成は揃える、`@SpringBootTest(webEnvironment=...)` を不必要に散らさない。
 - **`@DirtiesContext` は原則使わない**（キャッシュを退避させ再構築を強いる）。状態リークは設計で断つ。
-- **テスト並列化（`maxParallelForks` / JUnit 5 の `junit.jupiter.execution.parallel`）は採らない**。フォークはキャッシュが JVM 単位のため逆効果、JVM 内並列は `@MockBean`/`@MockkBean` や共有状態を使うテストを Spring 公式が非推奨とする。加えて DB を触るテストの後始末（共有コンテナの全テーブル TRUNCATE。[ADR-0070](../../docs/adr/0070-db-test-cleanup-via-truncate-not-transactional.md)）は JVM 内並列と両立しない（他スレッドのデータまで消す）。再評価は #690。
-- 速度を縮めたいときの効く順: ビルドキャッシュ/デーモン（[ADR-0015](../../docs/adr/0015-gradle-build-performance-tuning.md)）→ コンテキスト構成の共通化（#817 で実施済み。下記）→ （将来）隔離を整えた上での並列化。
+- **テストは JVM 内のクラス間並列で走る**（[ADR-0079](../../docs/adr/0079-in-jvm-class-level-test-parallelism.md) / #690。下記）。ただし**`maxParallelForks`（プロセス並列）は採らない**。キャッシュが JVM 単位のため、フォークすると 16 個のコンテキスト構築が各 JVM で重複する（ADR-0015 当時 forks=1/2/4 で 42s/61s/97s と単調悪化）。
+- 速度を縮めたいときの効く順: ビルドキャッシュ/デーモン（[ADR-0015](../../docs/adr/0015-gradle-build-performance-tuning.md)）→ コンテキスト構成の共通化（#817 で実施済み。下記）→ クラス間並列（#690 で実施済み。下記）。
 
 ### web 環境を要する `@SpringBootTest` は 1 構成に揃える（崩すと -20.5% が消える）
 
@@ -80,7 +80,31 @@ Spring テストの主コストは `ApplicationContext` の構築。速度の本
 - `RestTestClient` も JWT も使わないクラス（`ApiApplicationTests` / `McpDisabledByDefaultTest`）が `@AutoConfigureRestTestClient` と `@Import` を持つのは、**キーを一致させるためだけ**。不自然に見えても外さない。
 - 引き換えに「本番の `issuer-uri` 設定から `JwtDecoder` Bean が生成される」ことを確かめるコンテキストが無くなっている（API E2E もブラウザ E2E も decoder を差し替えるため、リポジトリ全体で担保が無い）。この穴は #813 が引き取る。
 - **`@WebMvcTest` スライスの 11 個は削減対象にしない**。`controllers` 引数ごとに 1 コンテキストになるのはスライステストの機械的帰結で、束ねると「そのコントローラだけを載せる」意図が壊れる。
-- **効果は推論せず実測で確かめる**。実測では 18→17 個で -3.7〜-6.3%、17→16 個で -14.1% と、1 個あたりの効果が 2 倍以上違った（機序は未特定）。ローカルは初回コンテキスト構築の振れが大きく（同一構成で 17.5s / 36.5s、外れ値では `:test` が 74 分停止）効果より測定ノイズが大きいため、**CI（`workflow_dispatch` で 3 回）で測る**。
+- **効果は推論せず実測で確かめる**。実測では 18→17 個で -3.7〜-6.3%、17→16 個で -14.1% と、1 個あたりの効果が 2 倍以上違った（機序は未特定）。ローカルは初回コンテキスト構築の振れが大きく（同一構成で 17.5s / 36.5s、外れ値では `:test` が 74 分停止）効果より測定ノイズが大きいため、**CI（`workflow_dispatch` で 3 回）で測る**。ただし **3 回で足りるのはこの -20.5% 規模の効果に対してだけ**で、10% 前後を測るなら各 8 回が要る（後述「`:test` の速度を測り直すときは各 8 回」）。
+
+### クラス間並列（並列にしてはいけないテストは 2 種類だけ）
+
+テストは**クラス間だけ並列**で走る（クラス内のメソッドは逐次のまま）。設定の出所は `build.gradle.kts` の `tasks.withType<Test>` にある `junit.jupiter.execution.parallel.*` の 3 行で、決定経緯は [ADR-0079](../../docs/adr/0079-in-jvm-class-level-test-parallelism.md)（CI -11.5% / ローカル -13.3%）。
+
+並列にしてはいけないのは次の 2 種類だけで、どちらも `@Execution(ExecutionMode.SAME_THREAD)` で閉じる。
+
+| 対象 | 理由 | 書き手がすること |
+|---|---|---|
+| DB を触るテスト | 全テーブル TRUNCATE（[ADR-0070](../../docs/adr/0070-db-test-cleanup-via-truncate-not-transactional.md)）が並行実行と両立せず、他スレッドのデータまで消す | **何もしなくてよい**。`PostgresContainerSupport` のクラス注釈が `@Inherited` で継承先すべてに効く |
+| `@WebMvcTest` スライス | `@MockkBean`（`@MockBean` 機構）が Spring 公式「Parallel Test Execution」の非推奨条件に該当する | **クラスに `@Execution(SAME_THREAD)` を付ける** |
+
+- **`@WebMvcTest` を新しく足すときは `@Execution(SAME_THREAD)` を忘れないこと**。付け忘れは例外にならず、非推奨条件のまま静かに走って後から不安定さとして出る。`TestParallelismRulesTest.webMvcTestsRunInSameThread` が機械強制するので `check` で落ちる（注釈の有無だけでなく**値が `SAME_THREAD` であること**まで見る。`CONCURRENT` の明示も付け忘れと同じ結果になるため）。
+- **並列が効いていること自体を `ParallelExecutionProbeTest` が守る**。設定 3 行が消えても全テストは緑のまま通り速度が静かに戻るだけなので、2 クラスが互いの到達を待ち合わせ、逐次実行なら必ずタイムアウトして落ちるプローブを置いている。これが落ちたら、まず `build.gradle.kts` の並列設定を疑う。
+- **`@AnalyzeClasses`（ArchUnit）の規約テストは並列化されない**。ArchUnit 独自の TestEngine で動くため `junit.jupiter.execution.parallel.*`（Jupiter engine の設定）の対象外になる。並列化されるのは自前で `ClassFileImporter` を回すメタテストのほう。
+- **テストを並列で走らせると個々のクラスは遅くなる**（per-class 合計は約 2 倍）。それでも壁時計が縮むのは実行が重なるためで、per-class time を見て「遅くなった」と判断しないこと。
+
+### `:test` の速度を測り直すときは各 8 回（3 回では符号が反転する）
+
+10% 前後の効果は**各 3 回では判定できない**。#690 では最初の各 3 回で「+6.1% 遅い」、次の各 3 回で「-14.1% 速い」と符号が反転し、各 8 回に増やして初めて安定した（-11.5%, 並べ替え検定 p=0.030）。上記「効果は推論せず実測で確かめる」の CI 3 回という手順は -20.5% 規模の効果には足りたが、一般には足りないと考えること。
+
+- **ローカルでも測れる**。baseline と parallel を**交互に**回してペアで比べれば、ランナー状態のドリフトが打ち消せる（#690 では 8 ペア中 7 ペアで符号が揃い、符号検定 p=0.035）。ADR-0077 の「ローカルは計測に使えない」は、単発の実行を 3 回だけ比べる前提の話。
+- **初回の実行は捨てる**（ウォームアップで 1.3〜1.5 倍遅い）。外れ値（#818 の 400 秒級ブロック）を引いた回も別扱いにする。
+- 壁時計は `--profile` レポートか、`:cleanTest :test --no-build-cache` を挟んだ前後の時刻で測る。`BUILD SUCCESSFUL in Xs` は compile 等を含むため使えない。
 
 ## E2E（ブラックボックス API テスト・ゲート外）
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,11 +108,24 @@ tasks.withType<Test> {
     // （42s→97s @ forks=4）。コンテキストキャッシュ統計の実測では distinct な ApplicationContext は
     // 16 個・ヒット率 99.7%（hit 4860 / miss 16）で、:test の時間は「一度きりの 16 コンテキスト構築 +
     // JVM ウォームアップ」が支配的。Spring のキャッシュは JVM 単位のためフォークすると 16 構築が
-    // 各 JVM で重複し JVM 起動も N 倍になる。JVM 内スレッド並列も @MockkBean(springmockk＝@MockBean 機構)が
-    // Spring 公式「Parallel Test Execution」の非推奨条件に該当するため不可。加えて DB を触るテストの
-    // 後始末（共有コンテナの全テーブル TRUNCATE。ADR-0070）が JVM 内並列と両立しない。
+    // 各 JVM で重複し JVM 起動も N 倍になる。
     // 詳細・根拠は ADR-0015 / #349、コンテキストを 18 → 16 に畳んだ経緯は ADR-0077 / #817。
-    // 並列化の再評価は #690（#338 はクローズ済みで受け皿がここへ移っている）。
+    //
+    // 一方 **JVM 内のクラス間並列は採用する**（#690 / ADR-0079）。CI 実測（各 8 回）で :test が
+    // 74.0s → 65.5s（-11.5%, 並べ替え検定 p=0.030）、ローカル（8 論理コア・8 ペア）でも 7/8 のペアで
+    // 速く 79.0s → 68.5s（-13.3%, 符号検定 p=0.035）。コンテキストキャッシュは並列でも劣化しない
+    // （baseline / parallel とも size=16 / hit=4860 / miss=16 / failure=0 で完全一致）。
+    //   - mode.default=same_thread        … クラス内のメソッドは逐次のまま（既存テストの前提を崩さない）
+    //   - mode.classes.default=concurrent … クラス間だけ並列にする
+    // 並列にしないテストは @Execution(SAME_THREAD) で個別に閉じる。対象は 2 つ:
+    //   - DB を触るテスト … 全テーブル TRUNCATE（ADR-0070）が並行実行と両立しないため。
+    //     PostgresContainerSupport のクラス注釈が @Inherited で継承先すべてに効く。
+    //   - @WebMvcTest スライス … @MockkBean（springmockk＝@MockBean 機構）が Spring 公式
+    //     「Parallel Test Execution」の非推奨条件に該当するため。付け忘れは
+    //     ControllerContractRulesTest.webMvcTestsRunInSameThread が機械強制する。
+    systemProperty("junit.jupiter.execution.parallel.enabled", "true")
+    systemProperty("junit.jupiter.execution.parallel.mode.default", "same_thread")
+    systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
     // ユビキタス言語カタログの再生成フラグ（-DubiquitousLanguage.update=true）をフォークした JVM へ引き渡す。
     // UbiquitousLanguageCatalogTest が docs/ubiquitous-language.md の自動生成ブロックを書き戻すために参照する。
     System.getProperty("ubiquitousLanguage.update")?.let {

--- a/docs/adr/0079-in-jvm-class-level-test-parallelism.md
+++ b/docs/adr/0079-in-jvm-class-level-test-parallelism.md
@@ -1,0 +1,101 @@
+# 0079. テストを JVM 内のクラス間並列で走らせる（DB / WebMvc は逐次のまま）
+
+- Status: Accepted
+- Date: 2026-08-25
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+テスト並列化は [ADR-0015](0015-gradle-build-performance-tuning.md) の時点で「採らない」と決め、`.claude/rules/testing.md` は再評価の条件を「#338 でテスト隔離を整えてから」と書いていた。しかし #338 はクローズ済みで受け皿が無く、トリガーが宙に浮いていた（#690 がその受け皿として立った）。
+
+不採用の根拠は 3 つあった。いずれも #690 で実測し直した。
+
+1. **フォーク（`maxParallelForks`）は逆効果** — ADR-0015 当時 forks=1/2/4 で 42s/61s/97s と単調悪化。Spring のコンテキストキャッシュが JVM 単位のため、フォークすると 16 個のコンテキスト構築が各 JVM で重複する。**この結論は今回も維持する**（今回フォークは実測していない）。
+2. **JVM 内並列は `@MockBean` / `@MockkBean` を使うテストを Spring 公式が非推奨としている** — これは `@WebMvcTest` スライスに限った話で、スイート全体の制約ではなかった。
+3. **全テーブル TRUNCATE（[ADR-0070](0070-db-test-cleanup-via-truncate-not-transactional.md)）が並行実行と両立しない** — これも DB を触るテストに限った話だった。
+
+つまり 2 と 3 は「並列にしてはいけないテストが 2 種類ある」という制約であって、「並列にできない」ではない。JUnit 5 の `@Execution(SAME_THREAD)` でその 2 種類だけを逐次側へ閉じれば、残りは並列にできる。
+
+#690 のフェーズ1 はこの部分適用について「素直に並列化できるのは Unit 群 25% だけで、利得上限は -19%」と見積もっていた。加えて [ADR-0077](0077-consolidate-web-test-contexts-trading-jwt-decoder-assurance.md)（#817）でコンテキストを 18 → 16 に畳んで -20.5% を取った結果、比較の基準線が下がり利得はさらに薄くなるはずだった。**推論ではこの時点で「採らない」に傾いていたが、実際に回して測ったところ逆の結果が出た。**
+
+### 実測
+
+同一コミットで環境変数によって並列を切り替え、baseline（並列なし）と parallel を比較した。
+
+**CI（ubuntu-latest / 4 コア・各 8 回）**
+
+| | baseline | parallel |
+|---|---:|---:|
+| `:test` 壁時計 中央値 | 74.0s | **65.5s（-11.5%）** |
+| 平均 | 72.2s | 62.9s（-13.0%） |
+| 分布 | 60–83s | 49–70s |
+
+Mann-Whitney の並べ替え検定（全 12870 通り）で片側 **p = 0.030**。
+
+**ローカル（macOS / 8 論理コア・16GB、baseline と parallel を交互に 8 ペア）**
+
+| | baseline | parallel |
+|---|---:|---:|
+| 中央値（8 ペア） | 79.0s | **68.5s（-13.3%）** |
+| 中央値（外れ値と初回を除く 6 ペア） | 77.5s | **67.0s（-13.5%）** |
+
+8 ペア中 7 ペアで parallel が速く、符号検定で片側 p = 0.035（外れ値と初回を除く 6 ペアでは 6/6・p = 0.016）。
+
+**付随して確認したこと**
+
+- **コンテキストキャッシュは並列でも劣化しない** — baseline / parallel とも `size = 16 / hitCount = 4860 / missCount = 16 / failureCount = 0` で完全に一致した。並列によるコンテキストの重複構築は起きていない。
+- **テストは壊れない** — CI 28 ジョブ + ローカル 8 実行のすべてが success。
+- **個々のクラスは約 2 倍に膨らむ** — per-class time の合計は 63.3s → 124.3s になる。それでも壁時計が縮むのは実行が重なるため（per-class 合計 / 壁時計 = baseline 0.86 → parallel 1.90）。
+
+### 測定方法についての注意（この数字を再現・更新するときのために）
+
+**各 3 回では判定できなかった。** 最初の計測は各 3 回で parallel が **+6.1% 遅い**という結果になり、2 回目の各 3 回では **-14.1% 速い**と符号が反転した。各 8 回へ増やして初めて安定した。ADR-0077 の「CI 3 回で測る」という手順は、-20.5% のような大きい効果には足りるが、**10% 前後の効果には足りない**。
+
+### `@AnalyzeClasses` の規約テストは並列化されない
+
+ArchUnit の `@AnalyzeClasses` は ArchUnit 独自の TestEngine で動くため、`junit.jupiter.execution.parallel.*`（JUnit Jupiter engine の設定）の対象外になる。実測でも `OnionLayerRulesTest` は 0.52s → 0.80s、`ControllerContractRulesTest` は 0.03s → 0.04s とほぼ動かない。一方、自前で `ClassFileImporter` を回すメタテスト（`ControllerPackageLayoutRuleTest` / `DtoDomainEnumRuleTest` 等）は Jupiter のテストなので並列化され、クラスパス走査が重なって 2.53s → 12.40s のように膨らむ。
+
+フェーズ1 が「Unit 群 25% が並列対象」と見積もった中身は、実際にはこれより狭い。それでも壁時計が縮んだのは、Unit 群が DB 群・WebMvc 群の実行時間に重なって隠れるためで、**利得の出どころは「並列化した群が速くなること」ではなく「逐次側の裏で他が終わること」**にある。
+
+### 採らなかった代替案
+
+- **`maxParallelForks`（プロセス並列）** — 上記 1 のとおり。コンテキスト構築の重複が JVM 数に比例するため、コンテキストが 16 個ある現状で有利になる理由が無い。
+- **スレッドごとにスキーマを分ける / フォークごとにコンテナを分ける** — DB 群も並列化する案。TRUNCATE 方式（ADR-0070）と Testcontainers の構成を作り直す必要があるのに対し、DB 群を逐次に閉じたままでも -11.5% が取れたため、複雑さに見合わない。
+- **クラス内のメソッドも並列にする（`mode.default=concurrent`）** — 既存テストがメソッド間の実行順や共有フィクスチャに依存していないことを一件ずつ確かめる必要がある。クラス間並列だけで効果が出ているため踏み込まない。
+
+## Decision（決定）
+
+**JUnit 5 の JVM 内クラス間並列を有効にする。** `build.gradle.kts` の `tasks.withType<Test>` に次を置く。
+
+- `junit.jupiter.execution.parallel.enabled = true`
+- `junit.jupiter.execution.parallel.mode.default = same_thread`（クラス内のメソッドは逐次のまま）
+- `junit.jupiter.execution.parallel.mode.classes.default = concurrent`（クラス間だけ並列）
+
+並列度は JUnit 既定の `dynamic` 戦略（利用可能プロセッサ数）に任せ、固定しない。
+
+**並列にしてはいけない 2 種類は `@Execution(SAME_THREAD)` で閉じる。**
+
+| 対象 | 理由 | 強制のしかた |
+|---|---|---|
+| DB を触るテスト | 全テーブル TRUNCATE（ADR-0070）が並行実行と両立しない | `PostgresContainerSupport` のクラス注釈。`@Execution` は `@Inherited` なので継承先すべてに効く |
+| `@WebMvcTest` スライス | `@MockkBean`（`@MockBean` 機構）が Spring 公式「Parallel Test Execution」の非推奨条件 | クラスごとに付与し、`TestParallelismRulesTest.webMvcTestsRunInSameThread` が機械強制する |
+
+**`maxParallelForks` は既定（1）のまま据え置く**（ADR-0015 の結論を維持）。
+
+## Consequences（結果・影響）
+
+### 得たもの
+
+- `:test` が CI で -11.5%、ローカルで -13.3%。ADR-0077 の -20.5% に続く短縮で、両者は独立に効く（コンテキスト削減は構築コストを、並列化は実行の重なりを削る）。
+- ADR-0070 の TRUNCATE 方式にも Testcontainers の共有コンテナ構成にも手を入れずに済んだ。
+
+### 引き受けたもの
+
+- **`@WebMvcTest` を足すときは `@Execution(SAME_THREAD)` が要る。** 付け忘れても例外にはならず、Spring の非推奨条件のまま静かに走って後から不安定さとして出る。これを防ぐため `TestParallelismRulesTest` で機械強制し、注釈の有無だけでなく**値が `SAME_THREAD` であること**まで検査する（`CONCURRENT` の明示も付け忘れと同じ結果になるため）。違反サンプル 2 種を `architecture/fixture/` に恒久的に置き、ルールが実際に噛むことを回帰テストで担保する（`.claude/rules/gates.md`）。
+- **並列設定自体が消えても全テストは緑のまま通り、速度が静かに戻るだけになる。** これを検出するため `ParallelExecutionProbeTest` を置く。2 クラスが互いの到達を待ち合わせ、逐次実行なら必ずタイムアウトして落ちる。壁時計を測る方式と違い測定ノイズに左右されない。
+- **テストの隠れた共有状態が露出しうる。** 今回の実測では 36 回の実行すべてが success だったが、将来テストを足したときに並列固有の不安定さが出る可能性は残る。その場合は当該クラスに `@Execution(SAME_THREAD)` を付けて逃がしたうえで、共有状態そのものを設計で断つ。
+- **外れ値は解消しない。** ローカル 8 ペア中 1 回、parallel 側で 506s（通常 66s の 7.7 倍）を観測した。ただし同じペアの baseline も 120s（通常 77s）と遅く、#818 が観測した同型の外れ値は baseline（並列なし）で起きている。並列固有のリスクとは言えないが、**並列化しても消えない**（原因は #818 が引き取る）。
+
+### 効果を測り直すときの手順
+
+`.claude/rules/testing.md` に手順を残す。要点は、**各 3 回では足りず各 8 回が要る**こと、ローカルでも交互に回せば測れること（ADR-0077 の「ローカルは計測に使えない」は 20% 規模の効果を 3 回で測る前提の話で、8 ペアの交互比較なら 7/8 で符号が揃った）。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -88,3 +88,4 @@
 | [0076](0076-browser-e2e-playwright-auth-emulator-boottestrun.md) | ブラウザ E2E を Playwright + Auth Emulator + bootTestRun で組み、ゲート外の独立ワークフローで回す | Accepted |
 | [0077](0077-consolidate-web-test-contexts-trading-jwt-decoder-assurance.md) | web 環境を要するテストコンテキストを 1 つに畳み、本番 JwtDecoder Bean 生成の担保を手放す | Accepted |
 | [0078](0078-audit-via-admin-activity-detect-only.md) | GCP の監査は Admin Activity ログに委ね、正規ルート外の変更検知だけを足す | Accepted |
+| [0079](0079-in-jvm-class-level-test-parallelism.md) | テストを JVM 内のクラス間並列で走らせる（DB / WebMvc は逐次のまま） | Accepted |

--- a/src/test/kotlin/com/example/api/architecture/TestParallelismRulesTest.kt
+++ b/src/test/kotlin/com/example/api/architecture/TestParallelismRulesTest.kt
@@ -1,0 +1,101 @@
+package com.example.api.architecture
+
+import com.example.api.architecture.fixture.ConcurrentWebMvcTestFixture
+import com.example.api.architecture.fixture.ParallelUnsafeWebMvcTestFixture
+import com.tngtech.archunit.core.domain.JavaClass
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.lang.ArchCondition
+import com.tngtech.archunit.lang.ArchRule
+import com.tngtech.archunit.lang.ConditionEvents
+import com.tngtech.archunit.lang.SimpleConditionEvent
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+
+/**
+ * テストコード自身に掛ける規約（#690 / ADR-0079）。
+ *
+ * テストはクラス間並列で走る（`build.gradle.kts` の `junit.jupiter.execution.parallel.*`）が、**並列にしてはいけない テストが 2
+ * 種類ある**。DB を触るテスト（全テーブル TRUNCATE が並行実行と両立しない。ADR-0070）と `@WebMvcTest` スライス（`@MockkBean` ＝
+ * `@MockBean` 機構が Spring 公式「Parallel Test Execution」の非推奨条件に該当する）。
+ *
+ * 前者は `PostgresContainerSupport` のクラス注釈が `@Inherited` で継承先すべてに効くので、継承しさえすれば守られる。
+ * 後者は**クラスごとに書くしかなく付け忘れが起きうる**。しかも付け忘れは例外にならず、非推奨条件のまま静かに走って 不安定さとして後から出るため、ここで機械強制する。
+ *
+ * 他の `〜RulesTest` と違い `@AnalyzeClasses` を使わないのは、それが `ImportOption.DoNotIncludeTests` で
+ * **テストコードを走査対象から外している**ため。本ルールの対象はテストコードそのものなので、`ClassFileImporter` で 明示的に読み込む。
+ */
+class TestParallelismRulesTest {
+    /**
+     * `@WebMvcTest` を付けたクラスは `@Execution(SAME_THREAD)` で並列対象から外す。
+     *
+     * `@Execution` の有無だけでなく**値が `SAME_THREAD` であること**まで見る。`CONCURRENT` を明示した場合も
+     * 並列で走ってしまい、付け忘れと同じ結果になるため。
+     */
+    val webMvcTestsRunInSameThread: ArchRule =
+        classes()
+            .that()
+            .areAnnotatedWith(WebMvcTest::class.java)
+            .should(runInSameThread())
+            .because("@WebMvcTest は @MockkBean を使うため、Spring 公式が JVM 内並列の非推奨条件としている（ADR-0079）")
+
+    @Test
+    fun `すべての @WebMvcTest が SAME_THREAD で走ること`() {
+        // fixture は「違反サンプル」なので走査から外す（除外し忘れるとゲートが常に赤くなる）。
+        val classes =
+            ClassFileImporter()
+                .withImportOption { location -> !location.contains(FIXTURE_PATH) }
+                .importPackages(ROOT_PACKAGE)
+
+        webMvcTestsRunInSameThread.check(classes)
+    }
+
+    @Test
+    fun `@Execution が無い @WebMvcTest は違反として検出されること`() {
+        val classes = ClassFileImporter().importClasses(ParallelUnsafeWebMvcTestFixture::class.java)
+
+        assertThrows<AssertionError> { webMvcTestsRunInSameThread.check(classes) }
+    }
+
+    @Test
+    fun `@Execution(CONCURRENT) を明示した @WebMvcTest も違反として検出されること`() {
+        // 付け忘れと同じく並列で走ってしまうため、注釈の有無ではなく値まで見ていることを担保する。
+        val classes = ClassFileImporter().importClasses(ConcurrentWebMvcTestFixture::class.java)
+
+        assertThrows<AssertionError> { webMvcTestsRunInSameThread.check(classes) }
+    }
+
+    @Test
+    fun `走査対象に @WebMvcTest が 1 つも無いと空振りするため、実際に拾えていることを確かめる`() {
+        // noClasses/classes の should は対象 0 件でも成功するため、母集団が空でないことを別途押さえる
+        // （.claude/rules/gates.md「空振りしているゲートは何もしていない」）。
+        val classes =
+            ClassFileImporter()
+                .withImportOption { location -> !location.contains(FIXTURE_PATH) }
+                .importPackages(ROOT_PACKAGE)
+        val webMvcTests = classes.filter { it.isAnnotatedWith(WebMvcTest::class.java) }
+
+        assert(webMvcTests.count() > 0) { "@WebMvcTest が 1 つも走査されていない（走査範囲の誤り）" }
+    }
+
+    private companion object {
+        const val ROOT_PACKAGE = "com.example.api"
+        const val FIXTURE_PATH = "/architecture/fixture/"
+
+        fun runInSameThread(): ArchCondition<JavaClass> =
+            object : ArchCondition<JavaClass>("@Execution(SAME_THREAD) が付いている") {
+                override fun check(item: JavaClass, events: ConditionEvents) {
+                    val execution = item.tryGetAnnotationOfType(Execution::class.java)
+                    val satisfied =
+                        execution.isPresent && execution.get().value == ExecutionMode.SAME_THREAD
+                    val message =
+                        "${item.name} に @Execution(ExecutionMode.SAME_THREAD) が付いていない" +
+                            "（現在: ${execution.map { it.value.name }.orElse("注釈なし")}）"
+                    events.add(SimpleConditionEvent(item, satisfied, message))
+                }
+            }
+    }
+}

--- a/src/test/kotlin/com/example/api/architecture/fixture/ParallelUnsafeWebMvcTestFixture.kt
+++ b/src/test/kotlin/com/example/api/architecture/fixture/ParallelUnsafeWebMvcTestFixture.kt
@@ -1,0 +1,25 @@
+package com.example.api.architecture.fixture
+
+import com.example.api.controller.HelloController
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+
+/**
+ * `TestParallelismRulesTest.webMvcTestsRunInSameThread` が**実際に違反を検出する**ことを確かめるための違反サンプル （ゲートの非空振り規約
+ * `.claude/rules/gates.md`）。
+ *
+ * 禁じたい形は 2 つあり、どちらも「`@WebMvcTest` が並列で走ってしまう」という同じ結果になる。
+ * 1. `@Execution` を付け忘れる（[ParallelUnsafeWebMvcTestFixture]）
+ * 2. `@Execution(CONCURRENT)` を明示する（[ConcurrentWebMvcTestFixture]）
+ *
+ * 本番ルールは走査時にこの fixture パッケージを除外するので、ここに置いてあってもゲートは緑のまま保たれる。
+ *
+ * どちらもテストメソッド（`@Test`）を持たないため、テストランナーは実行しない（Spring コンテキストも起動しない）。
+ */
+@WebMvcTest(HelloController::class) class ParallelUnsafeWebMvcTestFixture
+
+/** `@Execution` は付いているが値が `CONCURRENT` で、結局並列に走ってしまう違反サンプル。 */
+@WebMvcTest(HelloController::class)
+@Execution(ExecutionMode.CONCURRENT)
+class ConcurrentWebMvcTestFixture

--- a/src/test/kotlin/com/example/api/controller/CurrentAccountArgumentResolverIntegrationTest.kt
+++ b/src/test/kotlin/com/example/api/controller/CurrentAccountArgumentResolverIntegrationTest.kt
@@ -9,6 +9,8 @@ import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
@@ -40,6 +42,7 @@ import org.springframework.web.bind.annotation.RestController
  * `/api/test/current-account-probe` が生えてしまう。`@TestConfiguration` の nested class は Spring Boot の
  * `TestTypeExcludeFilter` が自動でコンポーネントスキャン対象から除外するため、明示 `@Import` した slice にしか現れない）。
  */
+@Execution(ExecutionMode.SAME_THREAD)
 @WebMvcTest(ProbeControllerConfiguration.CurrentAccountProbeController::class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(ProbeControllerConfiguration::class)

--- a/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/GlobalExceptionHandlerTest.kt
@@ -20,6 +20,8 @@ import io.mockk.every
 import java.util.UUID
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
@@ -35,6 +37,7 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester
  *
  * 業務ルール違反ではない例外（リクエストボディ不正・想定外例外）が RFC 9457 形式で返ることを、 [JockeyController] を踏み台にして確認する。
  */
+@Execution(ExecutionMode.SAME_THREAD)
 @WebMvcTest(JockeyController::class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class, RequestFingerprint::class)

--- a/src/test/kotlin/com/example/api/controller/HelloControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/HelloControllerTest.kt
@@ -4,6 +4,8 @@ import com.example.api.application.iam.world.WorldQueries
 import com.example.api.domain.iam.model.account.AccountRepository
 import com.ninjasquad.springmockk.MockkBean
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.test.context.TestConstructor
@@ -11,6 +13,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 
+@Execution(ExecutionMode.SAME_THREAD)
 @WebMvcTest(HelloController::class)
 @AutoConfigureMockMvc(addFilters = false)
 @TestConstructor(autowireMode = AutowireMode.ALL)

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingRegistrationControllerTest.kt
@@ -28,6 +28,8 @@ import java.time.LocalDate
 import java.util.UUID
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
@@ -38,6 +40,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 
+@Execution(ExecutionMode.SAME_THREAD)
 @WebMvcTest(BreedingRegistrationController::class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class)

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultControllerTest.kt
@@ -44,6 +44,8 @@ import java.util.UUID
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
@@ -54,6 +56,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 
+@Execution(ExecutionMode.SAME_THREAD)
 @WebMvcTest(BreedingResultController::class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class)

--- a/src/test/kotlin/com/example/api/controller/breeding/BreedingResultSummaryControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/BreedingResultSummaryControllerTest.kt
@@ -15,6 +15,8 @@ import io.mockk.every
 import java.util.UUID
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.http.HttpStatus
@@ -23,6 +25,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 
+@Execution(ExecutionMode.SAME_THREAD)
 @WebMvcTest(BreedingResultSummaryController::class)
 @AutoConfigureMockMvc(addFilters = false)
 @TestConstructor(autowireMode = AutowireMode.ALL)

--- a/src/test/kotlin/com/example/api/controller/breeding/CoveringReportControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/breeding/CoveringReportControllerTest.kt
@@ -27,6 +27,8 @@ import java.time.Year
 import java.util.UUID
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
@@ -37,6 +39,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 
+@Execution(ExecutionMode.SAME_THREAD)
 @WebMvcTest(CoveringReportController::class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class)

--- a/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/horse/BloodHorseControllerTest.kt
@@ -50,6 +50,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
@@ -61,6 +63,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 import tools.jackson.databind.json.JsonMapper
 
+@Execution(ExecutionMode.SAME_THREAD)
 @WebMvcTest(BloodHorseController::class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class)

--- a/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/inspection/HorseInspectionControllerTest.kt
@@ -34,6 +34,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
@@ -45,6 +47,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 import tools.jackson.databind.json.JsonMapper
 
+@Execution(ExecutionMode.SAME_THREAD)
 @WebMvcTest(HorseInspectionController::class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class)

--- a/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/jockey/JockeyControllerTest.kt
@@ -28,6 +28,8 @@ import io.mockk.every
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
@@ -38,6 +40,7 @@ import org.springframework.test.context.TestConstructor.AutowireMode
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.assertj.MockMvcTester
 
+@Execution(ExecutionMode.SAME_THREAD)
 @WebMvcTest(JockeyController::class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class, RequestFingerprint::class)

--- a/src/test/kotlin/com/example/api/controller/me/MeControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/me/MeControllerTest.kt
@@ -12,6 +12,8 @@ import com.github.michaelbull.result.getOrThrow
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
@@ -45,6 +47,7 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester
  * `SecurityContextRepository` に頼る）はフィルタ無しでは効かないため使わない。代わりに
  * `MockHttpServletRequestBuilder.principal(Principal)` で `userPrincipal` を直接差し込む。
  */
+@Execution(ExecutionMode.SAME_THREAD)
 @WebMvcTest(MeController::class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class, ProvisionMeUseCase::class)

--- a/src/test/kotlin/com/example/api/controller/world/WorldControllerTest.kt
+++ b/src/test/kotlin/com/example/api/controller/world/WorldControllerTest.kt
@@ -22,6 +22,8 @@ import io.mockk.every
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
@@ -44,6 +46,7 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester
  * テスト（`JockeyControllerTest` / `BloodHorseControllerTest`）はいずれも本物の resolver をそのまま使い
  * `AccountRepository` だけをスタブする流儀のため、そちらに合わせた。
  */
+@Execution(ExecutionMode.SAME_THREAD)
 @WebMvcTest(WorldController::class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(ClockConfiguration::class)

--- a/src/test/kotlin/com/example/api/support/ParallelExecutionProbeTest.kt
+++ b/src/test/kotlin/com/example/api/support/ParallelExecutionProbeTest.kt
@@ -1,0 +1,56 @@
+package com.example.api.support
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Test
+
+/**
+ * クラス間並列が**実際に効いている**ことを守るゲート（#690 / ADR-0079）。
+ *
+ * 並列化は `build.gradle.kts` の `junit.jupiter.execution.parallel.*` という設定 3 行に乗っており、消えても
+ * テストは全部緑のまま通る。速度が静かに戻るだけで誰も気づかないため、ここで能動的に検出する。
+ *
+ * 2 つのテストクラスが互いの到達を待ち合わせる。**クラス間並列が効いていれば即座に両方が揃い、逐次実行なら
+ * 必ずタイムアウトして落ちる**。壁時計を測る方式と違い測定ノイズに左右されず、設定の有無だけを判定できる。
+ *
+ * 落ちたときに疑うのは次の順:
+ * 1. `build.gradle.kts` の `parallel.enabled` / `parallel.mode.classes.default` が消えていないか
+ * 2. これらのクラスに `@Execution(SAME_THREAD)` が付いていないか（本クラスは並列側に居る必要がある）
+ * 3. 実行環境の CPU が 1 コアで、そもそも並列度が 1 になっていないか
+ */
+private object ParallelExecutionProbe {
+    val classA = CountDownLatch(1)
+    val classB = CountDownLatch(1)
+
+    /** 並列なら即座に揃うので、待つのは「効いていない」と判定するまでの猶予にすぎない。 */
+    const val TIMEOUT_SECONDS = 10L
+
+    const val FAILURE_MESSAGE =
+        "クラス間並列が効いていない（build.gradle.kts の junit.jupiter.execution.parallel 設定を確認すること）"
+}
+
+class ParallelExecutionProbeATest {
+    @Test
+    fun `別クラスのテストと同時に走っていること`() {
+        ParallelExecutionProbe.classA.countDown()
+        val met =
+            ParallelExecutionProbe.classB.await(
+                ParallelExecutionProbe.TIMEOUT_SECONDS,
+                TimeUnit.SECONDS,
+            )
+        check(met) { ParallelExecutionProbe.FAILURE_MESSAGE }
+    }
+}
+
+class ParallelExecutionProbeBTest {
+    @Test
+    fun `別クラスのテストと同時に走っていること`() {
+        ParallelExecutionProbe.classB.countDown()
+        val met =
+            ParallelExecutionProbe.classA.await(
+                ParallelExecutionProbe.TIMEOUT_SECONDS,
+                TimeUnit.SECONDS,
+            )
+        check(met) { ParallelExecutionProbe.FAILURE_MESSAGE }
+    }
+}

--- a/src/test/kotlin/com/example/api/support/PostgresContainerSupport.kt
+++ b/src/test/kotlin/com/example/api/support/PostgresContainerSupport.kt
@@ -4,6 +4,8 @@ import java.sql.Connection
 import java.sql.DriverManager
 import java.util.UUID
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.postgresql.PostgreSQLContainer
@@ -25,10 +27,19 @@ import org.testcontainers.utility.DockerImageName
  * **DB の後始末も本クラスが担う**（#440 / ADR-0070）。コンテナはプロセス内で共有されるため、テストが書いた行は 明示的に消さない限り後続のテストへ漏れる。
  * [truncateAllTables] を `@BeforeEach` に置くことで、継承した時点で 必ず後始末が効き、テスト側が書き忘れうる余地を無くしている。`@Transactional`
  * によるロールバック分離は 採らない（トランザクション意味論を検証するテストが実コミットを要求するため適用範囲を 100% にできず、 隔離方式が二重化する。ADR-0070）。
+ *
+ * **並列実行からの隔離も本クラスが担う**（#690 / ADR-0079）。テストはクラス間並列で走るが、全テーブル TRUNCATE
+ * 方式は並行実行と両立しない（他スレッドのデータまで消す）。クラス注釈の `@Execution(SAME_THREAD)` が `@Inherited` で継承先すべてに効き、DB
+ * を触るテストだけを 1 スレッドへ閉じ込める。
  */
 // テストが継承して共有コンテナを得るための基底クラス。object 化すると継承できないため、
 // 「companion のユーティリティだけなら object にせよ」という detekt の指摘はここでは当たらない。
 @Suppress("UtilityClassWithPublicConstructor")
+// DB を触るテストを 1 スレッドへ閉じ込める（#690 / ADR-0079）。クラス間並列の下では、
+// [truncateAllTables] が共有コンテナの全テーブルを消す（ADR-0070）ため、並行して走る別の DB テストの
+// データまで消してしまう。@Execution は @Inherited なので、本クラスを継承するテストすべてに効く。
+// **この 1 行が DB テストの隔離を支えているので外さないこと。**
+@Execution(ExecutionMode.SAME_THREAD)
 abstract class PostgresContainerSupport {
     companion object {
         @JvmStatic


### PR DESCRIPTION
Closes #690

## 何をしたか

テスト並列化の採否を実測で決め、**採用**した。JUnit 5 の JVM 内クラス間並列を有効にし、並列にしてはいけない 2 種類だけを `@Execution(SAME_THREAD)` で逐次側へ閉じる。

`.claude/rules/testing.md` は #338 のクローズで再評価のトリガーが宙に浮いており、#690 がその受け皿として立っていた。フェーズ1（Issue のコメント）で実行時間の内訳までは取れていたが、**Unit 群限定の並列を実際に回した数値だけが未実測**で、Issue が「推論で決めない」と要求していたためスパイクを組んで測った。

## なぜ従来の「採らない」が覆ったか

不採用の根拠は 3 つあったが、うち 2 つは「並列にしてはいけないテストが 2 種類ある」という話で、スイート全体の制約ではなかった。

| 従来の根拠 | 今回の扱い |
|---|---|
| フォーク（`maxParallelForks`）はキャッシュが JVM 単位のため逆効果 | **維持**（今回もフォークは採らない） |
| `@MockBean` / `@MockkBean` を Spring 公式が非推奨としている | `@WebMvcTest` スライスに限った話 → そこだけ `SAME_THREAD` |
| 全テーブル TRUNCATE（ADR-0070）が並行実行と両立しない | DB を触るテストに限った話 → そこだけ `SAME_THREAD` |

## 実測

同一コミットで環境変数により並列を切り替え、baseline と parallel を比較した。

**CI（ubuntu-latest / 4 コア・各 8 回）**

| | baseline | parallel |
|---|---:|---:|
| `:test` 壁時計 中央値 | 74.0s | **65.5s（-11.5%）** |
| 平均 | 72.2s | 62.9s（-13.0%） |
| 分布 | 60–83s | 49–70s |

Mann-Whitney の並べ替え検定（全 12870 通り）で片側 **p = 0.030**。

**ローカル（macOS / 8 論理コア・16GB、baseline と parallel を交互に 8 ペア）**

| | baseline | parallel |
|---|---:|---:|
| 中央値（8 ペア） | 79.0s | **68.5s（-13.3%）** |
| 中央値（外れ値・初回を除く 6 ペア） | 77.5s | **67.0s（-13.5%）** |

8 ペア中 7 ペアで parallel が速く、符号検定で片側 p = 0.035（6 ペアでは 6/6・p = 0.016）。

**付随して確認したこと**

- **コンテキストキャッシュは並列でも劣化しない** — baseline / parallel とも `size = 16 / hitCount = 4860 / missCount = 16 / failureCount = 0` で完全一致
- **テストは壊れない** — CI 28 ジョブ + ローカル 8 実行すべて success
- 個々のクラスは約 2 倍に膨らむ（per-class 合計 63.3s → 124.3s）が、実行が重なるため壁時計は縮む（合計 / 壁時計 = 0.86 → 1.90）

### 計測方法について（再現するとき用）

**各 3 回では判定できなかった。** 最初の各 3 回は「+6.1% 遅い」、次の各 3 回は「-14.1% 速い」と符号が反転し、各 8 回に増やして初めて安定した。ADR-0077 の「CI 3 回で測る」手順は -20.5% 規模には足りるが、10% 前後には足りない。この知見は `testing.md` に残した。

### `@AnalyzeClasses` の規約テストは並列化されない

ArchUnit 独自の TestEngine で動くため `junit.jupiter.execution.parallel.*`（Jupiter engine の設定）の対象外。実測でも `OnionLayerRulesTest` は 0.52s → 0.80s とほぼ動かない一方、自前で `ClassFileImporter` を回すメタテストは並列化されて `ControllerPackageLayoutRuleTest` が 2.53s → 12.40s に膨らんだ。

つまり利得の出どころは「並列化した群が速くなること」ではなく **「逐次側の裏で他が終わること」** にある。

## ゲートの非空振り確認（.claude/rules/gates.md）

新設した ArchUnit ルール `TestParallelismRulesTest.webMvcTestsRunInSameThread` は、緑を根拠にせず落ちることを見て確認した。

| 壊し方 | 結果 |
|---|---|
| fixture（`@Execution` なし） | FAIL（恒久的な回帰テストとして常設） |
| fixture（`@Execution(CONCURRENT)` 明示） | FAIL（同上） |
| 実コード（`HelloControllerTest` から `@Execution` を一時削除） | FAIL |
| 走査母集団が空でないこと | 別テストで担保（`classes().should()` は 0 件でも成功するため） |

実コードを壊したときの出力:

```
Architecture Violation [Priority: MEDIUM] - Rule 'classes that are annotated with @WebMvcTest
should @Execution(SAME_THREAD) が付いている, because @WebMvcTest は @MockkBean を使うため、
Spring 公式が JVM 内並列の非推奨条件としている（ADR-0079）' was violated (1 times):
com.example.api.controller.HelloControllerTest に @Execution(ExecutionMode.SAME_THREAD) が
付いていない（現在: 注釈なし）
```

`ParallelExecutionProbeTest`（並列設定そのものが消えたら落ちるプローブ）も、`@Execution(SAME_THREAD)` を付けて逐次化すると 1m7s でタイムアウト FAIL することをスパイク時に確認済み。

## 引き受けたトレードオフ

- **`@WebMvcTest` を足すときは `@Execution(SAME_THREAD)` が要る。** 付け忘れは例外にならず静かに非推奨条件へ落ちるため、上記 ArchUnit ルールで機械強制する（注釈の有無だけでなく値まで検査する）。
- **並列設定が消えても全テストは緑のまま速度だけ戻る。** これは `ParallelExecutionProbeTest` が検出する。
- **テストの隠れた共有状態が将来露出しうる。** 今回 36 回の実行はすべて success だったが、出たら当該クラスを `SAME_THREAD` へ逃がしたうえで共有状態を設計で断つ。
- **外れ値（#818）は解消しない。** ローカル 8 ペア中 1 回、parallel 側で 506s を観測した。ただし同ペアの baseline も 120s（通常 77s）と遅く、#818 が観測した同型の外れ値は baseline 側で起きているため並列固有とは言えない。

## 変更点

| ファイル | 内容 |
|---|---|
| `build.gradle.kts` | クラス間並列を有効化（`mode.default=same_thread` / `mode.classes.default=concurrent`）。`maxParallelForks` 据え置きの理由と今回の実測をコメントに残す |
| `PostgresContainerSupport` | `@Execution(SAME_THREAD)`。`@Inherited` なので継承する DB テストすべてに効く |
| `@WebMvcTest` 12 クラス | `@Execution(SAME_THREAD)` |
| `TestParallelismRulesTest`（新規） | 付け忘れを機械強制。`@AnalyzeClasses` はテストコードを走査しないため `ClassFileImporter` で明示的に読む |
| `fixture/ParallelUnsafeWebMvcTestFixture`（新規） | 違反サンプル 2 種 |
| `ParallelExecutionProbeTest`（新規） | 並列が効いていること自体を守るプローブ |
| `docs/adr/0079` + `README.md` | 決定と実測の記録 |
| `.claude/rules/testing.md` | 「並列化は採らない」を書き換え、規約と計測手順を追加 |

## 検証

- `./gradlew check` 緑（1m46s）
- `src/main` に変更が無いため差分カバレッジゲートは対象外

計測用のスパイク（切り替えスイッチ・計測ワークフロー）は `spike/690-unit-parallel-measure` に置いてあり、**この PR には含めていない**。
