### PR TITLE
docs: #843 差分ゲートの閾値を集約ゲートに追従させないと確定する

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -179,6 +179,7 @@ Kover 0.9 の検証ルールはパッケージ単位のフィルタを持てな�
 - **excludes 反転でゲート対象を決める**: 全体をゲート対象とし、探索段階のパッケージだけを `variant("mature")` の `excludes` に列挙する。パッケージが成熟したら `excludes` から外す＝ゲート対象へ昇格。**外し忘れても「より厳しくなる」安全側**（includes 方式では追加忘れが「緩くなる」危険側だった）。
 - **カバレッジ単位は LINE と BRANCH の 2 ボーンド**。下限は実測直下のキリ番（**LINE 95% / BRANCH 85%**。出所は `build.gradle.kts` の `minValue`）に固定した**手動ラチェット**。実測が上がったら手で下限を上げてよい（[#735](https://github.com/ptiringo/toy-box/issues/735) で 90% / 80% から引き上げ。そのときの実測は LINE 97.35% / BRANCH 90.36%）。割ると `./gradlew check`（CI の `koverVerifyMature`）が失敗する。
 - **自動ラチェット機構は持たない**（YAGNI）。手動で引き上げる。
+- **引き上げるとき差分ゲート（diff-cover の `--fail-under`）は触らない**。差分ゲートの閾値は集約ゲートの下限に追従させず独立に決めると [#843](https://github.com/ptiringo/toy-box/issues/843) で確定した（理由は [ADR-0055](../../docs/adr/0055-patch-coverage-diff-cover-gate.md) 決定 2-1。母集団が PR ごとに数行〜百数十行しかなく、ラチェットの「実測直下に固定」という論理が成立しない）。
 
 探索除外パッケージ（`build.gradle.kts` の `variant("mature")` の `excludes` が唯一の出所。ここは要約）:
 `domain.racing.model.race` / `domain.racing.service` / `e2e`（E2E テスト基盤）/ `dbdoc`（tbls ドキュメント生成基盤）/ `replay`（帰納的検証ハーネス）。
@@ -191,7 +192,7 @@ Kover 0.9 の検証ルールはパッケージ単位のフィルタを持てな�
 
 集約ゲート（成熟領域全体の絶対水準）を補完し、PR で変更した行のカバレッジを個別に検証するのが差分ゲートである（[ADR-0055](../../docs/adr/0055-patch-coverage-diff-cover-gate.md)）。母集団が厚い集約ゲートだけでは新規変更行のテスト漏れが薄まって見逃されるため、変更行そのものに閾値を課す。
 
-- **[diff-cover](https://github.com/Bachmann1234/diff-cover)**（pipx, 10.3.0, mise 管理）で変更行カバレッジを算出し、`--fail-under 90` で 90% 未満の PR を落とす。
+- **[diff-cover](https://github.com/Bachmann1234/diff-cover)**（pipx, 10.3.0, mise 管理）で変更行カバレッジを算出し、`--fail-under 90` で 90% 未満の PR を落とす（出所は `.github/workflows/api-tests.yml`。集約ゲートの LINE 下限とは**独立**の値で、ラチェットに連動しない）。
 - 入力は `koverVerifyMature` と同じ `mature` variant の XML（`build/reports/kover/reportMature.xml`）。探索領域（`excludes` denylist、出所は `build.gradle.kts` に一元化）は mature XML の時点で除外済みのため、差分ゲートにも自動で継承される。
 - CI（`api-tests.yml`）は **PR ジョブ限定**で実行する（`github.event_name == 'pull_request'`）。main への push では走らせない（push でも走る `koverVerifyMature` が最終防波堤）。
 

--- a/docs/adr/0055-patch-coverage-diff-cover-gate.md
+++ b/docs/adr/0055-patch-coverage-diff-cover-gate.md
@@ -4,7 +4,7 @@
 - Date: 2026-07-07
 - Deciders: Matsui
 
-> 注: 本 ADR が決めた差分ゲートの閾値（`--fail-under 90`）は現行も 90% で不変。一方、本文が引用する集約ゲート（`koverVerifyMature`）の **LINE 90% / BRANCH 80% は [ADR-0040](0040-coverage-gate-operation-model.md) 決定時点の値**で、その後 [#735](https://github.com/ptiringo/toy-box/issues/735) で **LINE 95% / BRANCH 85%** へ引き上げられた（**現行値の出所は `build.gradle.kts`**、要約は `.claude/rules/testing.md`）。したがって決定 2 の「`koverVerifyMature` の LINE 下限に揃えた」という関係は現在は成立していない（追従させるかは [#843](https://github.com/ptiringo/toy-box/issues/843) で判断する）。
+> 注: 本 ADR が決めた差分ゲートの閾値（`--fail-under 90`、**現行値の出所は `.github/workflows/api-tests.yml`**）は決定当時から不変。一方、本文が引用する集約ゲート（`koverVerifyMature`）の **LINE 90% / BRANCH 80% は [ADR-0040](0040-coverage-gate-operation-model.md) 決定時点の値**で、その後 [#735](https://github.com/ptiringo/toy-box/issues/735) で引き上げられた（**現行値の出所は `build.gradle.kts`**、要約は `.claude/rules/testing.md`）。決定 2 が書いた「`koverVerifyMature` の LINE 下限に揃えた」は **決定当時の事実の記述であって追従の約束ではない**と [#843](https://github.com/ptiringo/toy-box/issues/843) で確定した（2026-08-26。理由は決定 2 の追記を参照）。
 
 ## Context（背景・課題）
 
@@ -28,7 +28,17 @@ PR レビューで「この差分にテストが付いているか」を目視�
 
 ### 2. `--fail-under 90` のハードゲートとする
 
-変更行カバレッジが 90% 未満なら diff-cover が非ゼロ終了し、CI ジョブを失敗させる。閾値は `koverVerifyMature` の LINE 下限（90%）に揃えた。
+変更行カバレッジが 90% 未満なら diff-cover が非ゼロ終了し、CI ジョブを失敗させる。閾値は決定当時の `koverVerifyMature` の LINE 下限（当時 90%）と同値に置いた。
+
+#### 2-1. この同値は追従の約束ではない（[#843](https://github.com/ptiringo/toy-box/issues/843) で 2026-08-26 に確定）
+
+差分ゲートの閾値は集約ゲートの手動ラチェット（[ADR-0040](0040-coverage-gate-operation-model.md)）に**連動させず、独立に決める**。集約ゲートの下限を引き上げても `--fail-under` は動かさない。理由は 3 つ。
+
+- **守る対象が違う**: 集約ゲートは「成熟領域全体の絶対水準を下げない」ための機構で、下限は実測直下のキリ番に固定する。差分ゲートは「新規・変更行にテストを添えさせる」ための下限であり、守るのは水準ではなく習慣である。
+- **ラチェットの論理が移植できない**: 集約ゲートは母集団が数千行あり 1 行の増減が 0.1pt 未満しか動かないため「実測直下に固定」が意味を持つ。差分ゲートの母集団は PR ごとに数行〜百数十行で、1 行未カバーの重みが 1pt から数十 pt まで跳ねる。実測に張り付かせても、次の PR の実測は母集団ごと別物になる。
+- **離散性で誤検知が増える**: 閾値を集約ゲートの LINE 下限へ揃えると（判断時点では 95%）、差分 20 行未満の PR は 1 行未カバーで即失敗する。差分カバレッジは #687 で観測したとおり ktfmt の整形結果（ラムダを単独行へ折るか）でも上下するため、この既知のノイズに対する余裕が実質ゼロになる。
+
+判断時点（2026-08-26）の実測: diff-cover 導入後に `src/main/kotlin` を変更したマージ 7 件の PR ジョブは、差分 2〜109 行に対していずれも 97〜100%。閾値 90% を割った実例は #687 の 89%（整形起因。1 行に収め直して 98% へ回復）1 件だけで、これは追従させていても同じく落ちていた。つまり**追従は「落ちる PR を増やす」方向にしか効かず、見逃していた回帰は観測されていない**。
 
 ### 3. 入力は `mature` variant の XML とし、集約ゲートを補完する関係にする
 
@@ -56,6 +66,7 @@ diff-cover に食わせる XML は `koverVerifyMature` と同じ `mature` varian
 - **`--src-roots src/main/kotlin` の指定が必須**: 省略すると diff-cover がソースパスを解決できずレポートが空になる（実装時に確認済み）。
 - **main push では走らない**: 差分ゲートは PR の変更行という概念に依存するため、main への直接 push（通常は発生しない運用だが）には効かない。集約ゲート（`koverVerifyMature`）は push でも走るため、最終的な安全網は保たれる。
 - **ADR-0040 は不変**: 絶対水準の集約ゲートの設計・閾値は変更しない。本 ADR は #437 で委譲されていた差分カバレッジのみを新たに決定する。
+- **2 つの閾値は別々に動かす**（決定 2-1）: 集約ゲートの手動ラチェットで LINE / BRANCH の下限を引き上げるとき、`--fail-under` は触らない。差分ゲートの閾値を見直すのは、差分カバレッジ自身の実測（PR ジョブの diff-cover 出力）が根拠になったときに限る。運用手順は `.claude/rules/testing.md`。
 
 ## 関連
 


### PR DESCRIPTION
## 概要

diff-cover の差分ゲート `--fail-under 90` を `koverVerifyMature` の LINE 下限（現行 95%）に **追従させない**（独立の閾値とする）と確定し、ADR-0055 と `.claude/rules/testing.md` へ反映する。Closes #843。

閾値そのものは変えない（90 のまま）。変わるのは **なぜ 90 なのか** の理由づけと、次にラチェットを回すときの手順。

## 判断の根拠

### 1. 守る対象が違う

集約ゲート（[ADR-0040](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0040-coverage-gate-operation-model.md) の手動ラチェット）は「成熟領域全体の絶対水準を下げない」ための機構で、下限を実測直下のキリ番に固定する。差分ゲートは「新規・変更行にテストを添えさせる」ための下限で、守るのは水準ではなく習慣。

### 2. ラチェットの論理が移植できない

| | 母集団 | 1 行未カバーの重み |
| --- | ---: | --- |
| 集約ゲート（mature） | 3510 行 | 0.03pt |
| 差分ゲート（PR ごと） | 2〜109 行（実測） | 1pt 〜 50pt |

集約ゲートは母集団が厚いので「実測直下に固定」が意味を持つ。差分ゲートは母集団ごと PR で入れ替わるため、実測に張り付かせても次の PR の実測は別物になる。

### 3. 離散性と整形ノイズ

95% へ揃えると **差分 20 行未満の PR は 1 行未カバーで即失敗**する。差分カバレッジは #687 で観測したとおり ktfmt の整形結果（ラムダを単独行へ折るか）でも上下するため、この既知のノイズに対する余裕が実質ゼロになる。

## 実測（判断の裏取り）

diff-cover 導入（ADR-0055 / 2026-07-07）以降に `src/main/kotlin` を変更したマージ 7 件について、CI ジョブのログから diff-cover 出力を抽出した。

| ブランチ | 差分行数 | 未カバー | 差分カバレッジ |
| --- | ---: | ---: | ---: |
| feat/652-registration-number-uniqueness-in-world | 78 | 0 | 100% |
| refactor/680-tennis-error-value-objects | 2 | 0 | 100% |
| feat/712-mcp-local-world-scope | 44 | 0 | 100% |
| feat/495-blood-horse-get-by-id-e2e | 68 | 2 | 97% |
| feat/633-carried-over-horse-registration | 109 | 1 | 99% |
| feat/583-non-senbatsu-tracks | 98 | 0 | 100% |
| feat/565-sakamichi-tracklist | 72 | 0 | 100% |

90% を割った実例は #687 の 89%（整形起因。1 行に収め直して 98% へ回復）1 件のみで、これは追従させていても同じく落ちていた。つまり **追従は「落ちる PR を増やす」方向にしか効かず、見逃していた回帰は観測されていない**。

## 変更内容

- `docs/adr/0055-patch-coverage-diff-cover-gate.md`
  - 冒頭注記を「追従させるかは #843 で判断する」から確定済みの記述へ更新。差分ゲートの閾値の出所（`.github/workflows/api-tests.yml`）を併記
  - 決定 2 に **2-1** を追記。決定当時の同値が追従の約束ではないことと理由 3 点、判断時点の実測を時点つきで記録
  - Consequences に「2 つの閾値は別々に動かす」運用（ラチェット時に `--fail-under` は触らない）を追加
- `.claude/rules/testing.md`
  - ラチェット手順に「引き上げるとき diff-cover の `--fail-under` は触らない」を追加
  - 差分ゲート節の `--fail-under 90` に出所と、集約ゲートの LINE 下限と独立である旨を併記

## 検証

- `lefthook run pre-commit` 相当（コミット時）: editorconfig-check / gitleaks / adr-numbering / markdown-links いずれも緑
- Kotlin の変更なし（ドキュメントと規約のみ）

## 関連

- Closes #843
- #836 / #848 カバレッジ下限の具体値が ADR に散在する問題（この食い違いを見つけた出所）
- #735 集約ゲートを LINE 95% / BRANCH 85% へ引き上げた作業
- [ADR-0055](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0055-patch-coverage-diff-cover-gate.md) / [ADR-0040](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0040-coverage-gate-operation-model.md)
