### PR TITLE
chore: #847 Docker 到達性ガードを Gradle の Test タスクへ広げる

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -57,12 +57,21 @@ Testcontainers の PostgreSQL はプロセス内で共有されるため、テ�
 
 ## ローカルゲートと Docker
 
-pre-push（lefthook の `full-test`）は `./gradlew test` を丸ごと回す。**Testcontainers 依存テストも対象のまま**で、Docker 不要なテストだけを切り出す運用は採らない（[ADR-0071](../../docs/adr/0071-pre-push-docker-fail-fast-guard.md)。穴が空くのが永続化契約テストという最も守りたい場所になること、`@Tag` の付け忘れが危険側に転ぶことが理由）。したがって **push には Docker が要る**。
+pre-push（lefthook の `full-test`）は `./gradlew test` を丸ごと回す。**Testcontainers 依存テストも対象のまま**で、Docker 不要なテストだけを切り出す運用は採らない（[ADR-0071](../../docs/adr/0071-pre-push-docker-fail-fast-guard.md)。穴が空くのが永続化契約テストという最も守りたい場所になること、`@Tag` の付け忘れが危険側に転ぶことが理由）。したがって **push にも `test` / `check` にも Docker が要る**。
 
-- 要るのは **`.kt` / `.kts` / `.java` を含む push のとき**だけ（両コマンドの `glob`）。ドキュメントや設定だけの push はゲートごとスキップされ、Docker を落としていても通る。glob を当てる対象は `scripts/list-push-target-files.sh` が供給する（lefthook 既定の `{push_files}` は worktree で比較対象を取り違え、`.md` だけの push でもゲートが起動していた。#804）。
-- pre-push の先頭で `scripts/check-docker-available.sh` が Docker 到達性を確認し、駄目なら理由と対処を出して即座に落とす（`piped: true` で `full-test` は走らない）。ハングして「push が無反応」に見える状態を潰すためのガードで、ゲートの範囲は変えない。
+**Docker に到達できなければテストは 1 件も走らずに落ちる**。判定は `scripts/check-docker-available.sh` に一本化され、呼び出し口が 2 つある。
+
+- **pre-push の先頭**（lefthook の `docker-available`。`piped: true` で `full-test` は走らない）。ハングして「push が無反応」に見える状態を潰すためのガード（[ADR-0071](../../docs/adr/0071-pre-push-docker-fail-fast-guard.md)）。
+- **Gradle の全 `Test` タスク**（`test` / `e2eTest` / `replay`）の `doFirst`。手で `./gradlew test` / `check` を叩く経路を守る（#847）。無いと `PostgresContainerSupport` の静的初期化が `ExceptionInInitializerError` で落ち、そこから `NoClassDefFoundError` が連鎖して**真因 1 件が 172 件の失敗に埋もれる**（#690 の作業中に実測。「並列化でテストが壊れた」と誤診しかけた）。
+- **CI では Gradle 側のプローブは走らない**（環境変数 `CI` で分岐）。CI には Docker が必ずあるため純粋な追加コストにしかならない。lefthook 側は CI で動かないので分岐は要らない。
+- **pre-push では両方が走る（二重）**。片方を抑止する環境変数は置かない —— 誤って抑止されたときに「ガードが効いていないのに気づけない」危険側へ転ぶため（[gates.md](gates.md) の「忘れても安全側」）。重複は数秒で、全テストを回す pre-push の中では無視できる。
+
+その他:
+
+- pre-push でゲートが要るのは **`.kt` / `.kts` / `.java` を含む push のとき**だけ（両コマンドの `glob`）。ドキュメントや設定だけの push はゲートごとスキップされ、Docker を落としていても通る。glob を当てる対象は `scripts/list-push-target-files.sh` が供給する（lefthook 既定の `{push_files}` は worktree で比較対象を取り違え、`.md` だけの push でもゲートが起動していた。#804）。**Gradle 側には glob に相当する絞り込みが無い**（`Test` タスクが実行される時点で Docker は必ず要るため）。
 - 判定は `docker info` の成否のみ。**Docker は生きているが Testcontainers だけ失敗する**ケース（イメージの pull 不可・リソース枯渇等）はガードを素通りし、従来どおりテストの失敗として出る。
-- Docker が復旧しないまま push したいときは **`LEFTHOOK_EXCLUDE=docker-available,full-test git push`**（`--no-verify` は gitleaks 等まで飛ばすので最後の手段）。同じテストは CI（`api-tests.yml`）で走る。
+- Docker が復旧しないまま push したいときは **`LEFTHOOK_EXCLUDE=docker-available,full-test git push`**（`--no-verify` は gitleaks 等まで飛ばすので最後の手段）。同じテストは CI（`api-tests.yml`）で走る。**`test` / `check` 側に同種の逃げ道は無い**（Docker を復旧してから実行し直す）。
+- ガードの動作を確かめたいときは Docker を落とさずに `DOCKER_HOST=tcp://127.0.0.1:1` を被せればよい（`docker info` が接続拒否で非ゼロになる）。
 
 ## テスト実行性能（コンテキストキャッシュ優先・並列化しない）
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,8 +93,53 @@ kotlin {
     }
 }
 
+// テストを起動する前に Docker の到達性を確かめるプローブ（#847 / ADR-0071）。
+// 設定フェーズで値を確定させ、タスクアクションからは project を触らない（configuration cache は
+// problems=fail で運用しているため、doFirst の中で project を参照すると設定フェーズごと落ちる）。
+val dockerProbeScript =
+    layout.projectDirectory.file("scripts/check-docker-available.sh").asFile.absolutePath
+// CI には Docker が必ずあるので、プローブは純粋な追加コストにしかならない。ローカル専用にする。
+val runningOnCi = providers.environmentVariable("CI").isPresent
+
 tasks.withType<Test> {
     useJUnitPlatform()
+    // Docker 不在ならテストを 1 件も走らせずに落とす（#847）。
+    //
+    // Testcontainers に到達性が無いと、共有コンテナを起動する PostgresContainerSupport の静的
+    // 初期化が ExceptionInInitializerError で落ち、以降その基底クラスに触る全テストが
+    // NoClassDefFoundError を投げ続ける。実測（#690 の作業中）では 172 件の失敗のうち真因は 1 件で、
+    // 失敗一覧の先頭に出るとも限らないため「並列化でテストが壊れた」と誤診しかけた。原因 1 つに
+    // 対して失敗 1 つを返すのがこのガードの役割で、ゲートの範囲は変えない。
+    //
+    // pre-push では lefthook の docker-available（ADR-0071）と二重に走るが、これは許容する。
+    // 環境変数で片方を抑止する仕組みは置かない —— 誤って抑止されたときに「ガードが効いていないのに
+    // 気づけない」危険側へ転ぶため（.claude/rules/gates.md の「忘れても安全側」）。lefthook 側を
+    // 残すのは、Gradle の起動と設定フェーズ（worktree では --no-daemon）を待たずに数秒で落ちること
+    // 自体が ADR-0071 の価値だから。重複するのは数秒で、全テストを回す pre-push の中では無視できる。
+    if (!runningOnCi) {
+        // スクリプトのパスをローカルへ束縛してから doFirst に渡す。ラムダの中でトップレベルの
+        // `dockerProbeScript` を直に読むと、Kotlin DSL ではビルドスクリプトオブジェクトごと
+        // キャプチャされ、configuration cache が「cannot serialize Gradle script object
+        // references」で落ちる（実測）。
+        val probeScript = dockerProbeScript
+        doFirst {
+            val probe =
+                ProcessBuilder(probeScript)
+                    // 出力は inheritIO せずパイプで受ける。タスクアクションは Gradle デーモンの
+                    // プロセス内で走るため、inheritIO ではデーモンの stdout へ流れて呼び出した
+                    // 端末には何も出ない（実測。「詳細は上のメッセージ」と言いながら本文が消える）。
+                    .redirectErrorStream(true)
+                    // 対処の案内を Gradle 経路向けに切り替える（pre-push 向けの LEFTHOOK_EXCLUDE の
+                    // 案内はここでは的外れになる）。
+                    .apply { environment()["DOCKER_PROBE_CALLER"] = "gradle" }
+                    .start()
+            // waitFor より先に読み切る（パイプバッファが埋まるとプローブ側が書き込みで止まる）。
+            val output = probe.inputStream.bufferedReader().use { it.readText() }
+            if (probe.waitFor() != 0) {
+                throw GradleException("テストを起動しませんでした。\n\n$output")
+            }
+        }
+    }
     // テスト JVM の CDS（Class Data Sharing）を明示的に切る。
     // Kover の JVM agent は MANIFEST の `Boot-Class-Path` で自分自身をブートストラップクラスパスへ
     // 追記するため、JDK 既定の CDS アーカイブ（lib/server/classes.jsa）が存在する環境では

--- a/docs/adr/0071-pre-push-docker-fail-fast-guard.md
+++ b/docs/adr/0071-pre-push-docker-fail-fast-guard.md
@@ -83,5 +83,11 @@ Error）になり、この事象を実際に踏んだ。`git push` が 2 分待�
   ガードの守備範囲は「Docker に到達できない」ことに限る。
 - 成功パスでも完了検知の粒度（1 秒）ぶんの待ちが乗る。全テストを回す pre-push の中では無視できる。
 - 結論（守るべきルール）は `.claude/rules/testing.md` の「ローカルゲートと Docker」に置いた。
-- **関連 ADR**: [ADR-0056](0056-drop-karate-native-resttestclient-e2e.md)（何をゲート外へ切り出すかの
-  線引き）、[ADR-0040](0040-coverage-gate-operation-model.md)（「忘れても安全側」を採る判断基準）。
+- **本 ADR のガードは pre-push 限定である**。手で `./gradlew test` / `check` を叩く経路は素通りし、
+  そこでは 172 件のテスト失敗に真因 1 件が埋もれる（#847 で実測）。この射程は
+  [ADR-0080](0080-docker-guard-on-gradle-test-tasks.md) が Gradle の `Test` タスクへ広げた
+  （本 ADR の決定自体は有効なまま）。
+- **関連 ADR**: [ADR-0080](0080-docker-guard-on-gradle-test-tasks.md)（本 ADR の射程を Gradle の
+  `Test` タスクへ広げた決定）、[ADR-0056](0056-drop-karate-native-resttestclient-e2e.md)（何をゲート外へ
+  切り出すかの線引き）、[ADR-0040](0040-coverage-gate-operation-model.md)（「忘れても安全側」を採る
+  判断基準）。

--- a/docs/adr/0080-docker-guard-on-gradle-test-tasks.md
+++ b/docs/adr/0080-docker-guard-on-gradle-test-tasks.md
@@ -1,0 +1,107 @@
+# 0080. Docker 到達性ガードを Gradle の Test タスクへ広げる
+
+- Status: Accepted
+- Date: 2026-08-26
+- Deciders: Matsui
+
+## Context（背景・課題）
+
+Issue #847。[ADR-0071](0071-pre-push-docker-fail-fast-guard.md) で導入した Docker 到達性の fail fast
+ガードは **lefthook の pre-push からしか呼ばれない**。開発中に手で `./gradlew test` / `./gradlew check`
+を叩く経路（`.claude/rules/testing.md` が案内している通常の実行方法）は素通りする。
+
+Docker が落ちた状態でこの経路を通ると、**原因は 1 つなのに 172 件のテスト失敗**という形で落ちる。
+`#690` の作業中に実測した内訳は次のとおり。
+
+| 例外 | 件数 | 位置づけ |
+|---|---:|---|
+| `org.junit.jupiter.api.extension.ParameterResolutionException` | 121 | 連鎖 |
+| `java.lang.NoClassDefFoundError` | 50 | 連鎖 |
+| `java.lang.ExceptionInInitializerError` | **1** | **真因** |
+
+共有コンテナを起動する `PostgresContainerSupport` の `companion`（静的初期化）が
+`Could not find a valid Docker environment.` で失敗し、以降その基底クラスに触る全テストが
+`NoClassDefFoundError` を投げ続ける。真因が失敗一覧の先頭に出るとは限らない（実行順に埋もれる）ため、
+このとき並列化スパイク（#690）の検証中だったこともあり「並列化でテストが壊れた」と誤診しかけた。
+切り分けには `ExceptionInInitializerError` を JUnit の XML から抽出する手間がかかった。
+
+失敗の出方が原因を示さないぶん、**踏むたびに同じ切り分けコストがかかる**のが実害である。
+
+### 検討した案
+
+- **案 A: `Test` タスクの実行直前に到達性を確認して fail fast する**（採用）。ADR-0071 と同じガードを
+  同じスクリプトで呼ぶだけで、原因 1 つに対して失敗 1 つを返せる。テストは 1 件も起動しない。
+- **案 B: `PostgresContainerSupport` の静的初期化を try/catch し、原因を明示した例外に包み直す**（不採用）。
+  追加コストはゼロだが、**失敗件数（172）は 1 件も減らない**。真因のメッセージが読みやすくなるだけで、
+  「一覧のどこかに埋もれる」という実害の本体が残る。案 A を入れれば通常の経路では到達しないため、
+  二重に持つ価値も薄い。
+- **案 C: `Test` タスクに `onlyIf` を付け、Docker 不在ならテストごと skip する**（不採用）。ADR-0071 が
+  「Docker 不要なテストだけ切り出す運用は採らない」と決めた方針に正面から反する。加えて **skip は緑で
+  通る**ため、ゲートが何も検証していない状態を成功と誤読させる。危険側に転ぶ設計は採らない
+  （`.claude/rules/gates.md`）。
+- **案 D: 手当てしない**（不採用）。「Docker を起動しておけば済む」のは事実だが、それは切り分けコストを
+  毎回払い続ける選択であり、現に一度誤診を誘発している。
+
+### CI での扱い
+
+CI には Docker が必ずあるため、プローブは**純粋な追加コスト**にしかならない。環境変数 `CI` で分岐して
+ローカル専用にする。lefthook 側のガードは CI で動かないので分岐は要らない。
+
+### pre-push での二重実行
+
+pre-push は `docker-available`（lefthook）→ `full-test`（`./gradlew test`）の順に走るため、本 ADR の
+ガードを入れると**プローブが 2 回走る**。これは許容する。
+
+- lefthook 側を残すのは、**Gradle の起動と設定フェーズを待たずに数秒で落ちること自体が ADR-0071 の
+  価値**だから（worktree では `--no-daemon` で走るため起動はさらに重い）。
+- 片方を抑止する環境変数（`DOCKER_PROBE_SKIP` 等）は**置かない**。誤って抑止されたときに「ガードが
+  効いていないのに気づけない」危険側へ転ぶ。カバレッジゲートで includes ではなく excludes 反転を
+  選んだ（[ADR-0040](0040-coverage-gate-operation-model.md)）のと同じ「忘れても安全側」の基準による。
+- 重複するのは 1 回ぶんのプローブ時間だけで、全テストを回す pre-push の中では無視できる。
+
+### 実装上の落とし穴（実測で確認）
+
+- **`ProcessBuilder.inheritIO()` では失敗メッセージが端末に出ない**。タスクアクションは Gradle
+  デーモンのプロセス内で走るため、継承先はデーモンの stdout であってビルドを起動した端末ではない。
+  実測では「詳細は上のメッセージ」と案内しながら本文が丸ごと消えた。出力はパイプで受け切り、
+  `GradleException` のメッセージに載せて Gradle の "What went wrong" に出す。
+- **タスクアクションのラムダからビルドスクリプトのトップレベル `val` を直に読むと configuration cache
+  が落ちる**。Kotlin DSL ではスクリプトオブジェクトごとキャプチャされ、`cannot serialize Gradle script
+  object references` になる（本リポジトリは `org.gradle.configuration-cache.problems=fail` で運用して
+  いるため設定フェーズごと失敗する）。値は設定フェーズでローカル変数へ束縛してから渡す。
+
+## Decision（決定）
+
+**`tasks.withType<Test>` の `doFirst` から `scripts/check-docker-available.sh` を呼び、Docker に到達
+できなければテストを 1 件も起動せずに落とす。** ゲートの範囲（どのテストを走らせるか）は変えない。
+
+- 対象は Gradle の全 `Test` タスク（決定時点では `test` / `e2eTest` / `replay`。出所は `build.gradle.kts`）。
+  pre-push の `glob` に相当する絞り込みは置かない —— `Test` タスクが実行される時点で Docker は必ず要る。
+- **環境変数 `CI` が設定されていればプローブを飛ばす**。
+- 判定ロジックは pre-push と同じスクリプトに一本化し、**失敗時の対処案内だけ** 環境変数
+  `DOCKER_PROBE_CALLER`（`pre-push` 既定 / `gradle`）で出し分ける。pre-push 向けの
+  `LEFTHOOK_EXCLUDE=...` の案内は Gradle 経路では的外れになるため。
+- **pre-push では lefthook と Gradle の両方でプローブが走る**。これを抑止する仕組みは置かない。
+- [ADR-0071](0071-pre-push-docker-fail-fast-guard.md) は **Superseded にしない**。その決定（fail fast
+  する / テストの切り分けは行わない）はそのまま有効で、本 ADR はその射程を広げるだけである。
+
+## Consequences（結果・影響）
+
+- Docker 不在で `test` / `check` を直接叩いたとき、**172 件のテスト失敗が 1 件のタスク失敗になる**。
+  原因と対処がそのまま "What went wrong" に出るため、切り分けが不要になる。
+- **ローカルの `Test` タスク実行にプローブ 1 回ぶんの時間が乗る**（`docker info` の応答時間と完了検知
+  の粒度 1 秒で決まる。本 ADR 時点のローカル実測で成功時 2.07 秒）。タスクが UP-TO-DATE なら
+  実行されないため毎回払うわけではなく、CI では飛ばすので影響しない。
+- **ガードの守備範囲は ADR-0071 と同じ**「Docker に到達できない」ことに限る。Docker は生きているが
+  Testcontainers だけ失敗するケース（イメージの pull 不可・リソース枯渇等）は素通りし、従来どおり
+  テストの失敗として出る。
+- **pre-push の逃げ道（`LEFTHOOK_EXCLUDE=docker-available,full-test git push`）に相当するものは
+  `test` / `check` 側に無い**。Docker を復旧してから実行し直すことになる。案 C を採らない以上、
+  これは意図した帰結である。
+- ガードの非空振り確認は **Docker を落とさずに `DOCKER_HOST=tcp://127.0.0.1:1` を被せる**ことで
+  再現できる（`docker info` が接続拒否で非ゼロになる）。手順は `.claude/rules/testing.md` に置いた。
+- 結論（守るべきルール）は `.claude/rules/testing.md` の「ローカルゲートと Docker」に置いた。
+- **関連 ADR**: [ADR-0071](0071-pre-push-docker-fail-fast-guard.md)（本 ADR が射程を広げる元の決定）、
+  [ADR-0040](0040-coverage-gate-operation-model.md)（「忘れても安全側」を採る判断基準）、
+  [ADR-0070](0070-db-test-cleanup-via-truncate-not-transactional.md)（連鎖の起点になる共有コンテナの
+  後始末方式）。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -89,3 +89,4 @@
 | [0077](0077-consolidate-web-test-contexts-trading-jwt-decoder-assurance.md) | web 環境を要するテストコンテキストを 1 つに畳み、本番 JwtDecoder Bean 生成の担保を手放す | Accepted |
 | [0078](0078-audit-via-admin-activity-detect-only.md) | GCP の監査は Admin Activity ログに委ね、正規ルート外の変更検知だけを足す | Accepted |
 | [0079](0079-in-jvm-class-level-test-parallelism.md) | テストを JVM 内のクラス間並列で走らせる（DB / WebMvc は逐次のまま） | Accepted |
+| [0080](0080-docker-guard-on-gradle-test-tasks.md) | Docker 到達性ガードを Gradle の Test タスクへ広げる | Accepted |

--- a/scripts/check-docker-available.sh
+++ b/scripts/check-docker-available.sh
@@ -1,16 +1,27 @@
 #!/usr/bin/env bash
-# pre-push で全テストを起動する前に Docker の到達性を確認し、到達できなければ
-# 理由と対処を明示して即座に失敗させる（ADR-0071 / #679）。
+# テストを起動する前に Docker の到達性を確認し、到達できなければ理由と対処を明示して即座に
+# 失敗させる（ADR-0071 / #679。射程を Gradle の Test タスクへ広げたのは #847）。
 #
-# 背景: pre-push の `./gradlew test` は Testcontainers（PostgreSQL）に依存するため Docker
-# デーモンを要求する。デーモンが不調だと Testcontainers が接続を試み続けてテストが長時間
-# ハングし、端末上は「push が無反応」に見える。ネットワークやリモートを疑って切り分けに
-# 時間を取られ、最後は `--no-verify`（全フック迂回）へ逃げることになる。ゲートは残したまま、
-# 失敗を「速く・分かる形」に変えるのがこのスクリプトの役割。
+# 呼び出し元は 2 つあり、どちらも判定ロジックは同じ。失敗時の対処案内だけを
+# DOCKER_PROBE_CALLER で出し分ける（迂回の手順が経路ごとに違うため）。
+#
+#   - pre-push（lefthook の docker-available コマンド。既定）
+#     `./gradlew test` は Testcontainers（PostgreSQL）に依存するため Docker デーモンを要求する。
+#     デーモンが不調だと Testcontainers が接続を試み続けてテストが長時間ハングし、端末上は
+#     「push が無反応」に見える。ネットワークやリモートを疑って切り分けに時間を取られ、最後は
+#     `--no-verify`（全フック迂回）へ逃げることになる。
+#   - gradle（build.gradle.kts の tasks.withType<Test> の doFirst）
+#     Docker 不在のまま test / check を直接叩くと、共有コンテナの静的初期化
+#     （PostgresContainerSupport）が失敗し、そこから NoClassDefFoundError が連鎖して 172 件の
+#     テスト失敗になる。真因は ExceptionInInitializerError の 1 件だけで、失敗一覧の先頭に
+#     出るとも限らないため埋もれる（#847 で実測）。
+#
+# どちらもゲートの範囲は変えない。失敗を「速く・分かる形」に変えるのがこのスクリプトの役割。
 #
 # 使い方:
 #   scripts/check-docker-available.sh
 #   - 環境変数 DOCKER_PROBE_TIMEOUT_SECONDS で打ち切り秒数を上書きできる（既定 15）。
+#   - 環境変数 DOCKER_PROBE_CALLER で対処案内を切り替える（pre-push（既定）/ gradle）。
 # 終了コード: Docker に到達できれば 0、できなければ 1。
 #
 # 判定は `docker info` の成否だけで行い、`docker ps` 等は重ねない。実測した障害
@@ -23,25 +34,46 @@
 set -euo pipefail
 
 TIMEOUT_SECONDS="${DOCKER_PROBE_TIMEOUT_SECONDS:-15}"
+CALLER="${DOCKER_PROBE_CALLER:-pre-push}"
 
-# 到達不能の理由を示した上で、対処の選択肢（復旧・確認・ゲートを外して push）を出して落とす。
-fail() {
+# 到達不能の理由と、どちらの経路でも共通する対処（復旧・確認）を出す。
+fail_common() {
   cat >&2 <<EOF
 NG: Docker に到達できません（$1）。
 
-pre-push の全テスト（./gradlew test）は Testcontainers（PostgreSQL）を使うため Docker デーモンが
-要ります。テストを起動すると接続の再試行で長時間ハングし「push が無反応」に見えるため、起動前に
-打ち切りました。
+$2
 
 対処:
   1. Docker を起動する（Docker Desktop / colima / dockerd 等）。起動しているつもりなら再起動する
      （バックエンドが不調で API が 500 を返し続けることがある）。
   2. \`docker info\` を手で叩いて出力を確認する。
+EOF
+}
+
+# 経路ごとに違うのは 3 番目（今すぐ先へ進みたいときの逃げ道）だけ。
+fail() {
+  case "$CALLER" in
+    gradle)
+      fail_common "$1" "このプロジェクトのテストは Testcontainers（PostgreSQL）で本番ターゲットの DB を用意するため Docker
+デーモンが要ります。このまま起動すると共有コンテナの静的初期化が失敗し、原因を示さないテスト失敗が
+大量に出て真因が埋もれるため（#847）、テストを 1 件も走らせずに打ち切りました。"
+      cat >&2 <<EOF
+  3. Docker 不要なテストだけを回す運用は用意していません（ADR-0071。穴が空くのが永続化契約テスト
+     という最も守りたい場所になるため）。Docker を復旧してから実行し直してください。
+EOF
+      ;;
+    *)
+      fail_common "$1" "pre-push の全テスト（./gradlew test）は Testcontainers（PostgreSQL）を使うため Docker デーモンが
+要ります。テストを起動すると接続の再試行で長時間ハングし「push が無反応」に見えるため、起動前に
+打ち切りました。"
+      cat >&2 <<EOF
   3. どうしても今 push したいなら、テストゲートだけ外して push する:
        LEFTHOOK_EXCLUDE=docker-available,full-test git push
      （pre-push の他フックは残る。\`--no-verify\` は全フックを飛ばすので最後の手段）。
      同じテストは CI（api-tests.yml）でも走るため、壊れたまま push すれば CI が検出する。
 EOF
+      ;;
+  esac
   exit 1
 }
 


### PR DESCRIPTION
## 概要

Closes #847。

Docker が落ちた状態で `./gradlew test` / `./gradlew check` を**直接**叩くと、原因は 1 つ（Docker に到達できない）なのに **172 件のテスト失敗**として落ちる。`PostgresContainerSupport` の静的初期化が `ExceptionInInitializerError` で失敗し、以降その基底クラスに触る全テストが `NoClassDefFoundError` を投げ続けるため、真因 1 件が連鎖 171 件に埋もれる。[ADR-0071](https://github.com/ptiringo/toy-box/blob/main/docs/adr/0071-pre-push-docker-fail-fast-guard.md) の fail fast ガードは **pre-push 限定**でこの経路に効かなかった。

同じガードを **Gradle の全 `Test` タスク**へ広げ、Docker 不在ならテストを 1 件も起動せずに落とす。ゲートの範囲（どのテストを走らせるか）は変えない。

## 変更点

- **`build.gradle.kts`**: `tasks.withType<Test>` の `doFirst` から `scripts/check-docker-available.sh` を呼ぶ。環境変数 `CI` が立っていれば飛ばす（CI には Docker が必ずあるため純粋な追加コスト）。
- **`scripts/check-docker-available.sh`**: 判定ロジックは据え置き。**失敗時の対処案内だけ** `DOCKER_PROBE_CALLER`（`pre-push` 既定 / `gradle`）で出し分ける。pre-push 向けの `LEFTHOOK_EXCLUDE=...` の案内は Gradle 経路では的外れになるため。
- **ADR-0080**（新規）: 決定と却下案を記録。ADR-0071 は決定自体が有効なままなので **Superseded にせず**、相互リンクのみ追加した。
- **`.claude/rules/testing.md`**: 「ローカルゲートと Docker」を 2 つの呼び出し口・CI 分岐・二重実行・動作確認手順を含む形へ更新。

### 採らなかった案

- **静的初期化を try/catch して原因を明示する例外に包み直す**: 追加コストはゼロだが**失敗件数（172）が 1 件も減らない**。実害の本体は「一覧のどこかに埋もれる」ことなので、症状に効かない。
- **`onlyIf` で Docker 不在ならテストごと skip**: ADR-0071 の「Docker 不要なテストだけ切り出す運用は採らない」に正面から反する。加えて **skip は緑で通る**ため、何も検証していない状態を成功と誤読させる（危険側）。

### pre-push では二重に走る（許容した）

pre-push は `docker-available`（lefthook）→ `full-test`（`./gradlew test`）なのでプローブが 2 回走る。**片方を抑止する環境変数は置かなかった** —— 誤って抑止されたときに「ガードが効いていないのに気づけない」危険側へ転ぶため（`.claude/rules/gates.md` の「忘れても安全側」）。lefthook 側を残すのは、Gradle の起動と設定フェーズを待たずに数秒で落ちること自体が ADR-0071 の価値だから。

## 非空振りの確認（`.claude/rules/gates.md`）

**Docker を落とさずに `DOCKER_HOST=tcp://127.0.0.1:1` を被せる**と `docker info` が接続拒否で非ゼロになり、到達不能を再現できる。

### (a) ガードが発火し、テストが 1 件も走らずに落ちる

```
$ DOCKER_HOST=tcp://127.0.0.1:1 ./gradlew :test
> Task :test FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':test' (registered by plugin 'org.gradle.jvm-test-suite').
> テストを起動しませんでした。

  NG: Docker に到達できません（docker info が失敗しました（終了コード 1））。

  このプロジェクトのテストは Testcontainers（PostgreSQL）で本番ターゲットの DB を用意するため Docker
  デーモンが要ります。このまま起動すると共有コンテナの静的初期化が失敗し、原因を示さないテスト失敗が
  大量に出て真因が埋もれるため（#847）、テストを 1 件も走らせずに打ち切りました。

  対処:
    1. Docker を起動する（Docker Desktop / colima / dockerd 等）。起動しているつもりなら再起動する
       （バックエンドが不調で API が 500 を返し続けることがある）。
    2. `docker info` を手で叩いて出力を確認する。
    3. Docker 不要なテストだけを回す運用は用意していません（ADR-0071。穴が空くのが永続化契約テスト
       という最も守りたい場所になるため）。Docker を復旧してから実行し直してください。

BUILD FAILED in 8s
Configuration cache entry stored.
```

**172 件 → 1 件**。テストタスクは起動すらしていない。

### (b) `CI` が立っていれば skip される

同一コマンド・同一の Docker 到達不能状態で、`CI` の有無だけが結果を分けることを確認した（Docker 不要なテスト 1 本で対比）。

```
$ CI=true DOCKER_HOST=tcp://127.0.0.1:1 ./gradlew :test --tests "JockeyTest"
> Task :test
BUILD SUCCESSFUL in 6s

$ DOCKER_HOST=tcp://127.0.0.1:1 ./gradlew :test --tests "JockeyTest"
> Task :test FAILED
  NG: Docker に到達できません（docker info が失敗しました（終了コード 1））。
BUILD FAILED in 4s
```

### (c) 通常実行は緑のまま

```
$ ./gradlew check
> Task :test
BUILD SUCCESSFUL in 1m 34s
Configuration cache entry stored.
```

### 追加コストの実測

```
$ time scripts/check-docker-available.sh
scripts/check-docker-available.sh  0.68s user 1.89s system 123% cpu 2.073 total
```

成功時 **2.07 秒**。`Test` タスクが UP-TO-DATE なら実行されず、CI では飛ばす。

## 実装上の落とし穴（どちらも実測で踏んで直した）

- **`ProcessBuilder.inheritIO()` では失敗メッセージが端末に出ない**。タスクアクションは Gradle **デーモン**のプロセス内で走るため、継承先はデーモンの stdout であってビルドを起動した端末ではない。最初の実装は「詳細は上のメッセージ」と案内しながら本文が丸ごと消えていた。出力はパイプで受け切って `GradleException` に載せている。
- **タスクアクションのラムダからビルドスクリプトのトップレベル `val` を直に読むと configuration cache が落ちる**（`cannot serialize Gradle script object references`）。本リポジトリは `org.gradle.configuration-cache.problems=fail` なので設定フェーズごと失敗する。設定フェーズでローカル変数へ束縛してから渡している。

いずれも再発しないようコード側のコメントと ADR-0080 に残した。
