### PR TITLE
chore: #649 Gradle の deprecation ゲート（warning.mode=fail）を有効化する

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,12 @@ org.gradle.configuration-cache.problems=fail
 # （計測: clean test 87s→2s（フルヒット時））。CI でも setup-gradle が ~/.gradle を復元するため runner 間で効く。
 org.gradle.caching=true
 
+# deprecation の健全性ゲート: Gradle の非推奨 API を使う記述が混入したら警告で済まさず失敗させ、
+# 次のメジャー版で壊れる書き方を混入した時点で止める（#649）。
+# 長らく Kover プラグイン内部の deprecation（PrepareKover.kt の dependency notation）で有効化できず
+# 保留していたが、Kover 0.9.9 が解消したため有効化した。
+org.gradle.warning.mode=fail
+
 # Gradle デーモンの JVM 設定。既定ヒープ(512m)は Kotlin + Spring + detekt のビルドには小さく
 # GC 圧の原因になりうるため引き上げる（現規模では実測差は小さいが将来の肥大化に備える）。
 org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
## 概要

#649 の unblock 条件が満たされたので、Gradle の deprecation ゲート `org.gradle.warning.mode=fail` を有効化する。非推奨 API を使う記述が混入したら、警告で流さずビルドを失敗させる。

## なぜ今できるようになったか

保留していた理由は **Kover プラグイン内部の deprecation**（`kotlinx.kover.gradle.plugin.appliers.PrepareKoverKt.prepare` の `Using a Project object as a dependency notation`）で、こちらの `build.gradle.kts` からは制御できなかった。ゲートを入れると全ビルドが即失敗するため、Gradle に特定 deprecation の allowlist が無い以上、上流の修正を待つ方針を採っていた。

Kover **0.9.9**（2026-07-17）のリリースノートに該当の修正がある。

> ### Bugfixes
> * [`#818`](https://github.com/Kotlin/kotlinx-kover/issues/818) Fixed Gradle 9.6.0 deprecation warning

`gradle/libs.versions.toml` の `kover` は別作業で既に `0.9.9` へ追随済みだった（#649 本文は 0.9.8 時点の記述のまま）。したがって残作業は「deprecation がゼロであることの確認」と「ゲートの配線」だけだった。

## 変更

`gradle.properties` に 1 行（＋経緯のコメント）。位置は既存の `org.gradle.configuration-cache.problems=fail` と同系統の「警告で済ませず失敗させる」ゲートとして、build cache の宣言の直後に置いた。

```properties
# deprecation の健全性ゲート: Gradle の非推奨 API を使う記述が混入したら警告で済まさず失敗させ、
# 次のメジャー版で壊れる書き方を混入した時点で止める（#649）。
# 長らく Kover プラグイン内部の deprecation（PrepareKover.kt の dependency notation）で有効化できず
# 保留していたが、Kover 0.9.9 が解消したため有効化した。
org.gradle.warning.mode=fail
```

## 実測

### 1. 有効化の前提: deprecation がゼロであること

configuration cache がヒットすると設定フェーズごとスキップされて deprecation が再現しないため、無効化して測った。

```
$ ./gradlew build --warning-mode all --no-configuration-cache
BUILD SUCCESSFUL in 20s
29 actionable tasks: 10 executed, 19 from cache

$ grep -in "deprecat" build-warnall.log
（出力なし）
```

Gradle は現在 9.7.1（#649 起票時は 9.6）。

### 2. ゲート有効化後にビルドが緑であること

上のログは build cache のヒットが 19 件あり、キャッシュ復元されたタスクは実行フェーズを通らない。そこでキャッシュを使わず全タスクを実行して確認した。

```
$ ./gradlew clean build --no-build-cache
BUILD SUCCESSFUL in 2m 47s
31 actionable tasks: 31 executed
```

`./gradlew check` も緑（exit 0）。

### 3. ゲートが空振りしていないこと（ミューテーション）

`.claude/rules/gates.md`「ゲートを新設・変更したら、わざと違反する状態を作って落ちることを見るまで完了としない」に従い、#649 が自コード起因の deprecation として実際に踏んだ形（Kotlin DSL のプロパティ委譲による task 登録）を一時的に足して確認した。

```kotlin
// build.gradle.kts 末尾に一時追加（コミットしていない）
val mutationProbe by tasks.registering { }
```

```
$ ./gradlew help ; echo "exit=$?"

> Configure project :
The 'val name by registering { }' property delegate syntax has been deprecated. This is scheduled to be removed in Gradle 10. Use 'val element = register(name) { }' instead. Consult the upgrading guide for further information: https://docs.gradle.org/9.7.1/userguide/upgrading_version_9.html#kotlin_dsl_delegated_properties
	at Build_gradle.<init>(build.gradle.kts:465)

FAILURE: Build failed with an exception.

* What went wrong:
Deprecated Gradle features were used in this build, making it incompatible with Gradle 10

BUILD FAILED in 12s
exit=1
```

確認後にミューテーションは戻してあり、この PR の差分は `gradle.properties` の 6 行のみ（`git diff --stat` で確認）。

## 影響

- **開発者体験**: 非推奨 API を使った瞬間にビルドが落ちる。Gradle 10 への移行時にまとめて踏むはずだった負債を、混入時点に前倒しする
- **CI**: `gradle.properties` はそのまま読まれるため追加の配線は不要。CI 側で `--warning-mode` を明示している箇所は無いことを確認済み
- **抜け穴**: configuration cache がヒットすると設定フェーズの deprecation は再現しない。CC ミスヒット時・ビルドスクリプト変更時には評価されるため、混入した変更そのものは捕まる

Closes #649
