### PR TITLE
fix: #834 billing の budget が plan のたびに update 表示される問題を解消する

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,3 +1,8 @@
+# provider に設定されたプロジェクト。billing の budget_filter が projects/<project_number> 形式を
+# 要求するため、番号をハードコードせずここで引いて渡す。depends_on を持つモジュールの内側に置くと
+# plan 時に読まれず apply へ延期され、plan のたびに update が出るため、ルートで宣言する（#834）。
+data "google_project" "current" {}
+
 resource "google_project_service" "project" {
   for_each = toset([
     "artifactregistry",
@@ -67,13 +72,12 @@ module "identity_platform" {
 # 止めるのは Cloud Run の spend cap（Console 手設定）で、ここは検知のみ。
 # billingbudgets API 有効化に依存させ、初回 apply の順序レースを避ける。依存先は for_each 全体では
 # なく、このモジュールが実際に使う API のキーだけにする。
-# なお depends_on を持つモジュール内の data source は plan 時に読まれず apply へ延期されるため、
-# budget_filter.projects が unknown になり plan に update が出る（値は不変で実害なし。#834）。
 module "billing" {
   source = "./modules/billing"
 
   billing_account_id = var.billing_account_id
   monthly_amount_jpy = "3000"
+  project_number     = data.google_project.current.number
 
   depends_on = [google_project_service.project["billingbudgets"]]
 }

--- a/infra/modules/billing/main.tf
+++ b/infra/modules/billing/main.tf
@@ -1,7 +1,3 @@
-# 予算の対象プロジェクト。budget_filter は projects/<project_number> 形式を要求するため、
-# provider に設定された project を対象に番号を引く（番号をハードコードしない）。
-data "google_project" "target" {}
-
 # プロジェクト全体の月次予算アラート。
 # 到達しても課金は止まらない（検知のみ）。止めるのは Cloud Run の spend cap（Console 手設定・ADR-0074）。
 #
@@ -12,7 +8,7 @@ resource "google_billing_budget" "project_total" {
   display_name    = "toy-box project total"
 
   budget_filter {
-    projects        = ["projects/${data.google_project.target.number}"]
+    projects        = ["projects/${var.project_number}"]
     calendar_period = "MONTH"
   }
 

--- a/infra/modules/billing/variables.tf
+++ b/infra/modules/billing/variables.tf
@@ -8,3 +8,11 @@ variable "monthly_amount_jpy" {
   type        = string
   default     = "3000"
 }
+
+# budget_filter は projects/<project_number> 形式を要求するため番号で受け取る（番号をハードコードしない）。
+# data source をこのモジュール内に置くと、モジュールが depends_on を持つ都合で plan 時に読まれず
+# apply へ延期され、plan のたびに update が出る（#834）。そのためルートで引いて渡す。
+variable "project_number" {
+  description = "予算の対象プロジェクトのプロジェクト番号（ルートの data.google_project から供給する）"
+  type        = string
+}


### PR DESCRIPTION
Closes #834

## 何が起きていたか

`terraform plan` のたびに `module.billing.google_billing_budget.project_total` が update として計上されていた。食い違う属性は `budget_filter.projects` だけで、plan JSON の `after_unknown` が `{"projects": true}` ＝ unknown になっていた。

値の出所は `data.google_project.target.number`。**`depends_on` を持つモジュール内の data source は plan 時に読まれず apply へ延期される**（Terraform の保守的な挙動）ため、project number が unknown のまま plan されていた。PR #831 で `depends_on` を `google_project_service.project["billingbudgets"]`（plan で no-op ＝確定済み）へ絞っても解消しなかったことから、引き金は「依存先が未確定だから」ではなく**モジュールが `depends_on` を持っていること自体**と判明している。

実害は「plan に無関係な update が出てレビューのノイズになる」こと（project number は不変なので apply すれば同じ値に解決される）。`google_project_service` に API を 1 つ足すたびに再発する。

## 変更内容

Issue の案のうち **「ルートで `data "google_project"` を宣言し、project number を変数で billing モジュールへ渡す」**を採った。data source が `depends_on` 配下から出るので plan 時に読まれ、かつ初回 apply の順序レース対策である `depends_on` はそのまま残せる。

- `infra/main.tf`: ルートに `data "google_project" "current"` を宣言し、billing モジュールへ `project_number` として渡す。解消済みとなった #834 の注記をモジュール呼び出しのコメントから削除し、「ルートに置く理由」として data 宣言側へ移した
- `infra/modules/billing/main.tf`: モジュール内の `data "google_project" "target"` を削除し、`budget_filter.projects` の参照を `var.project_number` へ差し替え
- `infra/modules/billing/variables.tf`: `project_number` 変数を追加。モジュール内に data source を置けない理由をコメントで残した

`depends_on` を外す案は採っていない（初回 apply / destroy 後の再作成で billingbudgets API 有効化との順序レースが起きうる保険を手放すことになるため）。

## 検証

ローカルで CI と同じチェックを実行し、すべて緑:

- `terraform fmt -check -recursive` / `terraform validate` / `tflint --recursive` / `trivy config`

**本命の検証はこの PR の HCP speculative plan** で、`module.billing.google_billing_budget.project_total` の update が消えていること（＝ no changes、または他要因の差分のみ）を確認する。

## 他モジュールへの波及

同じ `depends_on` 構造は `prisma_postgres` / `identity_platform` / `audit` にもあるが、**data source を持つのは billing だけ**（`grep '^data ' infra/` で確認済み）なので、現状はこれらが差分を生むことはない。将来これらに data source を足すときは同じ方針（ルートで引いて渡す）に揃える。
