### PR TITLE
chore: #762 mise.lock の platform 欠落・エントリ二重化を機械ゲートで止める

### DIFF
--- a/.github/workflows/mise-lock-check.yml
+++ b/.github/workflows/mise-lock-check.yml
@@ -1,0 +1,40 @@
+# mise.lock 健全性チェックワークフロー
+#
+# 目的: mise.lock の http バックエンドツールが壊れたまま main へ入るのを止める（#762）。
+# `mise install` は、触ってすらいないツールの lock を書き換える。ツール名を指定した install は
+# http:kotlin-lsp を 2 エントリへ割り、引数なしの install（`mise bootstrap` が流す実体）は逆に
+# platform の checksum / URL を丸ごと落とす。後者が main に入ると、欠けた platform で
+# `mise install --locked` が解決できなくなる（#584 と同型）。機序と実測はスクリプト冒頭に書いてある。
+#
+# lefthook の pre-commit にも同じ検査を置いているが、`--no-verify` と worktree の hook sync 漏れ
+# （#807）で抜けるため、ここを backstop にする。lock を書き換えるのはローカルの mise だけなので、
+# 事後検知（push: main）は載せず PR で止めるだけにしている。
+
+name: Mise Lock Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "mise.toml"
+      - "mise.lock"
+      - "scripts/check-mise-lock-platforms.sh"
+  workflow_dispatch:
+
+jobs:
+  mise-lock-check:
+    runs-on: ubuntu-latest
+    name: Mise Lock Platform Check
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # 素の bash だけで動くのでツールのインストールは要らない（mise のセットアップも不要）。
+      - name: mise.lock platform check
+        run: scripts/check-mise-lock-platforms.sh

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -144,6 +144,22 @@ pre-commit:
       run: scripts/check-markdown-links.sh
       tags: lint
 
+    # mise.lock の http バックエンドツールの健全性チェック（#762）。
+    # `mise install` は、触ってすらいないツールの lock を書き換える。ツール名を指定した
+    # install は http:kotlin-lsp を 2 エントリへ割り、引数なしの install（`mise bootstrap`
+    # が流す実体）は逆に platform の checksum / URL を丸ごと落とす。後者が main に入ると、
+    # 欠けた platform で `mise install --locked` が解決できなくなる（#584 と同型）。
+    # 壊れるのは「触っていないツール」の側なので {staged_files} は渡さず常に全件を検査する
+    # （glob は発火の条件だけを絞る役。adr-numbering / markdown-links と同じ形）。
+    # 素の bash なのでコミットは実質重くならない。
+    mise-lock-platforms:
+      glob:
+        - "mise.toml"
+        - "mise.lock"
+        - "scripts/check-mise-lock-platforms.sh"
+      run: scripts/check-mise-lock-platforms.sh
+      tags: lint
+
 pre-push:
   # piped: 先頭のコマンドが落ちたら後続を打ち切る（docker-available → full-test の順で fail fast）。
   piped: true

--- a/mise.toml
+++ b/mise.toml
@@ -85,7 +85,9 @@ bin = "tfctl"
 # checksum は公式 SHA256SUMS（releases.hashicorp.com/tfctl/<version>/tfctl_<version>_SHA256SUMS）の値を固定する。
 # http バックエンドは aqua/ubi と異なり mise.lock に per-platform SHA を埋めないため、ここで明示して整合性を担保する。
 # バージョン更新時は version と 4 つの checksum を SHA256SUMS から更新すること。mise.lock 側は
-# `mise install` しても自ホスト分しか書き換わらないため、6 エントリ（linux の -musl 派生を含む）を手で揃える。
+# `mise install` しても自ホスト分しか書き換わらないため、6 エントリ（linux の -musl 派生を含む）を
+# `mise lock --platform linux-x64,linux-arm64,linux-x64-musl,linux-arm64-musl,macos-x64,macos-arm64 "http:tfctl"`
+# で揃える（platform 間で options が揃っているツールなので、このコマンドは冪等に働く。#762 で実測）。
 [tools."http:tfctl".platforms.macos-x64]
 url = "https://releases.hashicorp.com/tfctl/{{version}}/tfctl_{{version}}_darwin_amd64.zip"
 checksum = "sha256:19786ebddb3cbd922402d21577e85842385910a666e62b1f9b0de46520c527d7"
@@ -110,12 +112,35 @@ checksum = "sha256:5f2caf7900b8f43dd72f390b992bafceab4ae85bbc58b60325bb1888ef9a0
 # 供給経路: JetBrains 公式配布は download-cdn.jetbrains.com（GitHub Releases に資産なし → ubi / aqua 不可、
 # 公式 brew tap は macOS 限定）。クロスプラットフォーム再現性を保つため tfctl と同様に http バックエンドで
 # 直接指す。mac は `.sit`（実体は zip なので `format = "zip"` で明示）、Linux は `.tar.gz`。
-# 版は JetBrains ビルド番号（例 262.8190.0）。更新時は version と 4 checksum を差し替える。
+# 版は JetBrains ビルド番号（例 262.8190.0）。更新の手順は下の「バージョン更新時」を参照。
 #
 # checksum は公式 <asset>.sha256（同 URL に `.sha256` を付けたファイル）の値を固定する。http バックエンドは
 # aqua / ubi と異なり mise.lock に per-platform SHA を埋めないため、ここで明示して整合性を担保する。
 # strip_components=1 で version 付きトップディレクトリ（kotlin-server-<version>/）を剥がし、その直下の
 # ランチャ `kotlin-lsp.sh` を rename_exe でコマンド名 `kotlin-lsp` として PATH に出す。
+#
+# **`format = "zip"` は外せない**（#762 で実測）。`.sit` は実体こそ zip だが mise は拡張子から
+# それを推論しない。指定を外して再インストールすると、mise はアーカイブを展開せず 389MB の `.sit`
+# をそのまま `kotlin-lsp` にリネームしたうえで「✓ installed」と表示する。エラーは出ないので、
+# 壊れたバイナリが無言で PATH に載る。JetBrains は macOS 用の `.zip` を配布していない（404）ので、
+# 配布形式を揃えて回避する道も無い。
+#
+# この「macOS だけ options が違う」状態が mise.lock を汚す。lock の options はツール単位
+# （[tools.<tool>.options]）でしか表現できないため、mise は 1 エントリに収められず、`mise install`
+# のたびに lock を書き換える。これは upstream で意図された挙動（jdx/mise#10999）なので待っても
+# 直らない。壊れ方は 2 通り（mise 2026.8.12 で実測）:
+#   - ツール名を指定した install → macOS 分が別エントリへ切り出され、エントリが 2 つになる
+#   - 引数なしの install（`mise bootstrap` の実体）→ 逆に platform の checksum / URL が丸ごと消える
+# lock の正は「エントリ 1 つ・mise.toml が宣言する platform が全部載っている」状態とし、
+# `mise install` の後に出た lock の差分は `git checkout -- mise.lock` で捨てる。捨て忘れは
+# scripts/check-mise-lock-platforms.sh が pre-commit と CI で止める。
+# なお `mise lock --upgrade`（lockfile_version = 1）でもこの分裂は解消しない（実測）。
+#
+# バージョン更新時は version と 4 checksum を差し替えたうえで、
+# `mise lock --platform linux-x64,linux-arm64,linux-x64-musl,linux-arm64-musl,macos-x64,macos-arm64 "http:kotlin-lsp"`
+# で全 platform の checksum / URL を取得する（自ホスト分しか書き換わらない install と違い、
+# このコマンドは 6 platform 分を揃えられる）。出力は上記のとおり 2 エントリになるので、
+# 1 エントリへ手でまとめてからコミットする。
 [tools."http:kotlin-lsp"]
 version = "262.8190.0"
 strip_components = 1

--- a/scripts/check-mise-lock-platforms.sh
+++ b/scripts/check-mise-lock-platforms.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# mise.lock の http バックエンドツールが壊れていないかを検査する（#762）。
+#
+# mise.lock の options は**ツール単位**（[tools.<tool>.options]）でしか表現できない。一方
+# http:kotlin-lsp は macOS だけ format = "zip" を要求する（JetBrains の mac 配布が .sit で、
+# 拡張子からは zip と推論されないため）。platform 間で options が食い違うと 1 エントリに
+# 収まらず、mise は同じツールを複数の [[tools."http:kotlin-lsp"]] エントリへ割る。これは
+# upstream で意図された挙動として入っている（jdx/mise#10999 "disjoint platform variants
+# remain separate"）ので、mise 側の修正を待っても解消しない。
+#
+# 結果として `mise install` は、触ってすらいないツールの lock を 2 通りに壊す
+# （mise 2026.8.12 / macOS-x64 で実測）:
+#   1. ツール名を指定した install → macOS 分が別エントリへ切り出され、エントリが 2 つになる
+#   2. 引数なしの install（`mise bootstrap` が流す実体）→ 逆に macOS の 1 エントリだけが残り、
+#      Linux 4 platform の checksum / URL が lock から消える。この lock が main へ入ると
+#      Linux 側の `mise install --locked` が解決できなくなる（#584 と同型）
+#
+# lock の正は「http ツールごとに [[tools]] エントリが 1 つ、mise.toml が宣言する platform が
+# すべて載っている」状態とする。`mise install` の後に出た lock の差分は本題と無関係なので
+# `git checkout -- mise.lock` で捨てること。バージョンを上げるときだけ、per-platform の
+# checksum / URL を手で揃える（mise.toml 側のコメントも参照）。
+#
+# 使い方:
+#   scripts/check-mise-lock-platforms.sh
+#   - 引数は取らず常に全件を検査する。壊れるのは「触っていないツール」の側なので、
+#     lefthook からも {staged_files} は渡さない（glob は発火の条件だけを絞る役）。
+#   - リポジトリ root からの実行を前提とする。
+# 終了コード: 違反があれば 1、なければ 0。
+#
+# 互換: macOS 標準の bash 3.2 で動くよう連想配列/mapfile を使わない。
+set -euo pipefail
+
+CONFIG="mise.toml"
+LOCK="mise.lock"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "NG: $CONFIG がありません（リポジトリ root から実行してください）。" >&2
+  exit 1
+fi
+if [ ! -f "$LOCK" ]; then
+  echo "NG: $LOCK がありません。" >&2
+  exit 1
+fi
+
+# mise.toml が宣言する http バックエンドのツール名（http:NAME）。
+# 検査対象を http に絞るのは、per-platform の url / checksum を mise.toml 側で持つのが
+# この backend だけだからで（aqua / ubi / registry 経由は mise がレジストリから解決する）、
+# 「宣言した platform が lock に揃っているか」を照合できる相手もここに限られる。
+tools=$(grep -oE '^\[tools\."http:[^"]+"\]' "$CONFIG" | sed -e 's/^\[tools\."//' -e 's/"\]$//' | sort -u) || true
+
+if [ -z "$tools" ]; then
+  echo "NG: $CONFIG に http バックエンドのツール宣言（[tools.\"http:...\"]）が 1 つもありません。" >&2
+  echo "    この検査の前提が崩れています。意図的に廃止したならこのスクリプトごと外してください。" >&2
+  exit 1
+fi
+
+status=0
+
+for tool in $tools; do
+  # 1. [[tools."http:NAME"]] のエントリ数。1 でなければ二重化（または未 lock）。
+  entries=$(grep -cF "[[tools.\"$tool\"]]" "$LOCK") || true
+  if [ "$entries" -eq 0 ]; then
+    echo "NG: $LOCK に $tool のエントリがありません。" >&2
+    echo "    \`mise install \"$tool\"\` で lock を作ってからコミットしてください。" >&2
+    status=1
+    continue
+  fi
+  if [ "$entries" -gt 1 ]; then
+    echo "NG: $LOCK の $tool が $entries 個のエントリに分裂しています（期待は 1 個）。" >&2
+    echo "    platform ごとに options が食い違うと mise が別エントリへ割ります（仕様）。" >&2
+    echo "    \`git checkout -- $LOCK\` で戻してください（この差分は捨ててよい）。" >&2
+    status=1
+    continue
+  fi
+
+  # 2. mise.toml が宣言する platform が lock にすべて載っているか。
+  #    lock 側は musl 派生（linux-x64-musl 等）を自動で足すため、包含だけを見る。
+  declared=$(grep -F "[tools.\"$tool\".platforms." "$CONFIG" | sed -e 's/^.*\.platforms\.//' -e 's/\]$//' | sort -u) || true
+  if [ -z "$declared" ]; then
+    echo "NG: $CONFIG の $tool に per-platform の宣言（[tools.\"$tool\".platforms.*]）がありません。" >&2
+    status=1
+    continue
+  fi
+  locked=$(grep -F "[tools.\"$tool\".\"platforms." "$LOCK" | sed -e 's/^.*\."platforms\.//' -e 's/"\]$//' | sort -u) || true
+
+  missing=$(comm -23 <(printf '%s\n' "$declared") <(printf '%s\n' "$locked")) || true
+  if [ -n "$missing" ]; then
+    echo "NG: $LOCK の $tool から platform が欠けています:" >&2
+    for p in $missing; do
+      echo "    $p" >&2
+    done
+    echo "    引数なしの \`mise install\` は他 platform の checksum / URL を削除します。" >&2
+    echo "    この lock が main へ入ると、欠けた platform で \`mise install --locked\` が壊れます。" >&2
+    echo "    \`git checkout -- $LOCK\` で戻してください（この差分は捨ててよい）。" >&2
+    status=1
+  fi
+done
+
+exit "$status"


### PR DESCRIPTION
## 概要

`mise install` が無関係な `http:kotlin-lsp` のエントリを二重化する問題（#762）を、切り分け → 回避策の決定 → 機械ゲート化まで通した。

調査の結果、**Issue が挙げていた回避策 3 案のうち 2 案は実測で否定され、さらに Issue の記述より重い症状（platform データの消失）が見つかった**ため、「lock の正を固定し、捨て忘れを機械で止める」方針を採っている。

## 実測で分かったこと（mise 2026.8.12 / macOS-x64）

### 1. 仕様か不具合かの切り分け → 仕様

upstream PR [jdx/mise#10999](https://github.com/jdx/mise/pull/10999)（2026-07-15 マージ、現行 2026.8.12 に含まれる）が「per-platform で options が食い違うツールは lock で別エントリのまま保つ（disjoint platform variants remain separate）」を意図した挙動として入れている。lock の options がツール単位（`[tools.<tool>.options]`）でしか表現できない以上、待っても直らない。

### 2. Issue の記述より症状が重い

`mise install` の壊し方は 2 通りあった。

| 打ち方 | 壊れ方 |
| --- | --- |
| ツール名を指定（`mise install "http:tfctl"`） | macOS 分が別エントリへ切り出され、エントリが 2 つになる（Issue の記述どおり） |
| **引数なし（`mise bootstrap` が流す実体）** | **逆に platform の checksum / URL が丸ごと消える** |

現行 main の lock から引数なし `mise install` を打つと、`http:kotlin-lsp` の platform エントリが **6 件すべて消滅**した。この lock が main に入ると、欠けた platform で `mise install --locked` が解決できなくなる（#584 と同型）。**Issue の案 1「2 エントリある状態を正としてコミットする」はこの経路で壊れるため成立しない。**

### 3. `format = "zip"` は外せない（案 2 も不成立）

指定を外して再インストールすると、mise はアーカイブを展開せず **389MB の `.sit` をそのまま `kotlin-lsp` にリネームしたうえで「✓ installed」と表示**した。エラーが出ないので、壊れたバイナリが無言で PATH に載る。JetBrains は macOS 用の `.zip` を配布していない（404）ため、配布形式を揃えて回避する道も無い。

### 4. `mise lock --upgrade`（lockfile_version = 1）でも解消しない

mise が警告で案内してくる v1 形式へ上げても、`http:kotlin-lsp` は 2 エントリに分裂したままで、引数なし install で Linux が消える挙動も同じだった。v1 化自体は 136 platform エントリの書き換え（dprint の musl → gnu URL 変更等）を伴うため、別途判断が要る（残件として起票予定）。

### 5. 復旧・更新の手段

`mise lock --platform <6 platform> "<tool>"` は消えた platform を全件書き戻せる。options が揃っているツール（`http:tfctl`）では冪等で lock を一切変えなかった。従来「手で揃える」としていたバージョン更新手順をこれに統一した。

## 変更内容

- **`scripts/check-mise-lock-platforms.sh`（新規）** — http バックエンドのツールについて、(1) `[[tools]]` エントリが 1 つだけ、(2) `mise.toml` が宣言する platform が lock にすべて載っている、を検査する。素の bash（macOS 標準の bash 3.2 互換）。壊れるのは「触っていないツール」の側なので `{staged_files}` は渡さず常に全件を見る。
- **`lefthook.yml`** — pre-commit に `mise-lock-platforms` を追加（`adr-numbering` / `markdown-links` と同じ「glob は発火条件、検査は全件」の形）。
- **`.github/workflows/mise-lock-check.yml`（新規）** — pre-commit は `--no-verify` と worktree の hook sync 漏れ（#807）で抜けるため、CI を backstop に置く。`adr-check.yml` と同型で、素の bash だけで動くので mise のセットアップは要らない。
- **`mise.toml`** — kotlin-lsp のコメントに上記の実測を書き足し、lock が汚れる機序と「差分は `git checkout -- mise.lock` で捨てる」運用を明記。バージョン更新手順を `mise lock --platform` に統一し、**tfctl 側にだけあった「手で揃える」記述も同じ手順へ揃えた**（Issue の「やること 3」＝ 方針が不揃いだった状態の解消）。

## 検証

すべてローカルで実測した。

- 検査スクリプトの 3 ケース: 正常な lock で `exit 0` / 二重化を検出して `exit 1` / platform 欠落を検出して `exit 1`。壊れた lock は実際に `mise install` を打って作った。
- ゲートの End-to-End: 壊れた lock を stage して `lefthook run pre-commit` を実行 → `mise-lock-platforms` が落ち、lefthook が `exit 1` を返すことを確認（コミットがブロックされる）。
- lint: shellcheck / actionlint / zizmor / dprint / editorconfig-checker すべて緑。`lefthook run pre-commit` 全体も緑。
- Kotlin は変更していないため `./gradlew check` は対象外。

## 残件（このあと別 Issue へ切り出す）

- upstream への報告: 引数なし `mise install` が他 platform の checksum / URL を削除する挙動（データ損失）と、`format` 未指定時にアーカイブを展開せず「✓ installed」と表示する挙動。
- `lockfile_version = 1` へ上げるかの判断（mise が毎回 WARN を出す状態が続く）。

Closes #762
