### PR TITLE
chore: #857 mise.lock の checksum 形式の書き換えを検査で止める

### DIFF
--- a/scripts/check-mise-lock-platforms.sh
+++ b/scripts/check-mise-lock-platforms.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mise.lock の http バックエンドツールが壊れていないかを検査する（#762）。
+# mise.lock の http バックエンドツールが壊れていないかを検査する（#762 / #857）。
 #
 # mise.lock の options は**ツール単位**（[tools.<tool>.options]）でしか表現できない。一方
 # http:kotlin-lsp は macOS だけ format = "zip" を要求する（JetBrains の mac 配布が .sit で、
@@ -16,9 +16,26 @@
 #      Linux 側の `mise install --locked` が解決できなくなる（#584 と同型）
 #
 # lock の正は「http ツールごとに [[tools]] エントリが 1 つ、mise.toml が宣言する platform が
-# すべて載っている」状態とする。`mise install` の後に出た lock の差分は本題と無関係なので
-# `git checkout -- mise.lock` で捨てること。バージョンを上げるときだけ、per-platform の
-# checksum / URL を手で揃える（mise.toml 側のコメントも参照）。
+# すべて載っていて、checksum の形式が mise.toml の宣言と揃っている」状態とする。`mise install`
+# の後に出た lock の差分は本題と無関係なので `git checkout -- mise.lock` で捨てること。
+# バージョンを上げるときだけ、per-platform の checksum / URL を手で揃える
+# （mise.toml 側のコメントも参照）。
+#
+# 検出するもの:
+#   1. [[tools."http:NAME"]] エントリの二重化・欠落
+#   2. mise.toml が宣言する platform の lock からの欠落
+#   3. checksum の形式（sha256 / blake3 等の algo）が mise.toml の宣言と食い違うこと（#857）。
+#      `mise install --force` は lock の checksum を blake3 で書き直す（mise 2026.8.12 で実測）。
+#      blake3 も有効な checksum で `--locked` が壊れるわけではないが、本題と無関係な差分が PR に
+#      混ざる。#762 で潰したかったのは、まさにこの「触っていないのに lock が汚れる」状態
+#
+# 検出しないもの（既知の穴）:
+#   - checksum の**値**が配布物と一致するか。ここでは形式しか見ない（値の照合は install 時に
+#     mise 自身が行う）
+#   - http 以外の backend（aqua / ubi / registry）の lock エントリ。per-platform の url / checksum を
+#     mise.toml 側に持たないため、lock と突き合わせる相手がそもそも無い
+#   - lock 側にしか無い platform（musl 派生）の checksum 形式は、mise.toml が宣言する形式が
+#     ツール内で 1 種類のときだけ照合する。混在していれば期待値を決められないので飛ばす
 #
 # 使い方:
 #   scripts/check-mise-lock-platforms.sh
@@ -41,6 +58,21 @@ if [ ! -f "$LOCK" ]; then
   echo "NG: $LOCK がありません。" >&2
   exit 1
 fi
+
+# TOML セクション（$2 の見出し行）の直下にある checksum の algo（"sha256:..." の sha256）を出す。
+# 見つからなければ何も出さない。セクションは次の見出し行（^[）で終わる。
+checksum_algo() {
+  awk -v header="$2" '
+    $0 == header { in_section = 1; next }
+    /^\[/ { in_section = 0 }
+    in_section && $1 == "checksum" {
+      if (match($0, /"[^":]+:/)) {
+        print substr($0, RSTART + 1, RLENGTH - 2)
+        exit
+      }
+    }
+  ' "$1"
+}
 
 # mise.toml が宣言する http バックエンドのツール名（http:NAME）。
 # 検査対象を http に絞るのは、per-platform の url / checksum を mise.toml 側で持つのが
@@ -94,6 +126,46 @@ for tool in $tools; do
     echo "    \`git checkout -- $LOCK\` で戻してください（この差分は捨ててよい）。" >&2
     status=1
   fi
+
+  # 3. checksum の形式（algo）が mise.toml の宣言と一致するか（#857）。
+  #    mise.toml が宣言している platform は 1 対 1 で照合する。
+  algos=""
+  for p in $declared; do
+    want=$(checksum_algo "$CONFIG" "[tools.\"$tool\".platforms.$p]")
+    # mise.toml が checksum を書いていない platform は照合対象にしない（期待値が無い）。
+    [ -n "$want" ] || continue
+    algos="$algos
+$want"
+    got=$(checksum_algo "$LOCK" "[tools.\"$tool\".\"platforms.$p\"]")
+    # 欠落は検査 2 が報告済みなので、ここでは形式の食い違いだけを見る。
+    [ -n "$got" ] || continue
+    if [ "$got" != "$want" ]; then
+      echo "NG: $LOCK の $tool ($p) の checksum が $got 形式です（$CONFIG の宣言は ${want}）。" >&2
+      echo "    \`mise install --force\` は lock の checksum を書き直します。" >&2
+      echo "    \`git checkout -- $LOCK\` で戻してください（この差分は捨ててよい）。" >&2
+      status=1
+    fi
+  done
+
+  # 宣言側の形式が 1 種類なら、lock 側にしか無い platform（musl 派生）も同じ形式のはず。
+  # 混在しているツール、および 1 つも checksum を宣言していないツールでは期待値を決められない
+  # ので照合しない。
+  expected=$(printf '%s\n' "$algos" | grep -v '^$' | sort -u) || true
+  [ -n "$expected" ] || continue
+  if [ "$(printf '%s\n' "$expected" | wc -l)" -ne 1 ]; then
+    continue
+  fi
+  extra=$(comm -13 <(printf '%s\n' "$declared") <(printf '%s\n' "$locked")) || true
+  for p in $extra; do
+    got=$(checksum_algo "$LOCK" "[tools.\"$tool\".\"platforms.$p\"]")
+    [ -n "$got" ] || continue
+    if [ "$got" != "$expected" ]; then
+      echo "NG: $LOCK の $tool ($p) の checksum が $got 形式です（$CONFIG の宣言は ${expected}）。" >&2
+      echo "    \`mise install --force\` は lock の checksum を書き直します。" >&2
+      echo "    \`git checkout -- $LOCK\` で戻してください（この差分は捨ててよい）。" >&2
+      status=1
+    fi
+  done
 done
 
 exit "$status"


### PR DESCRIPTION
Closes #857

## やったこと

`scripts/check-mise-lock-platforms.sh` に **検査 3: checksum の形式（algo）が `mise.toml` の宣言と一致するか** を追加した。

`mise install --force` は lock の checksum を `mise.toml` が固定した `sha256:` から `blake3:` へ書き直す（#762 の作業中、mise 2026.8.12 で実測）。blake3 も有効な checksum なので `--locked` が壊れるわけではないが、本題と無関係な差分が PR に混ざる。#762 で潰したかったのは、まさにこの「触っていないのに lock が汚れる」状態だった。

- `mise.toml` が宣言する platform は 1 対 1 で照合する
- lock 側にしか無い platform（musl 派生）は、宣言側の形式がツール内で 1 種類のときだけ同じ形式かを見る（混在していれば期待値を決められないので飛ばす）
- TOML セクション直下の checksum の algo を読む `checksum_algo()` を追加。macOS 標準の bash 3.2 互換のため連想配列を使わず awk で完結させる

あわせて冒頭コメントに **「検出するもの / 検出しないもの（既知の穴）」** を明記した。#857 のもう一つの懸念が「ガードの守備範囲が誤解されうる（lock の中身の整合まで見ていると読めるが、実際は platform の網羅だけ）」だったため。値そのものの照合と http 以外の backend（aqua / ubi / registry）が対象外であることを書いてある。

判断の分岐（検査を足す / コメントに穴を明記するだけに留める）は前者を採った。per-platform の照合は既存ループに収まり、依存も配線も増えないため。

## ミューテーションによる発火の確認（.claude/rules/gates.md）

### 1. 正常系（現在の lock）

```
$ scripts/check-mise-lock-platforms.sh; echo "exit=$?"
exit=0
```

### 2. 宣言 platform（macos-x64）の checksum を blake3 へ書き換え

#857 に貼った `mise install --force` の実測と同じ差分を lock に作る。

```
$ scripts/check-mise-lock-platforms.sh; echo "exit=$?"
NG: mise.lock の http:kotlin-lsp (macos-x64) の checksum が blake3 形式です（mise.toml の宣言は sha256）。
    `mise install --force` は lock の checksum を書き直します。
    `git checkout -- mise.lock` で戻してください（この差分は捨ててよい）。
exit=1
```

### 3. lock 側にしか無い platform（linux-x64-musl）の checksum を blake3 へ書き換え

`mise.toml` に対応する宣言が無い platform も、宣言側の形式が 1 種類なら照合対象になる。

```
$ scripts/check-mise-lock-platforms.sh; echo "exit=$?"
NG: mise.lock の http:kotlin-lsp (linux-x64-musl) の checksum が blake3 形式です（mise.toml の宣言は sha256）。
    `mise install --force` は lock の checksum を書き直します。
    `git checkout -- mise.lock` で戻してください（この差分は捨ててよい）。
exit=1
```

### 4. 対照: `mise.toml` と lock の両方を blake3 に揃えた場合

形式が揃っていれば咎めない（偽陽性が出ない）ことの確認。

```
$ scripts/check-mise-lock-platforms.sh; echo "exit=$?"
exit=0
```

### 5. lefthook の glob

`scripts/check-mise-lock-platforms.sh` 1 本だけを stage して pre-commit を実行し、skip されず走ることを確認した。

```
┃  mise-lock-platforms ❯
✔️ mise-lock-platforms (0.29 seconds)
```

CI 側（`.github/workflows/mise-lock-check.yml`）の `paths` にも同スクリプトが入っているため、この PR 自体でジョブが起動する。

## 補足: 実装中に踏んだ罠

エラーメッセージで変数参照の直後に全角括弧を置くと、bash 3.2 が `$want）` までを変数名として解釈し `unbound variable` で落ちた（`set -u` 下）。`${want}` とブレースで囲んで解消してある。

## 検査しないもの（このスクリプトの守備範囲外）

- checksum の**値**が配布物と一致するか（値の照合は install 時に mise 自身が行う）
- http 以外の backend の lock エントリ（per-platform の url / checksum を `mise.toml` 側に持たないため、突き合わせる相手が無い）
- この検査スクリプト自体の恒久的な検証（#829 で判断する論点。今回はミューテーションによる一度きりの確認に留めている）
