### PR TITLE
fix: #859 MISE_ENV=ci をジョブ全体へ広げて差分カバレッジの 404 を止める

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -16,6 +16,13 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+    # http backend ツール（kotlin-lsp / tfctl）を config から外す（mise.ci.toml。#510）。
+    # **ジョブ全体に置く**。mise-action のステップにだけ付けると、後段で `mise exec` を使う
+    # ステップが素の mise.toml を読み、CI で使わない http ツールまで解決しにいく。実際に
+    # kotlin-lsp の配布物が上流から消えた 2026-08-30、差分カバレッジのステップだけが 404 で
+    # 落ちた（#859。この env はそのステップに届いていなかった）。
+    env:
+      MISE_ENV: ci
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -43,9 +50,7 @@ jobs:
 
       - name: Install mise
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        env:
-          # http backend ツール（kotlin-lsp/tfctl）を config から外す（mise.ci.toml。#510）。
-          MISE_ENV: ci
+        # MISE_ENV=ci はジョブの env で与える（このステップ限定にすると後段の mise exec に効かない）。
         with:
           # このジョブが使うツールだけを入れる（#464。バージョンの出所は mise.toml）。
           # 使うのは patch coverage 用の diff-cover のみ（JDK/Gradle は setup-java / setup-gradle が供給）。


### PR DESCRIPTION
#859 の応急対処（pin の貼り直しは #859 で追う。この PR は CI の穴だけを塞ぐ）。

## 何が起きていたか

`mise.toml` が pin している `http:kotlin-lsp@262.8190.0` の配布物が JetBrains の CDN から消え（2026-08-30 実測で `.sit` / `.tar.gz` とも 404）、**PR の API Tests が全滅する**状態になっていた。

```
mise ERROR Failed to install http:kotlin-lsp@262.8190.0: HTTP status client error (404 Not Found)
           for url (https://download-cdn.jetbrains.com/language-server/kotlin-server/262.8190.0/kotlin-server-262.8190.0.tar.gz)
```

CI は #510 で `MISE_ENV=ci`（`mise.ci.toml` の `disable_tools`）を入れており、kotlin-lsp / tfctl は config から外れているはずだった。ところがこの env は **mise-action のステップにしか付いていなかった**。差分カバレッジのステップは

```yaml
- name: Verify patch coverage
  if: github.event_name == 'pull_request'
  env:
    BASE_REF: ${{ github.base_ref }}
  run: |
    ./gradlew koverXmlReportMature --stacktrace
    mise exec -- diff-cover ...
```

で、ここの `mise exec` だけが素の `mise.toml` を読み、CI では使わない http backend ツールまで解決しにいっていた。

このステップは PR 限定（`if: github.event_name == 'pull_request'`）なので、**main は緑のまま PR だけが落ちる**。実測でも、直近の main 成功 run のジョブログには kotlin-lsp が 1 行も出てこない一方、PR #858 の Run API Tests は上記 404 で落ちている。

## 直し方

`MISE_ENV: ci` を **ジョブの env** へ移した。ジョブ内のどのステップから mise を呼んでも CI 用オーバーレイが効く。mise-action のステップ側には、なぜジョブに置いてあるかを 1 行残した。

## 実測

`MISE_ENV=ci` で http backend ツールが config から外れることの確認:

```
$ mise ls | grep -E "kotlin-lsp|tfctl"
http:kotlin-lsp           262.8190.0 (symlink)      .../mise.toml  262.8190.0
http:tfctl                0.4.0 (symlink)           .../mise.toml  0.4.0

$ MISE_ENV=ci mise ls | grep -E "kotlin-lsp|tfctl"
（出力なし ＝ disable_tools が効いている）
```

```
$ actionlint .github/workflows/api-tests.yml
actionlint OK
```

この PR 自体の Run API Tests が緑になることが、CI 上での最終確認になる。

## 残る課題

kotlin-lsp の pin は死んだままで、**新規セットアップ（`mise bootstrap` / `mise install`）はローカルでも 404 で落ちる**。上流は配布形式を `.vsix` へ変えており、URL テンプレート・checksum・アーカイブ内の構造の再検証が要る。それは #859 で対応する。
