### PR TITLE
fix: #818 詰まった DB への接続確立が無限に待つ穴を loginTimeout で塞ぐ

### DIFF
--- a/docs/adr/0071-pre-push-docker-fail-fast-guard.md
+++ b/docs/adr/0071-pre-push-docker-fail-fast-guard.md
@@ -81,6 +81,15 @@ Error）になり、この事象を実際に踏んだ。`git push` が 2 分待�
 - 判定は `docker info` 一本なので、**Docker は生きているが Testcontainers だけが失敗する**ケース
   （イメージの pull 不可、リソース枯渇等）は素通りする。そこは従来どおりテストの失敗として現れる。
   ガードの守備範囲は「Docker に到達できない」ことに限る。
+- 上記の「素通りする」ケースは、**テストの失敗ではなくハングとして現れうる**ことが後に判明した（#818）。
+  コンテナは起動したのに Postgres が応答を返せない状態では、pgjdbc の接続確立に実効的なタイムアウトが
+  1 つも掛からない（HikariCP の `connectionTimeout` は `DriverManager.setLoginTimeout()` 経由でしか
+  ドライバへ伝わらないが、pgjdbc は `loginTimeout` プロパティの既定値 `"0"` を先に読むため
+  `DriverManager` の値へフォールバックしない。`socketTimeout` も既定 0 で無制限）。実測では
+  `HikariPool-1 - Starting...` から 402.9 秒ブロックし、pre-push が 7 分近く無反応になった。本 ADR が
+  潰したかったハングが別経路で残っていたことになる。#818 で
+  `spring.datasource.hikari.data-source-properties.loginTimeout` を明示して接続確立にも上限を掛け、
+  この経路を塞いだ（本 ADR の決定自体は有効なまま）。
 - 成功パスでも完了検知の粒度（1 秒）ぶんの待ちが乗る。全テストを回す pre-push の中では無視できる。
 - 結論（守るべきルール）は `.claude/rules/testing.md` の「ローカルゲートと Docker」に置いた。
 - **本 ADR のガードは pre-push 限定である**。手で `./gradlew test` / `check` を叩く経路は素通りし、

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,21 @@ spring:
   #   - ローカル bootRun: spring-boot-docker-compose が compose.yaml の PostgreSQL を自動起動・自動配線。
   #   - テスト: Testcontainers の PostgreSQL を PostgresContainerSupport が注入。
   # driver-class-name は明示せず JDBC URL から導出させる（URL の差し替えだけで接続先を切り替えられる）。
+  # 以下に置くのは接続先ではなく接続確立のタイムアウトだけで、上記の「既定値を置かない」方針は保つ。
+  # 接続確立（TCP connect のあとの startup / 認証の応答待ち）に上限を掛ける（#818）。HikariCP の
+  # connectionTimeout は本来「プールから接続を借りる待ち時間」で、接続確立そのものへは
+  # DriverManager.setLoginTimeout() 経由でしか伝わらない。ところが pgjdbc は loginTimeout プロパティの
+  # 既定値 "0" を先に読むため DriverManager の値へフォールバックせず、HikariCP の意図が届かない。
+  # socketTimeout も既定 0（無制限）なので、詰まった DB に対して接続確立が**無限に待つ**（実測 402 秒
+  # ブロックし pre-push が 7 分無反応になった）。そこで loginTimeout をドライバへ直接渡して届かせる。
+  # loginTimeout は PostgreSQL ドライバのプロパティ（単位は秒）で、接続確立フェーズにのみ効く
+  # （クエリの実行時間は切らない）。値は connection-timeout と揃える運用で、一致は
+  # DataSourceLoginTimeoutTest が固定する。
+  datasource:
+    hikari:
+      connection-timeout: 30000
+      data-source-properties:
+        loginTimeout: 30
   # マイグレーションは Flyway（plain SQL）。db/migration 配下の V*.sql を起動時に適用する。
   flyway:
     enabled: true

--- a/src/test/kotlin/com/example/api/datasource/DataSourceLoginTimeoutTest.kt
+++ b/src/test/kotlin/com/example/api/datasource/DataSourceLoginTimeoutTest.kt
@@ -1,0 +1,35 @@
+package com.example.api.datasource
+
+import com.example.api.support.PostgresContainerSupport
+import com.zaxxer.hikari.HikariDataSource
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.context.TestConstructor.AutowireMode
+
+/**
+ * アプリの datasource が接続確立にも上限を持つことを検証する（#818）。
+ *
+ * HikariCP の `connectionTimeout` は「プールから接続を借りる待ち時間」であり、接続確立そのものには `DriverManager.setLoginTimeout()`
+ * 経由でしか伝わらない。そしてその経路は pgjdbc に効かない （理由と実測は [PgJdbcConnectTimeoutTest]）。そのため `loginTimeout`
+ * を接続プロパティとして 明示的に渡す必要があり、渡し忘れると詰まった DB に対して**無限に待つ**。
+ *
+ * 値が `connectionTimeout` とズレると「借用は 30 秒で諦めるのに接続確立は 5 分待つ」のような ちぐはぐが静かに生まれるため、一致まで含めて固定する。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class DataSourceLoginTimeoutTest(private val dataSource: HikariDataSource) :
+    PostgresContainerSupport() {
+    @Test
+    fun `接続確立のタイムアウトが設定され HikariCP の connectionTimeout と揃っている`() {
+        val loginTimeoutSeconds =
+            dataSource.dataSourceProperties.getProperty("loginTimeout")?.toIntOrNull() ?: 0
+
+        assert(loginTimeoutSeconds > 0)
+        assert(loginTimeoutSeconds.toLong() * MILLIS_PER_SECOND == dataSource.connectionTimeout)
+    }
+
+    private companion object {
+        const val MILLIS_PER_SECOND = 1_000L
+    }
+}

--- a/src/test/kotlin/com/example/api/datasource/PgJdbcConnectTimeoutTest.kt
+++ b/src/test/kotlin/com/example/api/datasource/PgJdbcConnectTimeoutTest.kt
@@ -1,0 +1,131 @@
+package com.example.api.datasource
+
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.sql.DriverManager
+import java.util.Properties
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import org.junit.jupiter.api.Test
+
+/**
+ * 「TCP は accept するが 1 バイトも返さない DB」に対し、pgjdbc の接続確立がいつ諦めるかを固定する（#818）。
+ *
+ * pre-push が 7 分近く無反応になった事象（`HikariPool-1 - Starting...` から 402.9 秒の空白）の原因は、 **接続確立フェーズに実効的なタイムアウトが
+ * 1 つも掛かっていない**ことだった。TCP connect 自体は `connectTimeout`（既定 10 秒）で切れるが、その後の startup / 認証の応答待ちは
+ * `socketTimeout` が 0（既定）のとき無制限に待つ。
+ *
+ * HikariCP は `connectionTimeout` を接続確立にも効かせようとして `DriverManager.setLoginTimeout()` を
+ * 呼ぶ（`PoolBase#setLoginTimeout` → `DriverDataSource#setLoginTimeout`）が、pgjdbc の `Driver#timeout()`
+ * は `PGProperty.LOGIN_TIMEOUT.getOrDefault(props)` を先に読み、`loginTimeout` の **既定値が文字列 "0"** であるため
+ * `timeout <= 0` の分岐に入る。`DriverManager.getLoginTimeout()` への フォールバックには到達せず、HikariCP の意図はドライバに届かない。
+ *
+ * よって接続確立を有限時間で諦めさせるには `loginTimeout` を接続プロパティとして明示的に渡すしかない （`application.yml` の
+ * `spring.datasource.hikari.data-source-properties.loginTimeout`）。
+ * 本テストはその前提（＝上流の挙動）を固定する。上流が既定値を改めてフォールバックが効くようになれば 1 つ目が落ちるので、そのとき設定の要否を再判断する。
+ */
+class PgJdbcConnectTimeoutTest {
+    /** 接続試行が待ち上限内に戻ったか。 */
+    private enum class ConnectOutcome {
+        /** 有限時間で（例外として）諦めた。 */
+        SETTLED,
+        /** 待ち上限を過ぎても戻ってこない。 */
+        STILL_BLOCKED,
+    }
+
+    @Test
+    fun `HikariCP が設定する DriverManager の loginTimeout では接続確立が止まらない`() {
+        withUnresponsiveServer { port ->
+            val original = DriverManager.getLoginTimeout()
+            // HikariCP が connectionTimeout から設定するもの。テストのため 1 秒へ縮める。
+            // pgjdbc はこの値を読まないので、並行して走る他テストの接続には影響しない。
+            DriverManager.setLoginTimeout(1)
+            try {
+                val outcome = attemptConnect(port, loginTimeoutSeconds = null, waitMillis = 2_000)
+
+                assert(outcome == ConnectOutcome.STILL_BLOCKED)
+            } finally {
+                DriverManager.setLoginTimeout(original)
+            }
+        }
+    }
+
+    @Test
+    fun `loginTimeout を接続プロパティで渡せば応答しない DB でも接続確立が有限時間で失敗する`() {
+        withUnresponsiveServer { port ->
+            val outcome = attemptConnect(port, loginTimeoutSeconds = 1, waitMillis = 5_000)
+
+            assert(outcome == ConnectOutcome.SETTLED)
+        }
+    }
+
+    /**
+     * 接続を [waitMillis] だけ待ち、戻ってきたかどうかを返す。
+     *
+     * 接続は成功しない前提なので、戻り値が接続かエラーかは問わない（どちらも「諦めた」）。呼び出しスレッドを ブロックさせないため別スレッドで試行し、待ち上限を過ぎたら放置する（daemon
+     * なので JVM 終了を妨げない）。
+     */
+    private fun attemptConnect(
+        port: Int,
+        loginTimeoutSeconds: Int?,
+        waitMillis: Long,
+    ): ConnectOutcome {
+        val properties =
+            Properties().apply {
+                setProperty("user", "unused")
+                setProperty("password", "unused")
+                loginTimeoutSeconds?.let { setProperty("loginTimeout", it.toString()) }
+            }
+        val executor = Executors.newSingleThreadExecutor { Thread(it).apply { isDaemon = true } }
+        try {
+            val attempt = executor.submit {
+                runCatching {
+                    DriverManager.getConnection(
+                            "jdbc:postgresql://127.0.0.1:$port/test",
+                            properties,
+                        )
+                        .close()
+                }
+            }
+            return try {
+                attempt.get(waitMillis, TimeUnit.MILLISECONDS)
+                ConnectOutcome.SETTLED
+            } catch (_: TimeoutException) {
+                ConnectOutcome.STILL_BLOCKED
+            }
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    /**
+     * 詰まった DB を模擬する。接続は受け付けるが読みも書きもしないので、クライアントは startup メッセージへの 応答を待ち続ける（コンテナは起動しているのに Postgres
+     * が応答を返せない状態と同じ形）。
+     */
+    private fun <T> withUnresponsiveServer(block: (Int) -> T): T {
+        val accepted = mutableListOf<Socket>()
+        ServerSocket(0, BACKLOG, InetAddress.getLoopbackAddress()).use { server ->
+            val accepter = Thread {
+                // 閉じられるまで受け付け続ける。close() 後の accept は例外になるのでそこで終わる。
+                runCatching {
+                    while (true) {
+                        accepted += server.accept()
+                    }
+                }
+            }
+            accepter.isDaemon = true
+            accepter.start()
+            try {
+                return block(server.localPort)
+            } finally {
+                accepted.forEach { socket -> runCatching { socket.close() } }
+            }
+        }
+    }
+
+    private companion object {
+        const val BACKLOG = 50
+    }
+}


### PR DESCRIPTION
Closes #818

## 何を直したか

**接続確立フェーズに実効的なタイムアウトが 1 つも掛かっていなかった。** Issue が挙げていた「HikariCP の
`connectionTimeout`（既定 30 秒）がなぜ効かなかったのか」の答えは、**HikariCP の意図が pgjdbc に届いて
いない**ことだった。

原典（HikariCP 7.0.2 / pgjdbc 42.7.13、いずれも Boot 4.1.1 の BOM が解決する版）で追った経路:

1. HikariCP は `connectionTimeout` を接続確立にも効かせようとして `DriverManager.setLoginTimeout(30)` を
   呼ぶ（`PoolBase#setLoginTimeout` → `DriverDataSource#setLoginTimeout`）
2. ところが pgjdbc の `Driver#timeout()` は `PGProperty.LOGIN_TIMEOUT.getOrDefault(props)` を先に読む。
   `getOrDefault` は `properties.getProperty(name, defaultValue)` で、**`loginTimeout` の既定値は文字列 `"0"`**
3. よって `timeout = 0` となり `timeout <= 0` の分岐に入り、**`DriverManager.getLoginTimeout()` への
   フォールバックには到達しない** → タイムアウト無しの `makeConnection` へ
4. さらに `ConnectionFactoryImpl#tryConnect` は `socketTimeout > 0` のときしか `setNetworkTimeout` を
   呼ばない。既定は `0` なので、**TCP connect のあとの startup / 認証の応答待ちは無制限にブロックする**
   （`connectTimeout` 既定 10 秒は TCP connect にしか効かない）

観測された 402.9 秒のブロックは「コンテナは起動したが Postgres が応答を返せる状態になるまで長時間かかり、
その間 pgjdbc が無限に待った」で説明がつく。環境要因が引き金だったとしても、**無限に待つ構造が無ければ
7 分の無反応にはならない**。

## 実測

「TCP は accept するが 1 バイトも返さないサーバ」に対して測った（本 PR のテストと同じ仕掛け）:

```
DriverManager.getLoginTimeout() = 3 (秒)
既定（Testcontainers 相当）  -> 10.0s 経っても戻らない（無限待ち）
loginTimeout=3 を明示        ->  3.0s で戻った: SQLException: 接続試行がタイムアウトしました。
socketTimeout=3 を明示       ->  6.0s で戻った: SQLException: 接続試行は失敗しました。
```

`DriverManager` に値をセットしても効かないこと、接続プロパティで渡せば効くことの両方が確認できる。

## 変更

- **`application.yml`**: `spring.datasource.hikari` に `connection-timeout: 30000` と
  `data-source-properties.loginTimeout: 30` を追加。`dataSourceProperties` は
  `DriverDataSource` の `driverProperties` を経て `driver.connect(url, props)` に渡るので、HikariCP の
  意図をドライバへ直接届かせる形になる。`loginTimeout` は接続確立フェーズにのみ効き、クエリの実行時間は
  切らない（`socketTimeout` を選ばなかった理由）
- **テストのみでなく全環境に入れた**: 同じ穴は本番（Cloud Run 起動時の Prisma Postgres 接続）にもあり、
  テストだけ特別扱いにすると datasource 構成が本番と分岐する
- **`PgJdbcConnectTimeoutTest`**: 応答しないサーバに対し、DriverManager 経由では止まらないこと／接続
  プロパティで渡せば有限時間で失敗することを固定する。上流が既定値を改めてフォールバックが効くように
  なれば前者が落ちるので、そのとき設定の要否を再判断できる
- **`DataSourceLoginTimeoutTest`**: アプリの datasource に `loginTimeout` が実際に届いており、値が
  `connectionTimeout` と揃っていることを検証する。ズレると「借用は 30 秒で諦めるのに接続確立は待ち続ける」
  ちぐはぐが静かに生まれるため、一致まで固定した
- **ADR-0071 の訂正**: Consequences の「Docker は生きているが Testcontainers だけが失敗するケースは
  テストの失敗として現れる」が実態と食い違っていた（実際はハングしうる）。実測と本 PR での対処を追記した。
  ADR-0071 の決定自体は有効なまま

## 検証

- `./gradlew check` 緑（ktfmt / detekt / test / koverVerifyMature）
- 修正前は `DataSourceLoginTimeoutTest` のみが落ち、`PgJdbcConnectTimeoutTest` の 2 件は通る（＝現状の
  上流挙動を正しく記述している）ことを確認済み

## 残る射程

Issue が「1 回しか観測していない」と書いていたとおり、**402 秒まで伸びた環境要因（メモリ圧・スワップ）
そのものは本 PR では解消していない**。本 PR が保証するのは「詰まったときに 30 秒で諦める」ことであり、
詰まること自体を防ぐものではない。
